### PR TITLE
feat: refactor empresas templates with tailwind

### DIFF
--- a/empresas/templates/empresas/busca.html
+++ b/empresas/templates/empresas/busca.html
@@ -1,76 +1,26 @@
 {% extends 'base.html' %}
-{% load static %}
+{% load i18n %}
 
-{% block title %}Buscar Empresas | Hubx{% endblock %}
+{% block title %}{% translate 'Buscar Empresas' %}{% endblock %}
 
 {% block content %}
-<section class="max-w-7xl mx-auto px-4 py-10">
-  <div class="text-center mb-10">
-    <h1 class="text-3xl font-bold text-neutral-900">Buscar Empresas</h1>
-    <p class="text-neutral-600 text-sm mt-1">Encontre empresas na plataforma HubX</p>
-  </div>
+<section class="max-w-7xl mx-auto px-4 py-10 space-y-6">
+  <header class="text-center">
+    <h1 class="text-3xl font-bold text-neutral-900">{% translate 'Buscar Empresas' %}</h1>
+    <p class="text-neutral-600 text-sm">{% translate 'Encontre empresas na plataforma HubX' %}</p>
+  </header>
 
-  <!-- Barra de busca -->
-  <form method="get" class="max-w-xl mx-auto mb-10 flex items-center gap-2">
-    <input
-      type="text"
-      name="q"
-      value="{{ q }}"
-      placeholder="Buscar por nome, tags ou palavras-chave..."
-      class="flex-grow px-4 py-2 rounded-xl border border-neutral-300 shadow-sm text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
-    />
-    <button type="submit" class="bg-primary-600 text-white px-4 py-2 rounded-xl hover:bg-primary-700 transition text-sm">
-      🔍
-    </button>
+  <form hx-get="{% url 'empresas:buscar' %}" hx-target="#resultado-busca" hx-push-url="true" class="max-w-xl mx-auto flex items-center gap-2">
+    <input type="text" name="q" value="{{ q }}" placeholder="{% translate 'Buscar por nome, CNPJ ou localização...' %}" class="flex-grow p-2 border rounded" />
+    <button type="submit" class="bg-primary-600 text-white px-4 py-2 rounded hover:bg-primary-700">🔍</button>
   </form>
 
-  <!-- Lista de empresas -->
-  {% if empresas %}
-    <div class="grid gap-6 sm:grid-cols-2 md:grid-cols-3">
-      {% for empresa in empresas %}
-      <div class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-5 flex flex-col justify-between">
-        <div class="flex justify-center mb-4">
-          {% if empresa.logo %}
-            <img src="{{ empresa.logo.url }}" alt="{{ empresa.nome }}" class="h-16 w-16 object-cover rounded-xl" />
-          {% else %}
-            <div class="h-16 w-16 rounded-xl bg-neutral-100 flex items-center justify-center text-lg font-semibold text-neutral-600">
-              {{ empresa.nome|first|upper }}
-            </div>
-          {% endif %}
-        </div>
-        <div class="text-center mb-2">
-          <h3 class="text-lg font-bold text-neutral-900">{{ empresa.nome }}</h3>
-          <p class="text-sm text-neutral-600">{{ empresa.tipo }}</p>
-          <p class="text-sm text-neutral-500">{{ empresa.municipio }}, {{ empresa.estado }}</p>
-        </div>
-        <div class="flex flex-wrap gap-1 justify-center my-2">
-          {% for tag in empresa.tags.all|slice:":3" %}
-            <span class="text-xs bg-primary-100 text-primary-800 rounded-full px-2 py-0.5">{{ tag.nome }}</span>
-          {% endfor %}
-          {% if empresa.tags.count > 3 %}
-            <span class="text-xs text-neutral-500">+{{ empresa.tags.count|add:"-3" }}</span>
-          {% endif %}
-        </div>
-        <div class="flex justify-center gap-3 mt-4">
-          <a href="{% url 'empresas:detail' empresa.id %}" class="text-sm text-blue-600 hover:underline">Ver</a>
-          {% if user == empresa.usuario %}
-            <a href="{% url 'empresas:editar' empresa.id %}" class="text-sm text-yellow-600 hover:underline">Editar</a>
-          {% endif %}
-        </div>
-      </div>
-      {% endfor %}
-    </div>
-  {% else %}
-    <!-- Estado vazio -->
-    <div class="text-center mt-20">
-      <p class="text-neutral-500 text-sm">Nenhuma empresa encontrada para <strong>{{ q }}</strong>.</p>
-    </div>
-  {% endif %}
+  <div id="resultado-busca">
+    {% include 'empresas/includes/empresas_table.html' with empresas=empresas %}
+  </div>
 
   <div class="mt-10 text-center">
-    <a href="{% url 'empresas:lista' %}" class="inline-block text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100">
-      Voltar para Minhas Empresas
-    </a>
+    <a href="{% url 'empresas:lista' %}" class="text-sm px-4 py-2 border rounded hover:bg-neutral-100">{% translate 'Voltar para Minhas Empresas' %}</a>
   </div>
 </section>
 {% endblock %}

--- a/empresas/templates/empresas/contato_confirm_delete.html
+++ b/empresas/templates/empresas/contato_confirm_delete.html
@@ -1,11 +1,15 @@
 {% extends 'base.html' %}
