### PR TITLE
feat: ajustar templates e views de notificacoes

### DIFF
--- a/notificacoes/templates/notificacoes/logs_list.html
+++ b/notificacoes/templates/notificacoes/logs_list.html
@@ -1,76 +1,64 @@
-{% if partial %}
-  {% for log in logs %}
-  <tr>
-    <td class="px-4 py-2">{{ log.data_envio|date:'d/m/Y H:i' }}</td>
-    <td class="px-4 py-2">{{ log.user.get_full_name|default:log.user.username }}</td>
-    <td class="px-4 py-2">{{ log.template.codigo }}</td>
-    <td class="px-4 py-2">{{ log.get_canal_display }}</td>
-    <td class="px-4 py-2">{{ log.get_status_display }}</td>
-    <td class="px-4 py-2 text-sm">{{ log.erro|default:'-' }}</td>
-  </tr>
-  {% endfor %}
-{% else %}
 {% extends 'base.html' %}
-{% block title %}Logs de Notificação | HubX{% endblock %}
+{% load i18n %}
+{% block title %}{% trans 'Logs de Notificação' %} | HubX{% endblock %}
 {% block content %}
 <div class="max-w-6xl mx-auto px-4 py-10">
   <div class="mb-8">
-    <h1 class="text-2xl font-bold text-neutral-900">Logs de Notificação</h1>
+    <h1 class="text-2xl font-bold text-neutral-900">{% trans 'Logs de Notificação' %}</h1>
   </div>
   <form method="get" class="bg-white border border-neutral-200 p-6 rounded-2xl shadow-sm mb-6 flex flex-col sm:flex-row gap-4 sm:items-end">
     <div>
-      <label for="inicio" class="block text-sm font-medium text-neutral-700 mb-1">De</label>
+      <label for="inicio" class="block text-sm font-medium text-neutral-700 mb-1">{% trans 'De' %}</label>
       <input type="date" name="inicio" id="inicio" value="{{ request.GET.inicio }}" class="form-input" hx-get="{% url 'notificacoes:logs_list' %}" hx-target="#tabela_logs" hx-include="closest form">
     </div>
     <div>
-      <label for="fim" class="block text-sm font-medium text-neutral-700 mb-1">Até</label>
+      <label for="fim" class="block text-sm font-medium text-neutral-700 mb-1">{% trans 'Até' %}</label>
       <input type="date" name="fim" id="fim" value="{{ request.GET.fim }}" class="form-input" hx-get="{% url 'notificacoes:logs_list' %}" hx-target="#tabela_logs" hx-include="closest form">
     </div>
     <div>
-      <label for="canal" class="block text-sm font-medium text-neutral-700 mb-1">Canal</label>
+      <label for="canal" class="block text-sm font-medium text-neutral-700 mb-1">{% trans 'Canal' %}</label>
       <select name="canal" id="canal" class="form-select" hx-get="{% url 'notificacoes:logs_list' %}" hx-target="#tabela_logs" hx-include="closest form">
-        <option value="" {% if not request.GET.canal %}selected{% endif %}>Todos</option>
+        <option value="" {% if not request.GET.canal %}selected{% endif %}>{% trans 'Todos' %}</option>
         <option value="email" {% if request.GET.canal == 'email' %}selected{% endif %}>E-mail</option>
         <option value="push" {% if request.GET.canal == 'push' %}selected{% endif %}>Push</option>
         <option value="whatsapp" {% if request.GET.canal == 'whatsapp' %}selected{% endif %}>WhatsApp</option>
       </select>
     </div>
     <div>
-      <label for="status" class="block text-sm font-medium text-neutral-700 mb-1">Status</label>
+      <label for="status" class="block text-sm font-medium text-neutral-700 mb-1">{% trans 'Status' %}</label>
       <select name="status" id="status" class="form-select" hx-get="{% url 'notificacoes:logs_list' %}" hx-target="#tabela_logs" hx-include="closest form">
-        <option value="" {% if not request.GET.status %}selected{% endif %}>Todos</option>
-        <option value="enviada" {% if request.GET.status == 'enviada' %}selected{% endif %}>Enviada</option>
-        <option value="falha" {% if request.GET.status == 'falha' %}selected{% endif %}>Falha</option>
+        <option value="" {% if not request.GET.status %}selected{% endif %}>{% trans 'Todos' %}</option>
+        <option value="enviada" {% if request.GET.status == 'enviada' %}selected{% endif %}>{% trans 'Enviada' %}</option>
+        <option value="falha" {% if request.GET.status == 'falha' %}selected{% endif %}>{% trans 'Falha' %}</option>
       </select>
     </div>
