### PR TITLE
test: add discussao test suite

### DIFF
--- a/tests/discussao/conftest.py
+++ b/tests/discussao/conftest.py
@@ -1,0 +1,141 @@
+import pytest
+from django.contrib.auth import get_user_model
+
+from accounts.models import UserType
+from agenda.models import Evento
+from discussao.models import CategoriaDiscussao
+from nucleos.models import Nucleo
+from organizacoes.models import Organizacao
+
+User = get_user_model()
+
+
+@pytest.fixture
+def organizacao(db):
+    return Organizacao.objects.create(nome="Org", cnpj="00.000.000/0001-99", slug="org")
+
+
+@pytest.fixture
+def outra_organizacao(db):
+    return Organizacao.objects.create(nome="Outra", cnpj="00.000.000/0002-99", slug="outra")
+
+
+@pytest.fixture
+def nucleo(organizacao):
+    return Nucleo.objects.create(nome="Nucleo", organizacao=organizacao)
+
+
+@pytest.fixture
+def evento(organizacao, nucleo):
+    return Evento.objects.create(
+        organizacao=organizacao,
+        nucleo=nucleo,
+        coordenador=None,
+        titulo="Evento",
+        descricao="",
+        data_inicio="2024-01-01",
+        data_fim="2024-01-02",
+        endereco="",
+        cidade="",
+        estado="SC",
+        cep="00000-000",
+        status=0,
+        publico_alvo=0,
+        numero_convidados=0,
+        numero_presentes=0,
+        valor_ingresso=0,
+        orcamento=0,
+    )
+
+
+@pytest.fixture
+def root_user(organizacao):
+    return User.objects.create_superuser(
+        email="root@example.com",
+        username="root",
+        password="pass",
+        organizacao=organizacao,
+    )
+
+
+@pytest.fixture
+def admin_user(organizacao):
+    return User.objects.create_user(
+        email="admin@example.com",
+        username="admin",
+        password="pass",
+        user_type=UserType.ADMIN,
+        organizacao=organizacao,
+    )
+
+
+@pytest.fixture
+def coordenador_user(organizacao, nucleo):
+    return User.objects.create_user(
+        email="coord@example.com",
+        username="coord",
+        password="pass",
+        user_type=UserType.COORDENADOR,
+        organizacao=organizacao,
+        nucleo=nucleo,
+    )
+
+
+@pytest.fixture
+def associado_user(organizacao):
+    return User.objects.create_user(
+        email="assoc@example.com",
+        username="assoc",
+        password="pass",
+        user_type=UserType.ASSOCIADO,
+        organizacao=organizacao,
+    )
+
+
+@pytest.fixture
+def nucleado_user(organizacao, nucleo):
+    return User.objects.create_user(
+        email="nuc@example.com",
+        username="nuc",
+        password="pass",
+        user_type=UserType.NUCLEADO,
+        organizacao=organizacao,
+        nucleo=nucleo,
+    )
+
+
+@pytest.fixture(autouse=True)
+def media_root(tmp_path, settings):
+    settings.MEDIA_ROOT = tmp_path
+    return tmp_path
+
+
+@pytest.fixture
+def categoria(organizacao):
+    return CategoriaDiscussao.objects.create(nome="Cat", organizacao=organizacao)
+
+
+@pytest.fixture(autouse=True)
+def patch_templates(monkeypatch):
+    from discussao import views
+
+    monkeypatch.setattr(views.CategoriaListView, "template_name", "base.html", raising=False)
+    monkeypatch.setattr(views.TopicoListView, "template_name", "base.html", raising=False)
+    monkeypatch.setattr(views.TopicoDetailView, "template_name", "base.html", raising=False)
+    monkeypatch.setattr(views.TopicoCreateView, "template_name", "base.html", raising=False)
+    monkeypatch.setattr(views.TopicoUpdateView, "template_name", "base.html", raising=False)
+    monkeypatch.setattr(views.TopicoDeleteView, "template_name", "base.html", raising=False)
+    monkeypatch.setattr(views.RespostaCreateView, "template_name", "base.html", raising=False)
+
+    monkeypatch.setattr(
+        views.TopicoUpdateView,
+        "get_object",
+        lambda self, queryset=None: self.object,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        views.TopicoDeleteView,
+        "get_object",
+        lambda self, queryset=None: self.object,
+        raising=False,
+    )

