### PR TITLE
Refactor templates using Tailwind semantics

### DIFF
--- a/agenda/templates/agenda/briefing_list.html
+++ b/agenda/templates/agenda/briefing_list.html
@@ -1,10 +1,13 @@
 {% extends "base.html" %}
+{% load i18n %}
 
-{% block title %}Briefings | Hubx{% endblock %}
+{% block title %}{% trans "Briefings" %} | Hubx{% endblock %}
 
 {% block content %}
 <section class="max-w-7xl mx-auto px-4 py-10">
-  <h1 class="text-2xl font-bold text-neutral-900 mb-6">Briefings de Eventos</h1>
+  <header class="mb-6">
+    <h1 class="text-2xl font-bold text-neutral-900">{% trans "Briefings de Eventos" %}</h1>
+  </header>
 
   {% if messages %}
     <div class="mb-4 space-y-2">
@@ -14,37 +17,39 @@
     </div>
   {% endif %}
 
-  <div class="overflow-x-auto bg-white border border-neutral-200 rounded-2xl shadow-sm">
-    <table class="min-w-full divide-y divide-neutral-200 table-auto text-sm">
-      <thead class="bg-neutral-50">
-        <tr>
-          <th class="px-4 py-2 text-left font-semibold text-neutral-700">Evento</th>
-          <th class="px-4 py-2 text-left font-semibold text-neutral-700">Objetivos</th>
-          <th class="px-4 py-2 text-left font-semibold text-neutral-700">Público Alvo</th>
-          <th class="px-4 py-2 text-left font-semibold text-neutral-700">Requisitos Técnicos</th>
-          <th class="px-4 py-2 text-left font-semibold text-neutral-700">Cronograma Resumido</th>
-          <th class="px-4 py-2 text-left font-semibold text-neutral-700">Conteúdo Programático</th>
-          <th class="px-4 py-2 text-left font-semibold text-neutral-700">Observações</th>
-        </tr>
-      </thead>
-      <tbody class="divide-y divide-neutral-200">
-        {% for briefing in briefings %}
+  <main>
+    <div class="overflow-x-auto bg-white border border-neutral-200 rounded-2xl shadow-sm">
+      <table class="min-w-full divide-y divide-neutral-200 table-auto text-sm">
+        <thead class="bg-neutral-50">
           <tr>
-            <td class="px-4 py-2">{{ briefing.evento }}</td>
-            <td class="px-4 py-2">{{ briefing.objetivos }}</td>
-            <td class="px-4 py-2">{{ briefing.publico_alvo }}</td>
-            <td class="px-4 py-2">{{ briefing.requisitos_tecnicos }}</td>
-            <td class="px-4 py-2">{{ briefing.cronograma_resumido }}</td>
-            <td class="px-4 py-2">{{ briefing.conteudo_programatico }}</td>
-            <td class="px-4 py-2">{{ briefing.observacoes }}</td>
+            <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Evento" %}</th>
+            <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Objetivos" %}</th>
+            <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Público Alvo" %}</th>
+            <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Requisitos Técnicos" %}</th>
+            <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Cronograma Resumido" %}</th>
+            <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Conteúdo Programático" %}</th>
+            <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Observações" %}</th>
           </tr>
-        {% empty %}
-          <tr>
-            <td colspan="7" class="px-4 py-4 text-center text-neutral-500">Nenhum briefing encontrado.</td>
-          </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-  </div>
+        </thead>
+        <tbody class="divide-y divide-neutral-200">
+          {% for briefing in briefings %}
+            <tr>
+              <td class="px-4 py-2">{{ briefing.evento }}</td>
+              <td class="px-4 py-2">{{ briefing.objetivos }}</td>
+              <td class="px-4 py-2">{{ briefing.publico_alvo }}</td>
+              <td class="px-4 py-2">{{ briefing.requisitos_tecnicos }}</td>
+              <td class="px-4 py-2">{{ briefing.cronograma_resumido }}</td>
+              <td class="px-4 py-2">{{ briefing.conteudo_programatico }}</td>
+              <td class="px-4 py-2">{{ briefing.observacoes }}</td>
+            </tr>
+          {% empty %}
+            <tr>
+              <td colspan="7" class="px-4 py-4 text-center text-neutral-500">{% trans "Nenhum briefing encontrado." %}</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </main>
 </section>
 {% endblock %}