-{% block title %}Remover Contato{% endblock %}
+{% load i18n %}
+{% block title %}{% translate 'Remover Contato' %}{% endblock %}
 {% block content %}
-<div class="max-w-xl mx-auto py-8">
-  <p>Confirma remover contato {{ contato.nome }}?</p>
-  <form method="post">
-    {% csrf_token %}
-    <button class="bg-red-600 text-white px-4 py-2 rounded">Remover</button>
-  </form>
-</div>
+<section class="max-w-md mx-auto py-10">
+  <div class="bg-red-50 text-red-800 p-6 rounded-md text-center space-y-4">
+    <p>{% blocktrans %}Confirma remover contato {{ contato.nome }}?{% endblocktrans %}</p>
+    <form method="post" class="flex justify-center gap-3">
+      {% csrf_token %}
+      <a href="#" onclick="history.back()" class="px-4 py-2 border rounded">{% translate 'Cancelar' %}</a>
+      <button type="submit" class="px-4 py-2 bg-red-600 text-white rounded">{% translate 'Remover' %}</button>
+    </form>
+  </div>
+</section>
 {% endblock %}

--- a/empresas/templates/empresas/contato_form.html
+++ b/empresas/templates/empresas/contato_form.html
@@ -1,11 +1,35 @@
 {% extends 'base.html' %}
-{% block title %}Contato{% endblock %}
+{% load i18n %}
+{% block title %}{% translate 'Contato' %}{% endblock %}
 {% block content %}
-<div class="max-w-xl mx-auto py-8">
-  <form method="post" class="space-y-4" hx-post="" hx-target="closest form" hx-swap="outerHTML">
+<section class="max-w-md mx-auto py-8">
+  <form method="post" class="space-y-4 bg-white border border-neutral-200 p-6 rounded-md" hx-post="" hx-target="closest form" hx-swap="outerHTML">
     {% csrf_token %}
-    {{ form.as_p }}
-    <button class="bg-primary-600 text-white px-4 py-2 rounded">Salvar</button>
+    <div>
+      <label for="{{ form.nome.id_for_label }}" class="block text-sm font-medium text-neutral-700">{% translate 'Nome' %}</label>
+      {{ form.nome|add_class:'w-full p-2 border rounded' }}
+      {{ form.nome.errors }}
+    </div>
+    <div>
+      <label for="{{ form.email.id_for_label }}" class="block text-sm font-medium text-neutral-700">{% translate 'E-mail' %}</label>
+      {{ form.email|add_class:'w-full p-2 border rounded' }}
+      {{ form.email.errors }}
+    </div>
+    <div>
+      <label for="{{ form.telefone.id_for_label }}" class="block text-sm font-medium text-neutral-700">{% translate 'Telefone' %}</label>
+      {{ form.telefone|add_class:'w-full p-2 border rounded' }}
+      {{ form.telefone.errors }}
+    </div>
+    <div>
+      <label for="{{ form.cargo.id_for_label }}" class="block text-sm font-medium text-neutral-700">{% translate 'Cargo' %}</label>
+      {{ form.cargo|add_class:'w-full p-2 border rounded' }}
+      {{ form.cargo.errors }}
+    </div>
+    <div class="flex items-center gap-2">
+      {{ form.principal }}
+      <label for="{{ form.principal.id_for_label }}" class="text-sm text-neutral-700">{% translate 'Contato principal' %}</label>
+    </div>
+    <button class="bg-primary-600 text-white px-4 py-2 rounded" type="submit">{% translate 'Salvar' %}</button>
   </form>
-</div>
+</section>
 {% endblock %}

--- a/empresas/templates/empresas/includes/empresas_table.html
+++ b/empresas/templates/empresas/includes/empresas_table.html
@@ -1,0 +1,49 @@
+{% load i18n %}
+{% if empresas %}
+<table class="min-w-full text-sm">
+  <thead class="bg-neutral-100">
+    <tr>
+      <th class="px-3 py-2 text-left font-semibold">{% translate "Nome" %}</th>
+      <th class="px-3 py-2 text-left font-semibold">{% translate "Contato principal" %}</th>
+      <th class="px-3 py-2 text-left font-semibold">{% translate "Setor" %}</th>
+      <th class="px-3 py-2 text-center font-semibold">{% translate "Ações" %}</th>
+    </tr>
+  </thead>
+  <tbody class="divide-y divide-neutral-200 bg-white">
+    {% for empresa in empresas %}
+    <tr>
+      <td class="px-3 py-2">{{ empresa.nome }}</td>
+      <td class="px-3 py-2">
+        {% with contato=empresa.contatos.first %}
+          {% if contato %}{{ contato.nome }}{% else %}-{% endif %}
+        {% endwith %}
+      </td>
+      <td class="px-3 py-2">{{ empresa.tipo }}</td>
+      <td class="px-3 py-2 text-center space-x-2">
+        <a href="{% url 'empresas:editar' empresa.pk %}" class="text-blue-600 hover:underline">{% translate "Editar" %}</a>
+        <a href="{% url 'empresas:remover' empresa.pk %}" class="text-red-600 hover:underline">
+          {% translate "Remover" %}
+        </a>
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% if is_paginated %}
+<nav class="mt-4 flex justify-center text-sm" aria-label="{% translate 'Paginação' %}">
+  {% if page_obj.has_previous %}
+    <a hx-get="?page={{ page_obj.previous_page_number }}&nome={{ request.GET.nome }}&segmento={{ request.GET.segmento }}" hx-target="#empresas-table" hx-push-url="true" class="px-3 py-1 border rounded-l">{% translate "Anterior" %}</a>
+  {% else %}
+    <span class="px-3 py-1 border rounded-l text-neutral-400">{% translate "Anterior" %}</span>
+  {% endif %}
+  <span class="px-3 py-1 border-t border-b">{{ page_obj.number }} / {{ page_obj.paginator.num_pages }}</span>
+  {% if page_obj.has_next %}
+    <a hx-get="?page={{ page_obj.next_page_number }}&nome={{ request.GET.nome }}&segmento={{ request.GET.segmento }}" hx-target="#empresas-table" hx-push-url="true" class="px-3 py-1 border rounded-r">{% translate "Próxima" %}</a>
+  {% else %}
+    <span class="px-3 py-1 border rounded-r text-neutral-400">{% translate "Próxima" %}</span>
+  {% endif %}
+</nav>
+{% endif %}
+{% else %}
+<p class="text-center text-neutral-500 py-10">{% translate "Nenhuma empresa encontrada." %}</p>
+{% endif %}

