### PR TITLE
feat: unify user settings page

### DIFF
--- a/configuracoes/templates/configuracoes/configuracoes.html
+++ b/configuracoes/templates/configuracoes/configuracoes.html
@@ -1,19 +1,26 @@
-{% extends "base.html" %}
+{% extends 'base.html' %}
+{% load i18n %}
+
+{% block title %}{% trans 'Configurações da Conta' %}{% endblock %}
 
 {% block content %}
-<div class="container mx-auto p-4">
-    <h1 class="text-2xl font-bold mb-4">Configurações de Conta</h1>
-    {% if success %}
-        <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded mb-4">
-            Configurações atualizadas com sucesso!
-        </div>
-    {% endif %}
-    <form method="post">
-        {% csrf_token %}
-        {{ form.as_p }}
-        <button type="submit" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">
-            Salvar
-        </button>
-    </form>
+<div class="max-w-4xl mx-auto px-4 py-8">
+  <h1 class="text-2xl font-bold mb-4">{% trans 'Configurações' %}</h1>
+  {% if messages %}
+    <div class="mb-4 space-y-2">
+      {% for message in messages %}
+        <p class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-green-100 text-green-700{% else %}bg-red-100 text-red-700{% endif %}">{{ message }}</p>
+      {% endfor %}
+    </div>
+  {% endif %}
+  <nav class="flex flex-wrap gap-4 border-b mb-4 text-sm" aria-label="{% trans 'Seções de Configuração' %}">
+    <button hx-get="{% url 'configuracoes' %}?tab=informacoes" hx-target="#content" class="py-2 px-3 rounded-t-md {% if tab == 'informacoes' %}bg-white border border-b-0{% else %}bg-gray-100{% endif %}">{% trans 'Informações Pessoais' %}</button>
+    <button hx-get="{% url 'configuracoes' %}?tab=seguranca" hx-target="#content" class="py-2 px-3 rounded-t-md {% if tab == 'seguranca' %}bg-white border border-b-0{% else %}bg-gray-100{% endif %}">{% trans 'Segurança' %}</button>
+    <button hx-get="{% url 'configuracoes' %}?tab=redes" hx-target="#content" class="py-2 px-3 rounded-t-md {% if tab == 'redes' %}bg-white border border-b-0{% else %}bg-gray-100{% endif %}">{% trans 'Conexões Sociais' %}</button>
+    <button hx-get="{% url 'configuracoes' %}?tab=notificacoes" hx-target="#content" class="py-2 px-3 rounded-t-md {% if tab == 'notificacoes' %}bg-white border border-b-0{% else %}bg-gray-100{% endif %}">{% trans 'Notificações' %}</button>
+  </nav>
+  <div id="content" class="bg-white p-6 rounded-b-md shadow" hx-get="{% url 'configuracoes' %}?tab={{ tab }}" hx-trigger="load">
+    {% include 'configuracoes/partials/'|add:tab|add:'.html' %}
+  </div>
 </div>
 {% endblock %}

--- a/configuracoes/templates/configuracoes/partials/informacoes.html
+++ b/configuracoes/templates/configuracoes/partials/informacoes.html
@@ -1,0 +1,17 @@
+{% load widget_tweaks i18n %}
+<form method="post" hx-post="{% url 'configuracoes' %}?tab=informacoes" hx-target="#content" class="space-y-4">
+  {% csrf_token %}
+  <input type="hidden" name="tab" value="informacoes">
+  {% for field in informacoes_form %}
+    <div>
+      <label for="{{ field.id_for_label }}" class="block text-sm font-medium">{{ field.label }}</label>
+      {{ field|add_class:'w-full p-2 border rounded-lg' }}
+      {% for error in field.errors %}
+        <p class="text-red-600 text-sm">{{ error }}</p>
+      {% endfor %}
+    </div>
+  {% endfor %}
+  <div class="text-right pt-2">
+    <button type="submit" class="bg-primary text-white px-4 py-2 rounded-lg">{% trans 'Salvar Alterações' %}</button>
+  </div>
+</form>

