### PR TITLE
Fix feed template moderation check

### DIFF
--- a/feed/templates/feed/feed.html
+++ b/feed/templates/feed/feed.html
@@ -37,7 +37,7 @@
 
       <div class="flex justify-between items-center text-sm text-neutral-500 mt-4">
         <a href="{% url 'feed:post_detail' post.pk %}" class="text-blue-600 hover:underline">Ver mais</a>
-        {% if post.autor == user or user.tipo_id|stringformat:"s" in ["1", "2"] %}
+        {% if post.autor == user or user_can_moderate %}
           <div class="flex gap-3">
             <a href="{% url 'feed:post_update' post.pk %}" class="text-yellow-600 hover:underline">Editar</a>
             <a href="{% url 'feed:post_delete' post.pk %}" class="text-red-600 hover:underline">Remover</a>

--- a/feed/views.py
+++ b/feed/views.py
@@ -23,7 +23,11 @@ def feed_global(request):
         )
         | Q(autor=user)
     ).distinct()
-    return render(request, "feed/feed.html", {"posts": posts})
+    context = {
+        "posts": posts,
+        "user_can_moderate": request.user.tipo_id in (1, 2),
+    }
+    return render(request, "feed/feed.html", context)
 
 
 @login_required


### PR DESCRIPTION
## Summary
- add `user_can_moderate` context value to feed view
- check new context variable in feed template instead of parsing a list

## Testing
- `python manage.py runserver 8000`
- `curl -I http://localhost:8000/feed/`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fc14104d08325aa789179e997e98d