### PR TITLE
test: add feed app pytest suite

### DIFF
--- a/tests/feed/conftest.py
+++ b/tests/feed/conftest.py
@@ -1,0 +1,110 @@
+import pytest
+from django.contrib.auth import get_user_model
+
+from accounts.models import UserType
+from agenda.factories import EventoFactory
+from feed.models import Post
+from nucleos.models import Nucleo, ParticipacaoNucleo
+from organizacoes.models import Organizacao
+
+User = get_user_model()
+
+
+@pytest.fixture(autouse=True)
+def add_nucleos_property():
+    if not hasattr(User, "nucleos"):
+        User.add_to_class("nucleos", property(lambda self: Nucleo.objects.filter(participacoes__user=self)))
+    if not hasattr(User, "eventos"):
+        from agenda.models import Evento
+
+        User.add_to_class("eventos", property(lambda self: Evento.objects.filter(organizacao=self.organizacao)))
+
+
+@pytest.fixture
+def organizacao(db):
+    return Organizacao.objects.create(nome="Org", cnpj="00.000.000/0001-01", slug="org")
+
+
+@pytest.fixture
+def root_user(db, organizacao):
+    return User.objects.create_superuser(
+        email="root@example.com",
+        username="root",
+        password="pass",
+        organizacao=organizacao,
+    )
+
+
+@pytest.fixture
+def admin_user(db, organizacao):
+    return User.objects.create_user(
+        email="admin@example.com",
+        username="admin",
+        password="pass",
+        user_type=UserType.ADMIN,
+        organizacao=organizacao,
+    )
+
+
+@pytest.fixture
+def coordenador_user(db, organizacao):
+    return User.objects.create_user(
+        email="coord@example.com",
+        username="coord",
+        password="pass",
+        user_type=UserType.COORDENADOR,
+        organizacao=organizacao,
+    )
+
+
+@pytest.fixture
+def associado_user(db, organizacao):
+    return User.objects.create_user(
+        email="assoc@example.com",
+        username="assoc",
+        password="pass",
+        user_type=UserType.ASSOCIADO,
+        organizacao=organizacao,
+    )
+
+
+@pytest.fixture
+def nucleado_user(db, organizacao):
+    return User.objects.create_user(
+        email="nucleo@example.com",
+        username="nucleo",
+        password="pass",
+        user_type=UserType.NUCLEADO,
+        organizacao=organizacao,
+    )
+
+
+@pytest.fixture
+def nucleo(db, organizacao, coordenador_user, nucleado_user):
+    n = Nucleo.objects.create(nome="N1", organizacao=organizacao)
+    ParticipacaoNucleo.objects.create(user=nucleado_user, nucleo=n, is_coordenador=False)
+    ParticipacaoNucleo.objects.create(user=coordenador_user, nucleo=n, is_coordenador=True)
+    return n
+
+
+@pytest.fixture
+def evento(db, organizacao, nucleo, admin_user):
+    return EventoFactory(organizacao=organizacao, nucleo=nucleo, coordenador=admin_user)
+
+
+@pytest.fixture(autouse=True)
+def media_root(tmp_path, settings):
+    settings.MEDIA_ROOT = tmp_path
+
+
+@pytest.fixture
+def posts(admin_user, nucleado_user, nucleo, evento, organizacao):
+    p1 = Post.objects.create(autor=admin_user, organizacao=organizacao, tipo_feed="global", conteudo="g")
+    p2 = Post.objects.create(autor=nucleado_user, organizacao=organizacao, tipo_feed="usuario", conteudo="u")
+    p3 = Post.objects.create(
+        autor=nucleado_user, organizacao=organizacao, tipo_feed="nucleo", nucleo=nucleo, conteudo="n"
+    )
+    p4 = Post.objects.create(
+        autor=nucleado_user, organizacao=organizacao, tipo_feed="evento", evento=evento, conteudo="e"
+    )
+    return p1, p2, p3, p4

