### PR TITLE
test: add comprehensive tokens tests

### DIFF
--- a/tests/tokens/test_forms.py
+++ b/tests/tokens/test_forms.py
@@ -1,0 +1,117 @@
+import pyotp
+import pytest
+from django.utils import timezone
+
+from accounts.factories import UserFactory
+from nucleos.factories import NucleoFactory
+from organizacoes.factories import OrganizacaoFactory
+from tokens.forms import (
+    Ativar2FAForm,
+    GerarCodigoAutenticacaoForm,
+    GerarTokenConviteForm,
+    TokenAcessoForm,
+    ValidarCodigoAutenticacaoForm,
+    ValidarTokenConviteForm,
+)
+from tokens.models import CodigoAutenticacao, TokenAcesso, TOTPDevice
+
+pytestmark = pytest.mark.django_db
+
+
+def test_token_acesso_form_choices():
+    form = TokenAcessoForm()
+    choices = [c[0] for c in form.fields["tipo_destino"].choices]
+    for choice in TokenAcesso.TipoUsuario.values:
+        assert choice in choices
+
+
+def test_gerar_token_convite_form_querysets():
+    user = UserFactory(is_staff=True)
+    org1 = OrganizacaoFactory()
+    org1.users.add(user)
+    nucleo1 = NucleoFactory(organizacao=org1)
+    form = GerarTokenConviteForm(user=user)
+    assert list(form.fields["organizacao"].queryset) == [org1]
+    assert list(form.fields["nucleos"].queryset) == [nucleo1]
+
+
+def test_validar_token_convite_form_errors():
+    form = ValidarTokenConviteForm({"codigo": "naoexiste"})
+    assert not form.is_valid()
+    assert "Token inválido" in form.errors["codigo"][0]
+
+    user = UserFactory(is_staff=True)
+    token = TokenAcesso.objects.create(
+        gerado_por=user,
+        tipo_destino=TokenAcesso.TipoUsuario.ADMIN,
+        data_expiracao=timezone.now() - timezone.timedelta(days=1),
+    )
+    form = ValidarTokenConviteForm({"codigo": token.codigo})
+    assert not form.is_valid()
+    assert "Token expirado" in form.errors["codigo"][0]
+
+
+def test_validar_token_convite_form_success():
+    user = UserFactory(is_staff=True)
+    token = TokenAcesso.objects.create(gerado_por=user, tipo_destino=TokenAcesso.TipoUsuario.ADMIN)
+    form = ValidarTokenConviteForm({"codigo": token.codigo})
+    assert form.is_valid()
+    assert form.token == token
+
+
+def test_gerar_codigo_autenticacao_form_save():
+    user = UserFactory()
+    form = GerarCodigoAutenticacaoForm({"usuario": user.pk})
+    assert form.is_valid()
+    codigo = form.save()
+    assert codigo.usuario == user
+    assert codigo.codigo.isdigit() and len(codigo.codigo) == 6
+
+
+def test_validar_codigo_autenticacao_form_flow():
+    user = UserFactory()
+    codigo = CodigoAutenticacao.objects.create(
+        usuario=user, codigo="123456", expira_em=timezone.now() + timezone.timedelta(minutes=10)
+    )
+
+    form_wrong = ValidarCodigoAutenticacaoForm({"codigo": "000000"}, usuario=user)
+    assert not form_wrong.is_valid()
+    codigo.refresh_from_db()
+    assert codigo.tentativas == 1
+
+    form_right = ValidarCodigoAutenticacaoForm({"codigo": codigo.codigo}, usuario=user)
+    assert form_right.is_valid()
+    codigo.refresh_from_db()
+    assert codigo.verificado is True
+
+    # terceira tentativa após já verificado não deve alterar
+    form_again = ValidarCodigoAutenticacaoForm({"codigo": "000000"}, usuario=user)
+    assert not form_again.is_valid()
+
+
+def test_validar_codigo_autenticacao_form_expirado_bloqueado():
+    user = UserFactory()
+    codigo = CodigoAutenticacao.objects.create(usuario=user)
+    codigo.expira_em = timezone.now() - timezone.timedelta(seconds=1)
+    codigo.codigo = "654321"
+    codigo.save(update_fields=["expira_em", "codigo"])
+    form = ValidarCodigoAutenticacaoForm({"codigo": codigo.codigo}, usuario=user)
+    assert not form.is_valid()
+    assert "expirado" in form.errors["codigo"][0]
+
+    codigo = CodigoAutenticacao.objects.create(usuario=user)
+    codigo.expira_em = timezone.now() + timezone.timedelta(minutes=10)
+    codigo.codigo = "222222"
+    codigo.save(update_fields=["expira_em", "codigo"])
+    for _ in range(4):
+        form = ValidarCodigoAutenticacaoForm({"codigo": "000000"}, usuario=user)
+        assert not form.is_valid()
+    assert "bloqueado" in form.errors["codigo"][0]
+
+
+def test_ativar_2fa_form():
+    user = UserFactory()
+    device = TOTPDevice.objects.create(usuario=user)
+    totp_code = pyotp.TOTP(device.secret).now()
+    form = Ativar2FAForm({"codigo_totp": totp_code}, device=device)
+    assert form.is_valid()

