### PR TITLE
refactor: padroniza templates diversos

### DIFF
--- a/agenda/templates/agenda/briefing_list.html
+++ b/agenda/templates/agenda/briefing_list.html
@@ -1,32 +1,50 @@
 {% extends "base.html" %}
+
+{% block title %}Briefings | Hubx{% endblock %}
+
 {% block content %}
-<section>
-    <h1>Briefings de Eventos</h1>
-    <table>
-        <thead>
-            <tr>
-                <th>Evento</th>
-                <th>Objetivos</th>
-                <th>Público Alvo</th>
-                <th>Requisitos Técnicos</th>
-                <th>Cronograma Resumido</th>
-                <th>Conteúdo Programático</th>
-                <th>Observações</th>
-            </tr>
-        </thead>
-        <tbody>
-            {% for briefing in briefings %}
-            <tr>
-                <td>{{ briefing.evento }}</td>
-                <td>{{ briefing.objetivos }}</td>
-                <td>{{ briefing.publico_alvo }}</td>
-                <td>{{ briefing.requisitos_tecnicos }}</td>
-                <td>{{ briefing.cronograma_resumido }}</td>
-                <td>{{ briefing.conteudo_programatico }}</td>
-                <td>{{ briefing.observacoes }}</td>
-            </tr>
-            {% endfor %}
-        </tbody>
+<section class="max-w-7xl mx-auto px-4 py-10">
+  <h1 class="text-2xl font-bold text-neutral-900 mb-6">Briefings de Eventos</h1>
+
+  {% if messages %}
+    <div class="mb-4 space-y-2">
+      {% for message in messages %}
+        <p class="rounded-xl px-4 py-2 text-sm {{ message.tags == 'success'|yesno:'bg-green-100 text-green-700,bg-red-100 text-red-700' }}">{{ message }}</p>
+      {% endfor %}
+    </div>
+  {% endif %}
+
+  <div class="overflow-x-auto bg-white border border-neutral-200 rounded-2xl shadow-sm">
+    <table class="min-w-full divide-y divide-neutral-200 table-auto text-sm">
+      <thead class="bg-neutral-50">
+        <tr>
+          <th class="px-4 py-2 text-left font-semibold text-neutral-700">Evento</th>
+          <th class="px-4 py-2 text-left font-semibold text-neutral-700">Objetivos</th>
+          <th class="px-4 py-2 text-left font-semibold text-neutral-700">Público Alvo</th>
+          <th class="px-4 py-2 text-left font-semibold text-neutral-700">Requisitos Técnicos</th>
+          <th class="px-4 py-2 text-left font-semibold text-neutral-700">Cronograma Resumido</th>
+          <th class="px-4 py-2 text-left font-semibold text-neutral-700">Conteúdo Programático</th>
+          <th class="px-4 py-2 text-left font-semibold text-neutral-700">Observações</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-neutral-200">
+        {% for briefing in briefings %}
+          <tr>
+            <td class="px-4 py-2">{{ briefing.evento }}</td>
+            <td class="px-4 py-2">{{ briefing.objetivos }}</td>
+            <td class="px-4 py-2">{{ briefing.publico_alvo }}</td>
+            <td class="px-4 py-2">{{ briefing.requisitos_tecnicos }}</td>
+            <td class="px-4 py-2">{{ briefing.cronograma_resumido }}</td>
+            <td class="px-4 py-2">{{ briefing.conteudo_programatico }}</td>
+            <td class="px-4 py-2">{{ briefing.observacoes }}</td>
+          </tr>
+        {% empty %}
+          <tr>
+            <td colspan="7" class="px-4 py-4 text-center text-neutral-500">Nenhum briefing encontrado.</td>
+          </tr>
+        {% endfor %}
+      </tbody>
     </table>
+  </div>
 </section>
 {% endblock %}

--- a/agenda/templates/agenda/inscricao_list.html
+++ b/agenda/templates/agenda/inscricao_list.html
@@ -1,34 +1,52 @@
 {% extends "base.html" %}
