### PR TITLE
feat: HTMX flows for token management

### DIFF
--- a/tokens/templates/tokens/_resultado.html
+++ b/tokens/templates/tokens/_resultado.html
@@ -1,0 +1,13 @@
+{% if codigo %}
+  <div class="bg-green-100 text-green-700 p-3 rounded" role="status">
+    Código gerado: <code class="font-mono text-lg">{{ codigo }}</code>
+  </div>
+{% elif token %}
+  <div class="bg-green-100 text-green-700 p-3 rounded" role="status">
+    Token: <code class="font-mono break-all">{{ token }}</code>
+  </div>
+{% elif success %}
+  <div class="bg-green-100 text-green-700 p-3 rounded" role="status">{{ success }}</div>
+{% elif error %}
+  <div class="bg-red-100 text-red-700 p-3 rounded" role="alert">{{ error }}</div>
+{% endif %}

--- a/tokens/templates/tokens/gerar_codigo_autenticacao.html
+++ b/tokens/templates/tokens/gerar_codigo_autenticacao.html
@@ -7,7 +7,10 @@
 <section class="max-w-md mx-auto px-4 py-12">
   <h1 class="text-2xl font-bold text-center mb-6">Gerar Código de Autenticação</h1>
 
-  <form method="post" action="{% url 'tokens:gerar_codigo' %}" class="bg-white rounded-2xl shadow p-6 space-y-4">
+  <form method="post" action="{% url 'tokens:gerar_codigo' %}"
+        hx-post="{% url 'tokens:gerar_codigo' %}"
+        hx-target="#resultado" hx-swap="innerHTML"
+        class="bg-white rounded-2xl shadow p-6 space-y-4">
     {% csrf_token %}
     {% for field in form %}
       <div>
@@ -15,7 +18,11 @@
         {% if field.field.widget.input_type == 'select' %}
           {{ field|add_class:"form-select" }}
         {% else %}
-          {{ field|add_class:"form-input" }}
+          {% if forloop.first %}
+            {{ field|add_class:"form-input"|attr:"autofocus" }}
+          {% else %}
+            {{ field|add_class:"form-input" }}
+          {% endif %}
         {% endif %}
         {% if field.errors %}
           <p class="text-sm text-red-600 mt-1">{{ field.errors.0 }}</p>

--- a/tokens/templates/tokens/gerar_token.html
+++ b/tokens/templates/tokens/gerar_token.html
@@ -6,7 +6,10 @@
 <section class="max-w-xl mx-auto px-4 py-10">
   <h1 class="text-2xl font-bold text-neutral-900 mb-6">Gerar Token de Acesso</h1>
 
-  <form method="post" action="{% url 'tokens:criar_token' %}" class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 space-y-6">
+  <form method="post" action="{% url 'tokens:criar_token' %}"
+        hx-post="{% url 'tokens:criar_token' %}"
+        hx-target="#resultado" hx-swap="innerHTML"
+        class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 space-y-6">
     {% csrf_token %}
 
     <div class="space-y-4">
@@ -16,7 +19,11 @@
           {% if field.field.widget.input_type == 'select' %}
             {{ field|add_class:"form-select" }}
           {% else %}
-            {{ field|add_class:"form-input" }}
+            {% if forloop.first %}
+              {{ field|add_class:"form-input"|attr:"autofocus" }}
+            {% else %}
+              {{ field|add_class:"form-input" }}
+            {% endif %}
           {% endif %}
           {% if field.errors %}
             <p class="text-red-500 text-xs mt-1">{{ field.errors }}</p>
@@ -32,10 +39,12 @@
     </div>
   </form>
 
-  {% if token %}
-    <div class="mt-6 text-center rounded-xl bg-green-100 px-4 py-3 text-sm text-green-700">
-      Código gerado: <strong>{{ token.codigo }}</strong>
-    </div>
-  {% endif %}
+  <div id="resultado" class="mt-6 text-center">
+    {% if token %}
+      <div class="rounded-xl bg-green-100 px-4 py-3 text-sm text-green-700">
+        Código gerado: <strong>{{ token.codigo }}</strong>
+      </div>
+    {% endif %}
+  </div>
 </section>
 {% endblock %}

--- a/tokens/templates/tokens/validar_codigo_autenticacao.html
+++ b/tokens/templates/tokens/validar_codigo_autenticacao.html
@@ -7,11 +7,14 @@
 <section class="max-w-md mx-auto px-4 py-12">
   <h1 class="text-2xl font-bold text-center mb-6">Validar Código de Autenticação</h1>
 
-  <form method="post" action="{% url 'tokens:validar_codigo' %}" class="bg-white rounded-2xl shadow p-6 space-y-4">
+  <form method="post" action="{% url 'tokens:validar_codigo' %}"
+        hx-post="{% url 'tokens:validar_codigo' %}"
+        hx-target="#resultado" hx-swap="innerHTML"
+        class="bg-white rounded-2xl shadow p-6 space-y-4">
     {% csrf_token %}
     <div>
       <label for="{{ form.codigo.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.codigo.label }}</label>
-      {{ form.codigo|add_class:"form-input text-center tracking-widest" }}
+      {{ form.codigo|add_class:"form-input text-center tracking-widest"|attr:"autofocus" }}
       {% if form.codigo.errors %}
         <p class="text-sm text-red-600 mt-1">{{ form.codigo.errors.0 }}</p>
       {% endif %}

--- a/tokens/templates/tokens/validar_token.html
+++ b/tokens/templates/tokens/validar_token.html
@@ -7,11 +7,14 @@
 <section class="max-w-md mx-auto px-4 py-12">
   <h1 class="text-2xl font-bold text-center mb-6">Validar Token de Convite</h1>
 
