### PR TITLE
feat: adicionar exclusão e confirmação de conta

### DIFF
--- a/accounts/templates/accounts/delete_account_confirm.html
+++ b/accounts/templates/accounts/delete_account_confirm.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+{% load i18n %}
+{% block title %}{% trans "Excluir Conta" %} - HubX{% endblock %}
+{% block content %}
+<section class="max-w-md mx-auto px-4 py-12">
+  <h1 class="text-2xl font-bold text-center mb-6">{% trans "Excluir Conta" %}</h1>
+  <p class="text-red-700 bg-red-100 rounded-xl px-4 py-2 mb-4 text-sm">
+    {% trans "A exclusão da conta é permanente e você perderá acesso aos seus dados." %}
+  </p>
+  <form method="post" class="bg-white rounded-2xl shadow p-6 space-y-4">
+    {% csrf_token %}
+    <div>
+      <label for="confirm" class="block text-sm font-medium text-neutral-700">{% trans "Digite EXCLUIR para confirmar" %}</label>
+      <input type="text" name="confirm" id="confirm" required class="form-input" />
+    </div>
+    <div class="text-right">
+      <button type="submit" class="bg-red-600 text-white py-2 px-4 rounded">{% trans "Confirmar exclusão" %}</button>
+    </div>
+  </form>
+</section>
+{% endblock %}

--- a/accounts/templates/accounts/email_confirm.html
+++ b/accounts/templates/accounts/email_confirm.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+{% load i18n %}
+{% block title %}{% trans "Confirmação de Email" %} - HubX{% endblock %}
+{% block content %}
+<section class="max-w-md mx-auto px-4 py-12">
+  {% if status == 'sucesso' %}
+    <div class="bg-green-100 text-green-700 rounded-xl px-4 py-3 text-center">
+      {% trans "Seu e-mail foi confirmado com sucesso." %}
+    </div>
+  {% else %}
+    <div class="bg-red-100 text-red-700 rounded-xl px-4 py-3 text-center">
+      {% trans "Link inválido ou expirado." %}
+    </div>
+  {% endif %}
+</section>
+{% endblock %}

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -47,4 +47,10 @@ urlpatterns = [
         views.perfil_midia_delete,
         name="midia_delete",
     ),
+    path("excluir/", views.excluir_conta, name="excluir_conta"),
+    path(
+        "confirmar-email/<str:token>/",
+        views.confirmar_email,
+        name="confirmar_email",
+    ),
 ]

--- a/tests/accounts/test_delete_account_view.py
+++ b/tests/accounts/test_delete_account_view.py
@@ -1,0 +1,22 @@
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from django.utils import timezone
+
+from accounts.models import SecurityEvent
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+def test_delete_account_view(client):
+    user = User.objects.create_user(email="del@example.com", username="del", password="pw")
+    client.force_login(user)
+    url = reverse("accounts:excluir_conta")
+    resp = client.post(url, {"confirm": "EXCLUIR"})
+    assert resp.status_code == 302
+    user.refresh_from_db()
+    assert user.deleted_at is not None
+    assert user.exclusao_confirmada
+    assert not user.is_active
+    assert SecurityEvent.objects.filter(usuario=user, evento="conta_excluida").exists()

--- a/tests/accounts/test_email_confirm_view.py
+++ b/tests/accounts/test_email_confirm_view.py
@@ -1,0 +1,34 @@
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from django.utils import timezone
+
+from accounts.models import AccountToken, SecurityEvent
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+def test_email_confirm_view_success(client):
+    user = User.objects.create_user(email="c@example.com", username="c", is_active=False)
+    token = AccountToken.objects.create(
+        usuario=user,
+        tipo=AccountToken.Tipo.EMAIL_CONFIRMATION,
+        expires_at=timezone.now() + timezone.timedelta(hours=1),
+    )
+    url = reverse("accounts:confirmar_email", args=[token.codigo])
+    resp = client.get(url)
+    assert resp.status_code == 200
+    token.refresh_from_db()
+    user.refresh_from_db()
+    assert token.used_at is not None
+    assert user.is_active
+    assert SecurityEvent.objects.filter(usuario=user, evento="email_confirmado").exists()
+
+
+@pytest.mark.django_db
+def test_email_confirm_view_error(client):
+    url = reverse("accounts:confirmar_email", args=["invalid"])
+    resp = client.get(url)
+    assert resp.status_code == 200
+    assert b"Link inv\xc3\xa1lido" in resp.content


### PR DESCRIPTION
## Summary
- permitir exclusão de conta via `excluir_conta`
- criar página de confirmação de email
- rotas e templates correspondentes
- testes de views para exclusão e confirmação

## Affected URLs
- `/accounts/excluir/`
- `/accounts/confirmar-email/<token>/`

## Risk
Baixo. Rotas novas e testes cobrem o fluxo.

## Rollback
Reverter este PR.

------
https://chatgpt.com/codex/tasks/task_e_68896662c3948325b463216997304ecd