### PR TITLE
Implement forum templates and HTMX

### DIFF
--- a/discussao/templates/discussao/comentario_item.html
+++ b/discussao/templates/discussao/comentario_item.html
@@ -1,0 +1,14 @@
+<article class="p-4 border-b border-neutral-200" id="coment-{{ comentario.id }}">
+  <header class="mb-2 flex items-center justify-between">
+    <div class="text-sm text-neutral-700">
+      {{ comentario.autor.get_full_name|default:comentario.autor.username }} - {{ comentario.created|date:"d/m/Y H:i" }}
+    </div>
+    {% if user == comentario.autor or user.get_tipo_usuario in ['admin','coordenador','root'] %}
+      <form method="post" hx-delete="{% url 'discussao:delete_comment' comentario.id %}" hx-target="#coment-{{ comentario.id }}" hx-swap="delete">
+        {% csrf_token %}
+        <button type="submit" class="text-red-600 text-xs">{% trans "Remover" %}</button>
+      </form>
+    {% endif %}
+  </header>
+  <div class="prose max-w-none text-sm">{{ comentario.conteudo|linebreaks }}</div>
+</article>

--- a/discussao/templates/discussao/topico_detail.html
+++ b/discussao/templates/discussao/topico_detail.html
@@ -1,0 +1,54 @@
+{% if partial %}
+  {% for comentario in comentarios %}
+  <article class="p-4 border-b border-neutral-200" id="coment-{{ comentario.id }}">
+    <header class="mb-2 flex items-center justify-between">
+      <div class="text-sm text-neutral-700">
+        {{ comentario.autor.get_full_name|default:comentario.autor.username }} - {{ comentario.created|date:"d/m/Y H:i" }}
+      </div>
+      {% if user == comentario.autor or user.get_tipo_usuario in ['admin','coordenador','root'] %}
+        <form method="post" hx-delete="{% url 'discussao:delete_comment' comentario.id %}" hx-target="#coment-{{ comentario.id }}" hx-swap="delete">
+          {% csrf_token %}
+          <button type="submit" class="text-red-600 text-xs">{% trans "Remover" %}</button>
+        </form>
+      {% endif %}
+    </header>
+    <div class="prose max-w-none text-sm">{{ comentario.conteudo|linebreaks }}</div>
+  </article>
+  {% endfor %}
+{% else %}
+{% extends 'base.html' %}
+{% load i18n %}
+{% block title %}{{ topico.titulo }} | HubX{% endblock %}
+{% block content %}
+<article class="max-w-3xl mx-auto px-4 py-10">
+  <header class="mb-6 border-b border-neutral-200 pb-4">
+    <h1 class="text-2xl font-bold text-neutral-900 mb-2">{{ topico.titulo }}</h1>
+    <p class="text-sm text-neutral-600">{% trans "Por" %} {{ topico.autor.get_full_name|default:topico.autor.username }} · {{ topico.created|date:"d/m/Y H:i" }}</p>
+  </header>
+  <div class="prose max-w-none mb-10">{{ topico.conteudo|linebreaks }}</div>
+  <section aria-labelledby="comentarios" class="space-y-4">
+    <h2 id="comentarios" class="text-xl font-semibold">{% trans "Coment\u00e1rios" %}</h2>
+    <div id="lista-comentarios">
+      {% include 'discussao/topico_detail.html' with partial=True only %}
+    </div>
+    {% if comentarios.has_previous or comentarios.has_next %}
+    <div class="flex justify-center gap-3 text-sm">
+      {% if comentarios.has_previous %}
+        <a hx-get="?page={{ comentarios.previous_page_number }}" hx-target="#lista-comentarios" class="px-3 py-1 border rounded-xl">{% trans "Anterior" %}</a>
+      {% endif %}
+      <span class="px-3 py-1">{% trans "P\u00e1gina" %} {{ comentarios.number }}</span>
+      {% if comentarios.has_next %}
+        <a hx-get="?page={{ comentarios.next_page_number }}" hx-target="#lista-comentarios" class="px-3 py-1 border rounded-xl">{% trans "Pr\u00f3xima" %}</a>
+      {% endif %}
+    </div>
+    {% endif %}
+    <form method="post" hx-post="{% url 'discussao:resposta_criar' topico.categoria.slug topico.slug %}" hx-target="#lista-comentarios" hx-swap="beforeend" class="space-y-4 mt-6">
+      {% csrf_token %}
+      <label for="id_conteudo" class="block text-sm font-medium text-neutral-700">{% trans "Comentar" %}</label>
+      <textarea name="conteudo" required class="form-textarea"></textarea>
+      <button type="submit" class="bg-primary-600 hover:bg-primary-700 text-white font-semibold py-2 px-4 rounded-xl">{% trans "Comentar" %}</button>
+    </form>
+  </section>
+</article>
+{% endblock %}
+{% endif %}