+
+{% block title %}Inscrições | Hubx{% endblock %}
+
 {% block content %}
-<section>
-    <h1>Lista de Inscrições</h1>
-    <table>
-        <thead>
-            <tr>
-                <th>Usuário</th>
-                <th>Evento</th>
-                <th>Status</th>
-                <th>Presente</th>
-                <th>Avaliação</th>
-                <th>Valor Pago</th>
-                <th>Método de Pagamento</th>
-                <th>Observação</th>
-            </tr>
-        </thead>
-        <tbody>
-            {% for inscricao in inscricoes %}
-            <tr>
-                <td>{{ inscricao.user }}</td>
-                <td>{{ inscricao.evento }}</td>
-                <td>{{ inscricao.get_status_display }}</td>
-                <td>{{ inscricao.presente }}</td>
-                <td>{{ inscricao.avaliacao }}</td>
-                <td>{{ inscricao.valor_pago }}</td>
-                <td>{{ inscricao.get_metodo_pagamento_display }}</td>
-                <td>{{ inscricao.observacao }}</td>
-            </tr>
-            {% endfor %}
-        </tbody>
+<section class="max-w-7xl mx-auto px-4 py-10">
+  <h1 class="text-2xl font-bold text-neutral-900 mb-6">Lista de Inscrições</h1>
+
+  {% if messages %}
+    <div class="mb-4 space-y-2">
+      {% for message in messages %}
+        <p class="rounded-xl px-4 py-2 text-sm {{ message.tags == 'success'|yesno:'bg-green-100 text-green-700,bg-red-100 text-red-700' }}">{{ message }}</p>
+      {% endfor %}
+    </div>
+  {% endif %}
+
+  <div class="overflow-x-auto bg-white border border-neutral-200 rounded-2xl shadow-sm">
+    <table class="min-w-full divide-y divide-neutral-200 table-auto text-sm">
+      <thead class="bg-neutral-50">
+        <tr>
+          <th class="px-4 py-2 text-left font-semibold text-neutral-700">Usuário</th>
+          <th class="px-4 py-2 text-left font-semibold text-neutral-700">Evento</th>
+          <th class="px-4 py-2 text-left font-semibold text-neutral-700">Status</th>
+          <th class="px-4 py-2 text-left font-semibold text-neutral-700">Presente</th>
+          <th class="px-4 py-2 text-left font-semibold text-neutral-700">Avaliação</th>
+          <th class="px-4 py-2 text-left font-semibold text-neutral-700">Valor Pago</th>
+          <th class="px-4 py-2 text-left font-semibold text-neutral-700">Método de Pagamento</th>
+          <th class="px-4 py-2 text-left font-semibold text-neutral-700">Observação</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-neutral-200">
+        {% for inscricao in inscricoes %}
+          <tr>
+            <td class="px-4 py-2">{{ inscricao.user }}</td>
+            <td class="px-4 py-2">{{ inscricao.evento }}</td>
+            <td class="px-4 py-2">{{ inscricao.get_status_display }}</td>
+            <td class="px-4 py-2">{{ inscricao.presente }}</td>
+            <td class="px-4 py-2">{{ inscricao.avaliacao }}</td>
+            <td class="px-4 py-2">{{ inscricao.valor_pago }}</td>
+            <td class="px-4 py-2">{{ inscricao.get_metodo_pagamento_display }}</td>
+            <td class="px-4 py-2">{{ inscricao.observacao }}</td>
+          </tr>
+        {% empty %}
+          <tr>
+            <td colspan="8" class="px-4 py-4 text-center text-neutral-500">Nenhuma inscrição encontrada.</td>
+          </tr>
+        {% endfor %}
+      </tbody>
     </table>
+  </div>
 </section>
 {% endblock %}

--- a/agenda/templates/agenda/material_list.html
+++ b/agenda/templates/agenda/material_list.html
@@ -1,18 +1,32 @@
 {% extends "base.html" %}