--- a/tests/feed/test_forms.py
+++ b/tests/feed/test_forms.py
@@ -1,0 +1,52 @@
+import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
+
+from feed.forms import CommentForm, PostForm
+
+
+@pytest.mark.django_db
+def test_postform_media_validation(nucleado_user):
+    pdf = SimpleUploadedFile("a.pdf", b"data", content_type="application/pdf")
+    img = SimpleUploadedFile("a.png", b"data", content_type="image/png")
+    form = PostForm(
+        data={"tipo_feed": "global", "conteudo": ""},
+        files={"image": img, "pdf": pdf},
+        user=nucleado_user,
+    )
+    assert not form.is_valid()
+    assert "Envie apenas imagem OU PDF, não ambos." in form.non_field_errors()[0]
+
+
+@pytest.mark.django_db
+def test_postform_content_required(nucleado_user):
+    form = PostForm(data={"tipo_feed": "global"}, user=nucleado_user)
+    assert not form.is_valid()
+    assert "Informe um conteúdo ou selecione uma mídia." in form.non_field_errors()[0]
+
+
+@pytest.mark.django_db
+def test_postform_nucleo_required(nucleado_user):
+    form = PostForm(data={"tipo_feed": "nucleo"}, user=nucleado_user)
+    assert not form.is_valid()
+    assert form.errors["nucleo"] == ["Selecione o núcleo."]
+
+
+@pytest.mark.django_db
+def test_postform_nucleo_membership(admin_user, nucleo):
+    form = PostForm(data={"tipo_feed": "nucleo", "nucleo": nucleo.id}, user=admin_user)
+    assert not form.is_valid()
+    assert form.errors["nucleo"] == ["Usuário não é membro do núcleo."]
+
+
+@pytest.mark.django_db
+def test_postform_evento_required(nucleado_user):
+    form = PostForm(data={"tipo_feed": "evento"}, user=nucleado_user)
+    assert not form.is_valid()
+    assert form.errors["evento"] == ["Selecione o evento."]
+
+
+@pytest.mark.django_db
+def test_commentform_text_required():
+    form = CommentForm(data={})
+    assert not form.is_valid()
+    assert "texto" in form.errors

--- a/tests/feed/test_models.py
+++ b/tests/feed/test_models.py
@@ -1,0 +1,48 @@
+import pytest
+from django.db import IntegrityError
+
+from feed.models import Comment, Like, Post
+
+
+@pytest.mark.django_db
+def test_post_creation(admin_user, organizacao):
+    post = Post.objects.create(
+        autor=admin_user,
+        organizacao=organizacao,
+        tipo_feed="global",
+        conteudo="Hello",
+    )
+    assert post.pk is not None
+    assert Post._meta.ordering == ["-created_at"]
+
+
+@pytest.mark.django_db
+def test_post_relationships(admin_user, organizacao):
+    post = Post.objects.create(
+        autor=admin_user,
+        organizacao=organizacao,
+        tipo_feed="global",
+    )
+    Comment.objects.create(post=post, user=admin_user, texto="c1")
+    Comment.objects.create(post=post, user=admin_user, texto="c2")
+    Like.objects.create(post=post, user=admin_user)
+
+    assert post.comments.count() == 2
+    assert post.likes.count() == 1
+
+
+@pytest.mark.django_db
+def test_like_uniqueness(admin_user, organizacao):
+    post = Post.objects.create(autor=admin_user, organizacao=organizacao)
+    Like.objects.create(post=post, user=admin_user)
+    with pytest.raises(IntegrityError):
+        Like.objects.create(post=post, user=admin_user)
+
+
+@pytest.mark.django_db
+def test_nested_comments(admin_user, organizacao):
+    post = Post.objects.create(autor=admin_user, organizacao=organizacao)
+    parent = Comment.objects.create(post=post, user=admin_user, texto="c1")
+    Comment.objects.create(post=post, user=admin_user, texto="c2", reply_to=parent)
+
+    assert parent.replies.count() == 1

