### PR TITLE
feat(accounts): add security event logs

### DIFF
--- a/accounts/api.py
+++ b/accounts/api.py
@@ -71,6 +71,11 @@ class AccountViewSet(viewsets.GenericViewSet):
         user = token.usuario
         user.set_password(new_password)
         user.save(update_fields=["password"])
+        SecurityEvent.objects.create(
+            usuario=user,
+            evento="senha_redefinida",
+            ip=request.META.get("REMOTE_ADDR"),
+        )
         token.used_at = timezone.now()
         token.save(update_fields=["used_at"])
         return Response({"detail": _("Senha redefinida.")})

--- a/tests/accounts/test_security_events.py
+++ b/tests/accounts/test_security_events.py
@@ -1,0 +1,51 @@
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from accounts.models import AccountToken, SecurityEvent
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+def test_security_events_flow():
+    user = User.objects.create_user(email="sec@example.com", username="sec", password="pass")
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    # enable 2FA
+    resp = client.post(reverse("accounts_api:account-enable-2fa"))
+    assert resp.status_code == 200
+    assert SecurityEvent.objects.filter(usuario=user, evento="2fa_habilitado").exists()
+
+    # disable 2FA
+    resp = client.post(reverse("accounts_api:account-disable-2fa"))
+    assert resp.status_code == 200
+    assert SecurityEvent.objects.filter(usuario=user, evento="2fa_desabilitado").exists()
+
+    # delete account
+    resp = client.delete(reverse("accounts_api:account-delete-me"))
+    assert resp.status_code == 204
+    assert SecurityEvent.objects.filter(usuario=user, evento="conta_excluida").exists()
+
+    # cancel deletion
+    resp = client.post(reverse("accounts_api:account-cancel-delete"))
+    assert resp.status_code == 200
+    assert SecurityEvent.objects.filter(usuario=user, evento="cancelou_exclusao").exists()
+
+
+@pytest.mark.django_db
+def test_reset_password_logs_security_event():
+    user = User.objects.create_user(email="reset@example.com", username="r", password="old")
+    token = AccountToken.objects.create(
+        usuario=user,
+        tipo=AccountToken.Tipo.PASSWORD_RESET,
+        expires_at=timezone.now() + timezone.timedelta(hours=1),
+    )
+    client = APIClient()
+    url = reverse("accounts_api:account-reset-password")
+    resp = client.post(url, {"token": token.codigo, "password": "newpass"})
+    assert resp.status_code == 200
+    assert SecurityEvent.objects.filter(usuario=user, evento="senha_redefinida").exists()


### PR DESCRIPTION
## Summary
- register SecurityEvent on password reset and change
- log 2FA and deletion events during account actions
- add regression tests for security event logging

## Testing
- `ruff check accounts/api.py accounts/views.py tests/accounts/test_security_events.py`
- `mypy accounts/api.py accounts/views.py tests/accounts/test_security_events.py` *(fails: Need type annotation for variables)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884f795b0b48325882d83562da8ba39