### PR TITLE
fix: improve finance templates accessibility

### DIFF
--- a/financeiro/templates/financeiro/importar_pagamentos.html
+++ b/financeiro/templates/financeiro/importar_pagamentos.html
@@ -1,23 +1,26 @@
 {% extends "base.html" %}
+{% load i18n %}
 
-{% block title %}Importar Pagamentos{% endblock %}
+{% block title %}{{ _('Importar Pagamentos') }}{% endblock %}
 
 {% block content %}
-<div class="max-w-3xl mx-auto p-4">
-  <h1 class="text-2xl font-semibold mb-4">Importar Pagamentos</h1>
+<section class="max-w-3xl mx-auto p-4">
+  <h1 class="text-2xl font-semibold mb-4">{{ _('Importar Pagamentos') }}</h1>
   <form id="upload-form" method="post" enctype="multipart/form-data"
         hx-post="/api/financeiro/importar-pagamentos/preview/" hx-target="#preview"
+        hx-on="htmx:afterRequest: document.getElementById('confirm-btn').removeAttribute('disabled')"
         class="space-y-4 border p-4 rounded-lg bg-white">
     {% csrf_token %}
-    <input type="file" name="file" class="block w-full border p-2 rounded" required />
-    <button type="submit" class="bg-primary text-white px-4 py-2 rounded">Pré-visualizar</button>
+    <label for="file" class="block text-sm font-medium text-gray-700">{{ _('Arquivo') }}</label>
+    <input id="file" type="file" name="file" class="block w-full border p-2 rounded" required />
+    <button type="submit" class="bg-primary text-white px-4 py-2 rounded">{{ _('Pré-visualizar') }}</button>
   </form>
   <div id="preview" class="mt-6"></div>
   <div id="messages" class="mt-4"></div>
   <div class="mt-4">
-    <button id="confirm-btn" hx-post="/api/financeiro/importar-pagamentos/confirmar/" hx-target="#messages" hx-include="#upload-form" class="bg-secondary text-white px-4 py-2 rounded">
-      Confirmar Importação
+    <button id="confirm-btn" disabled hx-post="/api/financeiro/importar-pagamentos/confirmar/" hx-target="#messages" hx-include="#upload-form" class="bg-secondary text-white px-4 py-2 rounded">
+      {{ _('Confirmar Importação') }}
     </button>
   </div>
-</div>
+</section>
 {% endblock %}

--- a/financeiro/templates/financeiro/inadimplencias.html
+++ b/financeiro/templates/financeiro/inadimplencias.html
@@ -1,46 +1,60 @@
 {% extends "base.html" %}
+{% load i18n %}
 
-{% block title %}Inadimplências{% endblock %}
+{% block title %}{{ _('Inadimplências') }}{% endblock %}
 
 {% block content %}