--- a/agenda/templates/agenda/inscricao_list.html
+++ b/agenda/templates/agenda/inscricao_list.html
@@ -1,10 +1,13 @@
 {% extends "base.html" %}
+{% load i18n %}
 
-{% block title %}Inscrições | Hubx{% endblock %}
+{% block title %}{% trans "Inscrições" %} | Hubx{% endblock %}
 
 {% block content %}
 <section class="max-w-7xl mx-auto px-4 py-10">
-  <h1 class="text-2xl font-bold text-neutral-900 mb-6">Lista de Inscrições</h1>
+  <header class="mb-6">
+    <h1 class="text-2xl font-bold text-neutral-900">{% trans "Lista de Inscrições" %}</h1>
+  </header>
 
   {% if messages %}
     <div class="mb-4 space-y-2">
@@ -14,39 +17,41 @@
     </div>
   {% endif %}
 
-  <div class="overflow-x-auto bg-white border border-neutral-200 rounded-2xl shadow-sm">
-    <table class="min-w-full divide-y divide-neutral-200 table-auto text-sm">
-      <thead class="bg-neutral-50">
-        <tr>
-          <th class="px-4 py-2 text-left font-semibold text-neutral-700">Usuário</th>
-          <th class="px-4 py-2 text-left font-semibold text-neutral-700">Evento</th>
-          <th class="px-4 py-2 text-left font-semibold text-neutral-700">Status</th>
-          <th class="px-4 py-2 text-left font-semibold text-neutral-700">Presente</th>
-          <th class="px-4 py-2 text-left font-semibold text-neutral-700">Avaliação</th>
-          <th class="px-4 py-2 text-left font-semibold text-neutral-700">Valor Pago</th>
-          <th class="px-4 py-2 text-left font-semibold text-neutral-700">Método de Pagamento</th>
-          <th class="px-4 py-2 text-left font-semibold text-neutral-700">Observação</th>
-        </tr>
-      </thead>
-      <tbody class="divide-y divide-neutral-200">
-        {% for inscricao in inscricoes %}
+  <main>
+    <div class="overflow-x-auto bg-white border border-neutral-200 rounded-2xl shadow-sm">
+      <table class="min-w-full divide-y divide-neutral-200 table-auto text-sm">
+        <thead class="bg-neutral-50">
           <tr>
-            <td class="px-4 py-2">{{ inscricao.user }}</td>
-            <td class="px-4 py-2">{{ inscricao.evento }}</td>
-            <td class="px-4 py-2">{{ inscricao.get_status_display }}</td>
-            <td class="px-4 py-2">{{ inscricao.presente }}</td>
-            <td class="px-4 py-2">{{ inscricao.avaliacao }}</td>
-            <td class="px-4 py-2">{{ inscricao.valor_pago }}</td>
-            <td class="px-4 py-2">{{ inscricao.get_metodo_pagamento_display }}</td>
-            <td class="px-4 py-2">{{ inscricao.observacao }}</td>
+            <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Usuário" %}</th>
+            <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Evento" %}</th>
+            <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Status" %}</th>
+            <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Presente" %}</th>
+            <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Avaliação" %}</th>
+            <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Valor Pago" %}</th>
+            <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Método de Pagamento" %}</th>
+            <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Observação" %}</th>
           </tr>
-        {% empty %}
-          <tr>
-            <td colspan="8" class="px-4 py-4 text-center text-neutral-500">Nenhuma inscrição encontrada.</td>
-          </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-  </div>
+        </thead>
+        <tbody class="divide-y divide-neutral-200">
+          {% for inscricao in inscricoes %}
+            <tr>
+              <td class="px-4 py-2">{{ inscricao.user }}</td>
+              <td class="px-4 py-2">{{ inscricao.evento }}</td>
+              <td class="px-4 py-2">{{ inscricao.get_status_display }}</td>
+              <td class="px-4 py-2">{{ inscricao.presente }}</td>
+              <td class="px-4 py-2">{{ inscricao.avaliacao }}</td>
+              <td class="px-4 py-2">{{ inscricao.valor_pago }}</td>
+              <td class="px-4 py-2">{{ inscricao.get_metodo_pagamento_display }}</td>
+              <td class="px-4 py-2">{{ inscricao.observacao }}</td>
+            </tr>
+          {% empty %}
+            <tr>
+              <td colspan="8" class="px-4 py-4 text-center text-neutral-500">{% trans "Nenhuma inscrição encontrada." %}</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </main>
 </section>
 {% endblock %}

