### PR TITLE
Refatora templates do feed para Tailwind/HTMX

### DIFF
--- a/feed/templates/feed/_grid.html
+++ b/feed/templates/feed/_grid.html
@@ -1,16 +1,16 @@
-{% load static %}
+{% load static i18n %}
 <section id="feed-grid" class="grid gap-6 grid-cols-1 sm:grid-cols-2 xl:grid-cols-3">
   {% for post in posts %}
     <article class="rounded-lg bg-white shadow p-6 space-y-4">
       <p class="text-xs text-neutral-500">
         {% if post.tipo_feed == 'nucleo' %}
-          Feed do Núcleo: {{ post.nucleo.nome }}
+          {% blocktrans with nome=post.nucleo.nome %}Feed do Núcleo: {{ nome }}{% endblocktrans %}
         {% elif post.tipo_feed == 'evento' %}
-          Feed do Evento: {{ post.evento.titulo }}
+          {% blocktrans with titulo=post.evento.titulo %}Feed do Evento: {{ titulo }}{% endblocktrans %}
         {% elif post.tipo_feed == 'usuario' %}
-          Mural do Usuário
+          {% trans "Mural do Usuário" %}
         {% else %}
-          Feed Global
+          {% trans "Feed Global" %}
         {% endif %}
       </p>
       <div class="flex items-center gap-4">
@@ -33,7 +33,7 @@
       </div>
       {% if post.pdf %}
         <div class="relative">
-          <img src="{% static 'img/pdf-placeholder.png' %}" alt="PDF" class="w-full rounded">
+          <img src="{% static 'img/pdf-placeholder.png' %}" alt="{% trans 'PDF' %}" class="w-full rounded">
           <a href="{{ post.pdf.url }}" target="_blank" class="absolute top-2 left-2 bg-white/90 hover:bg-white shadow rounded p-1.5 text-sm">
             <i class="fa-solid fa-eye"></i>
           </a>
@@ -50,10 +50,10 @@
         <div id="like-btn-{{ post.id }}">
           {% include 'feed/_like_button.html' with post=post %}
         </div>
-        <span>{{ post.comments.count }} comentários</span>
+        <span>{{ post.comments.count }} {% trans 'comentários' %}</span>
       </div>
     </article>
   {% empty %}
-    <p class="col-span-full text-center text-neutral-500">Nenhuma postagem encontrada.</p>
+    <p class="col-span-full text-center text-neutral-500">{% trans "Nenhuma postagem encontrada." %}</p>
   {% endfor %}
 </section>

--- a/feed/templates/feed/_post_list.html
+++ b/feed/templates/feed/_post_list.html
@@ -1,5 +1,5 @@
 {% comment %}Lista de postagens reutilizável com Tailwind{% endcomment %}
-{% load static %}
+{% load static i18n %}
 
 <div class="space-y-6">
   {% for post in posts %}
@@ -25,7 +25,7 @@
 
       {% if post.pdf %}
         <div class="relative">
-          <img src="{% static 'img/pdf-placeholder.png' %}" alt="PDF" class="rounded-xl shadow-sm max-w-full">
+          <img src="{% static 'img/pdf-placeholder.png' %}" alt="{% trans 'PDF' %}" class="rounded-xl shadow-sm max-w-full">
           <a href="{{ post.pdf.url }}" target="_blank" class="absolute top-2 left-2 bg-white/90 hover:bg-white shadow rounded p-1.5 text-sm">
             <i class="fa-solid fa-eye"></i>
           </a>
@@ -35,17 +35,17 @@
         </div>
       {% elif post.image %}
         <div class="feed-media">
-          <img src="{{ post.image.url }}" alt="mídia do post" class="rounded-xl shadow-sm max-w-full">
+          <img src="{{ post.image.url }}" alt="{% trans 'mídia do post' %}" class="rounded-xl shadow-sm max-w-full">
         </div>
       {% endif %}
     </article>
   {% empty %}
     <div class="text-center border border-neutral-200 rounded-2xl shadow-sm bg-white p-10">
       <div class="text-4xl mb-2">{{ empty_icon|default:"📝" }}</div>