-    <noscript><button type="submit" class="mt-2 sm:mt-0 bg-neutral-200 text-neutral-800 px-4 py-2 rounded-xl text-sm hover:bg-neutral-300">Filtrar</button></noscript>
+    <noscript><button type="submit" class="mt-2 sm:mt-0 bg-neutral-200 text-neutral-800 px-4 py-2 rounded-xl text-sm hover:bg-neutral-300">{% trans 'Filtrar' %}</button></noscript>
   </form>
   <div class="overflow-x-auto bg-white border border-neutral-200 rounded-2xl shadow-sm">
     <table class="min-w-full divide-y divide-neutral-200 text-sm">
       <thead class="bg-neutral-50">
         <tr>
-          <th class="px-4 py-2 text-left font-medium text-neutral-700">Data</th>
-          <th class="px-4 py-2 text-left font-medium text-neutral-700">Usuário</th>
-          <th class="px-4 py-2 text-left font-medium text-neutral-700">Template</th>
-          <th class="px-4 py-2 text-left font-medium text-neutral-700">Canal</th>
-          <th class="px-4 py-2 text-left font-medium text-neutral-700">Status</th>
-          <th class="px-4 py-2 text-left font-medium text-neutral-700">Erro</th>
+          <th class="px-4 py-2 text-left font-medium text-neutral-700">{% trans 'Data' %}</th>
+          <th class="px-4 py-2 text-left font-medium text-neutral-700">{% trans 'Usuário' %}</th>
+          <th class="px-4 py-2 text-left font-medium text-neutral-700">{% trans 'Template' %}</th>
+          <th class="px-4 py-2 text-left font-medium text-neutral-700">{% trans 'Canal' %}</th>
+          <th class="px-4 py-2 text-left font-medium text-neutral-700">{% trans 'Status' %}</th>
+          <th class="px-4 py-2 text-left font-medium text-neutral-700">{% trans 'Erro' %}</th>
         </tr>
       </thead>
       <tbody id="tabela_logs" class="divide-y divide-neutral-200">
-        {% include 'notificacoes/logs_list.html' with partial=True only %}
+        {% include 'notificacoes/logs_rows.html' %}
       </tbody>
     </table>
   </div>
   <div class="mt-4 flex justify-center gap-3">
     {% if logs.has_previous %}
-      <a hx-get="?page={{ logs.previous_page_number }}&{{ request.GET.urlencode }}" hx-target="#tabela_logs" hx-include="closest form" class="px-3 py-1 rounded-xl border border-neutral-300 text-sm">Anterior</a>
+      <a hx-get="?page={{ logs.previous_page_number }}&{{ request.GET.urlencode }}" hx-target="#tabela_logs" hx-include="closest form" class="px-3 py-1 rounded-xl border border-neutral-300 text-sm">{% trans 'Anterior' %}</a>
     {% endif %}
-    <span class="px-3 py-1 text-sm">Página {{ logs.number }} de {{ logs.paginator.num_pages }}</span>
+    <span class="px-3 py-1 text-sm">{% blocktrans %}Página {{ logs.number }} de {{ logs.paginator.num_pages }}{% endblocktrans %}</span>
     {% if logs.has_next %}
-      <a hx-get="?page={{ logs.next_page_number }}&{{ request.GET.urlencode }}" hx-target="#tabela_logs" hx-include="closest form" class="px-3 py-1 rounded-xl border border-neutral-300 text-sm">Próxima</a>
+      <a hx-get="?page={{ logs.next_page_number }}&{{ request.GET.urlencode }}" hx-target="#tabela_logs" hx-include="closest form" class="px-3 py-1 rounded-xl border border-neutral-300 text-sm">{% trans 'Próxima' %}</a>
     {% endif %}
   </div>
 </div>
 {% endblock %}
-{% endif %}

--- a/notificacoes/templates/notificacoes/logs_rows.html
+++ b/notificacoes/templates/notificacoes/logs_rows.html
@@ -1,0 +1,10 @@
+{% for log in logs %}
+  <tr>
+    <td class="px-4 py-2">{{ log.data_envio|date:'d/m/Y H:i' }}</td>
+    <td class="px-4 py-2">{{ log.user.get_full_name|default:log.user.username }}</td>
+    <td class="px-4 py-2">{{ log.template.codigo }}</td>
+    <td class="px-4 py-2">{{ log.get_canal_display }}</td>
+    <td class="px-4 py-2">{{ log.get_status_display }}</td>
+    <td class="px-4 py-2 text-sm">{{ log.erro|default:'-' }}</td>
+  </tr>
+{% endfor %}