--- a/empresas/templates/empresas/lista.html
+++ b/empresas/templates/empresas/lista.html
@@ -1,132 +1,31 @@
 {% extends "base.html" %}
-{% load static %}
+{% load i18n %}
 
-{% block title %}Empresas - HubX{% endblock %}
+{% block title %}{% translate "Empresas" %}{% endblock %}
 
 {% block content %}
-<div class="max-w-7xl mx-auto px-4 py-10">
+<section class="max-w-7xl mx-auto px-4 py-10 space-y-6">
+  <header class="flex items-center justify-between">
+    <h1 class="text-3xl font-bold text-neutral-900">{% translate "Empresas" %}</h1>
+    <a href="{% url 'empresas:nova' %}" class="bg-primary-600 text-white px-4 py-2 rounded-md text-sm hover:bg-primary-700">{% translate "Nova Empresa" %}</a>
+  </header>
 
-  <!-- Header -->
-  <div class="flex flex-col md:flex-row md:items-center md:justify-between mb-10 gap-4">
+  <form hx-get="{% url 'empresas:lista' %}" hx-target="#empresas-table" hx-push-url="true" class="grid grid-cols-1 sm:grid-cols-3 gap-4 bg-white border border-neutral-200 p-4 rounded-md">
     <div>
-      <h1 class="text-3xl font-bold text-neutral-900 mb-1">Empresas</h1>
-      <p class="text-neutral-600 text-sm">Descubra e conecte-se com empresas da sua região</p>
-    </div>
-    <a href="{% url 'empresas:nova' %}" class="inline-flex items-center gap-2 bg-primary-600 text-white text-sm px-4 py-2 rounded-xl hover:bg-primary-700 transition">
-      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-        <line x1="12" y1="5" x2="12" y2="19"/>
-        <line x1="5" y1="12" x2="19" y2="12"/>
-      </svg>
-      Nova Empresa
-    </a>
-  </div>
-
-  <!-- Filtros -->
-  <form method="get" class="grid md:grid-cols-4 gap-4 bg-white border border-neutral-200 p-6 rounded-2xl shadow-sm mb-10">
-    <div>
-      <label for="busca" class="block text-sm font-medium text-neutral-700 mb-1">Buscar</label>
-      <input type="text" id="busca" name="busca" placeholder="Nome da empresa..." value="{{ request.GET.busca }}"
-        class="w-full rounded-xl border border-neutral-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500">
+      <label for="nome" class="block text-sm font-medium text-neutral-700">{% translate "Nome" %}</label>
+      <input type="text" id="nome" name="nome" value="{{ request.GET.nome }}" class="w-full p-2 border rounded" />
     </div>
     <div>
-      <label for="tipo" class="block text-sm font-medium text-neutral-700 mb-1">Tipo</label>
-      <select id="tipo" name="tipo"
-        class="w-full rounded-xl border border-neutral-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500">
-        <option value="">Todos os tipos</option>
-        <option value="startup" {% if request.GET.tipo == 'startup' %}selected{% endif %}>Startup</option>
-        <option value="corporacao" {% if request.GET.tipo == 'corporacao' %}selected{% endif %}>Corporação</option>
-        <option value="ong" {% if request.GET.tipo == 'ong' %}selected{% endif %}>ONG</option>
-        <option value="cooperativa" {% if request.GET.tipo == 'cooperativa' %}selected{% endif %}>Cooperativa</option>
-      </select>
-    </div>
-    <div>
-      <label for="cidade" class="block text-sm font-medium text-neutral-700 mb-1">Cidade</label>
-      <input type="text" id="cidade" name="cidade" placeholder="Cidade..." value="{{ request.GET.cidade }}"
-        class="w-full rounded-xl border border-neutral-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500">
+      <label for="segmento" class="block text-sm font-medium text-neutral-700">{% translate "Segmento" %}</label>
+      <input type="text" id="segmento" name="segmento" value="{{ request.GET.segmento }}" class="w-full p-2 border rounded" />
     </div>
     <div class="flex items-end">
