### PR TITLE
feat: melhorar templates do financeiro

### DIFF
--- a/financeiro/templates/financeiro/importar_pagamentos.html
+++ b/financeiro/templates/financeiro/importar_pagamentos.html
@@ -6,12 +6,18 @@
 <div class="max-w-3xl mx-auto p-4">
   <h1 class="text-2xl font-semibold mb-4">Importar Pagamentos</h1>
   <form id="upload-form" method="post" enctype="multipart/form-data"
-        hx-post="/api/financeiro/importar-pagamentos/" hx-target="#preview"
+        hx-post="/api/financeiro/importar-pagamentos/preview/" hx-target="#preview"
         class="space-y-4 border p-4 rounded-lg bg-white">
     {% csrf_token %}
     <input type="file" name="file" class="block w-full border p-2 rounded" required />
     <button type="submit" class="bg-primary text-white px-4 py-2 rounded">Pré-visualizar</button>
   </form>
   <div id="preview" class="mt-6"></div>
+  <div id="messages" class="mt-4"></div>
+  <div class="mt-4">
+    <button id="confirm-btn" hx-post="/api/financeiro/importar-pagamentos/confirmar/" hx-target="#messages" hx-include="#upload-form" class="bg-secondary text-white px-4 py-2 rounded">
+      Confirmar Importação
+    </button>
+  </div>
 </div>
 {% endblock %}

--- a/financeiro/templates/financeiro/inadimplencias.html
+++ b/financeiro/templates/financeiro/inadimplencias.html
@@ -5,7 +5,7 @@
 {% block content %}
 <div class="p-4 max-w-6xl mx-auto">
   <h1 class="text-2xl font-semibold mb-2">Inadimplências</h1>
-  <div class="mb-4 grid grid-cols-1 md:grid-cols-3 gap-4">
+  <div class="mb-4 grid grid-cols-1 md:grid-cols-4 gap-4">
     <select name="centro" class="border p-2 rounded" hx-get="/api/financeiro/inadimplencias/" hx-target="#lista" hx-include="closest div">
       <option value="">Todos Centros</option>
       {% for c in centros %}
@@ -21,10 +21,26 @@
     <select name="status" class="border p-2 rounded" disabled>
       <option>Pendente</option>
     </select>
+    <input type="month" name="periodo" class="border p-2 rounded" hx-get="/api/financeiro/inadimplencias/" hx-target="#lista" hx-include="closest div">
   </div>
-  <div id="lista" hx-get="/api/financeiro/inadimplencias/" hx-target="this"></div>
-  <div class="mt-4">
+  <div id="lista" hx-get="/api/financeiro/inadimplencias/" hx-target="this">
+    <table class="min-w-full divide-y divide-gray-200">
+      <thead>
+        <tr class="bg-gray-50">
+          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">ID</th>
+          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">Centro de Custo</th>
+          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">Conta</th>
+          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">Valor</th>
+          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">Data de Vencimento</th>
+          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">Dias em atraso</th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </div>
+  <div class="mt-4 flex gap-4">
     <a href="/api/financeiro/inadimplencias/?format=csv" class="text-primary underline" hx-boost="false">Exportar CSV</a>
+    <a href="/api/financeiro/inadimplencias/?format=xlsx" class="text-primary underline" hx-boost="false">Exportar XLSX</a>
   </div>
 </div>
 {% endblock %}

--- a/financeiro/templates/financeiro/lancamentos_list.html
+++ b/financeiro/templates/financeiro/lancamentos_list.html
@@ -5,7 +5,7 @@
 {% block content %}
 <div class="p-4 max-w-6xl mx-auto">
   <h1 class="text-2xl font-semibold mb-2">Lançamentos</h1>
