### PR TITLE
feat: improve core templates

### DIFF
--- a/core/templates/core/about.html
+++ b/core/templates/core/about.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Sobre" %} - HubX{% endblock %}
+
+{% block content %}
+<section class="max-w-3xl mx-auto px-4 py-12 prose prose-indigo">
+  <h1>{% trans "Sobre o HubX" %}</h1>
+  <p>{% trans "HubX é uma plataforma colaborativa que integra comunidades de organizações, empresas e voluntários." %}</p>
+  <p>{% trans "Nosso objetivo é facilitar a comunicação, gestão de eventos e colaboração entre membros." %}</p>
+</section>
+{% endblock %}

--- a/core/templates/core/home.html
+++ b/core/templates/core/home.html
@@ -1,29 +1,72 @@
-{% extends 'base.html' %}
+{% extends "base.html" %}
+{% load i18n tz %}
 
-{% block title %}Página Inicial{% endblock %}
+{% block title %}{% trans "Bem-vindo ao HubX" %}{% endblock %}
 
 {% block content %}
-<section class="max-w-7xl mx-auto px-4 py-10 text-center">
-  <h1 class="text-3xl font-bold text-neutral-900 mb-4">Bem-vindo ao Hubx!</h1>
-  <p class="text-neutral-600 mb-10">Uma plataforma colaborativa para conectar organizações, empresas e pessoas.</p>
+<header class="bg-white">
+  <div class="max-w-7xl mx-auto px-4 py-16 text-center">
+    <h1 class="text-4xl font-bold text-neutral-900 mb-4">{% trans "Junte-se à comunidade Hubx.space" %}</h1>
+    <p class="text-neutral-600 mb-8">{% trans "Plataforma colaborativa que conecta organizações, empresas e pessoas." %}</p>
+    {% if user.is_authenticated %}
+    <div class="flex justify-center gap-4">
+      <a href="{% url 'dashboard:dashboard' %}" class="bg-primary text-white px-5 py-3 rounded-xl shadow hover:bg-primary/90">{% trans "Ir para Dashboard" %}</a>
+      <a href="{% url 'feed:listar' %}" class="bg-white border border-primary text-primary px-5 py-3 rounded-xl hover:bg-primary/5">{% trans "Ver Feed" %}</a>
+    </div>
+    {% else %}
+    <div class="flex justify-center gap-4">
+      <a href="{% url 'accounts:onboarding' %}" class="bg-primary text-white px-5 py-3 rounded-xl shadow hover:bg-primary/90">{% trans "Criar conta" %}</a>
+      <a href="{% url 'accounts:login' %}" class="bg-white border border-primary text-primary px-5 py-3 rounded-xl hover:bg-primary/5">{% trans "Entrar" %}</a>
+    </div>
+    {% endif %}
+  </div>
+</header>
 