--- a/agenda/templates/agenda/material_list.html
+++ b/agenda/templates/agenda/material_list.html
@@ -1,10 +1,13 @@
 {% extends "base.html" %}
+{% load i18n %}
 
-{% block title %}Materiais de Divulgação | Hubx{% endblock %}
+{% block title %}{% trans "Materiais de Divulgação" %} | Hubx{% endblock %}
 
 {% block content %}
 <section class="max-w-7xl mx-auto px-4 py-10">
-  <h1 class="text-2xl font-bold text-neutral-900 mb-6">Materiais de Divulgação</h1>
+  <header class="mb-6">
+    <h1 class="text-2xl font-bold text-neutral-900">{% trans "Materiais de Divulgação" %}</h1>
+  </header>
 
   {% if messages %}
     <div class="mb-4 space-y-2">
@@ -14,19 +17,21 @@
     </div>
   {% endif %}
 
-  <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-    {% for material in materiais %}
-      <article class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-5 flex flex-col">
-        <h2 class="text-lg font-semibold text-neutral-900 mb-2">{{ material.titulo }}</h2>
-        <p class="text-sm text-neutral-600 mb-4">{{ material.descricao }}</p>
-        {% if material.imagem_thumb %}
-          <img src="{{ material.imagem_thumb.url }}" alt="{{ material.titulo }}" class="mb-4 rounded-xl object-cover">
-        {% endif %}
-        <a href="{{ material.arquivo.url }}" class="mt-auto text-sm text-blue-600 hover:underline">Download</a>
-      </article>
-    {% empty %}
-      <p class="text-neutral-500">Nenhum material disponível.</p>
-    {% endfor %}
-  </div>
+  <main>
+    <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+      {% for material in materiais %}
+        <article class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-5 flex flex-col">
+          <h2 class="text-lg font-semibold text-neutral-900 mb-2">{{ material.titulo }}</h2>
+          <p class="text-sm text-neutral-600 mb-4">{{ material.descricao }}</p>
+          {% if material.imagem_thumb %}
+            <img src="{{ material.imagem_thumb.url }}" alt="{{ material.titulo }}" class="mb-4 rounded-xl object-cover">
+          {% endif %}
+          <a href="{{ material.arquivo.url }}" class="mt-auto text-sm text-blue-600 hover:underline">{% trans "Download" %}</a>
+        </article>
+      {% empty %}
+        <p class="text-neutral-500">{% trans "Nenhum material disponível." %}</p>
+      {% endfor %}
+    </div>
+  </main>
 </section>
 {% endblock %}

--- a/core/templates/core/home.html
+++ b/core/templates/core/home.html
@@ -1,29 +1,48 @@
 {% extends 'base.html' %}
+{% load i18n %}
 
-{% block title %}Página Inicial{% endblock %}
+{% block title %}{% trans "Página Inicial" %}{% endblock %}
 
 {% block content %}
-<section class="max-w-7xl mx-auto px-4 py-10 text-center">
-  <h1 class="text-3xl font-bold text-neutral-900 mb-4">Bem-vindo ao Hubx!</h1>
-  <p class="text-neutral-600 mb-10">Uma plataforma colaborativa para conectar organizações, empresas e pessoas.</p>
+<section class="max-w-7xl mx-auto px-4 py-10">
+  <header class="text-center mb-10">
+    <h1 class="text-3xl font-bold text-neutral-900 mb-2">{% trans "Bem-vindo ao Hubx!" %}</h1>
+    <p class="text-neutral-600">{% trans "Uma plataforma colaborativa para conectar organizações, empresas e pessoas." %}</p>
+  </header>
 
