### PR TITLE
docs: add frontend style guide and design disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ Inclui também geração de dados de teste e suporte a interface moderna com Tai
 - Sistema multi-tenant por organização
 - Geração automatizada de massa de dados para testes
 
+### Limitações de Design
+
+Algumas telas ainda estão em processo de migração para Tailwind CSS e HTMX. Isso
+significa que partes da interface podem apresentar diferenças visuais ou falta de
+feedback. Caso encontre problemas, abra uma issue ou envie um pull request.
+
 ---
 
 ### Uso do campo `redes_sociais`

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -12,6 +12,11 @@ urlpatterns = [
     # Registro de usuário
     path("register/", views.register_view, name="register"),
     path("password_reset/", views.password_reset, name="password_reset"),
+    path(
+        "password_reset/<str:code>/",
+        views.password_reset_confirm,
+        name="password_reset_confirm",
+    ),
     path("onboarding/", views.onboarding, name="onboarding"),
     path("nome/", views.nome, name="nome"),
     path("cpf/", views.cpf, name="cpf"),

--- a/docs/style_guide_frontend.md
+++ b/docs/style_guide_frontend.md
@@ -1,0 +1,32 @@
+# Style Guide Frontend
+
+Este guia resume o padrão visual dos templates do Hubx.
+
+## Tecnologias
+
+- HTML5 semântico
+- Tailwind CSS 3
+- HTMX para interações dinâmicas
+
+Evite JavaScript customizado sempre que possível. Utilize `hx-get` e `hx-post` para enviar e atualizar partes da página.
+
+## Estrutura básica
+
+```html
+<!DOCTYPE html>
+<html lang="pt-br">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Título</title>
+  </head>
+  <body>
+    <header>...</header>
+    <main>
+      <!-- conteúdo -->
+    </main>
+    <footer>...</footer>
+  </body>
+</html>
+```
+
+Aplique utilitários Tailwind diretamente nas tags para garantir consistência entre páginas.


### PR DESCRIPTION
## Summary
- add a brief design disclaimer to README
- document the frontend style guide under docs/
- handle password reset workflow in accounts views
- expose password reset confirm route

## Testing
- `ruff check accounts/views.py accounts/urls.py` *(fails: import ordering issues in repository)*
- `mypy accounts/views.py accounts/urls.py` *(fails: many type annotation issues in repository)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68894d1963388325b02ee1a0628300f6