-  <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-    <a href="{% url 'feed:listar' %}" class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 hover:bg-neutral-50">
-      <h2 class="text-lg font-semibold text-primary mb-2">Mural e Feed</h2>
-      <p class="text-sm text-neutral-600">Compartilhe novidades e acompanhe atualizações.</p>
-    </a>
-    <a href="{% url 'agenda:calendario' %}" class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 hover:bg-neutral-50">
-      <h2 class="text-lg font-semibold text-primary mb-2">Agenda</h2>
-      <p class="text-sm text-neutral-600">Organize eventos e gerencie inscrições.</p>
-    </a>
-    <a href="{% url 'nucleos:list' %}" class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 hover:bg-neutral-50">
-      <h2 class="text-lg font-semibold text-primary mb-2">Núcleos</h2>
-      <p class="text-sm text-neutral-600">Encontre grupos de interesse e colabore.</p>
-    </a>
-    <a href="{% url 'dashboard:dashboard' %}" class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 hover:bg-neutral-50">
-      <h2 class="text-lg font-semibold text-primary mb-2">Dashboard</h2>
-      <p class="text-sm text-neutral-600">Acompanhe métricas e atividades da sua conta.</p>
-    </a>
+<section class="py-12 bg-gray-50">
+  <div class="max-w-7xl mx-auto px-4 text-center">
+    <h2 class="text-2xl font-bold text-neutral-900 mb-8">{% trans "Principais Funcionalidades" %}</h2>
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+      <div class="bg-white rounded-xl shadow-lg p-6 text-center flex flex-col items-center">
+        <i class="fas fa-rss text-indigo-600 text-3xl mb-4"></i>
+        <h3 class="font-semibold text-neutral-900">{% trans "Feed/Mural" %}</h3>
+        <p class="text-sm text-neutral-600 mb-4">{% trans "Compartilhe novidades e acompanhe atualizações." %}</p>
+        <a href="{% url 'feed:listar' %}" class="text-sm font-medium text-indigo-600 hover:underline">{% trans "Acessar" %}</a>
+      </div>
+      <div class="bg-white rounded-xl shadow-lg p-6 text-center flex flex-col items-center">
+        <i class="fas fa-calendar-alt text-indigo-600 text-3xl mb-4"></i>
+        <h3 class="font-semibold text-neutral-900">{% trans "Agenda" %}</h3>
+        <p class="text-sm text-neutral-600 mb-4">{% trans "Organize eventos e gerencie inscrições." %}</p>
+        <a href="{% url 'agenda:calendario' %}" class="text-sm font-medium text-indigo-600 hover:underline">{% trans "Acessar" %}</a>
+      </div>
+      <div class="bg-white rounded-xl shadow-lg p-6 text-center flex flex-col items-center">
+        <i class="fas fa-users text-indigo-600 text-3xl mb-4"></i>
+        <h3 class="font-semibold text-neutral-900">{% trans "Núcleos" %}</h3>
+        <p class="text-sm text-neutral-600 mb-4">{% trans "Encontre grupos de interesse e colabore." %}</p>
+        <a href="{% url 'nucleos:list' %}" class="text-sm font-medium text-indigo-600 hover:underline">{% trans "Acessar" %}</a>
+      </div>
+      <div class="bg-white rounded-xl shadow-lg p-6 text-center flex flex-col items-center">
+        <i class="fas fa-chart-line text-indigo-600 text-3xl mb-4"></i>
+        <h3 class="font-semibold text-neutral-900">{% trans "Dashboard/Financeiro" %}</h3>
+        <p class="text-sm text-neutral-600 mb-4">{% trans "Acompanhe métricas e controle financeiro." %}</p>
+        <a href="{% url 'dashboard:dashboard' %}" class="text-sm font-medium text-indigo-600 hover:underline">{% trans "Acessar" %}</a>
+      </div>
+      <div class="bg-white rounded-xl shadow-lg p-6 text-center flex flex-col items-center">
+        <i class="fas fa-bell text-indigo-600 text-3xl mb-4"></i>
+        <h3 class="font-semibold text-neutral-900">{% trans "Notificações" %}</h3>
+        <p class="text-sm text-neutral-600 mb-4">{% trans "Centralize alertas e preferências de contato." %}</p>
+        <a href="{% url 'notificacoes:editar_preferencias' %}" class="text-sm font-medium text-indigo-600 hover:underline">{% trans "Acessar" %}</a>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="py-12">
+  <div class="max-w-7xl mx-auto px-4">
+    {% now 'Y-m-d' as today %}
+    <h2 class="text-xl font-semibold mb-4">{% trans "Próximos Eventos" %}</h2>
+    <div id="eventos-destaque" hx-get="{% url 'agenda:lista_eventos' today %}" hx-trigger="load" hx-swap="innerHTML">
+      <p class="text-center text-sm text-gray-500">{% trans "Carregando eventos..." %}</p>
+    </div>
   </div>
 </section>
 {% endblock %}

--- a/core/templates/core/privacy.html
+++ b/core/templates/core/privacy.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Política de Privacidade" %} - HubX{% endblock %}
+
+{% block content %}
+<section class="max-w-3xl mx-auto px-4 py-12 prose prose-indigo">
+  <h1>{% trans "Política de Privacidade" %}</h1>
+  <p>{% trans "Seus dados pessoais são tratados com segurança e apenas para fins da plataforma." %}</p>
+</section>
+{% endblock %}

--- a/core/templates/core/terms.html
+++ b/core/templates/core/terms.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Termos de Uso" %} - HubX{% endblock %}
+
+{% block content %}
+<section class="max-w-3xl mx-auto px-4 py-12 prose prose-indigo">
+  <h1>{% trans "Termos de Uso" %}</h1>
+  <p>{% trans "Ao utilizar o HubX, você concorda com nossas políticas de uso e privacidade." %}</p>
+</section>
+{% endblock %}

--- a/core/urls.py
+++ b/core/urls.py
@@ -6,4 +6,7 @@ app_name = "core"
 
 urlpatterns = [
     path("", views.home, name="home"),
+    path("sobre/", views.AboutView.as_view(), name="about"),
+    path("termos/", views.TermsView.as_view(), name="terms"),
+    path("privacidade/", views.PrivacyView.as_view(), name="privacy"),
 ]