--- a/discussao/templates/discussao/topico_novo.html
+++ b/discussao/templates/discussao/topico_novo.html
@@ -1,0 +1,39 @@
+{% extends "base.html" %}
+{% load widget_tweaks i18n %}
+
+{% block title %}{% trans "Novo T\u00f3pico" %} | HubX{% endblock %}
+
+{% block content %}
+<section class="max-w-2xl mx-auto px-4 py-10">
+  <h1 class="text-2xl font-bold text-neutral-900 mb-6">{% trans "Criar T\u00f3pico" %}</h1>
+  {% if messages %}
+  <div class="mb-4 space-y-2">
+    {% for message in messages %}
+      <p class="rounded-xl px-4 py-2 text-sm {{ message.tags == 'success'|yesno:'bg-green-100 text-green-700,bg-red-100 text-red-700' }}">{{ message }}</p>
+    {% endfor %}
+  </div>
+  {% endif %}
+  <form method="post" class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 space-y-6">
+    {% csrf_token %}
+    <div>
+      <label for="{{ form.titulo.id_for_label }}" class="block text-sm font-medium text-neutral-700 mb-1">{{ form.titulo.label }}</label>
+      {{ form.titulo|add_class:'form-input' }}
+      {% if form.titulo.errors %}<p class="text-sm text-red-600 mt-1">{{ form.titulo.errors.0 }}</p>{% endif %}
+    </div>
+    <div>
+      <label for="{{ form.conteudo.id_for_label }}" class="block text-sm font-medium text-neutral-700 mb-1">{{ form.conteudo.label }}</label>
+      {{ form.conteudo|add_class:'form-textarea' }}
+      {% if form.conteudo.errors %}<p class="text-sm text-red-600 mt-1">{{ form.conteudo.errors.0 }}</p>{% endif %}
+    </div>
+    <div>
+      <label for="{{ form.tags.id_for_label }}" class="block text-sm font-medium text-neutral-700 mb-1">{{ form.tags.label }}</label>
+      {{ form.tags|add_class:'form-select' }}
+      {% if form.tags.errors %}<p class="text-sm text-red-600 mt-1">{{ form.tags.errors.0 }}</p>{% endif %}
+    </div>
+    <div class="flex justify-end gap-3 pt-4 border-t border-neutral-100">
+      <a href="{% url 'discussao:topicos' categoria.slug %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100">{% trans "Cancelar" %}</a>
+      <button type="submit" class="text-sm px-4 py-2 rounded-xl bg-primary-600 text-white hover:bg-primary-700">{% trans "Publicar" %}</button>
+    </div>
+  </form>
+</section>
+{% endblock %}

