### PR TITLE
test: add pytest suite for organizacoes

### DIFF
--- a/tests/organizacoes/test_forms.py
+++ b/tests/organizacoes/test_forms.py
@@ -1,0 +1,40 @@
+import pytest
+
+from organizacoes.forms import OrganizacaoForm
+from organizacoes.models import Organizacao
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def faker_ptbr():
+    from faker import Faker
+
+    return Faker("pt_BR")
+
+
+def test_form_fields():
+    form = OrganizacaoForm()
+    assert list(form.fields.keys()) == [
+        "nome",
+        "cnpj",
+        "descricao",
+        "slug",
+        "avatar",
+        "cover",
+    ]
+
+
+def test_cnpj_duplicate_invalid(faker_ptbr):
+    cnpj = faker_ptbr.cnpj()
+    Organizacao.objects.create(nome="Org", cnpj=cnpj, slug="org")
+    form = OrganizacaoForm(data={"nome": "Outra", "cnpj": cnpj, "slug": "org2"})
+    assert not form.is_valid()
+    assert "cnpj" in form.errors
+
+
+def test_slug_required(faker_ptbr):
+    data = {"nome": "Sem Slug", "cnpj": faker_ptbr.cnpj()}
+    form = OrganizacaoForm(data=data)
+    assert not form.is_valid()
+    assert "slug" in form.errors

--- a/tests/organizacoes/test_models.py
+++ b/tests/organizacoes/test_models.py
@@ -1,0 +1,85 @@
+import os
+
+import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.db import IntegrityError
+from django.utils.text import slugify
+
+from organizacoes.models import Organizacao
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def faker_ptbr():
+    from faker import Faker
+
+    return Faker("pt_BR")
+
+
+@pytest.fixture
+def media_root(tmp_path, settings):
+    settings.MEDIA_ROOT = tmp_path
+    return tmp_path
+
+
+def test_str_representation(faker_ptbr):
+    org = Organizacao.objects.create(
+        nome="ONG Alpha",
+        cnpj=faker_ptbr.cnpj(),
+        slug="ong-alpha",
+    )
+    assert str(org) == "ONG Alpha"
+
+
+def test_slug_uniqueness_and_slugified(faker_ptbr):
+    name1 = faker_ptbr.company()
+    name2 = faker_ptbr.company()
+    org1 = Organizacao.objects.create(
+        nome=name1,
+        cnpj=faker_ptbr.cnpj(),
+        slug=slugify(name1),
+    )
+    org2 = Organizacao.objects.create(
+        nome=name2,
+        cnpj=faker_ptbr.cnpj(),
+        slug=slugify(name2),
+    )
+    assert org1.slug == slugify(name1)
+    assert org2.slug == slugify(name2)
+    assert org1.slug != org2.slug
+
+
+def test_cnpj_unique_constraint(faker_ptbr):
+    cnpj = faker_ptbr.cnpj()
+    Organizacao.objects.create(
+        nome=faker_ptbr.company(),
+        cnpj=cnpj,
+        slug="org-1",
+    )
+    with pytest.raises(IntegrityError):
+        Organizacao.objects.create(
+            nome=faker_ptbr.company(),
+            cnpj=cnpj,
+            slug="org-2",
+        )
+
+
+def test_file_upload_and_cleanup(media_root, faker_ptbr):
+    avatar = SimpleUploadedFile("avatar.png", b"avatarcontent", content_type="image/png")
+    cover = SimpleUploadedFile("cover.jpg", b"covercontent", content_type="image/jpeg")
+    org = Organizacao.objects.create(
+        nome=faker_ptbr.company(),
+        cnpj=faker_ptbr.cnpj(),
+        slug="org-files",
+        avatar=avatar,
+        cover=cover,
+    )
+    assert org.avatar.name.startswith("organizacoes/avatars/")
+    assert org.cover.name.startswith("organizacoes/capas/")
+    assert os.path.exists(org.avatar.path)
+    assert os.path.exists(org.cover.path)
+    org.delete()
+    # Arquivos permanecem após exclusão
+    assert os.path.exists(os.path.join(media_root, org.avatar.name))
+    assert os.path.exists(os.path.join(media_root, org.cover.name))

