### PR TITLE
feat: improve ContaAssociado string representation

### DIFF
--- a/financeiro/models/__init__.py
+++ b/financeiro/models/__init__.py
@@ -67,7 +67,7 @@ class ContaAssociado(TimeStampedModel):
         verbose_name_plural = "Contas dos Associados"
 
     def __str__(self) -> str:
-        return self.user.email if hasattr(self.user, "email") else str(self.user)
+        return f"{self.user.email} (saldo: {self.saldo})"
 
 
 class LancamentoFinanceiro(TimeStampedModel):

--- a/financeiro/tests/test_models.py
+++ b/financeiro/tests/test_models.py
@@ -31,3 +31,9 @@ def test_lancamento_atualiza_saldos():
     conta.refresh_from_db()
     assert centro.saldo == lanc.valor
     assert conta.saldo == lanc.valor
+
+
+def test_contaassociado_str():
+    user = UserFactory(email="teste@example.com")
+    conta = ContaAssociado.objects.create(user=user, saldo=10)
+    assert str(conta) == "teste@example.com (saldo: 10)"


### PR DESCRIPTION
## Summary
- improve `ContaAssociado.__str__` to show user email and balance
- add regression test for the string output

## Rationale
Alinha a modelagem ao requisito de que `ContaAssociado` esteja ligado ao
usuário e forneça representação mais informativa.

## Affected Areas
- `financeiro/models/__init__.py`
- `financeiro/tests/test_models.py`

## Risks
- Baixo, alteração apenas em método utilitário.

## Rollback
- Reverter o commit.

------
https://chatgpt.com/codex/tasks/task_e_6887fff963fc8325a4685aa8accf9ced