### PR TITLE
Refactor user type enum usage

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -7,6 +7,7 @@ from rest_framework import viewsets
 from rest_framework.permissions import IsAuthenticated
 
 from core.permissions import IsAdmin, IsCoordenador
+from accounts.models import UserType
 from accounts.serializers import UserSerializer
 
 User = get_user_model()
@@ -322,9 +323,9 @@ def termos(request):
 
         if username and pwd_hash:
             tipo_mapping = {
-                TokenAcesso.Tipo.ADMIN: User.Tipo.ADMIN,
-                TokenAcesso.Tipo.GERENTE: User.Tipo.GERENTE,
-                TokenAcesso.Tipo.CLIENTE: User.Tipo.CLIENTE,
+                TokenAcesso.Tipo.ADMIN: UserType.ADMIN,
+                TokenAcesso.Tipo.GERENTE: UserType.GERENTE,
+                TokenAcesso.Tipo.CLIENTE: UserType.CLIENTE,
             }
             user = User.objects.create(
                 username=username,
@@ -333,7 +334,7 @@ def termos(request):
                 last_name=last_name,
                 password=pwd_hash,
                 cpf=cpf_val,
-                tipo_id=tipo_mapping[token_obj.tipo_destino],
+                user_type=tipo_mapping[token_obj.tipo_destino],
             )
             if token_obj.nucleo_destino:
                 user.nucleo = token_obj.nucleo_destino

--- a/core/management/commands/corrigir_base_token.py
+++ b/core/management/commands/corrigir_base_token.py
@@ -15,19 +15,11 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         User = get_user_model()
 
-        # Garantir UserTypes padrao
-        tipos_padrao = ["root", "admin", "gerente", "cliente"]
-        tipos = {}
-        for desc in tipos_padrao:
-            tipo, _ = UserType.objects.get_or_create(descricao=desc)
-            tipos[desc] = tipo
-        self.stdout.write(f"UserTypes verificados: {', '.join(tipos_padrao)}")
-
-        # Atribuir tipo CLIENTE para usuarios sem tipo
-        qs_sem_tipo = User.objects.filter(tipo__isnull=True)
+        # Garantir campo user_type preenchido
+        qs_sem_tipo = User.objects.filter(user_type__isnull=True)
         count_users = qs_sem_tipo.count()
         if count_users:
-            qs_sem_tipo.update(tipo=tipos["cliente"])
+            qs_sem_tipo.update(user_type=UserType.CLIENTE)
         self.stdout.write(f"Usuarios atualizados: {count_users}")
 
         # Ajustar tokens incompletos

--- a/empresas/views.py
+++ b/empresas/views.py
@@ -8,6 +8,7 @@ from django.urls import reverse, reverse_lazy
 from django.views.generic import CreateView, DeleteView, ListView, UpdateView
 from rest_framework.permissions import BasePermission, SAFE_METHODS
 from rest_framework.response import Response