--- a/tests/feed/test_views.py
+++ b/tests/feed/test_views.py
@@ -1,0 +1,139 @@
+import pytest
+from django.contrib.messages import get_messages
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.http import HttpResponseForbidden
+from django.urls import reverse
+
+from feed.models import Comment, Like, Post
+
+pytestmark = pytest.mark.django_db
+
+
+def test_feedlist_global(client, admin_user, nucleado_user, posts):
+    client.force_login(admin_user)
+    url = reverse("feed:listar")
+    resp = client.get(url)
+    assert resp.status_code == 200
+    assert all(p.tipo_feed == "global" for p in resp.context["posts"])
+
+    client.force_login(nucleado_user)
+    resp2 = client.get(url)
+    assert all(p.organizacao == nucleado_user.organizacao for p in resp2.context["posts"])
+
+
+def test_feedlist_usuario(client, nucleado_user, admin_user, posts):
+    client.force_login(nucleado_user)
+    url = reverse("feed:listar") + "?tipo_feed=usuario"
+    resp = client.get(url)
+    ids = {p.id for p in resp.context["posts"]}
+    assert posts[1].id in ids
+    assert posts[0].id in ids
+
+
+def test_feedlist_nucleo(client, nucleado_user, posts, nucleo):
+    client.force_login(nucleado_user)
+    url = reverse("feed:listar") + f"?tipo_feed=nucleo&nucleo={nucleo.id}"
+    resp = client.get(url)
+    assert list(resp.context["posts"]) == [posts[2]]
+
+    url = reverse("feed:listar") + "?tipo_feed=nucleo&nucleo=9999"
+    resp2 = client.get(url)
+    assert list(resp2.context["posts"]) == []
+
+
+def test_feedlist_evento(client, nucleado_user, posts, evento):
+    client.force_login(nucleado_user)
+    url = reverse("feed:listar") + f"?tipo_feed=evento&evento={evento.id}"
+    resp = client.get(url)
+    assert list(resp.context["posts"]) == [posts[3]]
+
+
+def test_feedlist_search(client, nucleado_user, posts):
+    client.force_login(nucleado_user)
+    Post.objects.create(
+        autor=nucleado_user, organizacao=nucleado_user.organizacao, conteudo="busca", tipo_feed="global"
+    )
+    url = reverse("feed:listar") + "?q=busca"
+    resp = client.get(url)
+    assert all("busca" in p.conteudo for p in resp.context["posts"])
+
+
+def test_novapostagem_root_forbidden(client, root_user):
+    client.force_login(root_user)
+    resp = client.get(reverse("feed:nova_postagem"))
+    assert resp.status_code == 403 or isinstance(resp, HttpResponseForbidden)
+
+
+def test_novapostagem_create(client, associado_user):
+    client.force_login(associado_user)
+    data = {"tipo_feed": "global", "conteudo": "ola"}
+    resp = client.post(reverse("feed:nova_postagem"), data)
+    assert resp.status_code == 302
+    post = Post.objects.latest("id")
+    assert post.autor == associado_user
+    assert post.organizacao == associado_user.organizacao
+
+
+def test_novapostagem_file_upload(client, associado_user):
+    client.force_login(associado_user)
+    pdf = SimpleUploadedFile("file.pdf", b"data", content_type="application/pdf")
+    resp = client.post(reverse("feed:nova_postagem"), {"tipo_feed": "global", "arquivo": pdf})
+    assert resp.status_code in {302, 204}
+    post = Post.objects.latest("id")
+    assert post.pdf
+
+
+def test_create_comment(client, nucleado_user, posts):
+    client.force_login(nucleado_user)
+    post = posts[0]
+    url = reverse("feed:create_comment", args=[post.id])
+    resp = client.post(url, {"texto": "Oi"})
+    assert resp.status_code == 302
+    comment = Comment.objects.get(post=post, user=nucleado_user)
+    assert comment.texto == "Oi"
+
+
+def test_toggle_like(client, nucleado_user, posts):
+    client.force_login(nucleado_user)
+    post = posts[0]
+    url = reverse("feed:toggle_like", args=[post.id])
+    client.post(url)
+    assert Like.objects.filter(post=post, user=nucleado_user).exists()
+    client.post(url)
+    assert not Like.objects.filter(post=post, user=nucleado_user).exists()
+
+
+def test_post_update_permissions(client, nucleado_user, admin_user, posts):
+    post = posts[0]
+    client.force_login(nucleado_user)
+    url = reverse("feed:post_update", args=[post.id])
+    resp = client.post(url, {"tipo_feed": "global", "conteudo": "x"})
+    assert resp.status_code == 302
+    assert "permissao" in list(get_messages(resp.wsgi_request))[0].message.lower()
+
+    client.force_login(admin_user)
+    img = SimpleUploadedFile("pic.png", b"data", content_type="image/png")
+    resp2 = client.post(url, {"tipo_feed": "global", "conteudo": "y", "arquivo": img})
+    assert resp2.status_code == 302
+    post.refresh_from_db()
+    assert post.image.name
+
+
+def test_post_delete(client, admin_user, posts):
+    post = posts[0]
+    url = reverse("feed:post_delete", args=[post.id])
+    client.force_login(admin_user)
+    resp = client.post(url)
+    assert resp.status_code == 302
+    assert not Post.objects.filter(id=post.id).exists()
+
+
+def test_meu_mural(client, nucleado_user, posts):
+    client.force_login(nucleado_user)
+    url = reverse("feed:meu_mural")
+    resp = client.get(url)
+    contents = [p.conteudo for p in resp.context["posts"]]
+    assert posts[1].conteudo in contents
+    assert posts[0].conteudo in contents
+    assert posts[2].conteudo not in contents
+    assert posts[3].conteudo not in contents


### PR DESCRIPTION
## Summary
- add fixtures and tests for feed app covering models, forms and views

## Testing
- `ruff check tests/feed/conftest.py tests/feed/test_models.py tests/feed/test_forms.py tests/feed/test_views.py`
- `black tests/feed/conftest.py tests/feed/test_models.py tests/feed/test_forms.py tests/feed/test_views.py`
- `mypy --ignore-missing-imports tests/feed/conftest.py tests/feed/test_models.py tests/feed/test_forms.py tests/feed/test_views.py` *(fails: Unsupported dynamic base class)*
- `pytest tests/feed/` *(fails: various assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_68803101f998832593b18bd1f32b3b1a