-      <button type="submit" class="w-full bg-primary-600 text-white text-sm px-4 py-2 rounded-xl hover:bg-primary-700 transition">
-        Buscar
-      </button>
+      <button type="submit" class="w-full bg-primary-600 text-white p-2 rounded hover:bg-primary-700">{% translate "Filtrar" %}</button>
     </div>
   </form>
 
-  <!-- Lista de Empresas -->
-  {% if empresas %}
-    <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
-      {% for empresa in empresas %}
-        <div class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-5 flex flex-col h-full">
-          <div class="flex items-start gap-4 mb-4">
-            <div class="w-16 h-16 flex items-center justify-center bg-neutral-100 rounded-xl overflow-hidden">
-              {% if empresa.logo %}
-                <img src="{{ empresa.logo.url }}" alt="{{ empresa.nome }}" class="w-full h-full object-cover rounded-xl">
-              {% else %}
-                <span class="text-xl font-bold text-neutral-600">{{ empresa.nome|first|upper }}</span>
-              {% endif %}
-            </div>
-            <div class="flex-1 min-w-0">
-              <h3 class="text-base font-semibold text-neutral-900 truncate">{{ empresa.nome }}</h3>
-              <p class="text-xs text-primary-700 mt-1">{{ empresa.get_tipo_display }}</p>
-              {% if empresa.cidade %}
-                <p class="text-sm text-neutral-500 mt-1">{{ empresa.cidade }}, {{ empresa.estado }}</p>
-              {% endif %}
-            </div>
-          </div>
-          {% if empresa.descricao %}
-            <p class="text-sm text-neutral-600 mb-4 line-clamp-3">{{ empresa.descricao|truncatewords:20 }}</p>
-          {% endif %}
-          {% if empresa.tags.all %}
-            <div class="flex flex-wrap gap-2 mb-4">
-              {% for tag in empresa.tags.all|slice:":3" %}
-                <span class="text-xs bg-primary-100 text-primary-800 px-2 py-0.5 rounded-full">{{ tag.nome }}</span>
-              {% endfor %}
-              {% if empresa.tags.count > 3 %}
-                <span class="text-xs text-neutral-500">+{{ empresa.tags.count|add:"-3" }}</span>
-              {% endif %}
-            </div>
-          {% endif %}
-          <div class="mt-auto flex gap-2">
-            <a href="{% url 'empresas:detail' empresa.pk %}" class="text-sm text-blue-600 hover:underline">Ver</a>
-            {% if empresa.criador == user %}
-              <a href="{% url 'empresas:editar' empresa.pk %}" class="text-sm text-yellow-600 hover:underline">Editar</a>
-            {% endif %}
-          </div>
-        </div>
-      {% endfor %}
-    </div>
-
-    <!-- Paginação -->
-    {% if is_paginated %}
-      <div class="text-center mt-10">
-        <div class="inline-flex gap-2 items-center text-sm">
-          {% if page_obj.has_previous %}
-            <a href="?page={{ page_obj.previous_page_number }}" class="px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100">Anterior</a>
-          {% endif %}
-          <span class="px-4 py-2 text-neutral-500">Página {{ page_obj.number }} de {{ page_obj.paginator.num_pages }}</span>
-          {% if page_obj.has_next %}
-            <a href="?page={{ page_obj.next_page_number }}" class="px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100">Próxima</a>
-          {% endif %}
-        </div>
-      </div>
-    {% endif %}
-
-  {% else %}
-    <!-- Estado vazio -->
-    <div class="bg-white border border-neutral-200 rounded-2xl p-10 text-center shadow-sm mt-10">
-      <div class="mx-auto mb-6 w-20 h-20 bg-neutral-100 rounded-full flex items-center justify-center">
-        <svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-          <path d="M3 21h18"/><path d="M5 21V7l8-4v18"/><path d="M19 21V11l-6-4"/>
-        </svg>
-      </div>
-      <h3 class="text-xl font-semibold text-neutral-900 mb-2">Nenhuma empresa encontrada</h3>
-      <p class="text-neutral-600 mb-6">Seja o primeiro a cadastrar uma empresa na plataforma</p>
-      <a href="{% url 'empresas:nova' %}" class="inline-flex items-center gap-2 bg-primary-600 text-white text-sm px-4 py-2 rounded-xl hover:bg-primary-700">
-        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-          <line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/>
-        </svg>
-        Cadastrar Primeira Empresa
-      </a>
-    </div>
-  {% endif %}
-</div>
+  <div id="empresas-table">
+    {% include "empresas/includes/empresas_table.html" %}
+  </div>
+</section>
 {% endblock %}

--- a/empresas/templates/empresas/nova.html
+++ b/empresas/templates/empresas/nova.html
@@ -1,120 +1,81 @@
 {% extends "base.html" %}
-{% load custom_filters %}
-{% load static %}
+{% load custom_filters i18n %}
 
-{% block title %}Nova Empresa - HubX{% endblock %}
+{% block title %}{% translate 'Nova Empresa' %}{% endblock %}
 
 {% block content %}