-      <h3 class="text-lg font-semibold text-neutral-900 mb-1">{{ empty_title|default:"Nenhuma postagem ainda" }}</h3>
-      <p class="text-neutral-500 text-sm mb-4">{{ empty_message|default:"Seja o primeiro a compartilhar algo!" }}</p>
-      <a href="{% url 'feed:nova_postagem' %}" class="text-sm px-4 py-2 rounded-xl bg-primary-600 text-white hover:bg-primary-700">
-        {{ empty_button|default:"Criar postagem" }}
+      <h3 class="text-lg font-semibold text-neutral-900 mb-1">{{ empty_title|default:_("Nenhuma postagem ainda") }}</h3>
+      <p class="text-neutral-500 text-sm mb-4">{{ empty_message|default:_("Seja o primeiro a compartilhar algo!") }}</p>
+      <a href="{% url 'feed:nova_postagem' %}" class="text-sm px-4 py-2 rounded-xl bg-primary-600 text-white hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500">
+        {{ empty_button|default:_("Criar postagem") }}
       </a>
     </div>
   {% endfor %}

--- a/feed/templates/feed/feed.html
+++ b/feed/templates/feed/feed.html
@@ -1,35 +1,36 @@
 {% extends 'base.html' %}
+{% load i18n %}
 
-{% block title %}Feed | Hubx{% endblock %}
+{% block title %}{% trans "Feed" %} | Hubx{% endblock %}
 
 {% block content %}
 <section class="max-w-7xl mx-auto px-4 py-10">
 
   <!-- Cabeçalho -->
   <div class="flex items-center justify-between mb-6">
-    <h1 class="text-2xl font-bold text-neutral-900">Feed de Postagens</h1>
+    <h1 class="text-2xl font-bold text-neutral-900">{% trans "Feed de Postagens" %}</h1>
     <div class="flex gap-2">
-      <a href="{% url 'feed:meu_mural' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100">Mural</a>
+      <a href="{% url 'feed:meu_mural' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100 focus:outline-none focus:ring-2 focus:ring-indigo-500" aria-label="{% trans 'Mural' %}">{% trans "Mural" %}</a>
       {% if request.user.user_type != 'root' %}
-        <a href="{% url 'feed:nova_postagem' %}" target="_blank" class="inline-flex items-center gap-2 rounded bg-emerald-600 px-4 py-2 text-white hover:bg-emerald-700 focus-visible:ring">
+        <a href="{% url 'feed:nova_postagem' %}" target="_blank" class="inline-flex items-center gap-2 rounded bg-emerald-600 px-4 py-2 text-white hover:bg-emerald-700 focus:outline-none focus:ring-2 focus:ring-emerald-500" aria-label="{% trans 'Nova postagem' %}">
           <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
           </svg>
-          Nova postagem
+          {% trans "Nova postagem" %}
         </a>
       {% endif %}
     </div>
   </div>
 
   <div class="flex items-center gap-4 mb-4">
-    <label class="font-semibold">Núcleo:</label>
+    <label class="font-semibold">{% trans "Núcleo" %}:</label>
     <select id="filtro-nucleo" name="nucleo"
             hx-get="{% url 'feed:listar' %}"
             hx-target="#feed-grid"
             hx-indicator="#feed-loading"
             hx-include="#feed-search,#filtro-nucleo"
-            class="rounded border-gray-300">
-      <option value="">Global</option>
+            class="rounded border-gray-300 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+      <option value="">{% trans "Global" %}</option>
       {% for n in nucleos_do_usuario %}
         <option value="{{ n.id }}">{{ n.nome }}</option>
       {% endfor %}
@@ -37,14 +38,14 @@
   </div>
 
   <input type="search" name="q" id="feed-search"
-         placeholder="Buscar postagens…"
+         placeholder="{% trans 'Buscar postagens…' %}"
          hx-get="{% url 'feed:listar' %}"
          hx-trigger="keyup changed delay:500ms"
          hx-target="#feed-grid"
          hx-include="#filtro-nucleo"
-         class="w-full rounded border-gray-300 mb-6">
+         class="w-full rounded border-gray-300 mb-6 focus:outline-none focus:ring-2 focus:ring-indigo-500">
 
-  <div id="feed-loading" class="htmx-indicator">Carregando…</div>
+  <div id="feed-loading" class="htmx-indicator">{% trans "Carregando…" %}</div>
 
   {% include "feed/_grid.html" %}
 

--- a/feed/templates/feed/mural.html
+++ b/feed/templates/feed/mural.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
-{% load static %}
-{% block title %}Meu Mural{% endblock %}
+{% load static i18n %}
+{% block title %}{% trans "Meu Mural" %}{% endblock %}
 
 
 
@@ -9,13 +9,13 @@
 
   <!-- Cabeçalho -->
   <div class="flex items-center justify-between mb-6">