-  <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-    <a href="{% url 'feed:listar' %}" class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 hover:bg-neutral-50">
-      <h2 class="text-lg font-semibold text-primary mb-2">Mural e Feed</h2>
-      <p class="text-sm text-neutral-600">Compartilhe novidades e acompanhe atualizações.</p>
-    </a>
-    <a href="{% url 'agenda:calendario' %}" class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 hover:bg-neutral-50">
-      <h2 class="text-lg font-semibold text-primary mb-2">Agenda</h2>
-      <p class="text-sm text-neutral-600">Organize eventos e gerencie inscrições.</p>
-    </a>
-    <a href="{% url 'nucleos:list' %}" class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 hover:bg-neutral-50">
-      <h2 class="text-lg font-semibold text-primary mb-2">Núcleos</h2>
-      <p class="text-sm text-neutral-600">Encontre grupos de interesse e colabore.</p>
-    </a>
-    <a href="{% url 'dashboard:dashboard' %}" class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 hover:bg-neutral-50">
-      <h2 class="text-lg font-semibold text-primary mb-2">Dashboard</h2>
-      <p class="text-sm text-neutral-600">Acompanhe métricas e atividades da sua conta.</p>
-    </a>
-  </div>
+  <main>
+    <div class="grid gap-6 grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
+      <article class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 flex flex-col items-center text-center">
+        <i class="fa-solid fa-rss text-3xl text-primary mb-3" aria-hidden="true"></i>
+        <h2 class="text-lg font-semibold text-neutral-900 mb-1">{% trans "Mural e Feed" %}</h2>
+        <p class="text-sm text-neutral-600 mb-4">{% trans "Compartilhe novidades e acompanhe atualizações." %}</p>
+        <a href="{% url 'feed:listar' %}" class="mt-auto text-sm text-blue-600 hover:underline">{% trans "Acessar" %}</a>
+      </article>
+      <article class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 flex flex-col items-center text-center">
+        <i class="fa-solid fa-calendar-alt text-3xl text-primary mb-3" aria-hidden="true"></i>
+        <h2 class="text-lg font-semibold text-neutral-900 mb-1">{% trans "Agenda" %}</h2>
+        <p class="text-sm text-neutral-600 mb-4">{% trans "Organize eventos e gerencie inscrições." %}</p>
+        <a href="{% url 'agenda:calendario' %}" class="mt-auto text-sm text-blue-600 hover:underline">{% trans "Acessar" %}</a>
+      </article>
+      <article class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 flex flex-col items-center text-center">
+        <i class="fa-solid fa-users text-3xl text-primary mb-3" aria-hidden="true"></i>
+        <h2 class="text-lg font-semibold text-neutral-900 mb-1">{% trans "Núcleos" %}</h2>
+        <p class="text-sm text-neutral-600 mb-4">{% trans "Encontre grupos de interesse e colabore." %}</p>
+        <a href="{% url 'nucleos:list' %}" class="mt-auto text-sm text-blue-600 hover:underline">{% trans "Acessar" %}</a>
+      </article>
+      <article class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 flex flex-col items-center text-center">
+        <i class="fa-solid fa-hand-holding-dollar text-3xl text-primary mb-3" aria-hidden="true"></i>
+        <h2 class="text-lg font-semibold text-neutral-900 mb-1">{% trans "Financeiro" %}</h2>
+        <p class="text-sm text-neutral-600 mb-4">{% trans "Controle lançamentos e relatórios financeiros." %}</p>
+        <a href="{% url 'financeiro:lancamentos' %}" class="mt-auto text-sm text-blue-600 hover:underline">{% trans "Acessar" %}</a>
+      </article>
+      <article class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 flex flex-col items-center text-center">
+        <i class="fa-solid fa-bell text-3xl text-primary mb-3" aria-hidden="true"></i>
+        <h2 class="text-lg font-semibold text-neutral-900 mb-1">{% trans "Notificações" %}</h2>
+        <p class="text-sm text-neutral-600 mb-4">{% trans "Gerencie suas preferências e históricos de avisos." %}</p>
+        <a href="{% url 'accounts:notificacoes' %}" class="mt-auto text-sm text-blue-600 hover:underline">{% trans "Acessar" %}</a>
+      </article>
+    </div>
+  </main>
 </section>
 {% endblock %}

--- a/organizacoes/templates/organizacoes/update.html
+++ b/organizacoes/templates/organizacoes/update.html
@@ -1,18 +1,19 @@
 {% extends 'base.html' %}
+{% load i18n %}
 
-{% block title %}Editar Organização | Hubx{% endblock %}
+{% block title %}{% trans "Editar Organização" %} | Hubx{% endblock %}
 
 {% block content %}
 <section class="max-w-2xl mx-auto px-4 py-10">
-  <div class="mb-6 flex items-center gap-4">
+  <header class="mb-6 flex items-center gap-4">
     <a href="{% url 'organizacoes:list' %}" class="inline-flex items-center text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100">
       <svg class="mr-2" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
         <polyline points="15,18 9,12 15,6" />
       </svg>
-      Voltar
+      {% trans "Voltar" %}
     </a>
