### PR TITLE
feat: criar interface de notificações

### DIFF
--- a/Hubx/urls.py
+++ b/Hubx/urls.py
@@ -28,6 +28,7 @@ urlpatterns = [
     path("chat/", include(("chat.urls", "chat"), namespace="chat")),
     path("discussao/", include(("discussao.urls", "discussao"), namespace="discussao")),
     path("feed/", include(("feed.urls", "feed"), namespace="feed")),
+    path("notificacoes/", include(("notificacoes.urls", "notificacoes"), namespace="notificacoes")),
     path("financeiro/", include(("financeiro.urls", "financeiro"), namespace="financeiro")),
     path("select2/", include("django_select2.urls")),
     # APIs REST (subcaminhos específicos)

--- a/notificacoes/forms.py
+++ b/notificacoes/forms.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from django import forms
+
+from .models import NotificationTemplate, UserNotificationPreference
+
+
+class NotificationTemplateForm(forms.ModelForm):
+    class Meta:
+        model = NotificationTemplate
+        fields = ["codigo", "assunto", "corpo", "canal", "ativo"]
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.fields["corpo"].widget.attrs.setdefault("rows", 4)
+        if self.instance and self.instance.pk:
+            self.fields["codigo"].widget.attrs["readonly"] = True
+
+
+class UserNotificationPreferenceForm(forms.ModelForm):
+    class Meta:
+        model = UserNotificationPreference
+        fields = ["email", "push", "whatsapp"]

--- a/notificacoes/templates/notificacoes/logs_list.html
+++ b/notificacoes/templates/notificacoes/logs_list.html
@@ -1,0 +1,76 @@
+{% if partial %}
+  {% for log in logs %}
+  <tr>
+    <td class="px-4 py-2">{{ log.data_envio|date:'d/m/Y H:i' }}</td>
+    <td class="px-4 py-2">{{ log.user.get_full_name|default:log.user.username }}</td>
+    <td class="px-4 py-2">{{ log.template.codigo }}</td>
+    <td class="px-4 py-2">{{ log.get_canal_display }}</td>
+    <td class="px-4 py-2">{{ log.get_status_display }}</td>
+    <td class="px-4 py-2 text-sm">{{ log.erro|default:'-' }}</td>
+  </tr>
+  {% endfor %}
+{% else %}
+{% extends 'base.html' %}
+{% block title %}Logs de Notificação | HubX{% endblock %}
+{% block content %}
+<div class="max-w-6xl mx-auto px-4 py-10">
+  <div class="mb-8">
+    <h1 class="text-2xl font-bold text-neutral-900">Logs de Notificação</h1>
+  </div>
+  <form method="get" class="bg-white border border-neutral-200 p-6 rounded-2xl shadow-sm mb-6 flex flex-col sm:flex-row gap-4 sm:items-end">
+    <div>
+      <label for="inicio" class="block text-sm font-medium text-neutral-700 mb-1">De</label>
+      <input type="date" name="inicio" id="inicio" value="{{ request.GET.inicio }}" class="form-input" hx-get="{% url 'notificacoes:logs_list' %}" hx-target="#tabela_logs" hx-include="closest form">
+    </div>
+    <div>
+      <label for="fim" class="block text-sm font-medium text-neutral-700 mb-1">Até</label>
+      <input type="date" name="fim" id="fim" value="{{ request.GET.fim }}" class="form-input" hx-get="{% url 'notificacoes:logs_list' %}" hx-target="#tabela_logs" hx-include="closest form">
+    </div>
+    <div>
+      <label for="canal" class="block text-sm font-medium text-neutral-700 mb-1">Canal</label>
+      <select name="canal" id="canal" class="form-select" hx-get="{% url 'notificacoes:logs_list' %}" hx-target="#tabela_logs" hx-include="closest form">
+        <option value="" {% if not request.GET.canal %}selected{% endif %}>Todos</option>
+        <option value="email" {% if request.GET.canal == 'email' %}selected{% endif %}>E-mail</option>
+        <option value="push" {% if request.GET.canal == 'push' %}selected{% endif %}>Push</option>
+        <option value="whatsapp" {% if request.GET.canal == 'whatsapp' %}selected{% endif %}>WhatsApp</option>
+      </select>
+    </div>
+    <div>
+      <label for="status" class="block text-sm font-medium text-neutral-700 mb-1">Status</label>
+      <select name="status" id="status" class="form-select" hx-get="{% url 'notificacoes:logs_list' %}" hx-target="#tabela_logs" hx-include="closest form">
+        <option value="" {% if not request.GET.status %}selected{% endif %}>Todos</option>
+        <option value="enviada" {% if request.GET.status == 'enviada' %}selected{% endif %}>Enviada</option>
+        <option value="falha" {% if request.GET.status == 'falha' %}selected{% endif %}>Falha</option>
+      </select>
+    </div>
+    <noscript><button type="submit" class="mt-2 sm:mt-0 bg-neutral-200 text-neutral-800 px-4 py-2 rounded-xl text-sm hover:bg-neutral-300">Filtrar</button></noscript>
+  </form>
+  <div class="overflow-x-auto bg-white border border-neutral-200 rounded-2xl shadow-sm">
+    <table class="min-w-full divide-y divide-neutral-200 text-sm">
+      <thead class="bg-neutral-50">
+        <tr>
+          <th class="px-4 py-2 text-left font-medium text-neutral-700">Data</th>
+          <th class="px-4 py-2 text-left font-medium text-neutral-700">Usuário</th>
+          <th class="px-4 py-2 text-left font-medium text-neutral-700">Template</th>
+          <th class="px-4 py-2 text-left font-medium text-neutral-700">Canal</th>
+          <th class="px-4 py-2 text-left font-medium text-neutral-700">Status</th>
+          <th class="px-4 py-2 text-left font-medium text-neutral-700">Erro</th>
+        </tr>
+      </thead>
+      <tbody id="tabela_logs" class="divide-y divide-neutral-200">
+        {% include 'notificacoes/logs_list.html' with partial=True only %}
+      </tbody>
+    </table>
+  </div>
+  <div class="mt-4 flex justify-center gap-3">
+    {% if logs.has_previous %}
+      <a hx-get="?page={{ logs.previous_page_number }}&{{ request.GET.urlencode }}" hx-target="#tabela_logs" hx-include="closest form" class="px-3 py-1 rounded-xl border border-neutral-300 text-sm">Anterior</a>
+    {% endif %}
+    <span class="px-3 py-1 text-sm">Página {{ logs.number }} de {{ logs.paginator.num_pages }}</span>
+    {% if logs.has_next %}
+      <a hx-get="?page={{ logs.next_page_number }}&{{ request.GET.urlencode }}" hx-target="#tabela_logs" hx-include="closest form" class="px-3 py-1 rounded-xl border border-neutral-300 text-sm">Próxima</a>
+    {% endif %}
+  </div>
+</div>
+{% endblock %}
+{% endif %}

--- a/notificacoes/templates/notificacoes/preferencias.html
+++ b/notificacoes/templates/notificacoes/preferencias.html
@@ -1,0 +1,33 @@
+{% extends 'base.html' %}
+{% load widget_tweaks %}
+{% block title %}Preferências de Notificação | HubX{% endblock %}
+{% block content %}
+<div class="max-w-md mx-auto px-4 py-10">
+  <h1 class="text-2xl font-bold mb-6">Preferências de Notificação</h1>
+  {% if messages %}
+  <div class="mb-4 space-y-2">
+    {% for message in messages %}
+      <p class="rounded-xl px-4 py-2 text-sm {{ message.tags == 'success'|yesno:'bg-green-100 text-green-700,bg-red-100 text-red-700' }}">{{ message }}</p>
+    {% endfor %}
+  </div>
+  {% endif %}
+  <form method="post" class="bg-white p-6 rounded-2xl shadow space-y-4">
+    {% csrf_token %}
+    <div class="flex items-center">
+      {{ form.email|add_class:'form-checkbox' }}
+      <label for="{{ form.email.id_for_label }}" class="ml-2 text-sm font-medium">E-mail</label>
+    </div>
+    <div class="flex items-center">
+      {{ form.push|add_class:'form-checkbox' }}
+      <label for="{{ form.push.id_for_label }}" class="ml-2 text-sm font-medium">Push</label>
+    </div>
+    <div class="flex items-center">
+      {{ form.whatsapp|add_class:'form-checkbox' }}
+      <label for="{{ form.whatsapp.id_for_label }}" class="ml-2 text-sm font-medium">WhatsApp</label>
+    </div>
+    <div class="text-right pt-4 border-t border-neutral-100">
+      <button type="submit" class="bg-primary text-white px-4 py-2 rounded-xl hover:bg-primary/90">Salvar</button>
+    </div>
+  </form>
+</div>
+{% endblock %}

--- a/notificacoes/templates/notificacoes/template_form.html
+++ b/notificacoes/templates/notificacoes/template_form.html
@@ -1,0 +1,52 @@
+{% extends 'base.html' %}
+{% load widget_tweaks %}
+{% block title %}{% if form.instance.pk %}Editar Template{% else %}Novo Template{% endif %} | HubX{% endblock %}
+{% block content %}
+<div class="max-w-xl mx-auto px-4 py-10">
+  <div class="mb-8">
+    <h1 class="text-2xl font-bold text-neutral-900">{% if form.instance.pk %}Editar Template{% else %}Cadastrar Template{% endif %}</h1>
+  </div>
+  {% if messages %}
+  <div class="mb-4 space-y-2">
+    {% for message in messages %}
+      <p class="rounded-xl px-4 py-2 text-sm {{ message.tags == 'success'|yesno:'bg-green-100 text-green-700,bg-red-100 text-red-700' }}">{{ message }}</p>
+    {% endfor %}
+  </div>
+  {% endif %}
+  <form method="post" class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 space-y-6">
+    {% csrf_token %}
+    <div>
+      <label for="{{ form.codigo.id_for_label }}" class="block text-sm font-medium text-neutral-700 mb-1">Código</label>
+      {% if form.instance.pk %}
+        {{ form.codigo|add_class:'form-input'|attr:'readonly' }}
+      {% else %}
+        {{ form.codigo|add_class:'form-input' }}
+      {% endif %}
+      {% if form.codigo.errors %}<p class="text-sm text-red-600 mt-1">{{ form.codigo.errors.0 }}</p>{% endif %}
+    </div>
+    <div>
+      <label for="{{ form.assunto.id_for_label }}" class="block text-sm font-medium text-neutral-700 mb-1">Assunto</label>
+      {{ form.assunto|add_class:'form-input' }}
+      {% if form.assunto.errors %}<p class="text-sm text-red-600 mt-1">{{ form.assunto.errors.0 }}</p>{% endif %}
+    </div>
+    <div>
+      <label for="{{ form.corpo.id_for_label }}" class="block text-sm font-medium text-neutral-700 mb-1">Corpo</label>
+      {{ form.corpo|add_class:'form-textarea' }}
+      {% if form.corpo.errors %}<p class="text-sm text-red-600 mt-1">{{ form.corpo.errors.0 }}</p>{% endif %}
+    </div>
+    <div>
+      <label for="{{ form.canal.id_for_label }}" class="block text-sm font-medium text-neutral-700 mb-1">Canal</label>
+      {{ form.canal|add_class:'form-select' }}
+      {% if form.canal.errors %}<p class="text-sm text-red-600 mt-1">{{ form.canal.errors.0 }}</p>{% endif %}
+    </div>
+    <div class="flex items-center gap-2">
+      {{ form.ativo }}
+      <label for="{{ form.ativo.id_for_label }}" class="text-sm text-neutral-700">Ativo</label>
+    </div>
+    <div class="flex justify-end gap-3 pt-4 border-t border-neutral-100">
+      <a href="{% url 'notificacoes:templates_list' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100">Cancelar</a>
+      <button type="submit" class="text-sm px-4 py-2 rounded-xl bg-primary-600 text-white hover:bg-primary-700">Salvar</button>
+    </div>
+  </form>
+</div>
+{% endblock %}

--- a/notificacoes/templates/notificacoes/templates_list.html
+++ b/notificacoes/templates/notificacoes/templates_list.html
@@ -1,0 +1,52 @@
+{% extends 'base.html' %}
+{% block title %}Templates de Notificação | HubX{% endblock %}
+{% block content %}
+<div class="max-w-6xl mx-auto px-4 py-10">
+  <div class="flex items-center justify-between mb-8">
+    <div>
+      <h1 class="text-2xl font-bold text-neutral-900">Templates de Notificação</h1>
+      <p class="text-sm text-neutral-600">Gerencie as mensagens utilizadas nos envios.</p>
+    </div>
+    <a href="{% url 'notificacoes:template_create' %}" class="inline-flex items-center gap-2 bg-primary-600 text-white text-sm px-4 py-2 rounded-xl hover:bg-primary-700">
+      <span class="text-xl leading-none">+</span> Novo Template
+    </a>
+  </div>
+  {% if messages %}
+  <div class="mb-4 space-y-2">
+    {% for message in messages %}
+      <p class="rounded-xl px-4 py-2 text-sm {{ message.tags == 'success'|yesno:'bg-green-100 text-green-700,bg-red-100 text-red-700' }}">{{ message }}</p>
+    {% endfor %}
+  </div>
+  {% endif %}
+  {% if templates %}
+  <div class="overflow-x-auto bg-white border border-neutral-200 rounded-2xl shadow-sm">
+    <table class="min-w-full divide-y divide-neutral-200 text-sm">
+      <thead class="bg-neutral-50">
+        <tr>
+          <th class="px-4 py-2 text-left font-medium text-neutral-700">Código</th>
+          <th class="px-4 py-2 text-left font-medium text-neutral-700">Assunto</th>
+          <th class="px-4 py-2 text-left font-medium text-neutral-700">Canal</th>
+          <th class="px-4 py-2 text-left font-medium text-neutral-700">Ativo</th>
+          <th class="px-4 py-2 text-left font-medium text-neutral-700">Ações</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-neutral-200" id="templates_table">
+        {% for tpl in templates %}
+        <tr>
+          <td class="px-4 py-2 font-mono">{{ tpl.codigo }}</td>
+          <td class="px-4 py-2">{{ tpl.assunto }}</td>
+          <td class="px-4 py-2">{{ tpl.get_canal_display }}</td>
+          <td class="px-4 py-2">{{ tpl.ativo|yesno:'Sim,Não' }}</td>
+          <td class="px-4 py-2">
+            <a href="{% url 'notificacoes:template_edit' tpl.codigo %}" class="text-sm text-primary-600 hover:underline">Editar</a>
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  {% else %}
+    <p class="text-center text-neutral-600">Nenhum template cadastrado.</p>
+  {% endif %}
+</div>
+{% endblock %}

--- a/notificacoes/urls.py
+++ b/notificacoes/urls.py
@@ -1,0 +1,13 @@
+from django.urls import path
+
+from . import views
+
+app_name = "notificacoes"
+
+urlpatterns = [
+    path("templates/", views.list_templates, name="templates_list"),
+    path("templates/novo/", views.create_template, name="template_create"),
+    path("templates/<slug:codigo>/editar/", views.edit_template, name="template_edit"),
+    path("logs/", views.list_logs, name="logs_list"),
+    path("preferencias/", views.editar_preferencias, name="editar_preferencias"),
+]

--- a/notificacoes/views.py
+++ b/notificacoes/views.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from django.contrib import messages
+from django.contrib.admin.views.decorators import staff_member_required
+from django.contrib.auth.decorators import login_required, permission_required
+from django.core.paginator import Paginator
+from django.shortcuts import get_object_or_404, redirect, render
+
+from .forms import NotificationTemplateForm, UserNotificationPreferenceForm
+from .models import Canal, NotificationLog, NotificationStatus, NotificationTemplate, UserNotificationPreference
+
+
+@login_required
+@permission_required("notificacoes.change_notificationtemplate", raise_exception=True)
+def list_templates(request):
+    templates = NotificationTemplate.objects.all()
+    return render(request, "notificacoes/templates_list.html", {"templates": templates})
+
+
+@login_required
+@permission_required("notificacoes.change_notificationtemplate", raise_exception=True)
+def create_template(request):
+    if request.method == "POST":
+        form = NotificationTemplateForm(request.POST)
+        if form.is_valid():
+            form.save()
+            messages.success(request, "Template criado com sucesso.")
+            return redirect("notificacoes:templates_list")
+    else:
+        form = NotificationTemplateForm()
+    return render(request, "notificacoes/template_form.html", {"form": form})
+
+
+@login_required
+@permission_required("notificacoes.change_notificationtemplate", raise_exception=True)
+def edit_template(request, codigo: str):
+    template = get_object_or_404(NotificationTemplate, codigo=codigo)
+    if request.method == "POST":
+        form = NotificationTemplateForm(request.POST, instance=template)
+        if form.is_valid():
+            form.save()
+            messages.success(request, "Template atualizado com sucesso.")
+            return redirect("notificacoes:templates_list")
+    else:
+        form = NotificationTemplateForm(instance=template)
+    return render(request, "notificacoes/template_form.html", {"form": form, "template": template})
+
+
+@login_required
+@staff_member_required
+def list_logs(request):
+    logs = NotificationLog.objects.select_related("user", "template").order_by("-data_envio")
+    inicio = request.GET.get("inicio")
+    fim = request.GET.get("fim")
+    canal = request.GET.get("canal")
+    status = request.GET.get("status")
+    if inicio:
+        logs = logs.filter(data_envio__date__gte=inicio)
+    if fim:
+        logs = logs.filter(data_envio__date__lte=fim)
+    if canal in Canal.values:
+        logs = logs.filter(canal=canal)
+    if status in NotificationStatus.values:
+        logs = logs.filter(status=status)
+
+    paginator = Paginator(logs, 20)
+    page_obj = paginator.get_page(request.GET.get("page"))
+
+    context = {"logs": page_obj}
+    if request.headers.get("HX-Request"):
+        context["partial"] = True
+    return render(request, "notificacoes/logs_list.html", context)
+
+
+@login_required
+def editar_preferencias(request):
+    pref, _ = UserNotificationPreference.objects.get_or_create(user=request.user)
+    if request.method == "POST":
+        form = UserNotificationPreferenceForm(request.POST, instance=pref)
+        if form.is_valid():
+            form.save()
+            messages.success(request, "Preferências salvas com sucesso.")
+            return redirect("notificacoes:editar_preferencias")
+    else:
+        form = UserNotificationPreferenceForm(instance=pref)
+    return render(request, "notificacoes/preferencias.html", {"form": form})


### PR DESCRIPTION
## Motivação
Adicionar páginas web para administração de templates e logs de notificações, bem como preferências individuais de usuários.

## O que foi feito
- Criadas views e formulários (`NotificationTemplateForm` e `UserNotificationPreferenceForm`)
- Novos templates HTML utilizando Tailwind e HTMX
- Rotas adicionadas em `notificacoes/urls.py` e registradas em `Hubx/urls.py`
- Listagem paginada de logs com filtros dinâmicos via HTMX
- Página de preferências para usuários autenticados

## Rotas afetadas
- `/notificacoes/templates/`
- `/notificacoes/templates/novo/`
- `/notificacoes/templates/<codigo>/editar/`
- `/notificacoes/logs/`
- `/notificacoes/preferencias/`

## Riscos e rollback
Mudanças isoladas no app `notificacoes`; basta reverter o commit para remover a funcionalidade.

------
https://chatgpt.com/codex/tasks/task_e_6889690f76588325af392a5ad401b1bc