-    <h1 class="text-2xl font-bold text-neutral-900">Meu Mural</h1>
+    <h1 class="text-2xl font-bold text-neutral-900">{% trans "Meu Mural" %}</h1>
     <div class="flex gap-2">
-      <a href="{% url 'feed:listar' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100">Ver Feed Global</a>
+      <a href="{% url 'feed:listar' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100 focus:outline-none focus:ring-2 focus:ring-indigo-500" aria-label="{% trans 'Ver Feed Global' %}">{% trans "Ver Feed Global" %}</a>
       {% if request.user.user_type != 'root' %}
-      <a href="{% url 'feed:nova_postagem' %}" target="_blank" class="inline-flex items-center gap-2 px-4 py-2 rounded-md bg-blue-500 hover:bg-blue-600 text-white text-sm font-medium shadow-sm transition">
+      <a href="{% url 'feed:nova_postagem' %}" target="_blank" class="inline-flex items-center gap-2 px-4 py-2 rounded-md bg-blue-500 hover:bg-blue-600 text-white text-sm font-medium shadow-sm transition focus:outline-none focus:ring-2 focus:ring-blue-500" aria-label="{% trans 'Nova postagem' %}">
         <i class="fa-solid fa-circle-plus"></i>
-        Nova postagem
+        {% trans "Nova postagem" %}
       </a>
       {% endif %}
     </div>
@@ -24,8 +24,4 @@
   {% include "feed/_grid.html" with posts=posts %}
 
 </section>
-{% endblock %}
-
-{% block extra_js %}
-<script src="{% static 'feed/js/feed.js' %}"></script>
 {% endblock %}

--- a/feed/templates/feed/nova_postagem.html
+++ b/feed/templates/feed/nova_postagem.html
@@ -1,22 +1,22 @@
 {% extends "base.html" %}
-{% load static %}
+{% load static i18n %}
 
-{% block title %}Nova Postagem - Hubx{% endblock %}
+{% block title %}{% trans "Nova Postagem" %} - Hubx{% endblock %}
 
 {% block content %}
 <section class="max-w-2xl mx-auto px-4 py-10">
 
   <!-- Cabeçalho -->
   <div class="mb-6 flex items-center gap-4">
-    <a href="{% url 'feed:listar' %}" class="inline-flex items-center text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100">
+    <a href="{% url 'feed:listar' %}" class="inline-flex items-center text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100 focus:outline-none focus:ring-2 focus:ring-indigo-500" aria-label="{% trans 'Voltar' %}">
       <svg class="mr-2" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
         <polyline points="15,18 9,12 15,6"/>
       </svg>
-      Voltar
+      {% trans "Voltar" %}
     </a>
     <div>
-      <h1 class="text-2xl font-bold text-neutral-900">Nova Postagem</h1>
-      <p class="text-sm text-neutral-600">Compartilhe algo com sua comunidade</p>
+      <h1 class="text-2xl font-bold text-neutral-900">{% trans "Nova Postagem" %}</h1>
+      <p class="text-sm text-neutral-600">{% trans "Compartilhe algo com sua comunidade" %}</p>
     </div>
   </div>
 
@@ -37,32 +37,32 @@
         id="{{ form.conteudo.id_for_label }}"
         name="{{ form.conteudo.name }}"
         class="mt-1 block w-full rounded-xl border border-neutral-300 shadow-sm focus:ring-primary-500 focus:border-primary-500 text-sm"
-        placeholder="O que você gostaria de compartilhar?"
+          placeholder="{% trans 'O que você gostaria de compartilhar?' %}"
         rows="6"
         required
       >{{ form.conteudo.value|default_if_none:"" }}</textarea>
       {% if form.conteudo.errors %}
         <p class="text-red-500 text-xs mt-1">{{ form.conteudo.errors }}</p>
       {% endif %}
-      <p class="text-sm text-neutral-500 mt-1">Compartilhe ideias, atualizações ou conteúdos com sua rede.</p>
+        <p class="text-sm text-neutral-500 mt-1">{% trans "Compartilhe ideias, atualizações ou conteúdos com sua rede." %}</p>
     </div>
 
     <div class="mb-4">
-      <label for="id_tipo_feed" class="font-semibold mb-1 block">Tipo de Feed</label>
+        <label for="id_tipo_feed" class="font-semibold mb-1 block">{% trans "Tipo de Feed" %}</label>
       {{ form.tipo_feed|as_widget }}
     </div>
     <div class="mb-4">
