### PR TITLE
Add user profile avatar link in navbar

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -38,6 +38,15 @@
         <i class="fas fa-bars"></i>
       </button>
       <nav id="menu" class="hidden md:flex flex-col md:flex-row md:items-center gap-4 text-sm">
+        {% if user.is_authenticated %}
+        <a href="{% url 'accounts:perfil' %}" class="flex items-center hover:text-primary transition">
+          {% if user.avatar %}
+            <img src="{{ user.avatar.url }}" alt="{{ user.username }}" class="w-6 h-6 rounded-full object-cover" />
+          {% else %}
+            <i class="fas fa-user"></i>
+          {% endif %}
+        </a>
+        {% endif %}
         <a href="{% url 'dashboard:dashboard' %}" class="flex items-center gap-x-2 hover:text-primary transition">
           <i class="fas fa-tachometer-alt"></i> Dashboard
         </a>


### PR DESCRIPTION
## Summary
- show user avatar linking to profile in the navbar if logged in

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_687016c925b4832585064f867a6b36c2