-<div class="max-w-3xl mx-auto px-4 py-10">
-  <!-- Cabeçalho -->
-  <div class="flex items-start gap-4 mb-8">
-    <a href="{% url 'empresas:lista' %}" class="inline-flex items-center gap-2 text-sm px-3 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100">
-      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-        <polyline points="15,18 9,12 15,6"/>
-      </svg>
-      Voltar
-    </a>
+<section class="max-w-3xl mx-auto px-4 py-10 space-y-6">
+  <header class="flex items-start gap-4">
+    <a href="{% url 'empresas:lista' %}" class="text-sm px-3 py-2 border rounded hover:bg-neutral-100">{% translate 'Voltar' %}</a>
     <div>
-      <h1 class="text-2xl font-bold text-neutral-900 mb-1">Nova Empresa</h1>
-      <p class="text-sm text-neutral-600">Cadastre sua empresa na plataforma</p>
+      <h1 class="text-2xl font-bold text-neutral-900">{% translate 'Nova Empresa' %}</h1>
+      <p class="text-sm text-neutral-600">{% translate 'Cadastre sua empresa na plataforma' %}</p>
     </div>
-  </div>
+  </header>
 
-  <!-- Formulário -->
-  <form method="post" enctype="multipart/form-data" class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 space-y-6">
+  <form method="post" enctype="multipart/form-data" class="bg-white border border-neutral-200 rounded-md shadow-sm p-6 space-y-6">
     {% csrf_token %}
-
     <div class="grid md:grid-cols-2 gap-6">
       <div>
-        <label for="{{ form.nome.id_for_label }}" class="block text-sm font-medium text-neutral-700 mb-1">{{ form.nome.label }}</label>
-        {{ form.nome|add_class:"form-input" }}
-        {% if form.nome.errors %}
-          <p class="text-sm text-red-600 mt-1">{{ form.nome.errors }}</p>
-        {% endif %}
+        <label for="{{ form.nome.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.nome.label }}</label>
+        {{ form.nome|add_class:'w-full p-2 border rounded' }}
+        {{ form.nome.errors }}
       </div>
-
       <div>
-        <label for="{{ form.tipo.id_for_label }}" class="block text-sm font-medium text-neutral-700 mb-1">{{ form.tipo.label }}</label>
-        {{ form.tipo|add_class:"form-select" }}
-        {% if form.tipo.errors %}
-          <p class="text-sm text-red-600 mt-1">{{ form.tipo.errors }}</p>
-        {% endif %}
+        <label for="{{ form.tipo.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.tipo.label }}</label>
+        {{ form.tipo|add_class:'w-full p-2 border rounded' }}
+        {{ form.tipo.errors }}
       </div>
     </div>
-
     <div>
-      <label for="{{ form.descricao.id_for_label }}" class="block text-sm font-medium text-neutral-700 mb-1">{{ form.descricao.label }}</label>
-      {{ form.descricao|add_class:"form-textarea" }}
-      {% if form.descricao.errors %}
-        <p class="text-sm text-red-600 mt-1">{{ form.descricao.errors }}</p>
-      {% endif %}
-      <p class="text-xs text-neutral-500 mt-1">Descreva brevemente o que sua empresa faz e seus principais objetivos.</p>
+      <label for="{{ form.descricao.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.descricao.label }}</label>
+      {{ form.descricao|add_class:'w-full p-2 border rounded' }}
+      {{ form.descricao.errors }}
+      <p class="text-xs text-neutral-500 mt-1">{% translate 'Descreva brevemente o que sua empresa faz e seus principais objetivos.' %}</p>
     </div>
-
     <div class="grid md:grid-cols-2 gap-6">
       <div>
-        <label for="{{ form.cidade.id_for_label }}" class="block text-sm font-medium text-neutral-700 mb-1">{{ form.cidade.label }}</label>
-        {{ form.cidade|add_class:"form-input" }}
-        {% if form.cidade.errors %}
-          <p class="text-sm text-red-600 mt-1">{{ form.cidade.errors }}</p>
-        {% endif %}
+        <label for="{{ form.cidade.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.cidade.label }}</label>
+        {{ form.cidade|add_class:'w-full p-2 border rounded' }}
+        {{ form.cidade.errors }}
       </div>
       <div>
-        <label for="{{ form.estado.id_for_label }}" class="block text-sm font-medium text-neutral-700 mb-1">{{ form.estado.label }}</label>
-        {{ form.estado|add_class:"form-select" }}
-        {% if form.estado.errors %}
-          <p class="text-sm text-red-600 mt-1">{{ form.estado.errors }}</p>
-        {% endif %}
+        <label for="{{ form.estado.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.estado.label }}</label>
+        {{ form.estado|add_class:'w-full p-2 border rounded' }}
+        {{ form.estado.errors }}
       </div>
     </div>
-
     <div class="grid md:grid-cols-2 gap-6">
       <div>
-        <label for="{{ form.email.id_for_label }}" class="block text-sm font-medium text-neutral-700 mb-1">{{ form.email.label }}</label>
-        {{ form.email|add_class:"form-input" }}
-        {% if form.email.errors %}
-          <p class="text-sm text-red-600 mt-1">{{ form.email.errors }}</p>
-        {% endif %}
+        <label for="{{ form.email.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.email.label }}</label>
+        {{ form.email|add_class:'w-full p-2 border rounded' }}
+        {{ form.email.errors }}
       </div>
       <div>