--- a/notificacoes/templates/notificacoes/preferencias.html
+++ b/notificacoes/templates/notificacoes/preferencias.html
@@ -1,9 +1,10 @@
 {% extends 'base.html' %}
 {% load widget_tweaks %}
-{% block title %}Preferências de Notificação | HubX{% endblock %}
+{% load i18n %}
+{% block title %}{% trans 'Preferências de Notificação' %} | HubX{% endblock %}
 {% block content %}
 <div class="max-w-md mx-auto px-4 py-10">
-  <h1 class="text-2xl font-bold mb-6">Preferências de Notificação</h1>
+  <h1 class="text-2xl font-bold mb-6">{% trans 'Preferências de Notificação' %}</h1>
   {% if messages %}
   <div class="mb-4 space-y-2">
     {% for message in messages %}
@@ -15,18 +16,18 @@
     {% csrf_token %}
     <div class="flex items-center">
       {{ form.email|add_class:'form-checkbox' }}
-      <label for="{{ form.email.id_for_label }}" class="ml-2 text-sm font-medium">E-mail</label>
+      <label for="{{ form.email.id_for_label }}" class="ml-2 text-sm font-medium">{% trans 'E-mail' %}</label>
     </div>
     <div class="flex items-center">
       {{ form.push|add_class:'form-checkbox' }}
-      <label for="{{ form.push.id_for_label }}" class="ml-2 text-sm font-medium">Push</label>
+      <label for="{{ form.push.id_for_label }}" class="ml-2 text-sm font-medium">{% trans 'Push' %}</label>
     </div>
     <div class="flex items-center">
       {{ form.whatsapp|add_class:'form-checkbox' }}
-      <label for="{{ form.whatsapp.id_for_label }}" class="ml-2 text-sm font-medium">WhatsApp</label>
+      <label for="{{ form.whatsapp.id_for_label }}" class="ml-2 text-sm font-medium">{% trans 'WhatsApp' %}</label>
     </div>
     <div class="text-right pt-4 border-t border-neutral-100">
-      <button type="submit" class="bg-primary text-white px-4 py-2 rounded-xl hover:bg-primary/90">Salvar</button>
+      <button type="submit" class="bg-primary text-white px-4 py-2 rounded-xl hover:bg-primary/90">{% trans 'Salvar' %}</button>
     </div>
   </form>
 </div>

--- a/notificacoes/templates/notificacoes/template_form.html
+++ b/notificacoes/templates/notificacoes/template_form.html
@@ -1,10 +1,11 @@
 {% extends 'base.html' %}
 {% load widget_tweaks %}
-{% block title %}{% if form.instance.pk %}Editar Template{% else %}Novo Template{% endif %} | HubX{% endblock %}
+{% load i18n %}
+{% block title %}{% if form.instance.pk %}{% trans 'Editar Template' %}{% else %}{% trans 'Novo Template' %}{% endif %} | HubX{% endblock %}
 {% block content %}
 <div class="max-w-xl mx-auto px-4 py-10">
   <div class="mb-8">
-    <h1 class="text-2xl font-bold text-neutral-900">{% if form.instance.pk %}Editar Template{% else %}Cadastrar Template{% endif %}</h1>
+    <h1 class="text-2xl font-bold text-neutral-900">{% if form.instance.pk %}{% trans 'Editar Template' %}{% else %}{% trans 'Cadastrar Template' %}{% endif %}</h1>
   </div>
   {% if messages %}
   <div class="mb-4 space-y-2">
@@ -16,7 +17,7 @@
   <form method="post" class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 space-y-6">
     {% csrf_token %}
     <div>
-      <label for="{{ form.codigo.id_for_label }}" class="block text-sm font-medium text-neutral-700 mb-1">Código</label>
+      <label for="{{ form.codigo.id_for_label }}" class="block text-sm font-medium text-neutral-700 mb-1">{% trans 'Código' %}</label>
       {% if form.instance.pk %}
         {{ form.codigo|add_class:'form-input'|attr:'readonly' }}
       {% else %}
