### PR TITLE
Implement post detail/update/delete in feed

### DIFF
--- a/feed/templates/feed/post_delete.html
+++ b/feed/templates/feed/post_delete.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+{% block title %}Remover Postagem | Hubx{% endblock %}
+
+{% block content %}
+<section class="max-w-md mx-auto px-4 py-16">
+  <div class="bg-white border border-red-200 rounded-2xl shadow-sm p-6 text-center">
+    <h2 class="text-xl font-semibold text-red-700 mb-4">Remover Postagem</h2>
+    <p class="text-sm text-neutral-700">Tem certeza que deseja remover esta postagem?</p>
+
+    <form method="post" class="mt-6 flex justify-center gap-3">
+      {% csrf_token %}
+      <a href="{% url 'feed:post_detail' post.pk %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100">Cancelar</a>
+      <button type="submit" class="text-sm px-4 py-2 rounded-xl bg-red-600 text-white hover:bg-red-700">Remover</button>
+    </form>
+  </div>
+</section>
+{% endblock %}

--- a/feed/templates/feed/post_detail.html
+++ b/feed/templates/feed/post_detail.html
@@ -1,0 +1,43 @@
+{% extends 'base.html' %}
+{% block title %}Postagem | Hubx{% endblock %}
+
+{% block content %}
+<section class="max-w-3xl mx-auto px-4 py-10 space-y-6">
+  <div>
+    <a href="{% url 'feed:feed' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100">Voltar</a>
+  </div>
+
+  <article class="border border-neutral-200 bg-white rounded-2xl shadow-sm p-6 space-y-4">
+    <div class="flex items-center gap-4">
+      {% if post.autor.avatar %}
+        <img src="{{ post.autor.avatar.url }}" alt="{{ post.autor.username }}" class="w-10 h-10 rounded-full object-cover">
+      {% else %}
+        <div class="w-10 h-10 rounded-full bg-neutral-200 flex items-center justify-center text-neutral-600 font-bold">
+          {{ post.autor.username|first|upper }}
+        </div>
+      {% endif %}
+      <div>
+        <p class="text-sm font-medium text-neutral-800">{{ post.autor.get_full_name|default:post.autor.username }}</p>
+        <p class="text-xs text-neutral-500">{{ post.criado_em|date:"d/m/Y H:i" }}</p>
+      </div>
+    </div>
+
+    <div class="text-sm text-neutral-800 whitespace-pre-line">
+      {{ post.conteudo }}
+    </div>
+
+    {% if post.imagem %}
+      <div class="mt-2">
+        <img src="{{ post.imagem.url }}" alt="Imagem da postagem" class="rounded-xl shadow-sm max-w-full">
+      </div>
+    {% endif %}
+
+    {% if post.autor == user or user_can_moderate %}
+    <div class="flex justify-end gap-3 pt-4 border-t border-neutral-100 text-sm">
+      <a href="{% url 'feed:post_update' post.pk %}" class="text-yellow-600 hover:underline">Editar</a>
+      <a href="{% url 'feed:post_delete' post.pk %}" class="text-red-600 hover:underline">Remover</a>
+    </div>
+    {% endif %}
+  </article>
+</section>
+{% endblock %}