--- a/discussao/templates/discussao/topicos_list.html
+++ b/discussao/templates/discussao/topicos_list.html
@@ -1,0 +1,45 @@
+{% if partial %}
+  {% for topico in topicos %}
+  <tr>
+    <td class="px-4 py-2">
+      <a href="{% url 'discussao:topico_detalhe' categoria.slug topico.slug %}" class="text-primary-600 hover:underline">{{ topico.titulo }}</a>
+    </td>
+    <td class="px-4 py-2">{{ topico.autor.get_full_name|default:topico.autor.username }}</td>
+    <td class="px-4 py-2">{{ topico.created|date:"d/m/Y" }}</td>
+    <td class="px-4 py-2 text-center">{{ topico.num_comentarios }}</td>
+    <td class="px-4 py-2">{{ topico.last_activity|date:"d/m/Y H:i" }}</td>
+  </tr>
+  {% endfor %}
+{% else %}
+{% extends 'base.html' %}
+{% load i18n %}
+{% block title %}{{ categoria.nome }} | HubX{% endblock %}
+{% block content %}
+<div class="max-w-6xl mx-auto px-4 py-10">
+  <h1 class="text-2xl font-bold text-neutral-900 mb-6">{{ categoria.nome }}</h1>
+  <div class="mb-4 flex items-center gap-3">
+    <select name="ordenacao" id="ordenacao" class="form-select" hx-get="?" hx-target="#lista-topicos" hx-include="closest div">
+      <option value="recentes" {% if ordenacao == 'recentes' %}selected{% endif %}>{% trans "Mais recentes" %}</option>
+      <option value="comentados" {% if ordenacao == 'comentados' %}selected{% endif %}>{% trans "Mais comentados" %}</option>
+    </select>
+    <a href="{% url 'discussao:topico_criar' categoria.slug %}" class="ml-auto bg-primary-600 hover:bg-primary-700 text-white font-semibold py-2 px-4 rounded-xl">{% trans "Novo T\u00f3pico" %}</a>
+  </div>
+  <div class="overflow-x-auto bg-white border border-neutral-200 rounded-2xl shadow-sm">
+    <table class="min-w-full divide-y divide-neutral-200 text-sm">
+      <thead class="bg-neutral-50">
+        <tr>
+          <th class="px-4 py-2 text-left font-medium text-neutral-700">{% trans "T\u00edtulo" %}</th>
+          <th class="px-4 py-2 text-left font-medium text-neutral-700">{% trans "Autor" %}</th>
+          <th class="px-4 py-2 text-left font-medium text-neutral-700">{% trans "Criado em" %}</th>
+          <th class="px-4 py-2 text-center font-medium text-neutral-700">{% trans "Coment\u00e1rios" %}</th>
+          <th class="px-4 py-2 text-left font-medium text-neutral-700">{% trans "\u00daltima atividade" %}</th>
+        </tr>
+      </thead>
+      <tbody id="lista-topicos" class="divide-y divide-neutral-200">
+        {% include 'discussao/topicos_list.html' with partial=True only %}
+      </tbody>
+    </table>
+  </div>
+</div>
+{% endblock %}
+{% endif %}

--- a/discussao/urls.py
+++ b/discussao/urls.py
@@ -4,13 +4,13 @@ from .views import (
     CategoriaListView,
     InteracaoView,
     RespostaCreateView,
+    RespostaDeleteView,
     TopicoCreateView,
     TopicoDeleteView,
     TopicoDetailView,
     TopicoListView,
     TopicoUpdateView,
 )