@@ -25,27 +26,27 @@
       {% if form.codigo.errors %}<p class="text-sm text-red-600 mt-1">{{ form.codigo.errors.0 }}</p>{% endif %}
     </div>
     <div>
-      <label for="{{ form.assunto.id_for_label }}" class="block text-sm font-medium text-neutral-700 mb-1">Assunto</label>
+      <label for="{{ form.assunto.id_for_label }}" class="block text-sm font-medium text-neutral-700 mb-1">{% trans 'Assunto' %}</label>
       {{ form.assunto|add_class:'form-input' }}
       {% if form.assunto.errors %}<p class="text-sm text-red-600 mt-1">{{ form.assunto.errors.0 }}</p>{% endif %}
     </div>
     <div>
-      <label for="{{ form.corpo.id_for_label }}" class="block text-sm font-medium text-neutral-700 mb-1">Corpo</label>
+      <label for="{{ form.corpo.id_for_label }}" class="block text-sm font-medium text-neutral-700 mb-1">{% trans 'Corpo' %}</label>
       {{ form.corpo|add_class:'form-textarea' }}
       {% if form.corpo.errors %}<p class="text-sm text-red-600 mt-1">{{ form.corpo.errors.0 }}</p>{% endif %}
     </div>
     <div>
-      <label for="{{ form.canal.id_for_label }}" class="block text-sm font-medium text-neutral-700 mb-1">Canal</label>
+      <label for="{{ form.canal.id_for_label }}" class="block text-sm font-medium text-neutral-700 mb-1">{% trans 'Canal' %}</label>
       {{ form.canal|add_class:'form-select' }}
       {% if form.canal.errors %}<p class="text-sm text-red-600 mt-1">{{ form.canal.errors.0 }}</p>{% endif %}
     </div>
     <div class="flex items-center gap-2">
       {{ form.ativo }}
-      <label for="{{ form.ativo.id_for_label }}" class="text-sm text-neutral-700">Ativo</label>
+      <label for="{{ form.ativo.id_for_label }}" class="text-sm text-neutral-700">{% trans 'Ativo' %}</label>
     </div>
     <div class="flex justify-end gap-3 pt-4 border-t border-neutral-100">
-      <a href="{% url 'notificacoes:templates_list' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100">Cancelar</a>
-      <button type="submit" class="text-sm px-4 py-2 rounded-xl bg-primary-600 text-white hover:bg-primary-700">Salvar</button>
+      <a href="{% url 'notificacoes:templates_list' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100">{% trans 'Cancelar' %}</a>
+      <button type="submit" class="text-sm px-4 py-2 rounded-xl bg-primary-600 text-white hover:bg-primary-700">{% trans 'Salvar' %}</button>
     </div>
   </form>
 </div>

--- a/notificacoes/templates/notificacoes/templates_list.html
+++ b/notificacoes/templates/notificacoes/templates_list.html
@@ -1,14 +1,15 @@
 {% extends 'base.html' %}
-{% block title %}Templates de Notificação | HubX{% endblock %}
+{% load i18n %}
+{% block title %}{% trans 'Templates de Notificação' %} | HubX{% endblock %}
 {% block content %}
 <div class="max-w-6xl mx-auto px-4 py-10">
   <div class="flex items-center justify-between mb-8">
     <div>
-      <h1 class="text-2xl font-bold text-neutral-900">Templates de Notificação</h1>
-      <p class="text-sm text-neutral-600">Gerencie as mensagens utilizadas nos envios.</p>
+      <h1 class="text-2xl font-bold text-neutral-900">{% trans 'Templates de Notificação' %}</h1>
+      <p class="text-sm text-neutral-600">{% trans 'Gerencie as mensagens utilizadas nos envios.' %}</p>
     </div>
     <a href="{% url 'notificacoes:template_create' %}" class="inline-flex items-center gap-2 bg-primary-600 text-white text-sm px-4 py-2 rounded-xl hover:bg-primary-700">
-      <span class="text-xl leading-none">+</span> Novo Template
+      <span class="text-xl leading-none">+</span> {% trans 'Novo Template' %}
     </a>
   </div>
   {% if messages %}
@@ -23,11 +24,11 @@
     <table class="min-w-full divide-y divide-neutral-200 text-sm">
       <thead class="bg-neutral-50">
         <tr>
