### PR TITLE
Refatora views e rotas de agenda

### DIFF
--- a/agenda/urls.py
+++ b/agenda/urls.py
@@ -18,13 +18,12 @@ urlpatterns = [
     path("dia/<slug:dia_iso>/", views.lista_eventos, name="lista_eventos"),
     # CRUD
     path("evento/novo/", EventoCreateView.as_view(), name="evento_novo"),
-    path("novo/", EventoCreateView.as_view(), name="evento_create"),
-    path("<int:pk>/", EventoDetailView.as_view(), name="evento_detalhe"),
-    path("<int:pk>/editar/", EventoUpdateView.as_view(), name="evento_editar"),
-    path("<int:pk>/excluir/", EventoDeleteView.as_view(), name="evento_excluir"),
-    path("<int:pk>/inscrever/", EventoSubscribeView.as_view(), name="evento_subscribe"),
+    path("evento/<int:pk>/", EventoDetailView.as_view(), name="evento_detalhe"),
+    path("evento/<int:pk>/editar/", EventoUpdateView.as_view(), name="evento_editar"),
+    path("evento/<int:pk>/excluir/", EventoDeleteView.as_view(), name="evento_excluir"),
+    path("evento/<int:pk>/inscrever/", EventoSubscribeView.as_view(), name="evento_subscribe"),
     path(
-        "<int:pk>/inscrito/<int:user_id>/remover/",
+        "evento/<int:pk>/inscrito/<int:user_id>/remover/",
         EventoRemoveInscritoView.as_view(),
         name="evento_remover_inscrito",
     ),


### PR DESCRIPTION
## Summary
- replace `date.today()` with timezone-safe `timezone.localdate`
- centralize organization filtering with `_queryset_por_organizacao`
- reorder mixins and add permission checks
- compute event end times via annotation
- validate day slug with `date.fromisoformat`
- reorganize event routes under `evento/`

## Testing
- `ruff check agenda`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687539060ef08325ae4f1bbf0d6be7f3