--- a/tests/discussao/test_forms.py
+++ b/tests/discussao/test_forms.py
@@ -1,0 +1,88 @@
+import pytest
+
+from discussao.forms import (
+    CategoriaDiscussaoForm,
+    RespostaDiscussaoForm,
+    TopicoDiscussaoForm,
+)
+from discussao.models import CategoriaDiscussao, TopicoDiscussao
+from nucleos.models import Nucleo
+
+pytestmark = pytest.mark.django_db
+
+
+def test_categoria_form_fields():
+    form = CategoriaDiscussaoForm()
+    assert list(form.fields) == [
+        "nome",
+        "descricao",
+        "organizacao",
+        "nucleo",
+        "evento",
+        "icone",
+    ]
+
+
+def test_categoria_form_unique_together(organizacao):
+    CategoriaDiscussao.objects.create(nome="Cat", organizacao=organizacao)
+    form = CategoriaDiscussaoForm(data={"nome": "Cat", "organizacao": organizacao.pk})
+    assert not form.is_valid()
+
+
+def test_topico_form_validation(categoria, admin_user, nucleo, evento):
+    TopicoDiscussao.objects.create(
+        categoria=categoria,
+        titulo="Repetido",
+        conteudo="c",
+        autor=admin_user,
+        publico_alvo=0,
+    )
+    form = TopicoDiscussaoForm(
+        data={
+            "categoria": categoria.pk,
+            "titulo": "Repetido",
+            "conteudo": "c",
+            "publico_alvo": 0,
+            "tags": "",
+        }
+    )
+    assert not form.is_valid()
+    cat_nucleo = CategoriaDiscussao.objects.create(nome="N", organizacao=categoria.organizacao, nucleo=nucleo)
+    form2 = TopicoDiscussaoForm(
+        data={
+            "categoria": cat_nucleo.pk,
+            "titulo": "Ok",
+            "conteudo": "c",
+            "publico_alvo": 0,
+            "nucleo": nucleo.pk,
+            "tags": "",
+        }
+    )
+    assert form2.is_valid()
+    outro = Nucleo.objects.create(nome="Outro", organizacao=categoria.organizacao)
+    form3 = TopicoDiscussaoForm(
+        data={
+            "categoria": cat_nucleo.pk,
+            "titulo": "Err",
+            "conteudo": "c",
+            "publico_alvo": 0,
+            "nucleo": outro.pk,
+        }
+    )
+    assert not form3.is_valid()
+    form4 = TopicoDiscussaoForm(
+        data={
+            "categoria": categoria.pk,
+            "titulo": "x",
+            "conteudo": "c",
+            "publico_alvo": 3,
+        }
+    )
+    assert not form4.is_valid()
+
+
+def test_resposta_form_fields():
+    form = RespostaDiscussaoForm()
+    assert list(form.fields) == ["conteudo", "arquivo", "reply_to"]
+    form = RespostaDiscussaoForm(data={"conteudo": ""})
+    assert not form.is_valid()

--- a/tests/discussao/test_models.py
+++ b/tests/discussao/test_models.py
@@ -1,69 +1,75 @@
-from django.test import TestCase
+import pytest
 from django.contrib.contenttypes.models import ContentType
+from django.db import IntegrityError
+from django.utils.text import slugify
 
-from accounts.models import User
 from discussao.models import (
     CategoriaDiscussao,
-    TopicoDiscussao,
-    RespostaDiscussao,
     InteracaoDiscussao,
+    RespostaDiscussao,
+    TopicoDiscussao,
 )
 
+pytestmark = pytest.mark.django_db
 
-class DiscussaoModelTests(TestCase):
-    def setUp(self):
-        from organizacoes.models import Organizacao
 