--- a/core/views.py
+++ b/core/views.py
@@ -1,7 +1,18 @@
-from django.shortcuts import redirect, render
+from django.shortcuts import render
+from django.views.generic import TemplateView
 
 
 def home(request):
-    if request.user.is_authenticated:
-        return redirect("accounts:perfil")
     return render(request, "core/home.html")
+
+
+class AboutView(TemplateView):
+    template_name = "core/about.html"
+
+
+class TermsView(TemplateView):
+    template_name = "core/terms.html"
+
+
+class PrivacyView(TemplateView):
+    template_name = "core/privacy.html"

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Página não encontrada" %}{% endblock %}
+
+{% block content %}
+<section class="py-16 text-center">
+  <div class="max-w-md mx-auto bg-red-50 border border-red-200 rounded-xl p-8">
+    <h1 class="text-3xl font-bold text-red-700 mb-4">404</h1>
+    <p class="text-red-700 mb-6">{% trans "Página não encontrada." %}</p>
+    <a href="{% url 'core:home' %}" class="text-sm bg-primary text-white px-4 py-2 rounded hover:bg-primary/90">{% trans "Voltar para a Home" %}</a>
+  </div>
+</section>
+{% endblock %}

--- a/templates/500.html
+++ b/templates/500.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Erro interno do servidor" %}{% endblock %}
+
+{% block content %}
+<section class="py-16 text-center">
+  <div class="max-w-md mx-auto bg-red-50 border border-red-200 rounded-xl p-8">
+    <h1 class="text-3xl font-bold text-red-700 mb-4">500</h1>
+    <p class="text-red-700 mb-6">{% trans "Ocorreu um erro interno. Tente novamente mais tarde." %}</p>
+    <a href="{% url 'core:home' %}" class="text-sm bg-primary text-white px-4 py-2 rounded hover:bg-primary/90">{% trans "Voltar para a Home" %}</a>
+  </div>
+</section>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html lang="pt-br" class="h-full bg-gray-50">
-{% load static %}
+{% load static i18n %}
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -79,8 +79,14 @@
 
   <!-- Rodapé -->
   <footer class="bg-white border-t mt-10">
-    <div class="container mx-auto px-4 py-6 text-sm text-gray-500 text-center">
-      © {{ now|date:"Y" }} HubX. Todos os direitos reservados.
+    <div class="container mx-auto px-4 py-6 text-sm text-gray-500 flex flex-col items-center gap-2 md:flex-row md:justify-between">
+      <p>© {{ now|date:"Y" }} HubX. Todos os direitos reservados.</p>
+      <nav class="flex gap-4">
+        <a href="{% url 'core:about' %}" class="hover:text-primary">{% trans "Sobre" %}</a>
+        <a href="mailto:contato@hubx.space" class="hover:text-primary">{% trans "Contato" %}</a>
+        <a href="{% url 'core:privacy' %}" class="hover:text-primary">{% trans "Privacidade" %}</a>
+        <a href="{% url 'core:terms' %}" class="hover:text-primary">{% trans "Termos" %}</a>
+      </nav>
     </div>
   </footer>
 

--- a/tests/core/test_home.py
+++ b/tests/core/test_home.py
@@ -1,0 +1,31 @@
+import pytest
+from django.urls import reverse
+from django.contrib.auth import get_user_model
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+def test_home_anonymous(client):
+    response = client.get(reverse("core:home"))
+    assert response.status_code == 200
+    html = response.content.decode()
+    assert "Criar conta" in html
+    assert "Entrar" in html
+
+
+@pytest.mark.django_db
+def test_home_authenticated(client):
+    user = User.objects.create_user(username="u", email="u@example.com", password="pass")
+    client.force_login(user)
+    response = client.get(reverse("core:home"))
+    assert response.status_code == 200
+    html = response.content.decode()
+    assert "Dashboard" in html or "Ir para Dashboard" in html
+
+
+@pytest.mark.django_db
+def test_static_pages(client):
+    for name in ["about", "terms", "privacy"]:
+        resp = client.get(reverse(f"core:{name}"))
+        assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- expand home layout with responsive sections, CTA buttons and events via HTMX
- add static pages (sobre, termos e privacidade)
- create styled error pages
- expose new pages in `core.urls`
- include institutional links in base footer
- test anonymous and authenticated home access

## Testing
- `make format`
- `make test` *(fails: `make vet` due to existing ruff violations)*

------
https://chatgpt.com/codex/tasks/task_e_68897ca3657483259d82baa5e7934416