-        <label for="{{ form.telefone.id_for_label }}" class="block text-sm font-medium text-neutral-700 mb-1">{{ form.telefone.label }}</label>
-        {{ form.telefone|add_class:"form-input" }}
-        {% if form.telefone.errors %}
-          <p class="text-sm text-red-600 mt-1">{{ form.telefone.errors }}</p>
-        {% endif %}
+        <label for="{{ form.telefone.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.telefone.label }}</label>
+        {{ form.telefone|add_class:'w-full p-2 border rounded' }}
+        {{ form.telefone.errors }}
       </div>
     </div>
-
     <div>
-      <label for="{{ form.website.id_for_label }}" class="block text-sm font-medium text-neutral-700 mb-1">{{ form.website.label }}</label>
-      {{ form.website|add_class:"form-input" }}
-      {% if form.website.errors %}
-        <p class="text-sm text-red-600 mt-1">{{ form.website.errors }}</p>
-      {% endif %}
-      <p class="text-xs text-neutral-500 mt-1">Inclua http:// ou https:// no início da URL.</p>
+      <label for="{{ form.website.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.website.label }}</label>
+      {{ form.website|add_class:'w-full p-2 border rounded' }}
+      {{ form.website.errors }}
+      <p class="text-xs text-neutral-500 mt-1">{% translate 'Inclua http:// ou https:// no início da URL.' %}</p>
     </div>
-
     <div>
-      <label for="{{ form.logo.id_for_label }}" class="block text-sm font-medium text-neutral-700 mb-1">{{ form.logo.label }}</label>
-      {{ form.logo|add_class:"form-input" }}
-      {% if form.logo.errors %}
-        <p class="text-sm text-red-600 mt-1">{{ form.logo.errors }}</p>
-      {% endif %}
+      <label for="{{ form.logo.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.logo.label }}</label>
+      {{ form.logo|add_class:'w-full p-2 border rounded' }}
+      {{ form.logo.errors }}
       <p class="text-xs text-neutral-500 mt-1">PNG, JPG até 2MB</p>
     </div>
-
-    <!-- Ações -->
-    <div class="flex justify-end gap-3 pt-4 border-t border-neutral-100">
-      <a href="{% url 'empresas:lista' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100">
-        Cancelar
-      </a>
-      <button type="submit" class="text-sm px-4 py-2 rounded-xl bg-primary-600 text-white hover:bg-primary-700 inline-flex items-center gap-2">
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-          <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"/>
-        </svg>
-        Cadastrar Empresa
+    <div class="flex justify-end gap-3 border-t pt-4">
+      <a href="{% url 'empresas:lista' %}" class="text-sm px-4 py-2 border rounded">{% translate 'Cancelar' %}</a>
+      <button type="submit" class="text-sm px-4 py-2 bg-primary-600 text-white rounded hover:bg-primary-700 inline-flex items-center gap-2">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"/></svg>
+        {% translate 'Cadastrar Empresa' %}
       </button>
     </div>
   </form>
-</div>
+</section>
 {% endblock %}

--- a/empresas/templates/empresas/tag_confirm_delete.html
+++ b/empresas/templates/empresas/tag_confirm_delete.html
@@ -1,21 +1,16 @@
 {% extends 'base.html' %}
-{% block title %}Remover Item | Hubx{% endblock %}
-
+{% load i18n %}
+{% block title %}{% translate 'Remover Item' %}{% endblock %}
 {% block content %}
-<div class="max-w-md mx-auto px-4 py-16">
-  <div class="bg-white border border-red-200 rounded-2xl shadow-sm p-6 text-center">
-    <h2 class="text-xl font-semibold text-red-700 mb-4">Remover Item</h2>
-    <p class="text-sm text-neutral-700">Tem certeza que deseja remover <strong>{{ object.nome }}</strong>?</p>
-
-    <form method="post" class="mt-6 flex justify-center gap-3">
+<section class="max-w-md mx-auto py-16">
+  <div class="bg-red-50 text-red-800 p-6 rounded-md text-center space-y-4">
+    <h2 class="text-xl font-semibold">{% translate 'Remover Item' %}</h2>
+    <p class="text-sm">{% blocktrans %}Tem certeza que deseja remover <strong>{{ object.nome }}</strong>?{% endblocktrans %}</p>
+    <form method="post" class="flex justify-center gap-3">
       {% csrf_token %}
-      <a href="{% url 'empresas:tags_list' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100">
-        Cancelar
-      </a>
-      <button type="submit" class="text-sm px-4 py-2 rounded-xl bg-red-600 text-white hover:bg-red-700">
-        Remover
-      </button>
+      <a href="{% url 'empresas:tags_list' %}" class="px-4 py-2 border rounded text-sm">{% translate 'Cancelar' %}</a>
+      <button type="submit" class="px-4 py-2 bg-red-600 text-white rounded text-sm hover:bg-red-700">{% translate 'Remover' %}</button>
     </form>
   </div>
-</div>
+</section>
 {% endblock %}

--- a/empresas/templates/empresas/tag_form.html
+++ b/empresas/templates/empresas/tag_form.html
@@ -1,46 +1,28 @@
 {% extends 'base.html' %}