-        self.org = Organizacao.objects.create(nome="Org", cnpj="00.000.000/0001-99", slug="org")
-        self.user = User.objects.create_user(
-            username="u",
-            email="u@example.com",
-            password="pass",
-            organizacao=self.org,
+@pytest.fixture
+def categoria(organizacao):
+    return CategoriaDiscussao.objects.create(nome="Geral", organizacao=organizacao)
+
+
+@pytest.fixture
+def topico(categoria, admin_user):
+    return TopicoDiscussao.objects.create(
+        categoria=categoria,
+        titulo="Titulo Topico",
+        conteudo="Conteudo",
+        autor=admin_user,
+        publico_alvo=0,
+    )
+
+
+def test_categoria_slug_unique_and_autocreated(categoria, organizacao):
+    assert categoria.slug == slugify(categoria.nome)
+    with pytest.raises(IntegrityError):
+        CategoriaDiscussao.objects.create(
+            nome="Geral",
+            organizacao=organizacao,
         )
-        self.categoria = CategoriaDiscussao.objects.create(nome="Geral", organizacao=self.org)
 
-    def test_unique_categoria(self):
-        with self.assertRaises(Exception):
-            CategoriaDiscussao.objects.create(nome="Geral", organizacao=self.org)
 
-    def test_topico_slug_increment(self):
-        topico = TopicoDiscussao.objects.create(
-            categoria=self.categoria,
-            titulo="Primeiro Topico",
-            conteudo="oi",
-            autor=self.user,
-            publico_alvo=0,
-        )
-        slug = topico.slug
-        topico.incrementar_visualizacao()
-        topico.refresh_from_db()
-        self.assertEqual(topico.numero_visualizacoes, 1)
-        self.assertEqual(slug, topico.slug)
+def test_topico_slug_and_visualizacao(topico):
+    assert topico.slug == slugify(topico.titulo)
+    assert topico.numero_visualizacoes == 0
+    topico.incrementar_visualizacao()
+    topico.refresh_from_db()
+    assert topico.numero_visualizacoes == 1
 
-    def test_resposta_edit(self):
-        topico = TopicoDiscussao.objects.create(
-            categoria=self.categoria,
-            titulo="T",
-            conteudo="c",
-            autor=self.user,
-            publico_alvo=0,
-        )
-        resp = RespostaDiscussao.objects.create(topico=topico, autor=self.user, conteudo="olá")
-        resp.editar_resposta("novo")
-        resp.refresh_from_db()
-        self.assertTrue(resp.editado)
-        self.assertEqual(resp.conteudo, "novo")
 
-    def test_interacao_unique(self):
-        topico = TopicoDiscussao.objects.create(
-            categoria=self.categoria,
-            titulo="T2",
-            conteudo="c",
-            autor=self.user,
-            publico_alvo=0,
-        )
-        ct = ContentType.objects.get_for_model(topico)
-        InteracaoDiscussao.objects.create(user=self.user, content_type=ct, object_id=topico.id, tipo="like")
-        with self.assertRaises(Exception):
-            InteracaoDiscussao.objects.create(user=self.user, content_type=ct, object_id=topico.id, tipo="like")
+def test_resposta_editar_e_reply(topico, admin_user):
+    resp = RespostaDiscussao.objects.create(topico=topico, autor=admin_user, conteudo="olá")
+    filho = RespostaDiscussao.objects.create(topico=topico, autor=admin_user, conteudo="filho", reply_to=resp)
+    resp.editar_resposta("novo")
+    resp.refresh_from_db()
+    assert resp.editado is True
+    assert resp.conteudo == "novo"
+    assert filho in resp.respostas_filhas.all()
+
+
+def test_interacao_unique_and_toggle(topico, admin_user):
+    ct = ContentType.objects.get_for_model(topico)
+    like, created = InteracaoDiscussao.objects.get_or_create(
+        user=admin_user, content_type=ct, object_id=topico.id, defaults={"tipo": "like"}
+    )
+    assert created
+    assert InteracaoDiscussao.objects.count() == 1
+    like2, created2 = InteracaoDiscussao.objects.get_or_create(
+        user=admin_user, content_type=ct, object_id=topico.id, defaults={"tipo": "dislike"}
+    )
+    assert not created2
+    like2.tipo = "dislike"
+    like2.save()
+    assert InteracaoDiscussao.objects.count() == 1
+    assert InteracaoDiscussao.objects.get().tipo == "dislike"
+    with pytest.raises(IntegrityError):
+        InteracaoDiscussao.objects.create(user=admin_user, content_type=ct, object_id=topico.id, tipo="like")

--- a/tests/discussao/test_permissions.py
+++ b/tests/discussao/test_permissions.py
@@ -11,8 +11,12 @@ class DiscussaoPermissionTests(TestCase):
         from organizacoes.models import Organizacao
 
         self.org = Organizacao.objects.create(nome="Org", cnpj="00.000.000/0001-99", slug="org")
-        self.admin = User.objects.create_user(username="admin", email="a@a.com", password="pass", user_type=UserType.ADMIN, organizacao=self.org)
-        self.user = User.objects.create_user(username="u", email="u@u.com", password="pass", user_type=UserType.NUCLEADO, organizacao=self.org)
+        self.admin = User.objects.create_user(
+            username="admin", email="a@a.com", password="pass", user_type=UserType.ADMIN, organizacao=self.org
+        )
+        self.user = User.objects.create_user(
+            username="u", email="u@u.com", password="pass", user_type=UserType.NUCLEADO, organizacao=self.org
+        )
         self.categoria = CategoriaDiscussao.objects.create(nome="Cat", organizacao=self.org)
 
     def test_admin_can_create_topico(self):

--- a/tests/discussao/test_views.py
+++ b/tests/discussao/test_views.py
@@ -1,0 +1,173 @@
+import pytest
+from django.contrib.contenttypes.models import ContentType
+from django.urls import reverse
+
+from discussao.forms import RespostaDiscussaoForm
+from discussao.models import (
+    CategoriaDiscussao,
+    InteracaoDiscussao,
+    RespostaDiscussao,
+    TopicoDiscussao,
+)
+from nucleos.models import Nucleo
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def categoria(organizacao):
+    return CategoriaDiscussao.objects.create(nome="Cat", organizacao=organizacao)
+
+
+@pytest.fixture
+def categoria_outro(outra_organizacao):
+    return CategoriaDiscussao.objects.create(nome="Outra", organizacao=outra_organizacao)
+
+
+@pytest.fixture
+def topico(categoria, admin_user):
+    return TopicoDiscussao.objects.create(
+        categoria=categoria,
+        titulo="Meu Topico",
+        conteudo="c",
+        autor=admin_user,
+        publico_alvo=0,
+    )
+
+
+def test_categoria_list_view_org_filter(client, admin_user, categoria, categoria_outro):
+    client.force_login(admin_user)
+    url = reverse("discussao:categorias")
+    resp = client.get(url)
+    assert resp.status_code == 200
+    assert list(resp.context["categorias"]) == [categoria]
+
+
+def test_categoria_list_view_root_sees_all(client, root_user, categoria, categoria_outro):
+    client.force_login(root_user)
+    resp = client.get(reverse("discussao:categorias"))
+    assert resp.status_code == 200
+    assert set(resp.context["categorias"]) == {categoria, categoria_outro}
+
+
+def test_topico_list_view(client, admin_user, categoria, topico):
+    client.force_login(admin_user)
+    resp = client.get(reverse("discussao:topicos", args=[categoria.slug]))
+    assert resp.status_code == 200
+    assert list(resp.context["topicos"]) == [topico]
+
+
+def test_topico_detail_view_increments(client, admin_user, categoria, topico):
+    client.force_login(admin_user)
+    resp = client.get(reverse("discussao:topico_detalhe", args=[categoria.slug, topico.slug]))
+    assert resp.status_code == 200
+    topico.refresh_from_db()
+    assert topico.numero_visualizacoes == 1
+    assert isinstance(resp.context["resposta_form"], RespostaDiscussaoForm)
+
+
+def test_topico_create_permissions(client, associado_user, categoria):
+    client.force_login(associado_user)
+    url = reverse("discussao:topico_criar", args=[categoria.slug])
+    resp = client.get(url)
+    assert resp.status_code == 403
+
+
+def test_topico_create_success(client, admin_user, categoria):
+    client.force_login(admin_user)
+    url = reverse("discussao:topico_criar", args=[categoria.slug])
+    data = {
+        "categoria": categoria.pk,
+        "titulo": "Novo",
+        "conteudo": "c",
+        "publico_alvo": 0,
+    }
+    resp = client.post(url, data=data)
+    assert resp.status_code == 302
+    t = TopicoDiscussao.objects.get(titulo="Novo")
+    assert t.autor == admin_user and t.categoria == categoria
+
+
+def test_topico_create_invalid_nucleo(client, admin_user, categoria, nucleo):
+    cat = CategoriaDiscussao.objects.create(nome="N", organizacao=categoria.organizacao, nucleo=nucleo)
+    outro = Nucleo.objects.create(nome="Outro", organizacao=categoria.organizacao)
+    client.force_login(admin_user)
+    url = reverse("discussao:topico_criar", args=[cat.slug])
+    resp = client.post(
+        url,
+        data={
+            "categoria": cat.pk,
+            "titulo": "X",
+            "conteudo": "c",
+            "publico_alvo": 0,
+            "nucleo": outro.pk,
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.context["form"].errors
+
+
+def test_topico_update_permission(client, admin_user, associado_user, categoria, topico):
+    client.force_login(associado_user)
+    url = reverse("discussao:topico_editar", args=[categoria.slug, topico.slug])
+    resp = client.get(url)
+    assert resp.status_code == 403
+
+    client.force_login(admin_user)
+    resp2 = client.post(url, {"categoria": categoria.pk, "titulo": "Edit", "conteudo": "c", "publico_alvo": 0})
+    assert resp2.status_code == 302
+    topico.refresh_from_db()
+    assert topico.titulo == "Edit"
+
+
+def test_topico_delete_view(client, admin_user, associado_user, categoria, topico):
+    client.force_login(associado_user)
+    resp = client.post(reverse("discussao:topico_remover", args=[categoria.slug, topico.slug]))
+    assert resp.status_code == 403
+    assert TopicoDiscussao.objects.filter(pk=topico.pk).exists()
+
+    client.force_login(admin_user)
+    resp2 = client.post(reverse("discussao:topico_remover", args=[categoria.slug, topico.slug]))
+    assert resp2.status_code == 302
+    assert not TopicoDiscussao.objects.filter(pk=topico.pk).exists()
+
+
+def test_resposta_create(client, nucleado_user, categoria, topico):
+    client.force_login(nucleado_user)
+    url = reverse("discussao:resposta_criar", args=[categoria.slug, topico.slug])
+    resp = client.post(url, {"conteudo": "Oi"})
+    assert resp.status_code == 302
+    r = RespostaDiscussao.objects.get(topico=topico)
+    assert r.autor == nucleado_user
+
+
+def test_resposta_create_reply(client, nucleado_user, categoria, topico):
+    parent = RespostaDiscussao.objects.create(topico=topico, autor=nucleado_user, conteudo="p")
+    client.force_login(nucleado_user)
+    url = reverse("discussao:resposta_criar", args=[categoria.slug, topico.slug])
+    resp = client.post(url, {"conteudo": "filho", "reply_to": parent.id})
+    assert resp.status_code == 302
+    child = RespostaDiscussao.objects.get(reply_to=parent)
+    assert child.topico == topico
+
+
+def test_interacao_view_toggle(client, nucleado_user, categoria, topico):
+    client.force_login(nucleado_user)
+    ct = ContentType.objects.get_for_model(topico)
+    url = reverse("discussao:interacao", args=[ct.id, topico.id, "like"])
+    client.post(url)
+    assert InteracaoDiscussao.objects.filter(user=nucleado_user, object_id=topico.id).exists()
+    client.post(url)
+    assert not InteracaoDiscussao.objects.filter(user=nucleado_user, object_id=topico.id).exists()
+    url2 = reverse("discussao:interacao", args=[ct.id, topico.id, "dislike"])
+    client.post(url)
+    client.post(url2)
+    obj = InteracaoDiscussao.objects.get(user=nucleado_user, object_id=topico.id)
+    assert obj.tipo == "dislike"
+
+
+def test_interacao_requires_login(client, categoria, topico):
+    ct = ContentType.objects.get_for_model(topico)
+    resp = client.post(reverse("discussao:interacao", args=[ct.id, topico.id, "like"]))
+    assert resp.status_code == 302
+    assert "/accounts/login" in resp.headers["Location"]


### PR DESCRIPTION
## Summary
- create fixtures for discussao tests
- add model tests for discussao forum
- add form tests for discussao
- add view tests for discussao

## Testing
- `ruff check tests/discussao`
- `black tests/discussao`
- `pytest -q tests/discussao` *(fails: django.db.utils.IntegrityError, Method Not Allowed)*

------
https://chatgpt.com/codex/tasks/task_e_6880497b3484832592ffe5b14b18f257