### PR TITLE
Refatora templates de tokens e 2FA

### DIFF
--- a/accounts/templates/accounts/gerar_token.html
+++ b/accounts/templates/accounts/gerar_token.html
@@ -1,14 +1,32 @@
 {% extends "base.html" %}
+{% load widget_tweaks %}
+
 {% block title %}Gerar Token de Acesso | HubX{% endblock %}
 
 {% block content %}
-<h1>Gerar Token de Acesso</h1>
-<form method="post">
+<section class="max-w-md mx-auto px-4 py-12">
+  <h1 class="text-2xl font-bold text-center mb-6">Gerar Token de Acesso</h1>
+
+  <form method="post" action="" class="bg-white rounded-2xl shadow p-6 space-y-4">
     {% csrf_token %}
-    {{ form.as_p }}
-    <button type="submit" class="btn-primary">Gerar Token</button>
-</form>
-{% if token %}
-<p>Código gerado: <strong>{{ token.codigo }}</strong></p>
-{% endif %}
+    {% for field in form %}
+      <div>
+        <label for="{{ field.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ field.label }}</label>
+        {{ field|add_class:"form-input" }}
+        {% if field.errors %}
+          <p class="text-sm text-red-600 mt-1">{{ field.errors.0 }}</p>
+        {% endif %}
+      </div>
+    {% endfor %}
+    <div class="text-right">
+      <button type="submit" class="rounded-xl bg-primary px-4 py-2 text-white hover:bg-primary/90">Gerar Token</button>
+    </div>
+  </form>
+
+  {% if token %}
+    <div class="mt-6 text-center rounded-xl bg-green-100 px-4 py-3 text-sm text-green-700">
+      Código gerado: <strong>{{ token.codigo }}</strong>
+    </div>
+  {% endif %}
+</section>
 {% endblock %}

--- a/tokens/templates/tokens/ativar_2fa.html
+++ b/tokens/templates/tokens/ativar_2fa.html
@@ -1,8 +1,34 @@
 {% extends "base.html" %}
+{% load widget_tweaks %}
+
+{% block title %}Ativar 2FA | HubX{% endblock %}
+
 {% block content %}
-<h1>Ativar 2FA</h1>
-<form method="post">
-    {{ form.as_p }}
-    <button type="submit">Ativar</button>
-</form>
+<section class="max-w-md mx-auto px-4 py-12">
+  <h1 class="text-2xl font-bold text-center mb-6">Ativar Autenticação de Dois Fatores</h1>
+
+  {% if messages %}
+    <div class="mb-4 space-y-2">
+      {% for message in messages %}
+        <p class="rounded-xl px-4 py-2 text-sm {{ message.tags == 'success'|yesno:'bg-green-100 text-green-700,bg-red-100 text-red-700' }}">
+          {{ message }}
+        </p>
+      {% endfor %}
+    </div>
+  {% endif %}
+
+  <form method="post" action="{% url 'tokens:ativar_2fa' %}" class="bg-white rounded-2xl shadow p-6 space-y-4">
+    {% csrf_token %}
+    <div>
+      <label for="{{ form.codigo_totp.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.codigo_totp.label }}</label>
+      {{ form.codigo_totp|add_class:"form-input" }}
+      {% if form.codigo_totp.errors %}
+        <p class="text-sm text-red-600 mt-1">{{ form.codigo_totp.errors.0 }}</p>
+      {% endif %}
+    </div>
+    <div class="text-right">
+      <button type="submit" class="rounded-xl bg-primary px-4 py-2 text-white hover:bg-primary/90">Ativar</button>
+    </div>
+  </form>
+</section>
 {% endblock %}

--- a/tokens/templates/tokens/gerar_codigo_autenticacao.html
+++ b/tokens/templates/tokens/gerar_codigo_autenticacao.html
@@ -1,8 +1,32 @@
 {% extends "base.html" %}
+{% load widget_tweaks %}
+
+{% block title %}Gerar Código de Autenticação | HubX{% endblock %}
+
 {% block content %}
-<h1>Gerar Código de Autenticação</h1>
-<form method="post">
-    {{ form.as_p }}
-    <button type="submit">Gerar Código</button>
-</form>
+<section class="max-w-md mx-auto px-4 py-12">
+  <h1 class="text-2xl font-bold text-center mb-6">Gerar Código de Autenticação</h1>
+
+  <form method="post" action="{% url 'tokens:gerar_codigo' %}" class="bg-white rounded-2xl shadow p-6 space-y-4">
+    {% csrf_token %}
+    {% for field in form %}
+      <div>
+        <label for="{{ field.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ field.label }}</label>
+        {% if field.field.widget.input_type == 'select' %}
+          {{ field|add_class:"form-select" }}
+        {% else %}
+          {{ field|add_class:"form-input" }}
+        {% endif %}
+        {% if field.errors %}
+          <p class="text-sm text-red-600 mt-1">{{ field.errors.0 }}</p>
+        {% endif %}
+      </div>
+    {% endfor %}
+    <div class="text-right">
+      <button type="submit" class="rounded-xl bg-primary px-4 py-2 text-white hover:bg-primary/90">Gerar Código</button>
+    </div>
+  </form>
+
+  <div id="resultado" class="mt-6 text-center"></div>
+</section>
 {% endblock %}