-{% block title %}{% if form.instance.pk %}Editar Item | Hubx{% else %}Novo Item | Hubx{% endif %}{% endblock %}
-
+{% load i18n %}
+{% block title %}{% if form.instance.pk %}{% translate 'Editar Item' %}{% else %}{% translate 'Novo Item' %}{% endif %}{% endblock %}
 {% block content %}
-<div class="max-w-xl mx-auto px-4 py-10">
-  <div class="mb-8">
-    <h1 class="text-2xl font-bold text-neutral-900">
-      {% if form.instance.pk %}Editar{% else %}Cadastrar{% endif %} Item
-    </h1>
-    <p class="text-sm text-neutral-600 mt-1">Preencha o nome e descrição do item</p>
-  </div>
-
-  <form method="post" class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 space-y-6">
+<section class="max-w-xl mx-auto px-4 py-10 space-y-6">
+  <header>
+    <h1 class="text-2xl font-bold text-neutral-900">{% if form.instance.pk %}{% translate 'Editar' %}{% else %}{% translate 'Cadastrar' %}{% endif %} {% translate 'Item' %}</h1>
+    <p class="text-sm text-neutral-600">{% translate 'Preencha o nome e descrição do item' %}</p>
+  </header>
+  <form method="post" class="bg-white border border-neutral-200 rounded-md p-6 space-y-6">
     {% csrf_token %}
-
     <div>
-      <label for="{{ form.nome.id_for_label }}" class="block text-sm font-medium text-neutral-700 mb-1">
-        {{ form.nome.label }}
-      </label>
-      {{ form.nome|add_class:"form-input" }}
-      {% if form.nome.errors %}
-        <p class="text-sm text-red-600 mt-1">{{ form.nome.errors }}</p>
-      {% endif %}
+      <label for="{{ form.nome.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.nome.label }}</label>
+      {{ form.nome|add_class:'w-full p-2 border rounded' }}
+      {% if form.nome.errors %}<p class="text-sm text-red-600">{{ form.nome.errors }}</p>{% endif %}
     </div>
-
     <div>
-      <label for="{{ form.descricao.id_for_label }}" class="block text-sm font-medium text-neutral-700 mb-1">
-        {{ form.descricao.label }}
-      </label>
-      {{ form.descricao|add_class:"form-textarea" }}
-      {% if form.descricao.errors %}
-        <p class="text-sm text-red-600 mt-1">{{ form.descricao.errors }}</p>
-      {% endif %}
+      <label for="{{ form.descricao.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.descricao.label }}</label>
+      {{ form.descricao|add_class:'w-full p-2 border rounded' }}
+      {% if form.descricao.errors %}<p class="text-sm text-red-600">{{ form.descricao.errors }}</p>{% endif %}
     </div>
-
-    <div class="flex justify-end gap-3 pt-4 border-t border-neutral-100">
-      <a href="{% url 'empresas:tags_list' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100">
-        Cancelar
-      </a>
-      <button type="submit" class="text-sm px-4 py-2 rounded-xl bg-primary-600 text-white hover:bg-primary-700">
-        Salvar
-      </button>
+    <div class="flex justify-end gap-3 border-t pt-4">
+      <a href="{% url 'empresas:tags_list' %}" class="px-4 py-2 text-sm border rounded">{% translate 'Cancelar' %}</a>
+      <button type="submit" class="px-4 py-2 text-sm bg-primary-600 text-white rounded hover:bg-primary-700">{% translate 'Salvar' %}</button>
     </div>
   </form>
-</div>
+</section>
 {% endblock %}

--- a/empresas/templates/empresas/tags_list.html
+++ b/empresas/templates/empresas/tags_list.html
@@ -1,64 +1,55 @@
 {% extends 'base.html' %}
-{% load static %}
-{% block title %}Produtos e Serviços | Hubx{% endblock %}
-
+{% load i18n %}
+{% block title %}{% translate 'Produtos e Serviços' %}{% endblock %}
 {% block content %}
-<div class="max-w-6xl mx-auto px-4 py-10">
+<section class="max-w-6xl mx-auto px-4 py-10 space-y-6">
+  <header class="flex items-center justify-between">
+    <h1 class="text-2xl font-bold text-neutral-900">{% translate 'Produtos e Serviços' %}</h1>
+    <a href="{% url 'empresas:tags_create' %}" class="bg-primary-600 text-white text-sm px-4 py-2 rounded-md hover:bg-primary-700">{% translate 'Novo Item' %}</a>
+  </header>
 
-  <!-- Cabeçalho -->
-  <div class="flex items-center justify-between mb-8">
+  <form method="get" class="bg-white border border-neutral-200 p-4 rounded-md flex flex-col sm:flex-row gap-4 sm:items-end">
     <div>