--- a/configuracoes/templates/configuracoes/partials/notificacoes.html
+++ b/configuracoes/templates/configuracoes/partials/notificacoes.html
@@ -1,0 +1,17 @@
+{% load widget_tweaks i18n %}
+<form method="post" hx-post="{% url 'configuracoes' %}?tab=notificacoes" hx-target="#content" class="space-y-4">
+  {% csrf_token %}
+  <input type="hidden" name="tab" value="notificacoes">
+  {% for field in notificacoes_form %}
+    <div class="flex items-center">
+      {{ field|add_class:'form-checkbox' }}
+      <label for="{{ field.id_for_label }}" class="ml-2 text-sm font-medium">{{ field.label }}</label>
+      {% for error in field.errors %}
+        <p class="text-red-600 text-sm">{{ error }}</p>
+      {% endfor %}
+    </div>
+  {% endfor %}
+  <div class="text-right pt-2">
+    <button type="submit" class="bg-primary text-white px-4 py-2 rounded-lg">{% trans 'Salvar Alterações' %}</button>
+  </div>
+</form>

--- a/configuracoes/templates/configuracoes/partials/redes_sociais.html
+++ b/configuracoes/templates/configuracoes/partials/redes_sociais.html
@@ -1,0 +1,17 @@
+{% load widget_tweaks i18n %}
+<form method="post" hx-post="{% url 'configuracoes' %}?tab=redes" hx-target="#content" class="space-y-4">
+  {% csrf_token %}
+  <input type="hidden" name="tab" value="redes">
+  {% for field in redes_form %}
+    <div>
+      <label for="{{ field.id_for_label }}" class="block text-sm font-medium">{{ field.label }}</label>
+      {{ field|add_class:'w-full p-2 border rounded-lg' }}
+      {% for error in field.errors %}
+        <p class="text-red-600 text-sm">{{ error }}</p>
+      {% endfor %}
+    </div>
+  {% endfor %}
+  <div class="text-right pt-2">
+    <button type="submit" class="bg-primary text-white px-4 py-2 rounded-lg">{% trans 'Salvar Alterações' %}</button>
+  </div>
+</form>

--- a/configuracoes/templates/configuracoes/partials/seguranca.html
+++ b/configuracoes/templates/configuracoes/partials/seguranca.html
@@ -1,0 +1,17 @@
+{% load widget_tweaks i18n %}
+<form method="post" hx-post="{% url 'configuracoes' %}?tab=seguranca" hx-target="#content" class="space-y-4">
+  {% csrf_token %}
+  <input type="hidden" name="tab" value="seguranca">
+  {% for field in seguranca_form %}
+    <div>
+      <label for="{{ field.id_for_label }}" class="block text-sm font-medium">{{ field.label }}</label>
+      {{ field|add_class:'w-full p-2 border rounded-lg' }}
+      {% for error in field.errors %}
+        <p class="text-red-600 text-sm">{{ error }}</p>
+      {% endfor %}
+    </div>
+  {% endfor %}
+  <div class="text-right pt-2">
+    <button type="submit" class="bg-primary text-white px-4 py-2 rounded-lg">{% trans 'Salvar Alterações' %}</button>
+  </div>
+</form>

--- a/configuracoes/views.py
+++ b/configuracoes/views.py
@@ -1,18 +1,62 @@
+from django.contrib import messages
+from django.contrib.auth import update_session_auth_hash
+from django.contrib.auth.forms import PasswordChangeForm
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.shortcuts import render
 from django.views.generic import View
 
-from configuracoes.forms import ConfiguracaoContaForm
+from accounts.forms import InformacoesPessoaisForm, RedesSociaisForm
+from notificacoes.forms import UserNotificationPreferenceForm
+from notificacoes.models import UserNotificationPreference
 
 
 class ConfiguracoesView(LoginRequiredMixin, View):
+    """Exibe e processa formulários de configuração da conta."""
+
+    form_classes = {
+        "informacoes": InformacoesPessoaisForm,
+        "seguranca": PasswordChangeForm,
+        "redes": RedesSociaisForm,
+        "notificacoes": UserNotificationPreferenceForm,
+    }
+
+    def get_form(self, tab: str, data=None, files=None):
+        user = self.request.user
+        form_class = self.form_classes[tab]
+        if form_class is PasswordChangeForm:
+            return form_class(user, data)
+        if form_class is UserNotificationPreferenceForm:
+            pref, _ = UserNotificationPreference.objects.get_or_create(user=user)
+            return form_class(data, instance=pref)
+        return form_class(data, files, instance=user)
+
     def get(self, request):
-        form = ConfiguracaoContaForm(instance=request.user.configuracao)
-        return render(request, "configuracoes/configuracoes.html", {"form": form})
+        tab = request.GET.get("tab", "informacoes")
+        context = {f"{name}_form": self.get_form(name) for name in self.form_classes}
+        context.update({"tab": tab})
+        template = (
+            f"configuracoes/partials/{tab}.html"
+            if request.headers.get("HX-Request")
+            else "configuracoes/configuracoes.html"
+        )
+        return render(request, template, context)
 
     def post(self, request):