+
+{% block title %}Materiais de Divulgação | Hubx{% endblock %}
+
 {% block content %}
-<section>
-    <h1>Materiais de Divulgação</h1>
-    <div class="grid grid-cols-3 gap-4">
-        {% for material in materiais %}
-        <article>
-            <h2>{{ material.titulo }}</h2>
-            <p>{{ material.descricao }}</p>
-            {% if material.imagem_thumb %}
-            <img src="{{ material.imagem_thumb.url }}" alt="{{ material.titulo }}">
-            {% endif %}
-            <a href="{{ material.arquivo.url }}">Download</a>
-        </article>
-        {% endfor %}
+<section class="max-w-7xl mx-auto px-4 py-10">
+  <h1 class="text-2xl font-bold text-neutral-900 mb-6">Materiais de Divulgação</h1>
+
+  {% if messages %}
+    <div class="mb-4 space-y-2">
+      {% for message in messages %}
+        <p class="rounded-xl px-4 py-2 text-sm {{ message.tags == 'success'|yesno:'bg-green-100 text-green-700,bg-red-100 text-red-700' }}">{{ message }}</p>
+      {% endfor %}
     </div>
+  {% endif %}
+
+  <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+    {% for material in materiais %}
+      <article class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-5 flex flex-col">
+        <h2 class="text-lg font-semibold text-neutral-900 mb-2">{{ material.titulo }}</h2>
+        <p class="text-sm text-neutral-600 mb-4">{{ material.descricao }}</p>
+        {% if material.imagem_thumb %}
+          <img src="{{ material.imagem_thumb.url }}" alt="{{ material.titulo }}" class="mb-4 rounded-xl object-cover">
+        {% endif %}
+        <a href="{{ material.arquivo.url }}" class="mt-auto text-sm text-blue-600 hover:underline">Download</a>
+      </article>
+    {% empty %}
+      <p class="text-neutral-500">Nenhum material disponível.</p>
+    {% endfor %}
+  </div>
 </section>
 {% endblock %}

--- a/core/templates/core/home.html
+++ b/core/templates/core/home.html
@@ -1,4 +1,29 @@
-{% extends 'base.html' %} {% block title %}Página Inicial{% endblock %} {% block content %}
-<h2>Bem-vindo ao Hubx!</h2>
-<p>Uma plataforma para conectar organizações, empresas e pessoas.</p>
+{% extends 'base.html' %}
+
+{% block title %}Página Inicial{% endblock %}
+
+{% block content %}
+<section class="max-w-7xl mx-auto px-4 py-10 text-center">
+  <h1 class="text-3xl font-bold text-neutral-900 mb-4">Bem-vindo ao Hubx!</h1>
+  <p class="text-neutral-600 mb-10">Uma plataforma colaborativa para conectar organizações, empresas e pessoas.</p>
+
+  <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+    <a href="{% url 'feed:listar' %}" class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 hover:bg-neutral-50">
+      <h2 class="text-lg font-semibold text-primary mb-2">Mural e Feed</h2>
+      <p class="text-sm text-neutral-600">Compartilhe novidades e acompanhe atualizações.</p>
+    </a>
+    <a href="{% url 'agenda:calendario' %}" class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 hover:bg-neutral-50">
+      <h2 class="text-lg font-semibold text-primary mb-2">Agenda</h2>
+      <p class="text-sm text-neutral-600">Organize eventos e gerencie inscrições.</p>
+    </a>
+    <a href="{% url 'nucleos:list' %}" class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 hover:bg-neutral-50">
+      <h2 class="text-lg font-semibold text-primary mb-2">Núcleos</h2>
+      <p class="text-sm text-neutral-600">Encontre grupos de interesse e colabore.</p>
+    </a>
+    <a href="{% url 'dashboard:dashboard' %}" class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 hover:bg-neutral-50">
+      <h2 class="text-lg font-semibold text-primary mb-2">Dashboard</h2>
+      <p class="text-sm text-neutral-600">Acompanhe métricas e atividades da sua conta.</p>
+    </a>
+  </div>
+</section>
 {% endblock %}

