### PR TITLE
Refatoração do app organizações

### DIFF
--- a/organizacoes/forms.py
+++ b/organizacoes/forms.py
@@ -7,3 +7,9 @@ class OrganizacaoForm(forms.ModelForm):
     class Meta:
         model = Organizacao
         fields = ["nome", "cnpj", "descricao", "slug", "avatar", "cover"]
+
+    def clean_cnpj(self):
+        cnpj = self.cleaned_data.get("cnpj")
+        if Organizacao.objects.exclude(pk=self.instance.pk).filter(cnpj=cnpj).exists():
+            raise forms.ValidationError("Uma organização com este CNPJ já existe.")
+        return cnpj

--- a/organizacoes/models.py
+++ b/organizacoes/models.py
@@ -1,4 +1,3 @@
-from django.contrib.auth import get_user_model
 from django.db import models
 
 from core.models import TimeStampedModel
@@ -15,6 +14,7 @@ class Organizacao(TimeStampedModel):
     class Meta:
         verbose_name = "Organização"
         verbose_name_plural = "Organizações"
+        ordering = ["nome"]
 
     def __str__(self) -> str:
         return self.nome

--- a/organizacoes/templates/organizacoes/create.html
+++ b/organizacoes/templates/organizacoes/create.html
@@ -13,7 +13,7 @@
       </svg>
       Voltar
     </a>
-    <h1 class="text-2xl font-bold text-neutral-900">Cadastrar Organização</h1>
+    <h1 class="text-2xl font-bold text-neutral-900">{% block form_title %}Cadastrar Organização{% endblock %}</h1>
   </div>
 
   <!-- Formulário -->
@@ -47,10 +47,26 @@
     </div>
 
     <div>
-      <label for="{{ form.logo.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.logo.label }}</label>
-      {{ form.logo }}
-      {% if form.logo.errors %}
-        <p class="text-red-500 text-xs mt-1">{{ form.logo.errors }}</p>
+      <label for="{{ form.slug.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.slug.label }}</label>
+      {{ form.slug }}
+      {% if form.slug.errors %}
+        <p class="text-red-500 text-xs mt-1">{{ form.slug.errors }}</p>
+      {% endif %}
+    </div>
+
+    <div>
+      <label for="{{ form.avatar.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.avatar.label }}</label>
+      {{ form.avatar }}
+      {% if form.avatar.errors %}
+        <p class="text-red-500 text-xs mt-1">{{ form.avatar.errors }}</p>
+      {% endif %}
+    </div>
+
+    <div>
+      <label for="{{ form.cover.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.cover.label }}</label>
+      {{ form.cover }}
+      {% if form.cover.errors %}
+        <p class="text-red-500 text-xs mt-1">{{ form.cover.errors }}</p>
       {% endif %}
     </div>
 

--- a/organizacoes/templates/organizacoes/detail.html
+++ b/organizacoes/templates/organizacoes/detail.html
@@ -1,0 +1,25 @@
+{% extends 'base.html' %}
+
+{% block title %}{{ object.nome }} | Hubx{% endblock %}
+
+{% block content %}
+<section class="max-w-2xl mx-auto px-4 py-10 space-y-6">
+  <div class="text-center">
+    {% if object.avatar %}
+      <img src="{{ object.avatar.url }}" alt="{{ object.nome }}" class="w-24 h-24 rounded-full object-cover mx-auto mb-4">
+    {% else %}
+      <div class="w-24 h-24 bg-neutral-200 rounded-full flex items-center justify-center mx-auto mb-4 text-xl font-semibold text-neutral-600">
+        {{ object.nome|make_list|first|upper }}
+      </div>
+    {% endif %}
+    <h1 class="text-2xl font-bold text-neutral-900">{{ object.nome }}</h1>
+    <p class="text-sm text-neutral-600">{{ object.cnpj }}</p>
+    {% if object.descricao %}
+      <p class="text-neutral-700 mt-4">{{ object.descricao }}</p>
+    {% endif %}
+  </div>
+  <div class="flex justify-end">
+    <a href="{% url 'organizacoes:list' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100">Voltar</a>
+  </div>
+</section>
+{% endblock %}

--- a/organizacoes/templates/organizacoes/list.html
+++ b/organizacoes/templates/organizacoes/list.html
@@ -26,8 +26,8 @@
         <div class="border border-neutral-200 rounded-2xl shadow-sm bg-white p-4 flex flex-col gap-4">
           <div class="flex items-center gap-4">
             <div class="w-16 h-16 bg-neutral-100 rounded-xl flex items-center justify-center overflow-hidden">
-              {% if organizacao.logo %}
-                <img src="{{ organizacao.logo.url }}" alt="{{ organizacao.nome }}" class="w-full h-full object-cover rounded-xl">
+              {% if organizacao.avatar %}
+                <img src="{{ organizacao.avatar.url }}" alt="{{ organizacao.nome }}" class="w-full h-full object-cover rounded-xl">
               {% else %}
                 <span class="text-xl font-bold text-neutral-500">{{ organizacao.nome|make_list|first|upper }}</span>
               {% endif %}

--- a/organizacoes/urls.py
+++ b/organizacoes/urls.py
@@ -7,6 +7,7 @@ app_name = "organizacoes"
 urlpatterns = [
     path("", views.OrganizacaoListView.as_view(), name="list"),
     path("nova/", views.OrganizacaoCreateView.as_view(), name="create"),
+    path("<int:pk>/", views.OrganizacaoDetailView.as_view(), name="detail"),
     path("<int:pk>/editar/", views.OrganizacaoUpdateView.as_view(), name="update"),
     path("<int:pk>/remover/", views.OrganizacaoDeleteView.as_view(), name="delete"),
 ]

--- a/tests/organizacoes/test_models.py
+++ b/tests/organizacoes/test_models.py
@@ -83,3 +83,9 @@ def test_file_upload_and_cleanup(media_root, faker_ptbr):
     # Arquivos permanecem após exclusão
     assert os.path.exists(os.path.join(media_root, org.avatar.name))
     assert os.path.exists(os.path.join(media_root, org.cover.name))
+
+
+def test_ordering_by_nome(faker_ptbr):
+    Organizacao.objects.create(nome="B", cnpj=faker_ptbr.cnpj(), slug="b")
+    org_a = Organizacao.objects.create(nome="A", cnpj=faker_ptbr.cnpj(), slug="a")
+    assert list(Organizacao.objects.all())[0] == org_a


### PR DESCRIPTION
## Summary
- keep `cnpj` unique and required in `OrganizacaoForm`
- order organizations alphabetically
- allow ADMIN to list and view its organization while keeping CRUD to ROOT
- add detail view and route
- update templates to show all fields and drop logo
- show avatar/initial and CNPJ in list
- update tests to cover templates, permissions and ordering

## Testing
- `ruff check organizacoes/forms.py organizacoes/models.py organizacoes/views.py tests/organizacoes/test_models.py tests/organizacoes/test_views.py organizacoes/urls.py`
- `black organizacoes/forms.py organizacoes/models.py organizacoes/views.py tests/organizacoes/test_models.py tests/organizacoes/test_views.py organizacoes/urls.py`
- `isort organizacoes/forms.py organizacoes/models.py organizacoes/views.py tests/organizacoes/test_models.py tests/organizacoes/test_views.py organizacoes/urls.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68827ba75a608325b094e9e14f45a705