-      <h1 class="text-2xl font-bold text-neutral-900">Produtos e Serviços</h1>
-      <p class="text-sm text-neutral-600">Gerencie a lista de produtos e serviços</p>
-    </div>
-    <a href="{% url 'empresas:tags_create' %}" class="inline-flex items-center gap-2 bg-primary-600 text-white text-sm px-4 py-2 rounded-xl hover:bg-primary-700">
-      <span class="text-xl leading-none">+</span> Novo Item
-    </a>
-  </div>
-
-  <!-- Filtro -->
-  <form method="get" class="bg-white border border-neutral-200 p-6 rounded-2xl shadow-sm mb-10 flex flex-col sm:flex-row gap-4 sm:items-end">
-    <div>
-      <label for="categoria" class="block text-sm font-medium text-neutral-700 mb-1">Categoria</label>
-      <select name="categoria" id="categoria" onchange="this.form.submit()"
-        class="form-select w-full rounded-xl border border-neutral-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500">
-        <option value="" {% if not request.GET.categoria %}selected{% endif %}>Todas</option>
-        <option value="prod" {% if request.GET.categoria == 'prod' %}selected{% endif %}>Produtos</option>
-        <option value="serv" {% if request.GET.categoria == 'serv' %}selected{% endif %}>Serviços</option>
+      <label for="categoria" class="block text-sm font-medium text-neutral-700">{% translate 'Categoria' %}</label>
+      <select name="categoria" id="categoria" onchange="this.form.submit()" class="w-full p-2 border rounded">
+        <option value="" {% if not request.GET.categoria %}selected{% endif %}>{% translate 'Todas' %}</option>
+        <option value="prod" {% if request.GET.categoria == 'prod' %}selected{% endif %}>{% translate 'Produtos' %}</option>
+        <option value="serv" {% if request.GET.categoria == 'serv' %}selected{% endif %}>{% translate 'Serviços' %}</option>
       </select>
     </div>
     <div class="flex-1">
-      <label for="id_tag" class="block text-sm font-medium text-neutral-700 mb-1">Palavra-chave</label>
-      {{ form.tag|add_class:"form-input w-full rounded-xl border border-neutral-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500" }}
+      <label for="id_tag" class="block text-sm font-medium text-neutral-700">{% translate 'Palavra-chave' %}</label>
+      {{ form.tag|add_class:'w-full p-2 border rounded' }}
     </div>
     <noscript>
-      <button type="submit" class="mt-2 sm:mt-0 bg-neutral-200 text-neutral-800 px-4 py-2 rounded-xl text-sm hover:bg-neutral-300">Filtrar</button>
+      <button type="submit" class="bg-neutral-200 text-neutral-800 px-4 py-2 rounded text-sm hover:bg-neutral-300">{% translate 'Filtrar' %}</button>
     </noscript>
   </form>
 
-  <!-- Lista de Tags -->
   {% if object_list %}
-    <div class="grid gap-6 sm:grid-cols-2 md:grid-cols-3">
+  <table class="min-w-full text-sm">
+    <thead class="bg-neutral-100">
+      <tr>
+        <th class="px-3 py-2 text-left font-semibold">{% translate 'Nome' %}</th>
+        <th class="px-3 py-2 text-left font-semibold">{% translate 'Categoria' %}</th>
+        <th class="px-3 py-2 text-center font-semibold">{% translate 'Ações' %}</th>
+      </tr>
+    </thead>
+    <tbody class="divide-y divide-neutral-200 bg-white">
       {% for tag in object_list %}
-        <div class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-5 flex flex-col justify-between">
-          <div>
-            <h3 class="text-lg font-semibold text-neutral-900">{{ tag.nome }}</h3>
-            <p class="text-sm text-neutral-600">{{ tag.get_categoria_display }}</p>
-          </div>
-          <div class="flex justify-end gap-3 mt-4">
-            <a href="{% url 'empresas:tags_update' tag.id %}" class="text-sm text-yellow-600 hover:underline">Editar</a>
-            <a href="{% url 'empresas:tags_delete' tag.id %}" class="text-sm text-red-600 hover:underline">Remover</a>
-          </div>
-        </div>
+      <tr>
+        <td class="px-3 py-2">{{ tag.nome }}</td>
+        <td class="px-3 py-2">{{ tag.get_categoria_display }}</td>
+        <td class="px-3 py-2 text-center space-x-2">
+          <a href="{% url 'empresas:tags_update' tag.id %}" class="text-blue-600 hover:underline">{% translate 'Editar' %}</a>
+          <a href="{% url 'empresas:tags_delete' tag.id %}" class="text-red-600 hover:underline">{% translate 'Remover' %}</a>
+        </td>
+      </tr>
       {% endfor %}
-    </div>
+    </tbody>
+  </table>
   {% else %}
-    <div class="text-center bg-white border border-neutral-200 rounded-2xl p-10 shadow-sm">
-      <p class="text-neutral-500 mb-4">Nenhum item cadastrado.</p>
-      <a href="{% url 'empresas:tags_create' %}" class="inline-flex items-center gap-2 bg-primary-600 text-white text-sm px-4 py-2 rounded-xl hover:bg-primary-700">
-        <span class="text-xl leading-none">+</span> Cadastrar
-      </a>
-    </div>
+  <p class="text-center text-neutral-500">{% translate 'Nenhum item cadastrado.' %}</p>
   {% endif %}
-</div>
+</section>
 {% endblock %}


### PR DESCRIPTION
## Summary
- rebuild companies list with HTMX filters, table and pagination
- add responsive partial table for company lists
- update contact and tag templates with semantic markup
- improve company search and new company form styles
- add pagination and filtering logic in `lista_empresas`
- update search view with related optimizations

## Testing
- `ruff check empresas/views.py`
- `black --check empresas/views.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68897a8b41608325b1762940435a0f7b