--- a/organizacoes/templates/organizacoes/update.html
+++ b/organizacoes/templates/organizacoes/update.html
@@ -1,5 +1,83 @@
-{% extends 'organizacoes/create.html' %}
+{% extends 'base.html' %}
 
 {% block title %}Editar Organização | Hubx{% endblock %}
 
-{% block form_title %}Editar Organização{% endblock %}
+{% block content %}
+<section class="max-w-2xl mx-auto px-4 py-10">
+  <div class="mb-6 flex items-center gap-4">
+    <a href="{% url 'organizacoes:list' %}" class="inline-flex items-center text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100">
+      <svg class="mr-2" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+        <polyline points="15,18 9,12 15,6" />
+      </svg>
+      Voltar
+    </a>
+    <h1 class="text-2xl font-bold text-neutral-900">Editar Organização</h1>
+  </div>
+
+  {% if messages %}
+  <div class="mb-4 space-y-2">
+    {% for message in messages %}
+      <p class="rounded-xl px-4 py-2 text-sm {{ message.tags == 'success'|yesno:'bg-green-100 text-green-700,bg-red-100 text-red-700' }}">{{ message }}</p>
+    {% endfor %}
+  </div>
+  {% endif %}
+
+  <form method="post" enctype="multipart/form-data" class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 space-y-6">
+    {% csrf_token %}
+
+    <div class="grid md:grid-cols-2 gap-6">
+      <div>
+        <label for="{{ form.nome.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.nome.label }}</label>
+        {{ form.nome }}
+        {% if form.nome.errors %}
+          <p class="text-red-500 text-xs mt-1">{{ form.nome.errors }}</p>
+        {% endif %}
+      </div>
+      <div>
+        <label for="{{ form.cnpj.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.cnpj.label }}</label>
+        {{ form.cnpj }}
+        {% if form.cnpj.errors %}
+          <p class="text-red-500 text-xs mt-1">{{ form.cnpj.errors }}</p>
+        {% endif %}
+      </div>
+    </div>
+
+    <div>
+      <label for="{{ form.descricao.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.descricao.label }}</label>
+      {{ form.descricao }}
+      {% if form.descricao.errors %}
+        <p class="text-red-500 text-xs mt-1">{{ form.descricao.errors }}</p>
+      {% endif %}
+    </div>
+
+    <div>
+      <label for="{{ form.slug.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.slug.label }}</label>
+      {{ form.slug }}
+      {% if form.slug.errors %}
+        <p class="text-red-500 text-xs mt-1">{{ form.slug.errors }}</p>
+      {% endif %}
+    </div>
+
+    <div>
+      <label for="{{ form.avatar.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.avatar.label }}</label>
+      {{ form.avatar }}
+      {% if form.avatar.errors %}
+        <p class="text-red-500 text-xs mt-1">{{ form.avatar.errors }}</p>
+      {% endif %}
+    </div>
+
+    <div>
+      <label for="{{ form.cover.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.cover.label }}</label>
+      {{ form.cover }}
+      {% if form.cover.errors %}
+        <p class="text-red-500 text-xs mt-1">{{ form.cover.errors }}</p>
+      {% endif %}
+    </div>
+
+    <div class="flex justify-end gap-3 pt-4 border-t border-neutral-100">
+      <a href="{% url 'organizacoes:list' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100">Cancelar</a>
+      <button type="submit" class="text-sm px-4 py-2 rounded-xl bg-primary-600 text-white hover:bg-primary-700">Salvar</button>
+    </div>
+  </form>
+</section>
+{% endblock %}


### PR DESCRIPTION
## Summary
- refatora páginas listando briefings, inscrições e materiais
- ajusta home em layout de landing page
- recria formulário de edição de organização

## Testing
- `ruff check .` *(fails: E402, I001, F401 etc.)*
- `black --check .` *(fails: would reformat multiple files)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68896d7abe688325924ea5da30822ef2