-
 
 urlpatterns = [
     path("", CategoriaListView.as_view(), name="categorias"),
@@ -35,6 +35,11 @@ urlpatterns = [
         "<slug:categoria_slug>/<slug:topico_slug>/responder/",
         RespostaCreateView.as_view(),
         name="resposta_criar",
+    ),
+    path(
+        "comentario/<int:pk>/remover/",
+        RespostaDeleteView.as_view(),
+        name="delete_comment",
     ),
     path(
         "interacao/<int:content_type_id>/<int:object_id>/<str:tipo>/",

--- a/discussao/views.py
+++ b/discussao/views.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.contenttypes.models import ContentType
+from django.core.paginator import Paginator
+from django.db.models import Count, Max
 from django.http import HttpResponse, HttpResponseForbidden
-from django.shortcuts import get_object_or_404
-from django.urls import reverse, reverse_lazy
+from django.shortcuts import get_object_or_404, redirect, render
+from django.urls import reverse
+from django.utils.translation import gettext_lazy
 from django.views.generic import (
     CreateView,
     DeleteView,
@@ -16,12 +20,12 @@ from django.views.generic import (
 
 from accounts.models import UserType
 
-from .forms import CategoriaDiscussaoForm, TopicoDiscussaoForm, RespostaDiscussaoForm
+from .forms import RespostaDiscussaoForm, TopicoDiscussaoForm
 from .models import (
     CategoriaDiscussao,
-    TopicoDiscussao,
-    RespostaDiscussao,
     InteracaoDiscussao,
+    RespostaDiscussao,
+    TopicoDiscussao,
 )
 
 
@@ -31,12 +35,7 @@ class CategoriaListView(LoginRequiredMixin, ListView):
     context_object_name = "categorias"
 
     def get_queryset(self):
-        qs = (
-            super()
-            .get_queryset()
-            .select_related("organizacao", "nucleo", "evento")
-            .prefetch_related("topicos")
-        )
+        qs = super().get_queryset().select_related("organizacao", "nucleo", "evento").prefetch_related("topicos")
         user = self.request.user
         if user.user_type != UserType.ROOT:
             qs = qs.filter(organizacao=user.organizacao)
@@ -45,7 +44,7 @@ class CategoriaListView(LoginRequiredMixin, ListView):
 
 class TopicoListView(LoginRequiredMixin, ListView):
     model = TopicoDiscussao
-    template_name = "discussao/topicos.html"
+    template_name = "discussao/topicos_list.html"
     context_object_name = "topicos"
     paginate_by = 20
 
@@ -54,15 +53,26 @@ class TopicoListView(LoginRequiredMixin, ListView):
         return super().dispatch(request, *args, **kwargs)
 
     def get_queryset(self):
-        return (
+        ordenacao = self.request.GET.get("ordenacao", "recentes")
+        qs = (
             TopicoDiscussao.objects.filter(categoria=self.categoria)
             .select_related("categoria", "autor")
             .prefetch_related("respostas")
+            .annotate(
+                num_comentarios=Count("respostas"),
+                last_activity=Max("respostas__created"),
+            )
         )
+        if ordenacao == "comentados":
+            qs = qs.order_by("-num_comentarios")
+        else:
+            qs = qs.order_by("-created")
+        return qs
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["categoria"] = self.categoria
+        context["ordenacao"] = self.request.GET.get("ordenacao", "recentes")
         return context
 
 
@@ -74,25 +84,41 @@ class TopicoDetailView(LoginRequiredMixin, DetailView):
     def get_object(self, queryset=None):
         categoria = get_object_or_404(CategoriaDiscussao, slug=self.kwargs["categoria_slug"])
         obj = get_object_or_404(
-            TopicoDiscussao.objects.select_related("categoria", "autor")
-            .prefetch_related("respostas__autor"),
+            TopicoDiscussao.objects.select_related("categoria", "autor").prefetch_related("respostas__autor"),
             categoria=categoria,
             slug=self.kwargs["topico_slug"],
         )
         return obj
+
+    paginate_by = 10
 
     def get(self, request, *args, **kwargs):
         self.object = self.get_object()
         self.object.incrementar_visualizacao()
         context = self.get_context_data(object=self.object)
         context["resposta_form"] = RespostaDiscussaoForm()
+        if request.headers.get("Hx-Request"):
+            return render(
+                request,
+                "discussao/topico_detail.html",
+                {"comentarios": context["comentarios"], "partial": True, "user": request.user},
+            )
         return self.render_to_response(context)
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        comentarios_qs = self.object.respostas.select_related("autor")
+        paginator = Paginator(comentarios_qs, self.paginate_by)
+        page = self.request.GET.get("page")
+        comentarios = paginator.get_page(page)
+        context["comentarios"] = comentarios
+        return context
 
 
 class TopicoCreateView(LoginRequiredMixin, CreateView):
     model = TopicoDiscussao
     form_class = TopicoDiscussaoForm
-    template_name = "discussao/topico_form.html"
+    template_name = "discussao/topico_novo.html"
 
     def dispatch(self, request, *args, **kwargs):
         self.categoria = get_object_or_404(CategoriaDiscussao, slug=kwargs["categoria_slug"])
@@ -103,7 +129,9 @@ class TopicoCreateView(LoginRequiredMixin, CreateView):
     def form_valid(self, form):
         form.instance.autor = self.request.user
         form.instance.categoria = self.categoria
-        return super().form_valid(form)
+        response = super().form_valid(form)
+        messages.success(self.request, gettext_lazy("T\u00f3pico criado com sucesso"))
+        return response
 
     def get_success_url(self):
         return reverse("discussao:topico_detalhe", args=[self.categoria.slug, self.object.slug])
@@ -112,13 +140,11 @@ class TopicoCreateView(LoginRequiredMixin, CreateView):
 class TopicoUpdateView(LoginRequiredMixin, UpdateView):
     model = TopicoDiscussao
     form_class = TopicoDiscussaoForm
-    template_name = "discussao/topico_form.html"
+    template_name = "discussao/topico_novo.html"
 
     def dispatch(self, request, *args, **kwargs):
         self.categoria = get_object_or_404(CategoriaDiscussao, slug=kwargs["categoria_slug"])
-        self.object = get_object_or_404(
-            TopicoDiscussao, categoria=self.categoria, slug=kwargs["topico_slug"]
-        )
+        self.object = get_object_or_404(TopicoDiscussao, categoria=self.categoria, slug=kwargs["topico_slug"])
         if request.user != self.object.autor and request.user.user_type not in {UserType.ADMIN, UserType.ROOT}:
             return HttpResponseForbidden()
         return super().dispatch(request, *args, **kwargs)
@@ -133,9 +159,7 @@ class TopicoDeleteView(LoginRequiredMixin, DeleteView):
 
     def dispatch(self, request, *args, **kwargs):
         self.categoria = get_object_or_404(CategoriaDiscussao, slug=kwargs["categoria_slug"])
-        self.object = get_object_or_404(
-            TopicoDiscussao, categoria=self.categoria, slug=kwargs["topico_slug"]
-        )
+        self.object = get_object_or_404(TopicoDiscussao, categoria=self.categoria, slug=kwargs["topico_slug"])
         if request.user != self.object.autor and request.user.user_type not in {UserType.ADMIN, UserType.ROOT}:
             return HttpResponseForbidden()
         return super().dispatch(request, *args, **kwargs)
@@ -151,24 +175,53 @@ class RespostaCreateView(LoginRequiredMixin, CreateView):
 
     def dispatch(self, request, *args, **kwargs):
         self.categoria = get_object_or_404(CategoriaDiscussao, slug=kwargs["categoria_slug"])
-        self.topico = get_object_or_404(
-            TopicoDiscussao, categoria=self.categoria, slug=kwargs["topico_slug"]
-        )
+        self.topico = get_object_or_404(TopicoDiscussao, categoria=self.categoria, slug=kwargs["topico_slug"])
         return super().dispatch(request, *args, **kwargs)
 
     def form_valid(self, form):
         form.instance.autor = self.request.user
         form.instance.topico = self.topico
-        return super().form_valid(form)
+        response = super().form_valid(form)
+        if self.request.headers.get("Hx-Request"):
+            context = {"comentario": self.object, "user": self.request.user}
+            return render(self.request, "discussao/comentario_item.html", context)
+        messages.success(self.request, gettext_lazy("Coment\u00e1rio publicado"))
+        return response
 
     def get_success_url(self):
         return reverse("discussao:topico_detalhe", args=[self.categoria.slug, self.topico.slug])
 
 
+class RespostaDeleteView(LoginRequiredMixin, DeleteView):
+    model = RespostaDiscussao
+
+    def dispatch(self, request, *args, **kwargs):
+        self.object = get_object_or_404(RespostaDiscussao, pk=kwargs["pk"])
+        self.topico = self.object.topico
+        if request.user != self.object.autor and request.user.get_tipo_usuario not in {
+            UserType.ADMIN.value,
+            UserType.COORDENADOR.value,
+            UserType.ROOT.value,
+        }:
+            return HttpResponseForbidden()
+        return super().dispatch(request, *args, **kwargs)
+
+    def delete(self, request, *args, **kwargs):
+        super().delete(request, *args, **kwargs)
+        if request.headers.get("Hx-Request"):
+            return HttpResponse("")
+        messages.success(request, gettext_lazy("Coment\u00e1rio removido"))
+        return redirect(
+            "discussao:topico_detalhe",
+            categoria_slug=self.topico.categoria.slug,
+            topico_slug=self.topico.slug,
+        )
+
+
 class InteracaoView(LoginRequiredMixin, View):
     def post(self, request, content_type_id, object_id, tipo):
         content_type = get_object_or_404(ContentType, id=content_type_id)
-        obj = get_object_or_404(content_type.model_class(), id=object_id)
+        get_object_or_404(content_type.model_class(), id=object_id)
         interacao, created = InteracaoDiscussao.objects.get_or_create(
             user=request.user,
             content_type=content_type,


### PR DESCRIPTION
## Summary
- add discussion templates: topic creation, list, detail, comment item
- enable filtering and pagination via HTMX
- create delete comment endpoint and update views
- improve success messages and query annotations

## Testing
- `ruff check discussao/views.py discussao/urls.py`
- `mypy --ignore-missing-imports discussao/views.py` *(fails: many missing annotations in models)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688979b035b08325be6de9c2fc35da81