### PR TITLE
Refatora dashboards com Tailwind e HTMX

### DIFF
--- a/dashboard/templates/dashboard/admin.html
+++ b/dashboard/templates/dashboard/admin.html
@@ -1,14 +1,46 @@
 {% extends "base.html" %}
 {% load static %}
+{% load i18n %}
 
-{% block title %}Dashboard Admin | Hubx{% endblock %}
+{% block title %}{% trans "Dashboard Admin" %} | Hubx{% endblock %}
 
 {% block content %}
 <main class="max-w-7xl mx-auto px-4 py-10" role="main" aria-label="Dashboard">
-  <h1 class="text-3xl font-semibold text-neutral-900 text-center mb-10">Dashboard Administrativo</h1>
+  <h1 class="text-3xl font-semibold text-neutral-900 text-center mb-10">{% trans "Dashboard Administrativo" %}</h1>
+
   <div hx-get="{% url 'dashboard:metrics-partial' %}" hx-trigger="load, every 10s" hx-target="#metrics" hx-swap="innerHTML">
     {% include 'dashboard/partials/metrics_list.html' %}
   </div>
+
+  {% with labels='["Usuários","Eventos","Posts"]' data='['|add:num_users.total|stringformat:"d"|add:","|add:num_eventos.total|stringformat:"d"|add:","|add:num_posts.total|stringformat:"d"|add:"]' %}
+  {% include 'dashboard/partials/chart.html' with chart_id='metrics_chart' title=_('Distribuição de Métricas') labels=labels|safe data=data|safe %}
+  {% endwith %}
+
   <div hx-get="{% url 'dashboard:lancamentos-partial' %}" hx-trigger="load, every 30s" hx-target="#lancamentos" hx-swap="innerHTML"></div>
+
+  <div hx-get="{% url 'dashboard:notificacoes-partial' %}" hx-trigger="load, every 10s" hx-target="#notifications" hx-swap="innerHTML"></div>
+
+  <section class="mb-8">
+    <h2 class="text-xl font-semibold mb-4">{% trans "Ações Rápidas" %}</h2>
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+      <a href="{% url 'accounts:user-list' %}" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50">
+        <i class="fa-solid fa-user-gear mb-2"></i>
+        <span class="block">{% trans "Administrar Usuários" %}</span>
+      </a>
+      <a href="{% url 'agenda:evento-list' %}" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50">
+        <i class="fa-solid fa-calendar-check mb-2"></i>
+        <span class="block">{% trans "Aprovar Eventos" %}</span>
+      </a>
+      <a href="{% url 'financeiro:lancamento-list' %}" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50">
+        <i class="fa-solid fa-file-invoice-dollar mb-2"></i>
+        <span class="block">{% trans "Relatórios Financeiros" %}</span>
+      </a>
+      <a href="{% url 'notificacoes:logs-list' %}" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50">
+        <i class="fa-solid fa-bell mb-2"></i>
+        <span class="block">{% trans "Logs de Notificações" %}</span>
+      </a>
+    </div>
+  </section>
+
 </main>
 {% endblock %}

--- a/dashboard/templates/dashboard/cliente.html
+++ b/dashboard/templates/dashboard/cliente.html
@@ -1,13 +1,36 @@
 {% extends "base.html" %}
 {% load static %}
+{% load i18n %}
 
-{% block title %}Dashboard Cliente | Hubx{% endblock %}
+{% block title %}{% trans "Dashboard Cliente" %} | Hubx{% endblock %}
 
 {% block content %}
 <main class="max-w-7xl mx-auto px-4 py-10" role="main" aria-label="Dashboard">
-  <h1 class="text-3xl font-semibold text-neutral-900 text-center mb-10">Dashboard Cliente</h1>
+  <h1 class="text-3xl font-semibold text-neutral-900 text-center mb-10">{% trans "Dashboard Cliente" %}</h1>
+
   <div hx-get="{% url 'dashboard:metrics-partial' %}" hx-trigger="load, every 10s" hx-target="#metrics" hx-swap="innerHTML">
     {% include 'dashboard/partials/metrics_list.html' %}
   </div>
+
+  <div hx-get="{% url 'dashboard:eventos-partial' %}" hx-trigger="load, every 20s" hx-target="#upcoming-events" hx-swap="innerHTML"></div>
+
+  <div hx-get="{% url 'dashboard:tarefas-partial' %}" hx-trigger="load, every 20s" hx-target="#tasks" hx-swap="innerHTML"></div>
+
+  <div hx-get="{% url 'dashboard:notificacoes-partial' %}" hx-trigger="load, every 20s" hx-target="#notifications" hx-swap="innerHTML"></div>
+
+  <section class="mb-8">
+    <h2 class="text-xl font-semibold mb-4">{% trans "Atalhos" %}</h2>
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+      <a href="{% url 'agenda:evento-list' %}" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50">
+        <i class="fa-solid fa-calendar-plus mb-2"></i>
+        <span class="block">{% trans "Inscrever-se em Eventos" %}</span>
+      </a>
+      <a href="{% url 'feed:home' %}" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50">
+        <i class="fa-solid fa-rss mb-2"></i>
+        <span class="block">{% trans "Ver Feed" %}</span>
+      </a>
+    </div>
+  </section>
+
 </main>
 {% endblock %}

--- a/dashboard/templates/dashboard/gerente.html
+++ b/dashboard/templates/dashboard/gerente.html
@@ -1,13 +1,34 @@
 {% extends "base.html" %}
 {% load static %}
+{% load i18n %}
 
-{% block title %}Dashboard Gerente | Hubx{% endblock %}
+{% block title %}{% trans "Dashboard Gerente" %} | Hubx{% endblock %}
 
 {% block content %}
 <main class="max-w-7xl mx-auto px-4 py-10" role="main" aria-label="Dashboard">
-  <h1 class="text-3xl font-semibold text-neutral-900 text-center mb-10">Dashboard Gerente</h1>
+  <h1 class="text-3xl font-semibold text-neutral-900 text-center mb-10">{% trans "Dashboard Gerente" %}</h1>
+
   <div hx-get="{% url 'dashboard:metrics-partial' %}" hx-trigger="load, every 10s" hx-target="#metrics" hx-swap="innerHTML">
     {% include 'dashboard/partials/metrics_list.html' %}
   </div>
+
+  <div hx-get="{% url 'dashboard:tarefas-partial' %}" hx-trigger="load, every 15s" hx-target="#tasks" hx-swap="innerHTML"></div>
+
+  <div hx-get="{% url 'dashboard:notificacoes-partial' %}" hx-trigger="load, every 15s" hx-target="#notifications" hx-swap="innerHTML"></div>
+
+  <section class="mb-8">
+    <h2 class="text-xl font-semibold mb-4">{% trans "Ações Rápidas" %}</h2>
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+      <a href="{% url 'nucleos:pending-list' %}" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50">
+        <i class="fa-solid fa-clipboard-check mb-2"></i>
+        <span class="block">{% trans "Aprovar Tarefas" %}</span>
+      </a>
+      <a href="{% url 'agenda:evento-list' %}" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50">
+        <i class="fa-solid fa-calendar mb-2"></i>
+        <span class="block">{% trans "Gerenciar Eventos" %}</span>
+      </a>
+    </div>
+  </section>
+
 </main>
 {% endblock %}

--- a/dashboard/templates/dashboard/partials/chart.html
+++ b/dashboard/templates/dashboard/partials/chart.html
@@ -1,0 +1,18 @@
+{% load i18n %}
+<div class="p-4 bg-white rounded-lg shadow">
+  <h2 class="text-xl font-semibold mb-4">{{ title }}</h2>
+  <canvas id="{{ chart_id }}" class="w-full h-64"></canvas>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script>
+  (function(){
+    const ctx = document.getElementById('{{ chart_id }}');
+    if(ctx){
+      new Chart(ctx, {
+        type: '{{ type|default:"bar" }}',
+        data: {labels: {{ labels|safe }}, datasets:[{label: '{{ title }}', data: {{ data|safe }}, backgroundColor: '#3b82f6'}]},
+        options: {responsive: true, maintainAspectRatio: false}
+      });
+    }
+  })();
+</script>

--- a/dashboard/templates/dashboard/partials/metrics_list.html
+++ b/dashboard/templates/dashboard/partials/metrics_list.html
@@ -6,5 +6,6 @@
     {% include "dashboard/partials/metric_card.html" with title=_("Núcleos") value=num_nucleos.total icon="fa-users-rectangle" id="num_nucleos" %}
     {% include "dashboard/partials/metric_card.html" with title=_("Empresas") value=num_empresas.total icon="fa-city" id="num_empresas" %}
     {% include "dashboard/partials/metric_card.html" with title=_("Eventos") value=num_eventos.total icon="fa-calendar" id="num_eventos" %}
+    {% include "dashboard/partials/metric_card.html" with title=_("Posts") value=num_posts.total icon="fa-newspaper" id="num_posts" %}
   </div>
 </section>

--- a/dashboard/templates/dashboard/partials/notifications_list.html
+++ b/dashboard/templates/dashboard/partials/notifications_list.html
@@ -1,0 +1,14 @@
+{% load i18n %}
+<section class="mb-8" id="notifications">
+  <h2 class="text-xl font-semibold mb-4">{% trans "Notificações Recentes" %}</h2>
+  <ul class="space-y-2">
+    {% for log in notificacoes %}
+    <li class="p-4 bg-white rounded-lg shadow flex justify-between">
+      <span>{{ log.template.assunto }}</span>
+      <time datetime="{{ log.data_envio|date:'c' }}" class="text-sm text-neutral-600">{{ log.data_envio|date:'d/m/Y H:i' }}</time>
+    </li>
+    {% empty %}
+    <li class="p-4 bg-white rounded-lg shadow text-neutral-500">{% trans "Nenhuma notificação." %}</li>
+    {% endfor %}
+  </ul>
+</section>

--- a/dashboard/templates/dashboard/partials/pending_tasks.html
+++ b/dashboard/templates/dashboard/partials/pending_tasks.html
@@ -1,0 +1,14 @@
+{% load i18n %}
+<section class="mb-8" id="tasks">
+  <h2 class="text-xl font-semibold mb-4">{% trans "Tarefas Pendentes" %}</h2>
+  <ul class="space-y-2">
+    {% for task in tarefas %}
+    <li class="p-4 bg-white rounded-lg shadow flex justify-between">
+      <span>{{ task.get_tipo_display }} - {{ task.valor }}</span>
+      <time datetime="{{ task.data_vencimento|date:'c' }}" class="text-sm text-neutral-600">{{ task.data_vencimento|date:'d/m/Y' }}</time>
+    </li>
+    {% empty %}
+    <li class="p-4 bg-white rounded-lg shadow text-neutral-500">{% trans "Nenhuma tarefa pendente." %}</li>
+    {% endfor %}
+  </ul>
+</section>

--- a/dashboard/templates/dashboard/partials/upcoming_events.html
+++ b/dashboard/templates/dashboard/partials/upcoming_events.html
@@ -1,0 +1,14 @@
+{% load i18n %}
+<section class="mb-8" id="upcoming-events">
+  <h2 class="text-xl font-semibold mb-4">{% trans "Próximos Eventos" %}</h2>
+  <ul class="space-y-2">
+    {% for evento in eventos %}
+    <li class="p-4 bg-white rounded-lg shadow flex justify-between">
+      <span>{{ evento.titulo }}</span>
+      <time datetime="{{ evento.data_inicio|date:'c' }}" class="text-sm text-neutral-600">{{ evento.data_inicio|date:'d/m/Y' }}</time>
+    </li>
+    {% empty %}
+    <li class="p-4 bg-white rounded-lg shadow text-neutral-500">{% trans "Nenhum evento futuro." %}</li>
+    {% endfor %}
+  </ul>
+</section>

--- a/dashboard/templates/dashboard/root.html
+++ b/dashboard/templates/dashboard/root.html
@@ -1,13 +1,60 @@
 {% extends "base.html" %}
 {% load static %}
+{% load i18n %}
 
-{% block title %}Dashboard Root | Hubx{% endblock %}
+{% block title %}{% trans "Dashboard Root" %} | Hubx{% endblock %}
 
 {% block content %}
 <main class="max-w-7xl mx-auto px-4 py-10" role="main" aria-label="Dashboard">
-  <h1 class="text-3xl font-semibold text-neutral-900 text-center mb-10">Dashboard Root</h1>
+  <h1 class="text-3xl font-semibold text-neutral-900 text-center mb-10">{% trans "Dashboard Root" %}</h1>
+
   <div hx-get="{% url 'dashboard:metrics-partial' %}" hx-trigger="load, every 10s" hx-target="#metrics" hx-swap="innerHTML">
     {% include 'dashboard/partials/metrics_list.html' %}
   </div>
+
+  {% with labels='["Usuários","Eventos","Posts"]' data='['|add:num_users.total|stringformat:"d"|add:","|add:num_eventos.total|stringformat:"d"|add:","|add:num_posts.total|stringformat:"d"|add:"]' %}
+  {% include 'dashboard/partials/chart.html' with chart_id='root_chart' title=_('Distribuição de Métricas') labels=labels|safe data=data|safe %}
+  {% endwith %}
+
+  <section class="mb-8">
+    <h2 class="text-xl font-semibold mb-4">{% trans "Status dos Serviços" %}</h2>
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+      <div class="p-4 bg-white rounded-lg shadow">
+        <span class="block font-medium">{% trans "Celery" %}</span>
+        <span>{{ service_status.celery }}</span>
+      </div>
+      <div class="p-4 bg-white rounded-lg shadow">
+        <span class="block font-medium">{% trans "Fila de Mensagens" %}</span>
+        <span>{{ service_status.fila_mensagens }}</span>
+      </div>
+      <div class="p-4 bg-white rounded-lg shadow">
+        <span class="block font-medium">{% trans "Uso de Disco" %}</span>
+        <span>{{ service_status.disco }}%</span>
+      </div>
+    </div>
+  </section>
+
+  <section class="mb-8">
+    <h2 class="text-xl font-semibold mb-4">{% trans "Métricas de Segurança" %}</h2>
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+      <div class="p-4 bg-white rounded-lg shadow">
+        <span class="block font-medium">{% trans "Tentativas de Login Bloqueadas" %}</span>
+        <span>{{ security_metrics.login_bloqueados }}</span>
+      </div>
+    </div>
+  </section>
+
+  <div hx-get="{% url 'dashboard:notificacoes-partial' %}" hx-trigger="load, every 20s" hx-target="#notifications" hx-swap="innerHTML"></div>
+
+  <section class="mb-8">
+    <h2 class="text-xl font-semibold mb-4">{% trans "Ações Rápidas" %}</h2>
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+      <a href="{% url 'admin:index' %}" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50">
+        <i class="fa-solid fa-wrench mb-2"></i>
+        <span class="block">{% trans "Django Admin" %}</span>
+      </a>
+    </div>
+  </section>
+
 </main>
 {% endblock %}

--- a/dashboard/urls.py
+++ b/dashboard/urls.py
@@ -12,4 +12,7 @@ urlpatterns = [
     path("cliente/", views.ClienteDashboardView.as_view(), name="cliente"),
     path("metrics-partial/", views.metrics_partial, name="metrics-partial"),
     path("lancamentos-partial/", views.lancamentos_partial, name="lancamentos-partial"),
+    path("notificacoes-partial/", views.notificacoes_partial, name="notificacoes-partial"),
+    path("tarefas-partial/", views.tarefas_partial, name="tarefas-partial"),
+    path("eventos-partial/", views.eventos_partial, name="eventos-partial"),
 ]


### PR DESCRIPTION
## Summary
- amplia `DashboardService` com métricas de posts, notificações, tarefas e eventos
- cria parciais HTMX para métricas, notificações, tarefas pendentes e eventos
- refatora templates de dashboards (admin, gerente, cliente, root) com Tailwind, Chart.js e links rápidos

## Testing
- `ruff check dashboard`
- `pytest dashboard`

------
https://chatgpt.com/codex/tasks/task_e_688bc6dbdd048325a521f120d2ff7c64