--- a/tests/tokens/test_models.py
+++ b/tests/tokens/test_models.py
@@ -1,0 +1,67 @@
+import pytest
+from django.utils import timezone
+
+from accounts.factories import UserFactory
+from tokens.models import CodigoAutenticacao, TokenAcesso, TOTPDevice
+
+pytestmark = pytest.mark.django_db
+
+
+def test_token_acesso_creation_defaults():
+    user = UserFactory(is_staff=True)
+    token = TokenAcesso.objects.create(gerado_por=user, tipo_destino=TokenAcesso.TipoUsuario.ADMIN)
+    assert len(token.codigo) == 32
+    assert token.estado == TokenAcesso.Estado.NOVO
+    assert token.created_at is not None
+
+
+def test_token_acesso_states():
+    user = UserFactory(is_staff=True)
+    for estado in TokenAcesso.Estado.values:
+        token = TokenAcesso.objects.create(
+            gerado_por=user,
+            tipo_destino=TokenAcesso.TipoUsuario.ADMIN,
+            estado=estado,
+        )
+        token.refresh_from_db()
+        assert token.estado == estado
+
+
+def test_codigo_autenticacao_creation():
+    user = UserFactory()
+    codigo = CodigoAutenticacao(usuario=user)
+    codigo.save()
+    assert len(codigo.codigo) == 6
+    delta = codigo.expira_em - codigo.created_at
+    assert delta.total_seconds() == pytest.approx(600, rel=0.1)
+
+
+def test_codigo_autenticacao_is_expirado():
+    user = UserFactory()
+    expired = CodigoAutenticacao.objects.create(usuario=user)
+    expired.expira_em = timezone.now() - timezone.timedelta(minutes=1)
+    expired.save(update_fields=["expira_em"])
+    assert expired.is_expirado() is True
+    valid = CodigoAutenticacao.objects.create(usuario=user)
+    valid.expira_em = timezone.now() + timezone.timedelta(minutes=5)
+    valid.save(update_fields=["expira_em"])
+    assert valid.is_expirado() is False
+
+
+def test_totp_device_creation_and_totp():
+    user = UserFactory()
+    device = TOTPDevice(usuario=user)
+    device.save()
+    assert device.secret
+    totp = device.gerar_totp()
+    assert totp.isdigit() and len(totp) == 6
+
+
+def test_totp_device_confirmacao():
+    user = UserFactory()
+    device = TOTPDevice.objects.create(usuario=user)
+    assert device.confirmado is False
+    device.confirmado = True
+    device.save()
+    device.refresh_from_db()
+    assert device.confirmado is True

