### PR TITLE
feat: improve financeiro docs and logging

### DIFF
--- a/financeiro/models/__init__.py
+++ b/financeiro/models/__init__.py
@@ -9,8 +9,12 @@ from django.utils import timezone
 
 from core.models import TimeStampedModel
 
+"""Modelos do módulo financeiro."""
+
 
 class CentroCusto(TimeStampedModel):
+    """Centro de custos para organizar movimentações financeiras."""
+
     class Tipo(models.TextChoices):
         ORGANIZACAO = "organizacao", "Organização"
         NUCLEO = "nucleo", "Núcleo"
@@ -52,6 +56,8 @@ class CentroCusto(TimeStampedModel):
 
 
 class ContaAssociado(TimeStampedModel):
+    """Conta corrente vinculada a um usuário associado."""
+
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     user = models.ForeignKey(
         settings.AUTH_USER_MODEL,
@@ -126,18 +132,22 @@ class LancamentoFinanceiro(TimeStampedModel):
         return f"{self.get_tipo_display()} - {self.valor}"
 
     def save(self, *args, **kwargs) -> None:
+        """Define vencimento padrão e persiste o lançamento."""
         if not self.data_vencimento:
             self.data_vencimento = self.data_lancamento
         super().save(*args, **kwargs)
 
 
 class Aporte(LancamentoFinanceiro):
+    """Proxy de ``LancamentoFinanceiro`` para representar aportes."""
+
     class Meta:
         proxy = True
         verbose_name = "Aporte"
         verbose_name_plural = "Aportes"
 
     def save(self, *args, **kwargs):
+        """Garante tipo válido e salva o aporte."""
         if self.tipo not in {self.Tipo.APORTE_INTERNO, self.Tipo.APORTE_EXTERNO}:
             self.tipo = self.Tipo.APORTE_INTERNO
         super().save(*args, **kwargs)

--- a/financeiro/services/cobrancas.py
+++ b/financeiro/services/cobrancas.py
@@ -17,10 +17,12 @@ except Exception:  # pragma: no cover - núcleo opcional
 
 
 def _centro_organizacao() -> CentroCusto | None:
+    """Retorna o centro de custo principal da organização."""
     return CentroCusto.objects.filter(tipo=CentroCusto.Tipo.ORGANIZACAO).order_by("created_at").first()
 
 
 def _nucleos_do_usuario(user) -> Iterable[CentroCusto]:
+    """Obtém centros de custo dos núcleos ativos do usuário."""
     if not ParticipacaoNucleo:
         return []
     participacoes = getattr(user, "participacoes", None)
@@ -36,6 +38,7 @@ def _nucleos_do_usuario(user) -> Iterable[CentroCusto]:
 
 
 def gerar_cobrancas() -> None:
+    """Cria lançamentos de cobrança para associados e núcleos."""
     centro_org = _centro_organizacao()
     if not centro_org:
         return

--- a/financeiro/services/relatorios.py
+++ b/financeiro/services/relatorios.py
@@ -17,6 +17,7 @@ def _base_queryset(
     inicio: datetime | None,
     fim: datetime | None,
 ) -> Iterable[LancamentoFinanceiro]:
+    """Retorna queryset filtrado para geração de relatórios."""
     qs = LancamentoFinanceiro.objects.select_related("centro_custo").prefetch_related("conta_associado").all()
 
     if centro:
@@ -41,6 +42,7 @@ def gerar_relatorio(
     periodo_inicial: datetime | None = None,
     periodo_final: datetime | None = None,
 ) -> dict[str, Any]:
+    """Computa séries temporais e dados de inadimplência."""
     qs = _base_queryset(centro, nucleo, periodo_inicial, periodo_final)
 
     valores = (

--- a/financeiro/tasks/__init__.py
+++ b/financeiro/tasks/__init__.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
+import logging
+
 from celery import shared_task
 
 from ..services.cobrancas import gerar_cobrancas
+
+logger = logging.getLogger(__name__)
 
 
 @shared_task
 def gerar_cobrancas_mensais() -> None:
     """Gera cobranças mensais para associados ativos."""
+    logger.info("Gerando cobranças mensais")
     gerar_cobrancas()
+    logger.info("Cobranças geradas")
+    # metrics.cobrancas_total.inc()  # Exemplo de métrica Prometheus

--- a/financeiro/tasks/importar_pagamentos.py
+++ b/financeiro/tasks/importar_pagamentos.py
@@ -1,18 +1,26 @@
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 from celery import shared_task
 
 from ..services.importacao import ImportadorPagamentos
 
+logger = logging.getLogger(__name__)
+
 
 @shared_task
 def importar_pagamentos_async(file_path: str, user_id: str) -> None:
+    """Importa pagamentos de forma assíncrona."""
+    logger.info("Iniciando importação de pagamentos %s", file_path)
     service = ImportadorPagamentos(file_path)
     errors = service.process()
     log_path = Path(file_path).with_suffix(".log")
     if errors:
         log_path.write_text("\n".join(errors), encoding="utf-8")
+        logger.error("Erros na importação: %s", errors)
     else:
         log_path.write_text("ok", encoding="utf-8")
+    logger.info("Importação concluída")
+    # metrics.import_payments_total.inc()  # Exemplo de métrica Prometheus

--- a/financeiro/tests/test_aportes.py
+++ b/financeiro/tests/test_aportes.py
@@ -112,4 +112,3 @@ def test_aporte_externo(api_client):
     assert resp.status_code == 201
     centro.refresh_from_db()
     assert centro.saldo == 5
-

--- a/financeiro/tests/test_docstrings.py
+++ b/financeiro/tests/test_docstrings.py
@@ -1,0 +1,38 @@
+import inspect
+
+from financeiro.models import CentroCusto, ContaAssociado, LancamentoFinanceiro
+from financeiro.serializers import AporteSerializer, CentroCustoSerializer, LancamentoFinanceiroSerializer
+from financeiro.tasks import gerar_cobrancas_mensais
+from financeiro.tasks.importar_pagamentos import importar_pagamentos_async
+from financeiro.views import CentroCustoViewSet
+
+
+def test_public_docstrings():
+    objs = [
+        CentroCusto,
+        ContaAssociado,
+        LancamentoFinanceiro,
+        CentroCustoSerializer,
+        AporteSerializer,
+        CentroCustoViewSet,
+        gerar_cobrancas_mensais,
+        importar_pagamentos_async,
+    ]
+    for obj in objs:
+        assert inspect.getdoc(obj), f"{obj} sem docstring"
+
+
+def test_serializer_message_i18n():
+    centro = CentroCusto.objects.create(nome="C", tipo=CentroCusto.Tipo.ORGANIZACAO)
+    data = {
+        "centro_custo": str(centro.id),
+        "tipo": LancamentoFinanceiro.Tipo.MENSALIDADE_ASSOCIACAO,
+        "valor": "10",
+        "data_lancamento": "2024-01-02T00:00:00Z",
+        "data_vencimento": "2024-01-01T00:00:00Z",
+        "status": LancamentoFinanceiro.Status.PENDENTE,
+    }
+    serializer = LancamentoFinanceiroSerializer(data=data)
+    assert not serializer.is_valid()
+    msg = serializer.errors.get("non_field_errors", [""])[0]
+    assert "Vencimento" in msg

--- a/financeiro/views/__init__.py
+++ b/financeiro/views/__init__.py
@@ -9,6 +9,7 @@ from django.core.cache import cache
 from django.core.files.storage import default_storage
 from django.utils import timezone
 from django.utils.dateparse import parse_date
+from django.utils.translation import gettext_lazy as _
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
@@ -41,6 +42,8 @@ class AportePermission(IsAuthenticated):
 
 
 class CentroCustoViewSet(viewsets.ModelViewSet):
+    """CRUD dos centros de custo."""
+
     queryset = CentroCusto.objects.all()
     serializer_class = CentroCustoSerializer
     permission_classes = [IsAuthenticated]
@@ -61,6 +64,8 @@ class CentroCustoViewSet(viewsets.ModelViewSet):
 
 
 class FinanceiroViewSet(viewsets.ViewSet):
+    """Endpoints auxiliares do módulo financeiro."""
+
     permission_classes = [IsAuthenticated]
 
     def get_permissions(self):
@@ -108,10 +113,10 @@ class FinanceiroViewSet(viewsets.ViewSet):
         media_path = Path(settings.MEDIA_ROOT) / "importacoes"
         files = list(media_path.glob(f"{uid}_*"))
         if not files:
-            return Response({"detail": "Arquivo não encontrado"}, status=status.HTTP_404_NOT_FOUND)
+            return Response({"detail": _("Arquivo não encontrado")}, status=status.HTTP_404_NOT_FOUND)
         file_path = str(files[0])
         importar_pagamentos_async.delay(file_path, str(request.user.id))
-        return Response({"detail": "Importação iniciada"}, status=status.HTTP_202_ACCEPTED)
+        return Response({"detail": _("Importação iniciada")}, status=status.HTTP_202_ACCEPTED)
 
     @action(detail=False, methods=["get"], url_path="relatorios")
     def relatorios(self, request):
@@ -133,15 +138,15 @@ class FinanceiroViewSet(viewsets.ViewSet):
         inicio = _parse(pi)
         fim = _parse(pf)
         if pf and not fim:
-            return Response({"detail": "periodo_final inválido"}, status=400)
+            return Response({"detail": _("periodo_final inválido")}, status=400)
         if pi and not inicio:
-            return Response({"detail": "periodo_inicial inválido"}, status=400)
+            return Response({"detail": _("periodo_inicial inválido")}, status=400)
 
         user = request.user
         if user.user_type not in {UserType.ADMIN, UserType.ROOT}:
             centros_user = [str(c.id) for c in _nucleos_do_usuario(user)]
             if centro_id and centro_id not in centros_user:
-                return Response({"detail": "Sem permissão"}, status=403)
+                return Response({"detail": _("Sem permissão")}, status=403)
             if not centro_id:
                 centro_id = centros_user
 


### PR DESCRIPTION
## Summary
- document finance module in `docs/financeiro.md`
- add docstrings and i18n messages across financeiro
- log celery tasks for observability
- add small docstring/i18n tests

## Testing
- `ruff check financeiro --fix`
- `black financeiro financeiro/tests/test_docstrings.py`
- `pytest financeiro/tests/test_docstrings.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888f4bb827c832583aee915cfec4401