--- a/feed/templates/feed/post_update.html
+++ b/feed/templates/feed/post_update.html
@@ -1,0 +1,51 @@
+{% extends 'base.html' %}
+{% load static %}
+{% block title %}Editar Postagem - Hubx{% endblock %}
+
+{% block content %}
+<section class="max-w-2xl mx-auto px-4 py-10">
+  <div class="mb-6 flex items-center gap-4">
+    <a href="{% url 'feed:post_detail' post.pk %}" class="inline-flex items-center text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100">
+      <svg class="mr-2" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+        <polyline points="15,18 9,12 15,6"/>
+      </svg>
+      Voltar
+    </a>
+    <div>
+      <h1 class="text-2xl font-bold text-neutral-900">Editar Postagem</h1>
+      <p class="text-sm text-neutral-600">Atualize sua postagem</p>
+    </div>
+  </div>
+
+  <form method="post" enctype="multipart/form-data" class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 space-y-6">
+    {% csrf_token %}
+    <div>
+      <label for="{{ form.conteudo.id_for_label }}" class="block text-sm font-medium text-neutral-700">
+        {{ form.conteudo.label }}
+      </label>
+      <textarea id="{{ form.conteudo.id_for_label }}" name="{{ form.conteudo.name }}" class="mt-1 block w-full rounded-xl border border-neutral-300 shadow-sm focus:ring-primary-500 focus:border-primary-500 text-sm" rows="6" required>{{ form.conteudo.value|default_if_none:"" }}</textarea>
+      {% if form.conteudo.errors %}
+        <p class="text-red-500 text-xs mt-1">{{ form.conteudo.errors }}</p>
+      {% endif %}
+    </div>
+
+    <div>
+      <label for="{{ form.imagem.id_for_label }}" class="block text-sm font-medium text-neutral-700">
+        {{ form.imagem.label }}
+      </label>
+      <input type="file" id="{{ form.imagem.id_for_label }}" name="{{ form.imagem.name }}" accept="image/*" class="mt-2 block w-full text-sm text-neutral-600 file:mr-4 file:py-2 file:px-4 file:rounded-xl file:border-0 file:text-sm file:font-semibold file:bg-neutral-100 file:text-neutral-700 hover:file:bg-neutral-200">
+      {% if form.imagem.errors %}
+        <p class="text-red-500 text-xs mt-1">{{ form.imagem.errors }}</p>
+      {% endif %}
+      {% if post.imagem %}
+        <img src="{{ post.imagem.url }}" alt="" class="max-w-xs rounded-xl shadow-sm mt-2">
+      {% endif %}
+    </div>
+
+    <div class="flex justify-end gap-3 pt-4 border-t border-neutral-100">
+      <a href="{% url 'feed:post_detail' post.pk %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100">Cancelar</a>
+      <button type="submit" class="text-sm px-4 py-2 rounded-xl bg-primary-600 text-white hover:bg-primary-700">Salvar</button>
+    </div>
+  </form>
+</section>
+{% endblock %}

--- a/feed/urls.py
+++ b/feed/urls.py
@@ -7,4 +7,7 @@ urlpatterns = [
     path("", views.feed_global, name="feed"),
     path("mural/", views.meu_mural, name="meu_mural"),
     path("postar/", views.nova_postagem, name="nova_postagem"),
+    path("<int:pk>/", views.post_detail, name="post_detail"),
+    path("<int:pk>/editar/", views.post_update, name="post_update"),
+    path("<int:pk>/remover/", views.post_delete, name="post_delete"),
 ]

--- a/feed/views.py
+++ b/feed/views.py
@@ -1,5 +1,6 @@
 from django.contrib.auth.decorators import login_required
-from django.shortcuts import render, redirect
+from django.contrib import messages
+from django.shortcuts import render, redirect, get_object_or_404
 from django.db.models import Q
 
 from .models import Post
@@ -42,3 +43,47 @@ def nova_postagem(request):
     else:
         form = PostForm()
     return render(request, "feed/nova_postagem.html", {"form": form})
+
+
+@login_required
+def post_detail(request, pk):
+    post = get_object_or_404(Post, pk=pk)
+    context = {
+        "post": post,
+        "user_can_moderate": request.user.tipo_id in (1, 2),
+    }
+    return render(request, "feed/post_detail.html", context)
+
+
+@login_required
+def post_update(request, pk):
+    post = get_object_or_404(Post, pk=pk)
+    if request.user != post.autor and request.user.tipo_id not in (1, 2):
+        messages.error(request, "Você não tem permissão para editar esta postagem.")
+        return redirect("feed:post_detail", pk=pk)
+
+    if request.method == "POST":
+        form = PostForm(request.POST, request.FILES, instance=post)
+        if form.is_valid():
+            form.save()
+            messages.success(request, "Postagem atualizada com sucesso.")
+            return redirect("feed:post_detail", pk=post.pk)
+    else:
+        form = PostForm(instance=post)
+
+    return render(request, "feed/post_update.html", {"form": form, "post": post})
+
+
+@login_required
+def post_delete(request, pk):
+    post = get_object_or_404(Post, pk=pk)
+    if request.user != post.autor and request.user.tipo_id not in (1, 2):
+        messages.error(request, "Você não tem permissão para remover esta postagem.")
+        return redirect("feed:post_detail", pk=pk)
+
+    if request.method == "POST":
+        post.delete()
+        messages.success(request, "Postagem removida.")
+        return redirect("feed:feed")
+
+    return render(request, "feed/post_delete.html", {"post": post})


### PR DESCRIPTION
## Summary
- add new views and templates for Post detail, update and delete
- expose URL routes for the new views
- update feed views to handle permissions for editing and deleting posts

## Testing
- `python manage.py test`
- `python manage.py check`
- `python manage.py test feed`

------
https://chatgpt.com/codex/tasks/task_e_686fd2dce058832583e41621cfdd4a44