--- a/tests/tokens/test_views.py
+++ b/tests/tokens/test_views.py
@@ -1,0 +1,99 @@
+import pyotp
+import pytest
+from django.urls import reverse
+from django.utils import timezone
+
+from accounts.factories import UserFactory
+from nucleos.factories import NucleoFactory
+from organizacoes.factories import OrganizacaoFactory
+from tokens.models import CodigoAutenticacao, TokenAcesso, TOTPDevice
+
+pytestmark = pytest.mark.django_db
+
+
+def _login(client, user):
+    client.force_login(user)
+
+
+def test_criar_token_view_creates_token(client):
+    user = UserFactory(is_staff=True)
+    _login(client, user)
+    resp = client.post(reverse("tokens:criar_token"), {"tipo_destino": TokenAcesso.TipoUsuario.ADMIN})
+    assert resp.status_code == 200
+    token = TokenAcesso.objects.get(gerado_por=user)
+    assert token.tipo_destino == TokenAcesso.TipoUsuario.ADMIN
+    assert token.gerado_por == user
+
+
+def test_gerar_token_convite_view(client):
+    user = UserFactory(is_staff=True)
+    org = OrganizacaoFactory()
+    org.users.add(user)
+    nucleo = NucleoFactory(organizacao=org)
+    _login(client, user)
+    data = {
+        "tipo_destino": TokenAcesso.TipoUsuario.CONVIDADO,
+        "organizacao": org.pk,
+        "nucleos": [nucleo.pk],
+    }
+    resp = client.post(reverse("tokens:gerar_convite"), data)
+    assert resp.status_code == 200
+    json = resp.json()
+    token = TokenAcesso.objects.get(codigo=json["codigo"])
+    assert token.data_expiracao.date() == (timezone.now() + timezone.timedelta(days=30)).date()
+
+
+def test_validar_token_convite_view(client):
+    user = UserFactory()
+    gerador = UserFactory(is_staff=True)
+    token = TokenAcesso.objects.create(gerado_por=gerador, tipo_destino=TokenAcesso.TipoUsuario.ASSOCIADO)
+
+    _login(client, user)
+    resp = client.post(reverse("tokens:validar_convite"), {"codigo": token.codigo})
+    assert resp.status_code == 200
+    token.refresh_from_db()
+    assert token.estado == TokenAcesso.Estado.USADO
+    assert token.usuario == user
+
+    resp = client.post(reverse("tokens:validar_convite"), {"codigo": token.codigo})
+    assert resp.status_code == 400
+
+
+def test_gerar_codigo_autenticacao_view(client):
+    user = UserFactory()
+    _login(client, user)
+    resp = client.post(reverse("tokens:gerar_codigo"), {"usuario": user.pk})
+    assert resp.status_code == 200
+    json = resp.json()
+    assert "codigo" in json
+    assert CodigoAutenticacao.objects.filter(usuario=user).exists()
+
+
+def test_validar_codigo_autenticacao_view(client):
+    user = UserFactory()
+    _login(client, user)
+    codigo = CodigoAutenticacao.objects.create(
+        usuario=user, codigo="123456", expira_em=timezone.now() + timezone.timedelta(minutes=10)
+    )
+    resp = client.post(reverse("tokens:validar_codigo"), {"codigo": codigo.codigo})
+    assert resp.status_code == 200
+    codigo.refresh_from_db()
+    assert codigo.verificado is True
+
+    resp = client.post(reverse("tokens:validar_codigo"), {"codigo": "000000"})
+    assert resp.status_code == 400
+
+
+def test_ativar_e_desativar_2fa_views(client):
+    user = UserFactory()
+    _login(client, user)
+    device = TOTPDevice.objects.create(usuario=user)
+    totp = pyotp.TOTP(device.secret).now()
+    resp = client.post(reverse("tokens:ativar_2fa"), {"codigo_totp": totp})
+    assert resp.status_code == 200
+    device.refresh_from_db()
+    assert device.confirmado is True
+
+    resp = client.post(reverse("tokens:desativar_2fa"))
+    assert resp.status_code == 200
+    assert not TOTPDevice.objects.filter(usuario=user).exists()


### PR DESCRIPTION
## Summary
- add detailed unit tests for tokens models, forms and views
- cover token creation, code validation and 2FA flows

## Testing
- `ruff check tests/tokens/test_models.py tests/tokens/test_forms.py tests/tokens/test_views.py`
- `black --check tests/tokens/test_models.py tests/tokens/test_forms.py tests/tokens/test_views.py`
- `pytest tests/tokens/`

------
https://chatgpt.com/codex/tasks/task_e_688035fc2e908325bdb9cc80f981ff18