### PR TITLE
feat: add financeiro web templates

### DIFF
--- a/Hubx/urls.py
+++ b/Hubx/urls.py
@@ -28,6 +28,7 @@ urlpatterns = [
     path("chat/", include(("chat.urls", "chat"), namespace="chat")),
     path("discussao/", include(("discussao.urls", "discussao"), namespace="discussao")),
     path("feed/", include(("feed.urls", "feed"), namespace="feed")),
+    path("financeiro/", include(("financeiro.urls", "financeiro"), namespace="financeiro")),
     path("select2/", include("django_select2.urls")),
     # APIs REST (subcaminhos específicos)
     path(

--- a/financeiro/templates/financeiro/importar_pagamentos.html
+++ b/financeiro/templates/financeiro/importar_pagamentos.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+
+{% block title %}Importar Pagamentos{% endblock %}
+
+{% block content %}
+<div class="max-w-3xl mx-auto p-4">
+  <h1 class="text-2xl font-semibold mb-4">Importar Pagamentos</h1>
+  <form id="upload-form" method="post" enctype="multipart/form-data"
+        hx-post="/api/financeiro/importar-pagamentos/" hx-target="#preview"
+        class="space-y-4 border p-4 rounded-lg bg-white">
+    {% csrf_token %}
+    <input type="file" name="file" class="block w-full border p-2 rounded" required />
+    <button type="submit" class="bg-primary text-white px-4 py-2 rounded">Pré-visualizar</button>
+  </form>
+  <div id="preview" class="mt-6"></div>
+</div>
+{% endblock %}

--- a/financeiro/templates/financeiro/inadimplencias.html
+++ b/financeiro/templates/financeiro/inadimplencias.html
@@ -1,0 +1,30 @@
+{% extends "base.html" %}
+
+{% block title %}Inadimplências{% endblock %}
+
+{% block content %}
+<div class="p-4 max-w-6xl mx-auto">
+  <h1 class="text-2xl font-semibold mb-2">Inadimplências</h1>
+  <div class="mb-4 grid grid-cols-1 md:grid-cols-3 gap-4">
+    <select name="centro" class="border p-2 rounded" hx-get="/api/financeiro/inadimplencias/" hx-target="#lista" hx-include="closest div">
+      <option value="">Todos Centros</option>
+      {% for c in centros %}
+        <option value="{{ c.id }}">{{ c.nome }}</option>
+      {% endfor %}
+    </select>
+    <select name="nucleo" class="border p-2 rounded" hx-get="/api/financeiro/inadimplencias/" hx-target="#lista" hx-include="closest div">
+      <option value="">Todos Núcleos</option>
+      {% for n in nucleos %}
+        <option value="{{ n.id }}">{{ n.nome }}</option>
+      {% endfor %}
+    </select>
+    <select name="status" class="border p-2 rounded" disabled>
+      <option>Pendente</option>
+    </select>
+  </div>
+  <div id="lista" hx-get="/api/financeiro/inadimplencias/" hx-target="this"></div>
+  <div class="mt-4">
+    <a href="/api/financeiro/inadimplencias/?format=csv" class="text-primary underline" hx-boost="false">Exportar CSV</a>
+  </div>
+</div>
+{% endblock %}

--- a/financeiro/templates/financeiro/lancamentos_list.html
+++ b/financeiro/templates/financeiro/lancamentos_list.html
@@ -1,0 +1,30 @@
+{% extends "base.html" %}
+
+{% block title %}Lançamentos Financeiros{% endblock %}
+
+{% block content %}
+<div class="p-4 max-w-6xl mx-auto">
+  <h1 class="text-2xl font-semibold mb-2">Lançamentos</h1>
+  <div class="mb-4 grid grid-cols-1 md:grid-cols-3 gap-4">
+    <select name="status" id="filtro-status" class="border p-2 rounded" hx-get="/api/financeiro/lancamentos/" hx-target="#lista" hx-include="closest div">
+      <option value="">Todos Status</option>
+      <option value="pendente">Pendente</option>
+      <option value="pago">Pago</option>
+      <option value="cancelado">Cancelado</option>
+    </select>
+    <select name="centro" id="filtro-centro" class="border p-2 rounded" hx-get="/api/financeiro/lancamentos/" hx-target="#lista" hx-include="closest div">
+      <option value="">Todos Centros</option>
+      {% for c in centros %}
+        <option value="{{ c.id }}">{{ c.nome }}</option>
+      {% endfor %}
+    </select>
+    <select name="nucleo" id="filtro-nucleo" class="border p-2 rounded" hx-get="/api/financeiro/lancamentos/" hx-target="#lista" hx-include="closest div">
+      <option value="">Todos Núcleos</option>
+      {% for n in nucleos %}
+        <option value="{{ n.id }}">{{ n.nome }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div id="lista" hx-get="/api/financeiro/lancamentos/" hx-target="this"></div>
+</div>
+{% endblock %}

--- a/financeiro/templates/financeiro/relatorios.html
+++ b/financeiro/templates/financeiro/relatorios.html
@@ -1,0 +1,47 @@
+{% extends "base.html" %}
+
+{% block title %}Relatórios Financeiros{% endblock %}
+
+{% block content %}
+<div class="max-w-5xl mx-auto p-4 space-y-4">
+  <h1 class="text-2xl font-semibold mb-2">Relatórios</h1>
+  <form id="relatorio-form" class="space-y-4" hx-get="/api/financeiro/relatorios/" hx-target="#resultado">
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <div>
+        <label class="block text-sm font-medium text-gray-700">Centro de Custo</label>
+        <select name="centro" class="mt-1 block w-full border rounded p-2">
+          <option value="">Todos</option>
+          {% for c in centros %}
+            <option value="{{ c.id }}">{{ c.nome }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div>
+        <label class="block text-sm font-medium text-gray-700">Núcleo</label>
+        <select name="nucleo" class="mt-1 block w-full border rounded p-2">
+          <option value="">Todos</option>
+          {% for n in nucleos %}
+            <option value="{{ n.id }}">{{ n.nome }}</option>
+          {% endfor %}
+        </select>
+      </div>
+    </div>
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <div>
+        <label class="block text-sm font-medium text-gray-700">Período inicial</label>
+        <input type="month" name="periodo_inicial" class="mt-1 block w-full border rounded p-2" />
+      </div>
+      <div>
+        <label class="block text-sm font-medium text-gray-700">Período final</label>
+        <input type="month" name="periodo_final" class="mt-1 block w-full border rounded p-2" />
+      </div>
+    </div>
+    <button type="submit" class="bg-primary text-white px-4 py-2 rounded">Gerar Relatório</button>
+  </form>
+
+  <div id="resultado" class="mt-6"></div>
+  <div class="mt-4">
+    <a href="#" id="export-csv" class="text-primary underline" hx-boost="false">Exportar CSV</a>
+  </div>
+</div>
+{% endblock %}

--- a/financeiro/urls.py
+++ b/financeiro/urls.py
@@ -1,0 +1,17 @@
+from django.urls import path
+
+from .views import (
+    importar_pagamentos_view,
+    inadimplencias_view,
+    lancamentos_list_view,
+    relatorios_view,
+)
+
+app_name = "financeiro"
+
+urlpatterns = [
+    path("importar/", importar_pagamentos_view, name="importar_pagamentos"),
+    path("relatorios/", relatorios_view, name="relatorios"),
+    path("lancamentos/", lancamentos_list_view, name="lancamentos"),
+    path("inadimplencias/", inadimplencias_view, name="inadimplencias"),
+]


### PR DESCRIPTION
## Summary
- create HTML templates for financeiro features
- add views and urls for financeiro pages
- wire financeiro routes in project urls

## Testing
- `ruff check financeiro/urls.py financeiro/views/__init__.py Hubx/urls.py`
- `black financeiro/urls.py financeiro/views/__init__.py Hubx/urls.py -q`
- `mypy financeiro/urls.py financeiro/views/__init__.py Hubx/urls.py` *(fails: library stubs not installed)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68895ded98908325ab437a9347b126d6