### PR TITLE
feat: validate user media uploads

### DIFF
--- a/Hubx/settings.py
+++ b/Hubx/settings.py
@@ -133,6 +133,8 @@ STATIC_ROOT = BASE_DIR / "staticfiles"
 # Media files
 MEDIA_URL = "/media/"
 MEDIA_ROOT = BASE_DIR / "media"
+USER_MEDIA_MAX_SIZE = 50 * 1024 * 1024  # 50MB
+USER_MEDIA_ALLOWED_EXTS = [".jpg", ".jpeg", ".png", ".gif", ".pdf", ".mp4", ".webm"]
 
 DATA_UPLOAD_MAX_MEMORY_SIZE = 10 * 1024 * 1024
 FILE_UPLOAD_MAX_MEMORY_SIZE = DATA_UPLOAD_MAX_MEMORY_SIZE

--- a/tests/accounts/test_media_validation.py
+++ b/tests/accounts/test_media_validation.py
@@ -1,0 +1,29 @@
+import pytest
+from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
+from django.core.files.uploadedfile import SimpleUploadedFile
+
+from accounts.models import UserMedia
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+def test_user_media_invalid_extension(tmp_path, settings):
+    settings.MEDIA_ROOT = tmp_path
+    user = User.objects.create_user(email="u@example.com", username="u", password="pass")
+    f = SimpleUploadedFile("malware.exe", b"x", content_type="application/octet-stream")
+    media = UserMedia(user=user, file=f)
+    with pytest.raises(ValidationError):
+        media.clean()
+
+
+@pytest.mark.django_db
+def test_user_media_size_limit(tmp_path, settings):
+    settings.MEDIA_ROOT = tmp_path
+    settings.USER_MEDIA_MAX_SIZE = 1
+    user = User.objects.create_user(email="u2@example.com", username="u2", password="pass")
+    f = SimpleUploadedFile("video.mp4", b"xx", content_type="video/mp4")
+    media = UserMedia(user=user, file=f)
+    with pytest.raises(ValidationError):
+        media.clean()


### PR DESCRIPTION
## Summary
- add media validation settings
- validate user media file size and extension
- add tests for user media validation

## Affected packages
- accounts

## Rationale
Implement basic validation for user media uploads. Provides settings for allowed formats and file size.

## Risks
- None

## Rollback
- revert this PR

------
https://chatgpt.com/codex/tasks/task_e_6883f48d3ea8832583a4b099f143118a