-      <label for="id_nucleo" class="font-semibold mb-1 block">Núcleo</label>
+        <label for="id_nucleo" class="font-semibold mb-1 block">{% trans "Núcleo" %}</label>
       {{ form.nucleo|as_widget }}
     </div>
     <div class="mb-4">
-      <label for="id_evento" class="font-semibold mb-1 block">Evento</label>
+        <label for="id_evento" class="font-semibold mb-1 block">{% trans "Evento" %}</label>
       {{ form.evento|as_widget }}
     </div>
 
     <!-- Arquivo -->
     <div>
-      <label for="id_file" class="block text-sm font-medium text-neutral-700">Arquivo (imagem ou PDF)</label>
+        <label for="id_file" class="block text-sm font-medium text-neutral-700">{% trans "Arquivo (imagem ou PDF)" %}</label>
       <input type="file" id="id_file" name="arquivo" accept="image/*,.pdf"
              class="mt-2 block w-full text-sm text-neutral-600 file:mr-4 file:py-2 file:px-4 file:rounded-xl file:border-0 file:text-sm file:font-semibold file:bg-neutral-100 file:text-neutral-700 hover:file:bg-neutral-200">
       {% if form.image.errors or form.pdf.errors %}
@@ -75,37 +75,19 @@
     <!-- Ações -->
     <div class="flex justify-end gap-4 mt-6">
       <button type="submit"
-              class="inline-flex items-center gap-2 rounded bg-emerald-600 px-5 py-2 text-white hover:bg-emerald-700 focus-visible:ring">
+              class="inline-flex items-center gap-2 rounded bg-emerald-600 px-5 py-2 text-white hover:bg-emerald-700 focus:outline-none focus:ring-2 focus:ring-emerald-500" aria-label="{% trans 'Salvar' %}">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-5 w-5">
           <path fill-rule="evenodd" d="M16.704 5.29a1 1 0 0 1 0 1.42l-7.5 7.5a1 1 0 0 1-1.42 0l-3.5-3.5a1 1 0 1 1 1.42-1.42l2.79 2.79 6.79-6.79a1 1 0 0 1 1.42 0Z" clip-rule="evenodd" />
         </svg>
-        Salvar
+        {% trans "Salvar" %}
       </button>
       <a href="{% url 'feed:listar' %}"
-         class="inline-flex items-center gap-2 rounded border border-neutral-300 px-5 py-2 hover:bg-neutral-100">
-        Cancelar
+         class="inline-flex items-center gap-2 rounded border border-neutral-300 px-5 py-2 hover:bg-neutral-100 focus:outline-none focus:ring-2 focus:ring-neutral-500" aria-label="{% trans 'Cancelar' %}">
+        {% trans "Cancelar" %}
       </a>
     </div>
   </form>
 </section>
 
-<script>
-document.getElementById('id_file')?.addEventListener('change', function(e) {
-  const file = e.target.files[0];
-  if (file) {
-    const reader = new FileReader();
-    reader.onload = function(evt) {
-      const preview = document.createElement('div');
-      preview.className = "mt-4";
-      let inner = `<p class="text-sm text-neutral-500">${file.name}</p>`;
-      if (file.type.startsWith('image/')) {
-        inner = `<img src="${evt.target.result}" class="max-w-xs rounded-xl shadow-sm mb-2"/>` + inner;
-      }
-      preview.innerHTML = inner;
-      e.target.insertAdjacentElement('afterend', preview);
-    };
-    reader.readAsDataURL(file);
-  }
-});
-</script>
+<script src="{% static 'feed/js/feed.js' %}"></script>
 {% endblock %}

--- a/feed/templates/feed/post_delete.html
+++ b/feed/templates/feed/post_delete.html
@@ -1,16 +1,17 @@
 {% extends 'base.html' %}
-{% block title %}Remover Postagem | Hubx{% endblock %}
+{% load i18n %}
+{% block title %}{% trans "Remover Postagem" %} | Hubx{% endblock %}
 
 {% block content %}
 <section class="max-w-md mx-auto px-4 py-16">
   <div class="bg-white border border-red-200 rounded-2xl shadow-sm p-6 text-center">
-    <h2 class="text-xl font-semibold text-red-700 mb-4">Remover Postagem</h2>
-    <p class="text-sm text-neutral-700">Tem certeza que deseja remover esta postagem?</p>
+    <h2 class="text-xl font-semibold text-red-700 mb-4">{% trans "Remover Postagem" %}</h2>
+    <p class="text-sm text-neutral-700">{% trans "Tem certeza que deseja remover esta postagem?" %}</p>
 