+from accounts.models import UserType
 from rest_framework.status import HTTP_201_CREATED, HTTP_204_NO_CONTENT
 
 from core.permissions import (ClienteGerenteRequiredMixin, NoSuperadminMixin,
@@ -26,9 +27,9 @@ def lista_empresas(request):
     qs = Empresa.objects.select_related("organizacao", "usuario")
     if request.user.is_superuser:
         empresas = qs
-    elif request.user.tipo.descricao == "admin":
+    elif request.user.user_type == UserType.ADMIN:
         empresas = qs.filter(organizacao=request.user.organizacao)
-    elif request.user.tipo.descricao in ["client", "manager"]:
+    elif request.user.user_type in [UserType.CLIENTE, UserType.GERENTE]:
         empresas = qs.filter(usuario=request.user)
     else:
         return HttpResponseForbidden("Usuário não autorizado.")
@@ -50,7 +51,7 @@ def lista_empresas(request):
 @login_required
 @no_superadmin_required
 def nova_empresa(request):
-    if not request.user.is_authenticated or request.user.is_superuser or request.user.tipo.descricao == "admin":
+    if not request.user.is_authenticated or request.user.is_superuser or request.user.user_type == UserType.ADMIN:
         return HttpResponseForbidden("Usuário não autorizado a criar empresas.")
 
     if request.method == "POST":

--- a/feed/templates/feed/feed.html
+++ b/feed/templates/feed/feed.html
@@ -10,7 +10,7 @@
     <h1 class="text-2xl font-bold text-neutral-900">Feed de Postagens</h1>
     <div class="flex gap-2">
       <a href="{% url 'feed:meu_mural' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100">Mural</a>
-      {% if not request.user.tipo.descricao == "root" %}
+      {% if request.user.user_type != 'root' %}
         <a href="{% url 'feed:nova_postagem' %}" target="_blank" class="inline-flex items-center gap-2 rounded bg-emerald-600 px-4 py-2 text-white hover:bg-emerald-700 focus-visible:ring">
           <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />

--- a/feed/templates/feed/mural.html
+++ b/feed/templates/feed/mural.html
@@ -12,7 +12,7 @@
     <h1 class="text-2xl font-bold text-neutral-900">Meu Mural</h1>
     <div class="flex gap-2">
       <a href="{% url 'feed:listar' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100">Ver Feed Global</a>
-      {% if not request.user.tipo.descricao == "root" %}
+      {% if request.user.user_type != 'root' %}
       <a href="{% url 'feed:nova_postagem' %}" target="_blank" class="inline-flex items-center gap-2 px-4 py-2 rounded-md bg-blue-500 hover:bg-blue-600 text-white text-sm font-medium shadow-sm transition">
         <i class="fa-solid fa-circle-plus"></i>
         Nova postagem

--- a/feed/views.py
+++ b/feed/views.py
@@ -8,6 +8,7 @@ from django.urls import reverse_lazy
 from django.views.generic import CreateView, ListView, DetailView
 
 from .forms import PostForm, CommentForm, LikeForm
+from accounts.models import UserType
 from .models import Post, Comment, Like
 
 
@@ -55,7 +56,7 @@ class NovaPostagemView(LoginRequiredMixin, CreateView):
     success_url = reverse_lazy("feed:meu_mural")
 
     def dispatch(self, request, *args, **kwargs):
-        if request.user.tipo and request.user.tipo.descricao.lower() == "root":
+        if request.user.user_type == UserType.ROOT:
             return HttpResponseForbidden("Usuário root não pode publicar no feed.")
         return super().dispatch(request, *args, **kwargs)
 
@@ -135,7 +136,7 @@ def toggle_like(request, post_id):
 @login_required
 def post_update(request, pk):
     post = get_object_or_404(Post, pk=pk)
-    if request.user != post.autor and request.user.tipo_id not in (1, 2):
+    if request.user != post.autor and request.user.user_type not in {UserType.ROOT, UserType.ADMIN}:
         messages.error(request, "Você não tem permissão para editar esta postagem.")
         return redirect("feed:post_detail", pk=pk)
 
@@ -178,7 +179,7 @@ def post_update(request, pk):
 @login_required
 def post_delete(request, pk):
     post = get_object_or_404(Post, pk=pk)
-    if request.user != post.autor and request.user.tipo_id not in (1, 2):
+    if request.user != post.autor and request.user.user_type not in {UserType.ROOT, UserType.ADMIN}:
         messages.error(request, "Você não tem permissão para remover esta postagem.")
         return redirect("feed:post_detail", pk=pk)
 

--- a/nucleos/views.py
+++ b/nucleos/views.py
@@ -8,6 +8,7 @@ from django.views.generic import (CreateView, DeleteView, DetailView, ListView,
 
 from core.permissions import (AdminRequiredMixin, GerenteRequiredMixin,
                               NoSuperadminMixin)
+from accounts.models import UserType
 
 from .forms import NucleoForm, NucleoSearchForm
 from .models import Nucleo
@@ -24,9 +25,9 @@ class NucleoListView(
     def get_queryset(self):
         qs = super().get_queryset()
         user = self.request.user
-        if user.tipo_id == User.Tipo.ADMIN:
+        if user.user_type == UserType.ADMIN:
             qs = qs.filter(organizacao=user.organization)  # Corrigido para usar 'organization' ao filtrar
-        elif user.tipo_id == User.Tipo.GERENTE:
+        elif user.user_type == UserType.GERENTE:
             qs = qs.filter(membros=user)
         form = NucleoSearchForm(self.request.GET)
         if form.is_valid() and form.cleaned_data["nucleo"]:
@@ -49,7 +50,7 @@ class NucleoCreateView(
     success_url = reverse_lazy("nucleos:list")
 
     def form_valid(self, form):
-        if self.request.user.tipo_id == User.Tipo.ADMIN:
+        if self.request.user.user_type == UserType.ADMIN:
             form.instance.organizacao = self.request.user.organization  # Corrigido para usar 'organization' ao criar
         messages.success(self.request, "Núcleo criado com sucesso.")
         return super().form_valid(form)
@@ -66,9 +67,9 @@ class NucleoUpdateView(
     def get_queryset(self):
         qs = super().get_queryset()
         user = self.request.user
-        if user.tipo_id == User.Tipo.ADMIN:
+        if user.user_type == UserType.ADMIN:
             qs = qs.filter(organizacao=user.organizacao)  # Corrigido para usar 'organizacao' ao filtrar
-        elif user.tipo_id == User.Tipo.GERENTE:
+        elif user.user_type == UserType.GERENTE:
             qs = qs.filter(membros=user)
         return qs
 
@@ -92,7 +93,7 @@ class NucleoDeleteView(
     def get_queryset(self):
         qs = super().get_queryset()
         user = self.request.user
-        if user.tipo_id == User.Tipo.ADMIN:
+        if user.user_type == UserType.ADMIN:
             qs = qs.filter(organizacao=user.organizacao)  # Corrigido para usar 'organizacao' ao filtrar
         return qs
 
@@ -110,9 +111,9 @@ class NucleoDetailView(
     def get_queryset(self):
         qs = super().get_queryset()
         user = self.request.user
-        if user.tipo_id == User.Tipo.ADMIN:
+        if user.user_type == UserType.ADMIN:
             qs = qs.filter(organizacao=user.organizacao)  # Corrigido para usar 'organizacao' ao filtrar
-        elif user.tipo_id == User.Tipo.GERENTE:
+        elif user.user_type == UserType.GERENTE:
             qs = qs.filter(membros=user)
         return qs
 
@@ -123,12 +124,12 @@ class NucleoMemberRemoveView(
     def post(self, request, pk, user_id):
         nucleo = get_object_or_404(Nucleo, pk=pk)
         if (
-            request.user.tipo_id == User.Tipo.ADMIN
+            request.user.user_type == UserType.ADMIN
             and nucleo.organizacao != request.user.organization  # Corrigido para usar 'organization'
         ):
             return redirect("nucleos:list")
         if (
-            request.user.tipo_id == User.Tipo.GERENTE
+            request.user.user_type == UserType.GERENTE
             and request.user not in nucleo.membros.all()
         ):
             return redirect("nucleos:list")

--- a/scripts/create_admin_users.py
+++ b/scripts/create_admin_users.py
@@ -14,7 +14,6 @@ from organizacoes.models import Organizacao
 
 # Criar usuários admin para cada organização
 print("Criando usuários admin para cada organização...")
-admin_type = UserType.objects.get(descricao="admin")
 organizacoes = Organizacao.objects.all()
 
 for organizacao in organizacoes:
@@ -22,7 +21,7 @@ for organizacao in organizacoes:
         username=f"admin_{organizacao.id}",
         email=f"admin_{organizacao.id}@hubx.com",
         password="1234Hubx!",
-        tipo=admin_type,
+        user_type=UserType.ADMIN,
         organizacao=organizacao
     )
 

--- a/scripts/create_gerente_cliente_users.py
+++ b/scripts/create_gerente_cliente_users.py
@@ -16,8 +16,6 @@ from faker import Faker
 # Criar usuários gerente e cliente
 print("Criando usuários gerente e cliente para cada núcleo...")
 fake = Faker("pt_BR")
-gerente_type = UserType.objects.get(descricao="gerente")
-cliente_type = UserType.objects.get(descricao="cliente")
 nucleos = Nucleo.objects.all()
 
 for nucleo in nucleos:
@@ -26,7 +24,7 @@ for nucleo in nucleos:
         username=f"gerente_{nucleo.id}",
         email=f"gerente_{nucleo.id}@hubx.com",
         password="1234Hubx!",
-        tipo=gerente_type,
+        user_type=UserType.GERENTE,
         nucleo=nucleo
     )
 
@@ -36,7 +34,7 @@ for nucleo in nucleos:
             username=f"cliente_{nucleo.id}_{i}",
             email=f"cliente_{nucleo.id}_{i}@hubx.com",
             password="1234Hubx!",
-            tipo=cliente_type,
+            user_type=UserType.CLIENTE,
             nucleo=nucleo
         )
 

--- a/scripts/create_root_user.py
+++ b/scripts/create_root_user.py
@@ -13,11 +13,10 @@ from accounts.models import User, UserType
 
 # Criar usuário root
 print("Criando usuário root...")
-root_type = UserType.objects.get(descricao="root")
 User.objects.create_superuser(
     username="root",
     email="root@hubx.com",
     password="1234Hubx!",
-    tipo=root_type
+    user_type=UserType.ROOT
 )
 print("Usuário root criado com sucesso!")

--- a/scripts/populate_user_types.py
+++ b/scripts/populate_user_types.py
@@ -11,16 +11,6 @@ django.setup()
 
 from accounts.models import UserType
 
-# Populando tipos de usuário
-print("Populando tabela UserType...")
-user_types = [
-    {"id": 1, "descricao": "root"},
-    {"id": 2, "descricao": "admin"},
-    {"id": 3, "descricao": "gerente"},
-    {"id": 4, "descricao": "cliente"},
-]
-
-for user_type in user_types:
-    UserType.objects.get_or_create(id=user_type["id"], defaults={"descricao": user_type["descricao"]})
-
-print("População concluída com sucesso!")
+print("Tipos disponíveis:")
+for choice in UserType:
+    print(f"- {choice.value}")

--- a/tests/agenda/test_feedback.py
+++ b/tests/agenda/test_feedback.py
@@ -52,7 +52,7 @@ def feedbacks(evento_passado, usuario):
         username="outro_pessoa",
         email="outro_pessoa@example.com",
         password="12345",
-        tipo=usuario.tipo,
+        user_type=usuario.user_type,
     )
     FeedbackNota.objects.create(evento=evento_passado, usuario=usuario, nota=4)
     FeedbackNota.objects.create(evento=evento_passado, usuario=outro_usuario, nota=5)  # Usar outro usuário para evitar duplicação

--- a/tests/agenda/test_inscricoes.py
+++ b/tests/agenda/test_inscricoes.py
@@ -56,7 +56,7 @@ def gerente(organizacao):
         username="gerente",
         email="gerente@example.com",
         password="12345",
-        tipo_id=User.Tipo.GERENTE,
+        user_type=UserType.GERENTE,
         organizacao=organizacao,
     )
 

--- a/tokens/forms.py
+++ b/tokens/forms.py
@@ -4,6 +4,7 @@ from django.contrib.auth import get_user_model
 from .models import TokenAcesso, CodigoAutenticacao, TOTPDevice
 from organizacoes.models import Organizacao
 from nucleos.models import Nucleo
+from accounts.models import UserType
 
 User = get_user_model()
 
@@ -17,7 +18,7 @@ class TokenAcessoForm(forms.ModelForm):
         self.user = user
         super().__init__(*args, **kwargs)
 
-        if user and user.tipo_id == User.Tipo.SUPERADMIN:
+        if user and user.user_type == UserType.ROOT:
             self.fields["tipo_destino"].choices = [(TokenAcesso.Tipo.ADMIN, "admin")]
         elif user:
             self.fields["tipo_destino"].choices = [
@@ -29,7 +30,7 @@ class TokenAcessoForm(forms.ModelForm):
         cleaned = super().clean()
         if (
             self.user
-            and self.user.tipo_id == User.Tipo.ADMIN
+            and self.user.user_type == UserType.ADMIN
             and cleaned.get("tipo_destino")
             in {TokenAcesso.Tipo.GERENTE, TokenAcesso.Tipo.CLIENTE}
         ):


### PR DESCRIPTION
## Summary
- centralize `UserType` enum and drop FK usage
- update scripts and forms to rely on enum
- fix permissions and views checking `user_type`
- adjust tests to new API

## Testing
- `pytest -q` *(fails: AttributeError: objects)*
- `python manage.py makemigrations` *(fails: FieldError: Unknown field(s) specified)*

------
https://chatgpt.com/codex/tasks/task_e_687aae8ce86083258b6ba0ed5142f33a