-  <form method="post" action="{% url 'tokens:validar_convite' %}" class="bg-white rounded-2xl shadow p-6 space-y-4">
+  <form method="post" action="{% url 'tokens:validar_convite' %}"
+        hx-post="{% url 'tokens:validar_convite' %}"
+        hx-target="#resultado" hx-swap="innerHTML"
+        class="bg-white rounded-2xl shadow p-6 space-y-4">
     {% csrf_token %}
     <div>
       <label for="{{ form.codigo.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.codigo.label }}</label>
-      {{ form.codigo|add_class:"form-input" }}
+      {{ form.codigo|add_class:"form-input"|attr:"autofocus" }}
       {% if form.codigo.errors %}
         <p class="text-sm text-red-600 mt-1">{{ form.codigo.errors.0 }}</p>
       {% endif %}

--- a/tokens/views.py
+++ b/tokens/views.py
@@ -41,6 +41,16 @@ def criar_token(request):
             token = form.save(commit=False)
             token.gerado_por = request.user
             token.save()
+            if request.headers.get("HX-Request") == "true":
+                return render(request, "tokens/_resultado.html", {"token": token.codigo})
+        else:
+            if request.headers.get("HX-Request") == "true":
+                return render(
+                    request,
+                    "tokens/_resultado.html",
+                    {"error": form.errors.as_text()},
+                    status=400,
+                )
     else:
         form = TokenAcessoForm()
 
@@ -63,7 +73,11 @@ class GerarTokenConviteView(View):
             )
             token.save()
             token.nucleos.set(form.cleaned_data["nucleos"])
+            if request.headers.get("HX-Request") == "true":
+                return render(request, "tokens/_resultado.html", {"token": token.codigo})
             return JsonResponse({"codigo": token.codigo})
+        if request.headers.get("HX-Request") == "true":
+            return render(request, "tokens/_resultado.html", {"error": "Dados inválidos"}, status=400)
         return JsonResponse({"error": "Dados inválidos"}, status=400)
 
 
@@ -75,7 +89,11 @@ class ValidarTokenConviteView(View):
             token.usuario = request.user
             token.estado = TokenAcesso.Estado.USADO
             token.save()
+            if request.headers.get("HX-Request") == "true":
+                return render(request, "tokens/_resultado.html", {"success": "Token validado"})
             return JsonResponse({"success": "Token validado"})
+        if request.headers.get("HX-Request") == "true":
+            return render(request, "tokens/_resultado.html", {"error": form.errors.as_text()}, status=400)
         return JsonResponse({"error": form.errors.as_text()}, status=400)
 
 
@@ -85,7 +103,11 @@ class GerarCodigoAutenticacaoView(View):
         if form.is_valid():
             codigo = form.save()
             # TODO: enviar via email/SMS
+            if request.headers.get("HX-Request") == "true":
+                return render(request, "tokens/_resultado.html", {"codigo": codigo.codigo})
             return JsonResponse({"codigo": codigo.codigo})
+        if request.headers.get("HX-Request") == "true":
+            return render(request, "tokens/_resultado.html", {"error": "Dados inválidos"}, status=400)
         return JsonResponse({"error": "Dados inválidos"}, status=400)
 
 
@@ -93,7 +115,11 @@ class ValidarCodigoAutenticacaoView(View):
     def post(self, request, *args, **kwargs):
         form = ValidarCodigoAutenticacaoForm(request.POST, usuario=request.user)
         if form.is_valid():
+            if request.headers.get("HX-Request") == "true":
+                return render(request, "tokens/_resultado.html", {"success": "Código validado"})
             return JsonResponse({"success": "Código validado"})
+        if request.headers.get("HX-Request") == "true":
+            return render(request, "tokens/_resultado.html", {"error": form.errors.as_text()}, status=400)
         return JsonResponse({"error": form.errors.as_text()}, status=400)
 
 
@@ -104,11 +130,17 @@ class Ativar2FAView(View):
         if form.is_valid():
             device.confirmado = True
             device.save()
+            if request.headers.get("HX-Request") == "true":
+                return render(request, "tokens/_resultado.html", {"success": "2FA ativado"})
             return JsonResponse({"success": "2FA ativado"})
+        if request.headers.get("HX-Request") == "true":
+            return render(request, "tokens/_resultado.html", {"error": form.errors.as_text()}, status=400)
         return JsonResponse({"error": form.errors.as_text()}, status=400)
 
 
 class Desativar2FAView(View):
     def post(self, request, *args, **kwargs):
         TOTPDevice.objects.filter(usuario=request.user).delete()
+        if request.headers.get("HX-Request") == "true":
+            return render(request, "tokens/_resultado.html", {"success": "2FA desativado"})
         return JsonResponse({"success": "2FA desativado"})


### PR DESCRIPTION
## Summary
- allow async token operations with HTMX
- show server messages in a new partial
- update templates to post via HTMX

## Affected URLs
- `/tokens/novo/`
- `/tokens/convites/gerar/`
- `/tokens/convites/validar/`
- `/tokens/codigo/gerar/`
- `/tokens/codigo/validar/`
- `/tokens/2fa/ativar/`
- `/tokens/2fa/desativar/`

## Rationale
Implements the asynchronous UX for generating and validating tokens in line with the frontend style guide.

## Risk
Low. Views keep JSON responses for non-HTMX requests.

## Rollback
Revert this PR.

------
https://chatgpt.com/codex/tasks/task_e_68897be1f13c8325bd0e38767f2ea550