--- a/tests/organizacoes/test_views.py
+++ b/tests/organizacoes/test_views.py
@@ -1,0 +1,112 @@
+import pytest
+from django.urls import reverse
+from django.utils.text import slugify
+
+from accounts.models import User, UserType
+from organizacoes.models import Organizacao
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def faker_ptbr():
+    from faker import Faker
+
+    return Faker("pt_BR")
+
+
+@pytest.fixture
+def superadmin_user(client):
+    user = User.objects.create_user(
+        username="root",
+        email="root@example.com",
+        password="pass",
+        user_type=UserType.ROOT,
+    )
+    client.force_login(user)
+    return client
+
+
+@pytest.fixture
+def admin_user(client):
+    user = User.objects.create_user(
+        username="admin",
+        email="admin@example.com",
+        password="pass",
+        user_type=UserType.ADMIN,
+    )
+    client.force_login(user)
+    return client
+
+
+@pytest.fixture
+def organizacao(faker_ptbr):
+    name = faker_ptbr.company()
+    return Organizacao.objects.create(nome=name, cnpj=faker_ptbr.cnpj(), slug=slugify(name))
+
+
+def test_list_view_superadmin(superadmin_user, organizacao):
+    url = reverse("organizacoes:list")
+    response = superadmin_user.get(url)
+    assert response.status_code == 200
+    assert set(response.context["object_list"]) == set(Organizacao.objects.all())
+
+
+def test_list_view_denied_for_non_superadmin(admin_user):
+    url = reverse("organizacoes:list")
+    response = admin_user.get(url)
+    assert response.status_code == 403
+
+
+def test_create_view_superadmin(superadmin_user, faker_ptbr):
+    url = reverse("organizacoes:create")
+    data = {"nome": "Nova Org", "cnpj": faker_ptbr.cnpj(), "slug": "nova-org"}
+    response = superadmin_user.post(url, data=data, follow=True)
+    assert response.status_code == 200
+    assert Organizacao.objects.filter(nome="Nova Org").exists()
+    msgs = list(response.context["messages"])
+    assert any("criada" in m.message.lower() for m in msgs)
+
+
+def test_create_view_denied_for_admin(admin_user, faker_ptbr):
+    url = reverse("organizacoes:create")
+    data = {"nome": "Org X", "cnpj": faker_ptbr.cnpj(), "slug": "org-x"}
+    response = admin_user.post(url, data=data)
+    assert response.status_code == 403
+    assert not Organizacao.objects.filter(nome="Org X").exists()
+
+
+def test_update_view_superadmin(superadmin_user, organizacao):
+    url = reverse("organizacoes:update", args=[organizacao.pk])
+    response = superadmin_user.post(
+        url,
+        {"nome": "Editada", "cnpj": organizacao.cnpj, "slug": "editada"},
+        follow=True,
+    )
+    assert response.status_code == 200
+    organizacao.refresh_from_db()
+    assert organizacao.nome == "Editada"
+    msgs = list(response.context["messages"])
+    assert any("atualizada" in m.message.lower() for m in msgs)
+
+
+def test_update_view_denied_for_admin(admin_user, organizacao):
+    url = reverse("organizacoes:update", args=[organizacao.pk])
+    response = admin_user.post(url, {"nome": "X", "cnpj": organizacao.cnpj, "slug": "x"})
+    assert response.status_code == 403
+    organizacao.refresh_from_db()
+    assert organizacao.nome != "X"
+
+
+def test_delete_view_superadmin(superadmin_user, organizacao):
+    url = reverse("organizacoes:delete", args=[organizacao.pk])
+    response = superadmin_user.post(url, follow=True)
+    assert response.status_code == 200
+    assert not Organizacao.objects.filter(pk=organizacao.pk).exists()
+
+
+def test_delete_view_denied_for_admin(admin_user, organizacao):
+    url = reverse("organizacoes:delete", args=[organizacao.pk])
+    response = admin_user.post(url)
+    assert response.status_code == 403
+    assert Organizacao.objects.filter(pk=organizacao.pk).exists()


### PR DESCRIPTION
## Summary
- add pytest fixtures and tests for `organizacoes`
- cover models, forms and views

## Testing
- `mypy tests/organizacoes/test_models.py tests/organizacoes/test_forms.py tests/organizacoes/test_views.py --ignore-missing-imports --follow-imports=skip`
- `pytest tests/organizacoes -q`


------
https://chatgpt.com/codex/tasks/task_e_68801dc35a3c8325ab7ae429d89f2949