### PR TITLE
test: adiciona suite para configuracoes

### DIFF
--- a/tests/configuracoes/test_forms.py
+++ b/tests/configuracoes/test_forms.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import pytest
+
+from configuracoes.forms import ConfiguracaoContaForm
+
+pytestmark = pytest.mark.django_db
+
+
+def test_form_fields():
+    form = ConfiguracaoContaForm()
+    assert list(form.fields.keys()) == [
+        "receber_notificacoes_email",
+        "receber_notificacoes_whatsapp",
+        "tema_escuro",
+    ]
+
+
+def test_form_valid_data(admin_user):
+    config = admin_user.configuracao
+    data = {
+        "receber_notificacoes_email": False,
+        "receber_notificacoes_whatsapp": True,
+        "tema_escuro": True,
+    }
+    form = ConfiguracaoContaForm(data=data, instance=config)
+    assert form.is_valid()
+    obj = form.save()
+    config.refresh_from_db()
+    assert obj == config
+    assert config.receber_notificacoes_email is False
+    assert config.receber_notificacoes_whatsapp is True
+    assert config.tema_escuro is True
+
+
+def test_form_boolean_coercion(admin_user):
+    config = admin_user.configuracao
+    data = {"receber_notificacoes_email": "on"}
+    form = ConfiguracaoContaForm(data=data, instance=config)
+    assert form.is_valid()
+    form.save()
+    config.refresh_from_db()
+    assert config.receber_notificacoes_email is True
+    assert config.receber_notificacoes_whatsapp is False
+    assert config.tema_escuro is False

--- a/tests/configuracoes/test_models.py
+++ b/tests/configuracoes/test_models.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.db import IntegrityError
+
+from configuracoes.models import ConfiguracaoConta
+
+User = get_user_model()
+
+pytestmark = pytest.mark.django_db
+
+
+def test_configuracao_criada_automaticamente(admin_user):
+    assert ConfiguracaoConta.objects.filter(user=admin_user).exists()
+
+
+def test_configuracao_valores_padrao(admin_user):
+    config = admin_user.configuracao
+    assert config.receber_notificacoes_email is True
+    assert config.receber_notificacoes_whatsapp is False
+    assert config.tema_escuro is False
+
+
+def test_configuracao_unica_por_usuario(admin_user):
+    with pytest.raises(IntegrityError):
+        ConfiguracaoConta.objects.create(user=admin_user)

--- a/tests/configuracoes/test_views.py
+++ b/tests/configuracoes/test_views.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import pytest
+from django.test import override_settings
+from django.urls import reverse
+
+from configuracoes.forms import ConfiguracaoContaForm
+
+pytestmark = pytest.mark.django_db
+
+
+@override_settings(ROOT_URLCONF="tests.configuracoes.urls")
+def test_view_get_autenticado(admin_client):
+    resp = admin_client.get(reverse("configuracoes"))
+    assert resp.status_code == 200
+    assert isinstance(resp.context["form"], ConfiguracaoContaForm)
+    assert "configuracoes/configuracoes.html" in [t.name for t in resp.templates]
+
+
+@override_settings(ROOT_URLCONF="tests.configuracoes.urls")
+def test_view_get_redirect_nao_autenticado(client):
+    resp = client.get(reverse("configuracoes"))
+    assert resp.status_code == 302
+    assert "/accounts/login" in resp.headers["Location"]
+
+
+@override_settings(ROOT_URLCONF="tests.configuracoes.urls")
+def test_view_post_atualiza_configuracao(admin_client, admin_user):
+    url = reverse("configuracoes")
+    data = {
+        "receber_notificacoes_email": False,
+        "receber_notificacoes_whatsapp": True,
+        "tema_escuro": True,
+    }
+    resp = admin_client.post(url, data)
+    assert resp.status_code == 200
+    admin_user.configuracao.refresh_from_db()
+    assert admin_user.configuracao.tema_escuro is True
+    assert admin_user.configuracao.receber_notificacoes_email is False
+    assert admin_user.configuracao.receber_notificacoes_whatsapp is True
+    assert resp.context.get("success") is True

--- a/tests/configuracoes/urls.py
+++ b/tests/configuracoes/urls.py
@@ -1,0 +1,9 @@
+from django.urls import include, path
+
+from configuracoes.views import ConfiguracoesView
+
+urlpatterns = [
+    path("configuracoes/", ConfiguracoesView.as_view(), name="configuracoes"),
+    path("accounts/", include(("accounts.urls", "accounts"), namespace="accounts")),
+    path("", include("Hubx.urls")),
+]


### PR DESCRIPTION
## Summary
- cria fixtures e clientes autenticados para usuarios
- testa modelo `ConfiguracaoConta`
- valida `ConfiguracaoContaForm`
- cobre view de configuracoes com GET e POST

## Testing
- `ruff check tests/configuracoes`
- `black tests/configuracoes -q`
- `mypy --config-file /tmp/mypy.ini tests/configuracoes`
- `pytest tests/configuracoes -q`


------
https://chatgpt.com/codex/tasks/task_e_68805598e4d0832582c9a56d12fbf359