### PR TITLE
feat: limpeza e relatório no populate_test_data

### DIFF
--- a/scripts/usuarios.md
+++ b/scripts/usuarios.md
@@ -1,0 +1,20 @@
+# Usuários criados
+
+| Usuário | E-mail | Senha |
+|--------|--------|------|
+| root | root@hubx.com | 1234Hubx! |
+| admin_3 | admin_3@example.com | 1234Hubx! |
+| coord_3 | coord_3@example.com | 1234Hubx! |
+| nucleado_3 | nucleado_3@example.com | 1234Hubx! |
+| assoc_3 | assoc_3@example.com | 1234Hubx! |
+| guest_3 | guest_3@example.com | 1234Hubx! |
+| admin_2 | admin_2@example.com | 1234Hubx! |
+| coord_2 | coord_2@example.com | 1234Hubx! |
+| nucleado_2 | nucleado_2@example.com | 1234Hubx! |
+| assoc_2 | assoc_2@example.com | 1234Hubx! |
+| guest_2 | guest_2@example.com | 1234Hubx! |
+| admin_1 | admin_1@example.com | 1234Hubx! |
+| coord_1 | coord_1@example.com | 1234Hubx! |
+| nucleado_1 | nucleado_1@example.com | 1234Hubx! |
+| assoc_1 | assoc_1@example.com | 1234Hubx! |
+| guest_1 | guest_1@example.com | 1234Hubx! |


### PR DESCRIPTION
## Summary
- improve populate_test_data with cleanup of existing data
- ensure root user uniqueness and skip token creation
- generate usuarios.md listing created credentials

## Testing
- `python scripts/populate_test_data.py`
- `pytest -q` *(fails: 6 failed, 1 error)*

------
https://chatgpt.com/codex/tasks/task_e_688156e8c8c883259658848b7aeae28b