### PR TITLE
Limit organizations app to root users

### DIFF
--- a/organizacoes/tests.py
+++ b/organizacoes/tests.py
@@ -1,3 +1,29 @@
 from django.test import TestCase
+from django.urls import reverse
+from django.contrib.auth import get_user_model
 
-# Create your tests here.
+from .models import Organizacao
+
+
+class OrganizacaoPermissionsTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.root_user = User.objects.create_user(
+            username="rootuser", password="pass", tipo_id=User.Tipo.SUPERADMIN
+        )
+        self.admin_user = User.objects.create_user(
+            username="adminuser", password="pass", tipo_id=User.Tipo.ADMIN
+        )
+        org = Organizacao.objects.create(nome="Org 1", cnpj="00.000.000/0001-00")
+        self.admin_user.organizacao = org
+        self.admin_user.save()
+
+    def test_root_can_access_list(self):
+        self.client.force_login(self.root_user)
+        response = self.client.get(reverse("organizacoes:list"))
+        self.assertEqual(response.status_code, 200)
+
+    def test_admin_cannot_access_list(self):
+        self.client.force_login(self.admin_user)
+        response = self.client.get(reverse("organizacoes:list"))
+        self.assertEqual(response.status_code, 403)

--- a/organizacoes/views.py
+++ b/organizacoes/views.py
@@ -1,6 +1,6 @@
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth import get_user_model
-from core.permissions import AdminRequiredMixin, SuperadminRequiredMixin
+from core.permissions import SuperadminRequiredMixin
 from django.contrib import messages
 from django.urls import reverse_lazy
 from django.views.generic import ListView, CreateView, UpdateView, DeleteView
@@ -11,15 +11,12 @@ from .forms import OrganizacaoForm
 User = get_user_model()
 
 
-class OrganizacaoListView(AdminRequiredMixin, LoginRequiredMixin, ListView):
+class OrganizacaoListView(SuperadminRequiredMixin, LoginRequiredMixin, ListView):
     model = Organizacao
     template_name = "organizacoes/list.html"
 
     def get_queryset(self):
-        qs = super().get_queryset()
-        if self.request.user.tipo_id == User.Tipo.ADMIN:
-            qs = qs.filter(pk=self.request.user.organizacao_id)
-        return qs
+        return super().get_queryset()
 
 
 class OrganizacaoCreateView(SuperadminRequiredMixin, LoginRequiredMixin, CreateView):
@@ -33,33 +30,27 @@ class OrganizacaoCreateView(SuperadminRequiredMixin, LoginRequiredMixin, CreateV
         return super().form_valid(form)
 
 
-class OrganizacaoUpdateView(AdminRequiredMixin, LoginRequiredMixin, UpdateView):
+class OrganizacaoUpdateView(SuperadminRequiredMixin, LoginRequiredMixin, UpdateView):
     model = Organizacao
     form_class = OrganizacaoForm
     template_name = "organizacoes/update.html"
     success_url = reverse_lazy("organizacoes:list")
 
     def get_queryset(self):
-        qs = super().get_queryset()
-        if self.request.user.tipo_id == User.Tipo.ADMIN:
-            qs = qs.filter(pk=self.request.user.organizacao_id)
-        return qs
+        return super().get_queryset()
 
     def form_valid(self, form):
         messages.success(self.request, "Organização atualizada com sucesso.")
         return super().form_valid(form)
 
 
-class OrganizacaoDeleteView(AdminRequiredMixin, LoginRequiredMixin, DeleteView):
+class OrganizacaoDeleteView(SuperadminRequiredMixin, LoginRequiredMixin, DeleteView):
     model = Organizacao
     template_name = "organizacoes/delete.html"
     success_url = reverse_lazy("organizacoes:list")
 
     def get_queryset(self):
-        qs = super().get_queryset()
-        if self.request.user.tipo_id == User.Tipo.ADMIN:
-            qs = qs.filter(pk=self.request.user.organizacao_id)
-        return qs
+        return super().get_queryset()
 
     def delete(self, request, *args, **kwargs):
         messages.success(self.request, "Organização removida.")

--- a/templates/base.html
+++ b/templates/base.html
@@ -56,9 +56,11 @@
         <a href="{% url 'nucleos:list' %}" class="flex items-center gap-x-2 hover:text-primary transition">
           <i class="fas fa-users"></i> Núcleos
         </a>
+        {% if user.is_authenticated and user.tipo_id == 4 %}
         <a href="{% url 'organizacoes:list' %}" class="flex items-center gap-x-2 hover:text-primary transition">
           <i class="fas fa-sitemap"></i> Organizações
         </a>
+        {% endif %}
         <a href="{% url 'tokens:criar_token' %}" class="flex items-center gap-x-2 hover:text-primary transition">
           <i class="fas fa-key"></i> Token
         </a>


### PR DESCRIPTION
## Summary
- restrict all organization views to `SuperadminRequiredMixin`
- show "Organizações" menu only for root users
- verify restrictions in `OrganizacaoPermissionsTests`

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_686fdcdb32788325829d30370dd74870