-    <form method="post" class="mt-6 flex justify-center gap-3">
+    <form method="post" hx-post="{% url 'feed:post_delete' post.pk %}" class="mt-6 flex justify-center gap-3">
       {% csrf_token %}
-      <a href="{% url 'feed:post_detail' post.pk %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100">Cancelar</a>
-      <button type="submit" class="text-sm px-4 py-2 rounded-xl bg-red-600 text-white hover:bg-red-700">Remover</button>
+      <a href="{% url 'feed:post_detail' post.pk %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100 focus:outline-none focus:ring-2 focus:ring-neutral-500" aria-label="{% trans 'Cancelar' %}">{% trans "Cancelar" %}</a>
+      <button type="submit" class="text-sm px-4 py-2 rounded-xl bg-red-600 text-white hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500" aria-label="{% trans 'Remover' %}">{% trans "Remover" %}</button>
     </form>
   </div>
 </section>

--- a/feed/templates/feed/post_detail.html
+++ b/feed/templates/feed/post_detail.html
@@ -1,11 +1,11 @@
 {% extends 'base.html' %}
-{% load static %}
-{% block title %}Postagem | Hubx{% endblock %}
+{% load static i18n %}
+{% block title %}{% trans "Postagem" %} | Hubx{% endblock %}
 
 {% block content %}
 <section class="max-w-3xl mx-auto px-4 py-10 space-y-6">
   <div>
-    <a href="{% url 'feed:listar' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100">Voltar</a>
+    <a href="{% url 'feed:listar' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100 focus:outline-none focus:ring-2 focus:ring-indigo-500" aria-label="{% trans 'Voltar' %}">{% trans "Voltar" %}</a>
   </div>
 
   <article class="border border-neutral-200 bg-white rounded-2xl shadow-sm p-6 space-y-4">
@@ -33,7 +33,7 @@
       </div>
     {% elif post.image %}
       <div class="mt-2">
-        <img src="{{ post.image.url }}" alt="Imagem" class="rounded-xl shadow-sm max-w-full">
+        <img src="{{ post.image.url }}" alt="{% trans 'Imagem' %}" class="rounded-xl shadow-sm max-w-full">
       </div>
     {% endif %}
 
@@ -42,14 +42,14 @@
     </div>
 
     <div class="mt-6">
-      <h3 class="text-lg font-medium">Comentários</h3>
+      <h3 class="text-lg font-medium">{% trans "Comentários" %}</h3>
       <form method="post" action="{% url 'feed:create_comment' post.id %}" hx-post="{% url 'feed:create_comment' post.id %}" hx-target="#comments" hx-swap="afterbegin" class="space-y-2">
         {% csrf_token %}
         {{ comment_form.texto }}
         {% if comment_form.texto.errors %}
           <p class="text-red-500 text-xs">{{ comment_form.texto.errors }}</p>
         {% endif %}
-        <button type="submit" class="px-4 py-2 rounded-xl bg-blue-500 text-white hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500" aria-label="Enviar comentário">Enviar</button>
+        <button type="submit" class="px-4 py-2 rounded-xl bg-blue-500 text-white hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500" aria-label="{% trans 'Enviar comentário' %}">{% trans "Enviar" %}</button>
       </form>
 
       <ul id="comments" class="mt-4 space-y-4">
@@ -61,8 +61,8 @@
 
     {% if post.autor == user or user_can_moderate %}
     <div class="flex justify-end gap-3 pt-4 border-t border-neutral-100 text-sm">
-      <a href="{% url 'feed:post_update' post.pk %}" class="text-yellow-600 hover:underline">Editar</a>
-      <a href="{% url 'feed:post_delete' post.pk %}" class="text-red-600 hover:underline">Remover</a>
+      <a href="{% url 'feed:post_update' post.pk %}" class="text-yellow-600 hover:underline focus:outline-none focus:ring-2 focus:ring-yellow-500" aria-label="{% trans 'Editar postagem' %}">{% trans "Editar" %}</a>
+      <a href="{% url 'feed:post_delete' post.pk %}" class="text-red-600 hover:underline focus:outline-none focus:ring-2 focus:ring-red-500" aria-label="{% trans 'Remover postagem' %}">{% trans "Remover" %}</a>
     </div>
     {% endif %}
   </article>

--- a/feed/templates/feed/post_update.html
+++ b/feed/templates/feed/post_update.html
@@ -1,23 +1,23 @@
 {% extends 'base.html' %}
