### PR TITLE
feat: add password reset request endpoint

### DIFF
--- a/accounts/tasks.py
+++ b/accounts/tasks.py
@@ -9,6 +9,20 @@ from .models import AccountToken, User
 
 
 @shared_task
+def send_password_reset_email(token_id: int) -> None:
+    token = AccountToken.objects.select_related("usuario").get(pk=token_id)
+    if token.used_at or token.expires_at < timezone.now():
+        return
+    url = f"{settings.FRONTEND_URL}/reset-password/?token={token.codigo}"
+    send_mail(
+        "Redefina sua senha",
+        f"Acesse o link para redefinir sua senha: {url}",
+        settings.DEFAULT_FROM_EMAIL,
+        [token.usuario.email],
+    )
+
+
+@shared_task
 def send_confirmation_email(token_id: int) -> None:
     token = AccountToken.objects.select_related("usuario").get(pk=token_id)
     if token.used_at or token.expires_at < timezone.now():

--- a/tests/accounts/test_password_reset_request.py
+++ b/tests/accounts/test_password_reset_request.py
@@ -1,0 +1,27 @@
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from accounts.models import AccountToken
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+def test_request_password_reset(monkeypatch, settings):
+    settings.CELERY_TASK_ALWAYS_EAGER = True
+    settings.FRONTEND_URL = "http://testserver"
+    called = {}
+
+    def fake_delay(token_id: int) -> None:
+        called["id"] = token_id
+
+    monkeypatch.setattr("accounts.tasks.send_password_reset_email.delay", fake_delay)
+    user = User.objects.create_user(email="pw@example.com", username="pw")
+    client = APIClient()
+    url = reverse("accounts_api:account-request-password-reset")
+    resp = client.post(url, {"email": "pw@example.com"})
+    assert resp.status_code == 204
+    token = AccountToken.objects.filter(usuario=user, tipo=AccountToken.Tipo.PASSWORD_RESET).latest("created_at")
+    assert called["id"] == token.id


### PR DESCRIPTION
## Summary
- add Celery task for password reset email
- expose `/api/accounts/request-password-reset/` endpoint
- test password reset request flow

## Affected Requisitos
- REQ-ACCOUNTS-001

## Riscos
- baixo risco, nova rota isolada

## Rollback
- revert this PR

------
https://chatgpt.com/codex/tasks/task_e_68850e7d6a908325a60cd0dd513d8a91