--- a/tokens/templates/tokens/gerar_token.html
+++ b/tokens/templates/tokens/gerar_token.html
@@ -6,7 +6,7 @@
 <section class="max-w-xl mx-auto px-4 py-10">
   <h1 class="text-2xl font-bold text-neutral-900 mb-6">Gerar Token de Acesso</h1>
 
-  <form method="post" class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 space-y-6">
+  <form method="post" action="{% url 'tokens:criar_token' %}" class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 space-y-6">
     {% csrf_token %}
 
     <div class="space-y-4">
@@ -33,7 +33,7 @@
   </form>
 
   {% if token %}
-    <div class="mt-6 alert alert-success">
+    <div class="mt-6 text-center rounded-xl bg-green-100 px-4 py-3 text-sm text-green-700">
       Código gerado: <strong>{{ token.codigo }}</strong>
     </div>
   {% endif %}

--- a/tokens/templates/tokens/validar_codigo_autenticacao.html
+++ b/tokens/templates/tokens/validar_codigo_autenticacao.html
@@ -1,8 +1,26 @@
 {% extends "base.html" %}
+{% load widget_tweaks %}
+
+{% block title %}Validar Código de Autenticação | HubX{% endblock %}
+
 {% block content %}
-<h1>Validar Código de Autenticação</h1>
-<form method="post">
-    {{ form.as_p }}
-    <button type="submit">Validar Código</button>
-</form>
+<section class="max-w-md mx-auto px-4 py-12">
+  <h1 class="text-2xl font-bold text-center mb-6">Validar Código de Autenticação</h1>
+
+  <form method="post" action="{% url 'tokens:validar_codigo' %}" class="bg-white rounded-2xl shadow p-6 space-y-4">
+    {% csrf_token %}
+    <div>
+      <label for="{{ form.codigo.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.codigo.label }}</label>
+      {{ form.codigo|add_class:"form-input text-center tracking-widest" }}
+      {% if form.codigo.errors %}
+        <p class="text-sm text-red-600 mt-1">{{ form.codigo.errors.0 }}</p>
+      {% endif %}
+    </div>
+    <div class="text-right">
+      <button type="submit" class="rounded-xl bg-primary px-4 py-2 text-white hover:bg-primary/90">Validar Código</button>
+    </div>
+  </form>
+
+  <div id="resultado" class="mt-6 text-center"></div>
+</section>
 {% endblock %}

--- a/tokens/templates/tokens/validar_token.html
+++ b/tokens/templates/tokens/validar_token.html
@@ -1,8 +1,26 @@
 {% extends "base.html" %}
+{% load widget_tweaks %}
+
+{% block title %}Validar Token de Convite | HubX{% endblock %}
+
 {% block content %}
-<h1>Validar Token de Convite</h1>
-<form method="post">
-    {{ form.as_p }}
-    <button type="submit">Validar Token</button>
-</form>
+<section class="max-w-md mx-auto px-4 py-12">
+  <h1 class="text-2xl font-bold text-center mb-6">Validar Token de Convite</h1>
+
+  <form method="post" action="{% url 'tokens:validar_convite' %}" class="bg-white rounded-2xl shadow p-6 space-y-4">
+    {% csrf_token %}
+    <div>
+      <label for="{{ form.codigo.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.codigo.label }}</label>
+      {{ form.codigo|add_class:"form-input" }}
+      {% if form.codigo.errors %}
+        <p class="text-sm text-red-600 mt-1">{{ form.codigo.errors.0 }}</p>
+      {% endif %}
+    </div>
+    <div class="text-right">
+      <button type="submit" class="rounded-xl bg-primary px-4 py-2 text-white hover:bg-primary/90">Validar Token</button>
+    </div>
+  </form>
+
+  <div id="resultado" class="mt-6 text-center"></div>
+</section>
 {% endblock %}


### PR DESCRIPTION
## Descrição
- padroniza geracao e validacao de tokens
- aplica Tailwind e herança de `base.html`
- cria layout uniforme para 2FA e códigos de autenticação

## Referências
- Requisitos de contas e tokens

## Riscos
- baixo, somente ajuste de templates

## Rollback
- reverter o commit

------
https://chatgpt.com/codex/tasks/task_e_6889626eb8448325a702acbb71dd00f3