-<div class="p-4 max-w-6xl mx-auto">
-  <h1 class="text-2xl font-semibold mb-2">Inadimplências</h1>
-  <div class="mb-4 grid grid-cols-1 md:grid-cols-4 gap-4">
-    <select name="centro" class="border p-2 rounded" hx-get="/api/financeiro/inadimplencias/" hx-target="#lista" hx-include="closest div">
-      <option value="">Todos Centros</option>
-      {% for c in centros %}
-        <option value="{{ c.id }}">{{ c.nome }}</option>
-      {% endfor %}
-    </select>
-    <select name="nucleo" class="border p-2 rounded" hx-get="/api/financeiro/inadimplencias/" hx-target="#lista" hx-include="closest div">
-      <option value="">Todos Núcleos</option>
-      {% for n in nucleos %}
-        <option value="{{ n.id }}">{{ n.nome }}</option>
-      {% endfor %}
-    </select>
-    <select name="status" class="border p-2 rounded" disabled>
-      <option>Pendente</option>
-    </select>
-    <input type="month" name="periodo" class="border p-2 rounded" hx-get="/api/financeiro/inadimplencias/" hx-target="#lista" hx-include="closest div">
-  </div>
+<section class="p-4 max-w-6xl mx-auto">
+  <h1 class="text-2xl font-semibold mb-2">{{ _('Inadimplências') }}</h1>
+  <fieldset class="mb-4 grid grid-cols-1 md:grid-cols-4 gap-4">
+    <legend class="sr-only">{{ _('Filtros') }}</legend>
+    <div>
+      <label for="filtro-centro" class="block text-sm font-medium text-gray-700">{{ _('Centro de Custo') }}</label>
+      <select id="filtro-centro" name="centro" class="border p-2 rounded" hx-get="/api/financeiro/inadimplencias/" hx-target="#lista" hx-include="closest fieldset">
+        <option value="">{{ _('Todos Centros') }}</option>
+        {% for c in centros %}
+          <option value="{{ c.id }}">{{ c.nome }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div>
+      <label for="filtro-nucleo" class="block text-sm font-medium text-gray-700">{{ _('Núcleo') }}</label>
+      <select id="filtro-nucleo" name="nucleo" class="border p-2 rounded" hx-get="/api/financeiro/inadimplencias/" hx-target="#lista" hx-include="closest fieldset">
+        <option value="">{{ _('Todos Núcleos') }}</option>
+        {% for n in nucleos %}
+          <option value="{{ n.id }}">{{ n.nome }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div>
+      <label for="filtro-status" class="block text-sm font-medium text-gray-700">{{ _('Status') }}</label>
+      <select id="filtro-status" name="status" class="border p-2 rounded" disabled>
+        <option>{{ _('Pendente') }}</option>
+      </select>
+    </div>
+    <div>
+      <label for="filtro-periodo" class="block text-sm font-medium text-gray-700">{{ _('Período') }}</label>
+      <input id="filtro-periodo" type="month" name="periodo" class="border p-2 rounded" hx-get="/api/financeiro/inadimplencias/" hx-target="#lista" hx-include="closest fieldset" />
+    </div>
+  </fieldset>
   <div id="lista" hx-get="/api/financeiro/inadimplencias/" hx-target="this">
     <table class="min-w-full divide-y divide-gray-200">
       <thead>
         <tr class="bg-gray-50">
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">ID</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">Centro de Custo</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">Conta</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">Valor</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">Data de Vencimento</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">Dias em atraso</th>
+          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{{ _('ID') }}</th>
+          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{{ _('Centro de Custo') }}</th>
+          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{{ _('Conta') }}</th>
+          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{{ _('Valor') }}</th>
+          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{{ _('Data de Vencimento') }}</th>
+          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{{ _('Dias em atraso') }}</th>
         </tr>
       </thead>
       <tbody></tbody>
     </table>
   </div>
   <div class="mt-4 flex gap-4">
-    <a href="/api/financeiro/inadimplencias/?format=csv" class="text-primary underline" hx-boost="false">Exportar CSV</a>
-    <a href="/api/financeiro/inadimplencias/?format=xlsx" class="text-primary underline" hx-boost="false">Exportar XLSX</a>
+    <a href="/api/financeiro/inadimplencias/?format=csv" class="text-primary underline" hx-boost="false" aria-label="{{ _('Exportar inadimplências em CSV') }}">{{ _('Exportar CSV') }}</a>
+    <a href="/api/financeiro/inadimplencias/?format=xlsx" class="text-primary underline" hx-boost="false" aria-label="{{ _('Exportar inadimplências em XLSX') }}">{{ _('Exportar XLSX') }}</a>
   </div>
-</div>
+</section>
 {% endblock %}

--- a/financeiro/templates/financeiro/lancamentos_list.html
+++ b/financeiro/templates/financeiro/lancamentos_list.html
@@ -1,49 +1,66 @@
 {% extends "base.html" %}
+{% load i18n %}
 
-{% block title %}Lançamentos Financeiros{% endblock %}
+{% block title %}{{ _('Lançamentos Financeiros') }}{% endblock %}
 
 {% block content %}
-<div class="p-4 max-w-6xl mx-auto">
-  <h1 class="text-2xl font-semibold mb-2">Lançamentos</h1>
-  <div class="mb-4 grid grid-cols-1 md:grid-cols-5 gap-4">
-    <select name="status" id="filtro-status" class="border p-2 rounded" hx-get="/api/financeiro/lancamentos/" hx-target="#lista" hx-include="closest div">
-      <option value="">Todos Status</option>
-      <option value="pendente">Pendente</option>
-      <option value="pago">Pago</option>
-      <option value="cancelado">Cancelado</option>
-    </select>
-    <select name="centro" id="filtro-centro" class="border p-2 rounded" hx-get="/api/financeiro/lancamentos/" hx-target="#lista" hx-include="closest div">
-      <option value="">Todos Centros</option>
-      {% for c in centros %}
-        <option value="{{ c.id }}">{{ c.nome }}</option>
-      {% endfor %}
-    </select>
-    <select name="nucleo" id="filtro-nucleo" class="border p-2 rounded" hx-get="/api/financeiro/lancamentos/" hx-target="#lista" hx-include="closest div">
-      <option value="">Todos Núcleos</option>
-      {% for n in nucleos %}
-        <option value="{{ n.id }}">{{ n.nome }}</option>
-      {% endfor %}
-    </select>
-    <input type="month" name="periodo_inicial" class="border p-2 rounded" hx-get="/api/financeiro/lancamentos/" hx-target="#lista" hx-include="closest div">
-    <input type="month" name="periodo_final" class="border p-2 rounded" hx-get="/api/financeiro/lancamentos/" hx-target="#lista" hx-include="closest div">
-  </div>
+<section class="p-4 max-w-6xl mx-auto">
+  <h1 class="text-2xl font-semibold mb-2">{{ _('Lançamentos') }}</h1>
+  <fieldset class="mb-4 grid grid-cols-1 md:grid-cols-5 gap-4">
+    <legend class="sr-only">{{ _('Filtros') }}</legend>
+    <div>
+      <label for="filtro-status" class="block text-sm font-medium text-gray-700">{{ _('Status') }}</label>
+      <select name="status" id="filtro-status" class="border p-2 rounded" hx-get="/api/financeiro/lancamentos/" hx-target="#lista" hx-include="closest fieldset">
+        <option value="">{{ _('Todos Status') }}</option>
+        <option value="pendente">{{ _('Pendente') }}</option>
+        <option value="pago">{{ _('Pago') }}</option>
+        <option value="cancelado">{{ _('Cancelado') }}</option>
+      </select>
+    </div>
+    <div>
+      <label for="filtro-centro" class="block text-sm font-medium text-gray-700">{{ _('Centro de Custo') }}</label>
+      <select name="centro" id="filtro-centro" class="border p-2 rounded" hx-get="/api/financeiro/lancamentos/" hx-target="#lista" hx-include="closest fieldset">
+        <option value="">{{ _('Todos Centros') }}</option>
+        {% for c in centros %}
+          <option value="{{ c.id }}">{{ c.nome }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div>
+      <label for="filtro-nucleo" class="block text-sm font-medium text-gray-700">{{ _('Núcleo') }}</label>
+      <select name="nucleo" id="filtro-nucleo" class="border p-2 rounded" hx-get="/api/financeiro/lancamentos/" hx-target="#lista" hx-include="closest fieldset">
+        <option value="">{{ _('Todos Núcleos') }}</option>
+        {% for n in nucleos %}
+          <option value="{{ n.id }}">{{ n.nome }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div>
+      <label for="filtro-periodo-inicial" class="block text-sm font-medium text-gray-700">{{ _('Período inicial') }}</label>
+      <input id="filtro-periodo-inicial" type="month" name="periodo_inicial" class="border p-2 rounded" hx-get="/api/financeiro/lancamentos/" hx-target="#lista" hx-include="closest fieldset" />
+    </div>
+    <div>
+      <label for="filtro-periodo-final" class="block text-sm font-medium text-gray-700">{{ _('Período final') }}</label>
+      <input id="filtro-periodo-final" type="month" name="periodo_final" class="border p-2 rounded" hx-get="/api/financeiro/lancamentos/" hx-target="#lista" hx-include="closest fieldset" />
+    </div>
+  </fieldset>
   <div id="lista" hx-get="/api/financeiro/lancamentos/" hx-target="this">
     <table class="min-w-full divide-y divide-gray-200">
       <thead>
         <tr class="bg-gray-50">
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">ID</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">Centro de Custo</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">Conta Associada</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">Tipo</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">Valor</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">Data de Lançamento</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">Status</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">Data de Vencimento</th>
+          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{{ _('ID') }}</th>
+          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{{ _('Centro de Custo') }}</th>
+          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{{ _('Conta Associada') }}</th>
+          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{{ _('Tipo') }}</th>
+          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{{ _('Valor') }}</th>
+          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{{ _('Data de Lançamento') }}</th>
+          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{{ _('Status') }}</th>
+          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{{ _('Data de Vencimento') }}</th>
           <th class="px-3 py-2"></th>
         </tr>
       </thead>
       <tbody></tbody>
     </table>
   </div>
-</div>
+</section>
 {% endblock %}

--- a/financeiro/templates/financeiro/relatorios.html
+++ b/financeiro/templates/financeiro/relatorios.html
@@ -1,25 +1,26 @@
 {% extends "base.html" %}
+{% load i18n %}
 
-{% block title %}Relatórios Financeiros{% endblock %}
+{% block title %}{{ _('Relatórios Financeiros') }}{% endblock %}
 
 {% block content %}
-<div class="max-w-5xl mx-auto p-4 space-y-4">
-  <h1 class="text-2xl font-semibold mb-2">Relatórios</h1>
+<section class="max-w-5xl mx-auto p-4 space-y-4">
+  <h1 class="text-2xl font-semibold mb-2">{{ _('Relatórios') }}</h1>
   <form id="relatorio-form" class="space-y-4" hx-get="/api/financeiro/relatorios/" hx-target="#relatorio">
     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
       <div>
-        <label class="block text-sm font-medium text-gray-700">Centro de Custo</label>
-        <select name="centro" class="mt-1 block w-full border rounded p-2">
-          <option value="">Todos</option>
+        <label for="rel-centro" class="block text-sm font-medium text-gray-700">{{ _('Centro de Custo') }}</label>
+        <select id="rel-centro" name="centro" class="mt-1 block w-full border rounded p-2">
+          <option value="">{{ _('Todos') }}</option>
           {% for c in centros %}
             <option value="{{ c.id }}">{{ c.nome }}</option>
           {% endfor %}
         </select>
       </div>
       <div>
-        <label class="block text-sm font-medium text-gray-700">Núcleo</label>
-        <select name="nucleo" class="mt-1 block w-full border rounded p-2">
-          <option value="">Todos</option>
+        <label for="rel-nucleo" class="block text-sm font-medium text-gray-700">{{ _('Núcleo') }}</label>
+        <select id="rel-nucleo" name="nucleo" class="mt-1 block w-full border rounded p-2">
+          <option value="">{{ _('Todos') }}</option>
           {% for n in nucleos %}
             <option value="{{ n.id }}">{{ n.nome }}</option>
           {% endfor %}
@@ -28,21 +29,21 @@
     </div>
     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
       <div>
-        <label class="block text-sm font-medium text-gray-700">Período inicial</label>
-        <input type="month" name="periodo_inicial" class="mt-1 block w-full border rounded p-2" />
+        <label for="rel-periodo-inicial" class="block text-sm font-medium text-gray-700">{{ _('Período inicial') }}</label>
+        <input id="rel-periodo-inicial" type="month" name="periodo_inicial" class="mt-1 block w-full border rounded p-2" />
       </div>
       <div>
-        <label class="block text-sm font-medium text-gray-700">Período final</label>
-        <input type="month" name="periodo_final" class="mt-1 block w-full border rounded p-2" />
+        <label for="rel-periodo-final" class="block text-sm font-medium text-gray-700">{{ _('Período final') }}</label>
+        <input id="rel-periodo-final" type="month" name="periodo_final" class="mt-1 block w-full border rounded p-2" />
       </div>
     </div>
-    <button type="submit" class="bg-primary text-white px-4 py-2 rounded">Gerar Relatório</button>
+    <button type="submit" class="bg-primary text-white px-4 py-2 rounded">{{ _('Gerar Relatório') }}</button>
   </form>
 
   <div id="relatorio" class="mt-6"></div>
   <div class="mt-4 flex gap-4">
-    <a href="#" id="export-csv" class="text-primary underline" hx-boost="false">Exportar CSV</a>
-    <a href="#" id="export-xlsx" class="text-primary underline" hx-boost="false">Exportar XLSX</a>
+    <a href="#" id="export-csv" class="text-primary underline" hx-boost="false" aria-label="{{ _('Exportar relatório em CSV') }}">{{ _('Exportar CSV') }}</a>
+    <a href="#" id="export-xlsx" class="text-primary underline" hx-boost="false" aria-label="{{ _('Exportar relatório em XLSX') }}">{{ _('Exportar XLSX') }}</a>
   </div>
-</div>
+</section>
 {% endblock %}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,8 +3,8 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        primary: { DEFAULT: "#3B82F6" },
-        secondary: { DEFAULT: "#10B981" },
+        primary: { DEFAULT: "#1D4ED8" },
+        secondary: { DEFAULT: "#047857" },
       },
       fontFamily: { sans: ["Inter", "ui-sans-serif", "system-ui"] },
     },


### PR DESCRIPTION
## Summary
- add labels and semantics to finance filters and forms
- ensure confirm button activates after preview
- adjust primary and secondary colors for WCAG contrast

## Testing
- `ruff check .` *(fails: E402, I001 in existing files)*
- `black --check .` *(fails: would reformat multiple files)*
- `mypy .` *(fails: missing annotations, missing stubs)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688b950369d08325be1de690f2366bca