-{% load static %}
-{% block title %}Editar Postagem - Hubx{% endblock %}
+{% load static i18n %}
+{% block title %}{% trans "Editar Postagem" %} - Hubx{% endblock %}
 
 {% block content %}
 <section class="max-w-2xl mx-auto px-4 py-10">
   <div class="mb-6 flex items-center gap-4">
-    <a href="{% url 'feed:post_detail' post.pk %}" class="inline-flex items-center text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100">
+    <a href="{% url 'feed:post_detail' post.pk %}" class="inline-flex items-center text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100 focus:outline-none focus:ring-2 focus:ring-indigo-500" aria-label="{% trans 'Voltar' %}">
       <svg class="mr-2" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
         <polyline points="15,18 9,12 15,6"/>
       </svg>
-      Voltar
+      {% trans "Voltar" %}
     </a>
     <div>
-      <h1 class="text-2xl font-bold text-neutral-900">Editar Postagem</h1>
-      <p class="text-sm text-neutral-600">Atualize sua postagem</p>
+      <h1 class="text-2xl font-bold text-neutral-900">{% trans "Editar Postagem" %}</h1>
+      <p class="text-sm text-neutral-600">{% trans "Atualize sua postagem" %}</p>
     </div>
   </div>
 
-  <form method="post" enctype="multipart/form-data" class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 space-y-6">
+  <form method="post" enctype="multipart/form-data" hx-post="{% url 'feed:post_update' post.pk %}" hx-encoding="multipart/form-data" class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 space-y-6">
     {% csrf_token %}
     <div>
       <label for="{{ form.conteudo.id_for_label }}" class="block text-sm font-medium text-neutral-700">
@@ -30,14 +30,14 @@
     </div>
 
     <div>
-      <label for="id_file" class="block text-sm font-medium text-neutral-700">Arquivo (imagem ou PDF)</label>
+      <label for="id_file" class="block text-sm font-medium text-neutral-700">{% trans "Arquivo (imagem ou PDF)" %}</label>
       <input type="file" id="id_file" name="arquivo" accept="image/*,.pdf" class="mt-2 block w-full text-sm text-neutral-600 file:mr-4 file:py-2 file:px-4 file:rounded-xl file:border-0 file:text-sm file:font-semibold file:bg-neutral-100 file:text-neutral-700 hover:file:bg-neutral-200">
       {% if form.image.errors or form.pdf.errors %}
         <p class="text-red-500 text-xs mt-1">{{ form.image.errors }} {{ form.pdf.errors }}</p>
       {% endif %}
       {% if post.pdf %}
         <div class="relative mt-2">
-          <img src="{% static 'img/pdf-placeholder.png' %}" alt="PDF" class="max-w-xs rounded-xl shadow-sm">
+          <img src="{% static 'img/pdf-placeholder.png' %}" alt="{% trans 'PDF' %}" class="max-w-xs rounded-xl shadow-sm">
           <a href="{{ post.pdf.url }}" target="_blank" class="absolute top-2 left-2 bg-white/90 hover:bg-white shadow rounded p-1.5 text-sm">
             <i class="fa-solid fa-eye"></i>
           </a>
@@ -51,9 +51,10 @@
     </div>
 
     <div class="flex justify-end gap-3 pt-4 border-t border-neutral-100">
-      <a href="{% url 'feed:post_detail' post.pk %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100">Cancelar</a>
-      <button type="submit" class="text-sm px-4 py-2 rounded-xl bg-primary-600 text-white hover:bg-primary-700">Salvar</button>
+      <a href="{% url 'feed:post_detail' post.pk %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100 focus:outline-none focus:ring-2 focus:ring-neutral-500" aria-label="{% trans 'Cancelar' %}">{% trans "Cancelar" %}</a>
+      <button type="submit" class="text-sm px-4 py-2 rounded-xl bg-primary-600 text-white hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500" aria-label="{% trans 'Salvar' %}">{% trans "Salvar" %}</button>
     </div>
   </form>
 </section>
+<script src="{% static 'feed/js/feed.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Refatora templates do feed com Tailwind, i18n e atributos HTMX
- Remove scripts inline e adiciona feedback de foco e acessibilidade
- Garante permissões e redirecionamentos HTMX nas views de edição e exclusão

## Testing
- `ruff check feed/views.py`
- `black feed/views.py`
- `pytest feed -q`


------
https://chatgpt.com/codex/tasks/task_e_688bb412558483258065319c4beeb9da