-  <div class="mb-4 grid grid-cols-1 md:grid-cols-3 gap-4">
+  <div class="mb-4 grid grid-cols-1 md:grid-cols-5 gap-4">
     <select name="status" id="filtro-status" class="border p-2 rounded" hx-get="/api/financeiro/lancamentos/" hx-target="#lista" hx-include="closest div">
       <option value="">Todos Status</option>
       <option value="pendente">Pendente</option>
@@ -24,7 +24,26 @@
         <option value="{{ n.id }}">{{ n.nome }}</option>
       {% endfor %}
     </select>
+    <input type="month" name="periodo_inicial" class="border p-2 rounded" hx-get="/api/financeiro/lancamentos/" hx-target="#lista" hx-include="closest div">
+    <input type="month" name="periodo_final" class="border p-2 rounded" hx-get="/api/financeiro/lancamentos/" hx-target="#lista" hx-include="closest div">
   </div>
-  <div id="lista" hx-get="/api/financeiro/lancamentos/" hx-target="this"></div>
+  <div id="lista" hx-get="/api/financeiro/lancamentos/" hx-target="this">
+    <table class="min-w-full divide-y divide-gray-200">
+      <thead>
+        <tr class="bg-gray-50">
+          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">ID</th>
+          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">Centro de Custo</th>
+          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">Conta Associada</th>
+          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">Tipo</th>
+          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">Valor</th>
+          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">Data de Lançamento</th>
+          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">Status</th>
+          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">Data de Vencimento</th>
+          <th class="px-3 py-2"></th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </div>
 </div>
 {% endblock %}

--- a/financeiro/templates/financeiro/relatorios.html
+++ b/financeiro/templates/financeiro/relatorios.html
@@ -5,7 +5,7 @@
 {% block content %}
 <div class="max-w-5xl mx-auto p-4 space-y-4">
   <h1 class="text-2xl font-semibold mb-2">Relatórios</h1>
-  <form id="relatorio-form" class="space-y-4" hx-get="/api/financeiro/relatorios/" hx-target="#resultado">
+  <form id="relatorio-form" class="space-y-4" hx-get="/api/financeiro/relatorios/" hx-target="#relatorio">
     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
       <div>
         <label class="block text-sm font-medium text-gray-700">Centro de Custo</label>
@@ -39,9 +39,10 @@
     <button type="submit" class="bg-primary text-white px-4 py-2 rounded">Gerar Relatório</button>
   </form>
 
-  <div id="resultado" class="mt-6"></div>
-  <div class="mt-4">
+  <div id="relatorio" class="mt-6"></div>
+  <div class="mt-4 flex gap-4">
     <a href="#" id="export-csv" class="text-primary underline" hx-boost="false">Exportar CSV</a>
+    <a href="#" id="export-xlsx" class="text-primary underline" hx-boost="false">Exportar XLSX</a>
   </div>
 </div>
 {% endblock %}

--- a/financeiro/views/__init__.py
+++ b/financeiro/views/__init__.py
@@ -130,6 +130,11 @@ class FinanceiroViewSet(viewsets.ViewSet):
             payload["token_erros"] = Path(result.errors_file).stem
         return Response(payload, status=status.HTTP_201_CREATED)
 
+    @action(detail=False, methods=["post"], url_path="importar-pagamentos/preview")
+    def importar_pagamentos_preview(self, request):
+        """Alias para compatibilidade com a rota /preview/ utilizada nos templates."""
+        return self.importar_pagamentos(request)
+
     @action(detail=False, methods=["post"], url_path="importar-pagamentos/confirmar")
     def confirmar_importacao(self, request):
         serializer = ImportarPagamentosConfirmacaoSerializer(data=request.data)


### PR DESCRIPTION
## Summary
- adicionar alias de rota para `/preview` na importação de pagamentos
- aprimorar templates de financeiro com filtros e exportações

## Testing
- `ruff check financeiro/views/__init__.py`
- `mypy financeiro/views/__init__.py` *(fails: many missing type hints)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688979ed211c8325b745eafd8431b7ed