-          <th class="px-4 py-2 text-left font-medium text-neutral-700">Código</th>
-          <th class="px-4 py-2 text-left font-medium text-neutral-700">Assunto</th>
-          <th class="px-4 py-2 text-left font-medium text-neutral-700">Canal</th>
-          <th class="px-4 py-2 text-left font-medium text-neutral-700">Ativo</th>
-          <th class="px-4 py-2 text-left font-medium text-neutral-700">Ações</th>
+          <th class="px-4 py-2 text-left font-medium text-neutral-700">{% trans 'Código' %}</th>
+          <th class="px-4 py-2 text-left font-medium text-neutral-700">{% trans 'Assunto' %}</th>
+          <th class="px-4 py-2 text-left font-medium text-neutral-700">{% trans 'Canal' %}</th>
+          <th class="px-4 py-2 text-left font-medium text-neutral-700">{% trans 'Ativo' %}</th>
+          <th class="px-4 py-2 text-left font-medium text-neutral-700">{% trans 'Ações' %}</th>
         </tr>
       </thead>
       <tbody class="divide-y divide-neutral-200" id="templates_table">
@@ -38,7 +39,7 @@
           <td class="px-4 py-2">{{ tpl.get_canal_display }}</td>
           <td class="px-4 py-2">{{ tpl.ativo|yesno:'Sim,Não' }}</td>
           <td class="px-4 py-2">
-            <a href="{% url 'notificacoes:template_edit' tpl.codigo %}" class="text-sm text-primary-600 hover:underline">Editar</a>
+            <a href="{% url 'notificacoes:template_edit' tpl.codigo %}" class="text-sm text-primary-600 hover:underline">{% trans 'Editar' %}</a>
           </td>
         </tr>
         {% endfor %}
@@ -46,7 +47,7 @@
     </table>
   </div>
   {% else %}
-    <p class="text-center text-neutral-600">Nenhum template cadastrado.</p>
+    <p class="text-center text-neutral-600">{% trans 'Nenhum template cadastrado.' %}</p>
   {% endif %}
 </div>
 {% endblock %}

--- a/notificacoes/views.py
+++ b/notificacoes/views.py
@@ -5,6 +5,7 @@ from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.auth.decorators import login_required, permission_required
 from django.core.paginator import Paginator
 from django.shortcuts import get_object_or_404, redirect, render
+from django.utils.translation import gettext_lazy as _
 
 from .forms import NotificationTemplateForm, UserNotificationPreferenceForm
 from .models import Canal, NotificationLog, NotificationStatus, NotificationTemplate, UserNotificationPreference
@@ -24,7 +25,7 @@ def create_template(request):
         form = NotificationTemplateForm(request.POST)
         if form.is_valid():
             form.save()
-            messages.success(request, "Template criado com sucesso.")
+            messages.success(request, _("Template criado com sucesso."))
             return redirect("notificacoes:templates_list")
     else:
         form = NotificationTemplateForm()
@@ -39,7 +40,7 @@ def edit_template(request, codigo: str):
         form = NotificationTemplateForm(request.POST, instance=template)
         if form.is_valid():
             form.save()
-            messages.success(request, "Template atualizado com sucesso.")
+            messages.success(request, _("Template atualizado com sucesso."))
             return redirect("notificacoes:templates_list")
     else:
         form = NotificationTemplateForm(instance=template)
@@ -67,9 +68,10 @@ def list_logs(request):
     page_obj = paginator.get_page(request.GET.get("page"))
 
     context = {"logs": page_obj}
-    if request.headers.get("HX-Request"):
-        context["partial"] = True
-    return render(request, "notificacoes/logs_list.html", context)
+    template_name = (
+        "notificacoes/logs_rows.html" if request.headers.get("HX-Request") else "notificacoes/logs_list.html"
+    )
+    return render(request, template_name, context)
 
 
 @login_required
@@ -79,7 +81,7 @@ def editar_preferencias(request):
         form = UserNotificationPreferenceForm(request.POST, instance=pref)
         if form.is_valid():
             form.save()
-            messages.success(request, "Preferências salvas com sucesso.")
+            messages.success(request, _("Preferências salvas com sucesso."))
             return redirect("notificacoes:editar_preferencias")
     else:
         form = UserNotificationPreferenceForm(instance=pref)


### PR DESCRIPTION
## Summary
- adapt notification templates to always extend `base.html`
- add gettext translations and partial for log rows
- update views to use partial template when requested via HTMX

## Testing
- `ruff check notificacoes/views.py`
- `mypy notificacoes`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6889796633a48325a9339fc45f70887e