-        form = ConfiguracaoContaForm(request.POST, instance=request.user.configuracao)
+        tab = request.GET.get("tab", request.POST.get("tab", "informacoes"))
+        form = self.get_form(tab, request.POST, request.FILES)
         if form.is_valid():
-            form.save()
-            return render(request, "configuracoes/configuracoes.html", {"form": form, "success": True})
-        return render(request, "configuracoes/configuracoes.html", {"form": form})
+            saved = form.save()
+            if isinstance(form, PasswordChangeForm):
+                update_session_auth_hash(request, saved)
+            messages.success(request, "Alterações salvas com sucesso.")
+        else:
+            messages.error(request, "Corrija os erros abaixo.")
+
+        context = {f"{name}_form": form if name == tab else self.get_form(name) for name in self.form_classes}
+        context["tab"] = tab
+        template = (
+            f"configuracoes/partials/{tab}.html"
+            if request.headers.get("HX-Request")
+            else "configuracoes/configuracoes.html"
+        )
+        return render(request, template, context)

--- a/tests/configuracoes/test_views.py
+++ b/tests/configuracoes/test_views.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import pytest
+from django.contrib.auth.forms import PasswordChangeForm
 from django.test import override_settings
 from django.urls import reverse
 
-from configuracoes.forms import ConfiguracaoContaForm
+from accounts.forms import InformacoesPessoaisForm, RedesSociaisForm
+from notificacoes.forms import UserNotificationPreferenceForm
+from notificacoes.models import UserNotificationPreference
 
 pytestmark = pytest.mark.django_db
 
@@ -13,7 +16,10 @@ pytestmark = pytest.mark.django_db
 def test_view_get_autenticado(admin_client):
     resp = admin_client.get(reverse("configuracoes"))
     assert resp.status_code == 200
-    assert isinstance(resp.context["form"], ConfiguracaoContaForm)
+    assert isinstance(resp.context["informacoes_form"], InformacoesPessoaisForm)
+    assert isinstance(resp.context["seguranca_form"], PasswordChangeForm)
+    assert isinstance(resp.context["redes_form"], RedesSociaisForm)
+    assert isinstance(resp.context["notificacoes_form"], UserNotificationPreferenceForm)
     assert "configuracoes/configuracoes.html" in [t.name for t in resp.templates]
 
 
@@ -25,25 +31,12 @@ def test_view_get_redirect_nao_autenticado(client):
 
 
 @override_settings(ROOT_URLCONF="tests.configuracoes.urls")
-def test_view_post_atualiza_configuracao(admin_client, admin_user):
-    url = reverse("configuracoes")
-    data = {
-        "receber_notificacoes_email": False,
-        "frequencia_notificacoes_email": "diaria",
-        "receber_notificacoes_whatsapp": True,
-        "frequencia_notificacoes_whatsapp": "semanal",
-        "idioma": "es-ES",
-        "tema": "escuro",
-        "tema_escuro": True,
-    }
+def test_view_post_atualiza_preferencias(admin_client, admin_user):
+    url = reverse("configuracoes") + "?tab=notificacoes"
+    data = {"email": False, "push": False, "whatsapp": True, "tab": "notificacoes"}
     resp = admin_client.post(url, data)
     assert resp.status_code == 200
-    admin_user.configuracao.refresh_from_db()
-    assert admin_user.configuracao.frequencia_notificacoes_email == "diaria"
-    assert admin_user.configuracao.tema_escuro is True
-    assert admin_user.configuracao.tema == "escuro"
-    assert admin_user.configuracao.receber_notificacoes_email is False
-    assert admin_user.configuracao.frequencia_notificacoes_whatsapp == "semanal"
-    assert admin_user.configuracao.receber_notificacoes_whatsapp is True
-    assert admin_user.configuracao.idioma == "es-ES"
-    assert resp.context.get("success") is True
+    pref = UserNotificationPreference.objects.get(user=admin_user)
+    assert pref.email is False
+    assert pref.push is False
+    assert pref.whatsapp is True


### PR DESCRIPTION
## Summary
- create tabs for user settings with HTMX
- add partial forms for info, security, networks and notifications
- update view to handle multiple forms
- adjust tests accordingly

## Testing
- `ruff check configuracoes/views.py tests/configuracoes/test_views.py`
- `pytest -m "not slow" -q`


------
https://chatgpt.com/codex/tasks/task_e_68897c1d04a48325b87ae11190761ae7