-    <h1 class="text-2xl font-bold text-neutral-900">Editar Organização</h1>
-  </div>
+    <h1 class="text-2xl font-bold text-neutral-900">{% trans "Editar Organização" %}</h1>
+  </header>
 
   {% if messages %}
   <div class="mb-4 space-y-2">
@@ -22,6 +23,7 @@
   </div>
   {% endif %}
 
+  <main>
   <form method="post" enctype="multipart/form-data" class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 space-y-6">
     {% csrf_token %}
 
@@ -75,9 +77,10 @@
     </div>
 
     <div class="flex justify-end gap-3 pt-4 border-t border-neutral-100">
-      <a href="{% url 'organizacoes:list' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100">Cancelar</a>
-      <button type="submit" class="text-sm px-4 py-2 rounded-xl bg-primary-600 text-white hover:bg-primary-700">Salvar</button>
+      <a href="{% url 'organizacoes:list' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100">{% trans "Cancelar" %}</a>
+      <button type="submit" class="text-sm px-4 py-2 rounded-xl bg-primary-600 text-white hover:bg-primary-700">{% trans "Salvar" %}</button>
     </div>
   </form>
+  </main>
 </section>
 {% endblock %}

--- a/tokens/templates/tokens/ativar_2fa.html
+++ b/tokens/templates/tokens/ativar_2fa.html
@@ -1,11 +1,14 @@
 {% extends "base.html" %}
-{% load widget_tweaks %}
+{% load widget_tweaks i18n %}
 
-{% block title %}Ativar 2FA | HubX{% endblock %}
+{% block title %}{% trans "Ativar 2FA" %} | HubX{% endblock %}
 
 {% block content %}
 <section class="max-w-md mx-auto px-4 py-12">
-  <h1 class="text-2xl font-bold text-center mb-6">Ativar Autenticação de Dois Fatores</h1>
+  <header class="text-center mb-6">
+    <h1 class="text-2xl font-bold">{% trans "Ativar Autenticação de Dois Fatores" %}</h1>
+    <p class="text-sm text-neutral-600 mt-2">{% trans "Escaneie o QR Code no aplicativo autenticador ou digite o código exibido." %}</p>
+  </header>
 
   {% if messages %}
     <div class="mb-4 space-y-2">
@@ -17,18 +20,23 @@
     </div>
   {% endif %}
 
-  <form method="post" action="{% url 'tokens:ativar_2fa' %}" class="bg-white rounded-2xl shadow p-6 space-y-4">
-    {% csrf_token %}
-    <div>
-      <label for="{{ form.codigo_totp.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.codigo_totp.label }}</label>
-      {{ form.codigo_totp|add_class:"form-input" }}
-      {% if form.codigo_totp.errors %}
-        <p class="text-sm text-red-600 mt-1">{{ form.codigo_totp.errors.0 }}</p>
-      {% endif %}
-    </div>
-    <div class="text-right">
-      <button type="submit" class="rounded-xl bg-primary px-4 py-2 text-white hover:bg-primary/90">Ativar</button>
-    </div>
-  </form>
+  <main>
+    <form method="post" action="{% url 'tokens:ativar_2fa' %}" class="bg-white rounded-2xl shadow p-6 space-y-4">
+      {% csrf_token %}
+      <div>
+        <label for="{{ form.codigo_totp.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.codigo_totp.label }}</label>
+        {{ form.codigo_totp|add_class:"form-input" }}
+        {% if form.codigo_totp.errors %}
+          <p class="text-sm text-red-600 mt-1">{{ form.codigo_totp.errors.0 }}</p>
+        {% endif %}
+      </div>
+      <div class="text-right">
+        <button type="submit" class="rounded-xl bg-primary px-4 py-2 text-white hover:bg-primary/90">{% trans "Ativar" %}</button>
+      </div>
+    </form>
+  </main>
+  <footer class="mt-6 text-center">
+    <a href="{% url 'accounts:seguranca' %}" class="text-sm text-blue-600 hover:underline">{% trans "Voltar ao perfil de segurança" %}</a>
+  </footer>
 </section>
 {% endblock %}


### PR DESCRIPTION
## Summary
- improve agenda templates with semantic sections and i18n
- redesign home page into grid of actionable cards
- enhance organization edit and token 2FA pages with headings and links

## Testing
- `ruff check .` *(fails: Module level import not at top of file)*
- `black --check .` *(fails: would reformat 18 files)*
- `mypy .` *(fails: Found 413 errors)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68897a0d84048325b688a32d4ee77079