### PR TITLE
feat: add search and pagination to org list

### DIFF
--- a/organizacoes/forms.py
+++ b/organizacoes/forms.py
@@ -8,6 +8,13 @@ class OrganizacaoForm(forms.ModelForm):
         model = Organizacao
         fields = ["nome", "cnpj", "descricao", "slug", "avatar", "cover"]
 
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        base_cls = "w-full p-2 border rounded-lg"
+        for field in self.fields.values():
+            existing = field.widget.attrs.get("class", "")
+            field.widget.attrs["class"] = f"{existing} {base_cls}".strip()
+
     def clean_cnpj(self):
         cnpj = self.cleaned_data.get("cnpj")
         if Organizacao.objects.exclude(pk=self.instance.pk).filter(cnpj=cnpj).exists():

--- a/organizacoes/templates/organizacoes/list.html
+++ b/organizacoes/templates/organizacoes/list.html
@@ -3,7 +3,7 @@
 {% block title %}Organizações | Hubx{% endblock %}
 
 {% block content %}
-<section class="max-w-6xl mx-auto px-4 py-10">
+<section class="max-w-6xl mx-auto px-4 py-10" id="org-list">
 
   <!-- Cabeçalho -->
   <div class="flex items-center justify-between mb-8">
@@ -19,6 +19,11 @@
       Nova Organização
     </a>
   </div>
+
+  <form hx-get="{% url 'organizacoes:list' %}" hx-target="#org-list" hx-push-url="true" class="mb-6 flex gap-2">
+    <input type="text" name="q" value="{{ request.GET.q }}" placeholder="Buscar" class="w-full p-2 border rounded-lg" />
+    <button type="submit" class="px-4 py-2 bg-primary-600 text-white rounded-lg">Buscar</button>
+  </form>
 
   {% if object_list %}
     <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
@@ -43,6 +48,15 @@
           </div>
         </div>
       {% endfor %}
+    </div>
+    <div class="mt-6 flex justify-center gap-2">
+      {% if page_obj.has_previous %}
+        <a hx-get="?page={{ page_obj.previous_page_number }}{% if request.GET.q %}&q={{ request.GET.q }}{% endif %}" hx-target="#org-list" hx-push-url="true" class="px-3 py-1 border rounded">Anterior</a>
+      {% endif %}
+      <span class="px-3 py-1">{{ page_obj.number }} / {{ page_obj.paginator.num_pages }}</span>
+      {% if page_obj.has_next %}
+        <a hx-get="?page={{ page_obj.next_page_number }}{% if request.GET.q %}&q={{ request.GET.q }}{% endif %}" hx-target="#org-list" hx-push-url="true" class="px-3 py-1 border rounded">Próxima</a>
+      {% endif %}
     </div>
   {% else %}
     <div class="text-center border border-neutral-200 rounded-2xl shadow-sm p-10 bg-white">

--- a/organizacoes/views.py
+++ b/organizacoes/views.py
@@ -22,9 +22,14 @@ User = get_user_model()
 class OrganizacaoListView(AdminRequiredMixin, LoginRequiredMixin, ListView):
     model = Organizacao
     template_name = "organizacoes/list.html"
+    paginate_by = 10
 
     def get_queryset(self):
-        return super().get_queryset()
+        qs = super().get_queryset()
+        query = self.request.GET.get("q")
+        if query:
+            qs = qs.filter(nome__icontains=query)
+        return qs.order_by("nome")
 
 
 class OrganizacaoCreateView(SuperadminRequiredMixin, LoginRequiredMixin, CreateView):

--- a/tests/organizacoes/test_views.py
+++ b/tests/organizacoes/test_views.py
@@ -143,6 +143,25 @@ def test_ordering_by_nome(superadmin_user, faker_ptbr):
     assert objs[0].nome == "A Org"
 
 
+def test_list_search(superadmin_user, faker_ptbr):
+    org_a = Organizacao.objects.create(nome="Alpha Org", cnpj=faker_ptbr.cnpj(), slug="a")
+    Organizacao.objects.create(nome="Beta Org", cnpj=faker_ptbr.cnpj(), slug="b")
+    url = reverse("organizacoes:list") + "?q=Alpha"
+    resp = superadmin_user.get(url)
+    content = resp.content.decode()
+    assert org_a.nome in content and "Beta Org" not in content
+
+
+def test_list_pagination(superadmin_user, faker_ptbr):
+    for i in range(12):
+        Organizacao.objects.create(nome=f"Org {i}", cnpj=faker_ptbr.cnpj(), slug=f"org-{i}")
+    url = reverse("organizacoes:list")
+    resp1 = superadmin_user.get(url)
+    assert len(resp1.context["object_list"]) == 10
+    resp2 = superadmin_user.get(url + "?page=2")
+    assert len(resp2.context["object_list"]) == 2
+
+
 def test_detail_view_admin_access(admin_user, organizacao):
     url = reverse("organizacoes:detail", args=[organizacao.pk])
     resp = admin_user.get(url)


### PR DESCRIPTION
## Summary
- enhance `OrganizacaoForm` styling
- support search and pagination in org list view
- expose search form and HTMX pagination in template
- cover search and pagination with tests

## Affected Routes
- `/organizacoes/` (list view supports `?q` and `?page`)

## Risks
- minimal: added pagination may affect existing consumption

## Rollback
- revert commit 90f99c64 via `git revert`

------
https://chatgpt.com/codex/tasks/task_e_68897bab224c8325823c23c6b84c262c