### PR TITLE
Ajusta templates do app empresas

### DIFF
--- a/empresas/templates/empresas/contato_form.html
+++ b/empresas/templates/empresas/contato_form.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load i18n %}
+{% load i18n custom_filters %}
 {% block title %}{% translate 'Contato' %}{% endblock %}
 {% block content %}
 <section class="max-w-md mx-auto py-8">

--- a/empresas/templates/empresas/nova.html
+++ b/empresas/templates/empresas/nova.html
@@ -22,9 +22,21 @@
         {{ form.nome.errors }}
       </div>
       <div>
+        <label for="{{ form.cnpj.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.cnpj.label }}</label>
+        {{ form.cnpj|add_class:'w-full p-2 border rounded' }}
+        {{ form.cnpj.errors }}
+      </div>
+    </div>
+    <div class="grid md:grid-cols-2 gap-6">
+      <div>
         <label for="{{ form.tipo.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.tipo.label }}</label>
         {{ form.tipo|add_class:'w-full p-2 border rounded' }}
         {{ form.tipo.errors }}
+      </div>
+      <div>
+        <label for="{{ form.tags_field.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.tags_field.label }}</label>
+        {{ form.tags_field|add_class:'w-full p-2 border rounded' }}
+        {{ form.tags_field.errors }}
       </div>
     </div>
     <div>
@@ -35,9 +47,9 @@
     </div>
     <div class="grid md:grid-cols-2 gap-6">
       <div>
-        <label for="{{ form.cidade.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.cidade.label }}</label>
-        {{ form.cidade|add_class:'w-full p-2 border rounded' }}
-        {{ form.cidade.errors }}
+        <label for="{{ form.municipio.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.municipio.label }}</label>
+        {{ form.municipio|add_class:'w-full p-2 border rounded' }}
+        {{ form.municipio.errors }}
       </div>
       <div>
         <label for="{{ form.estado.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.estado.label }}</label>
@@ -45,23 +57,11 @@
         {{ form.estado.errors }}
       </div>
     </div>
-    <div class="grid md:grid-cols-2 gap-6">
-      <div>
-        <label for="{{ form.email.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.email.label }}</label>
-        {{ form.email|add_class:'w-full p-2 border rounded' }}
-        {{ form.email.errors }}
-      </div>
-      <div>
-        <label for="{{ form.telefone.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.telefone.label }}</label>
-        {{ form.telefone|add_class:'w-full p-2 border rounded' }}
-        {{ form.telefone.errors }}
-      </div>
-    </div>
     <div>
-      <label for="{{ form.website.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.website.label }}</label>
-      {{ form.website|add_class:'w-full p-2 border rounded' }}
-      {{ form.website.errors }}
-      <p class="text-xs text-neutral-500 mt-1">{% translate 'Inclua http:// ou https:// no início da URL.' %}</p>
+      <label for="{{ form.palavras_chave.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.palavras_chave.label }}</label>
+      {{ form.palavras_chave|add_class:'w-full p-2 border rounded' }}
+      {{ form.palavras_chave.errors }}
+      <p class="text-xs text-neutral-500 mt-1">{% translate 'Separe por vírgulas.' %}</p>
     </div>
     <div>
       <label for="{{ form.logo.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.logo.label }}</label>

--- a/empresas/templates/empresas/tag_form.html
+++ b/empresas/templates/empresas/tag_form.html
@@ -1,11 +1,11 @@
 {% extends 'base.html' %}
-{% load i18n %}
+{% load i18n custom_filters %}
 {% block title %}{% if form.instance.pk %}{% translate 'Editar Item' %}{% else %}{% translate 'Novo Item' %}{% endif %}{% endblock %}
 {% block content %}
 <section class="max-w-xl mx-auto px-4 py-10 space-y-6">
   <header>
     <h1 class="text-2xl font-bold text-neutral-900">{% if form.instance.pk %}{% translate 'Editar' %}{% else %}{% translate 'Cadastrar' %}{% endif %} {% translate 'Item' %}</h1>
-    <p class="text-sm text-neutral-600">{% translate 'Preencha o nome e descrição do item' %}</p>
+    <p class="text-sm text-neutral-600">{% translate 'Preencha o nome e a categoria do item' %}</p>
   </header>
   <form method="post" class="bg-white border border-neutral-200 rounded-md p-6 space-y-6">
     {% csrf_token %}
@@ -15,9 +15,9 @@
       {% if form.nome.errors %}<p class="text-sm text-red-600">{{ form.nome.errors }}</p>{% endif %}
     </div>
     <div>
-      <label for="{{ form.descricao.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.descricao.label }}</label>
-      {{ form.descricao|add_class:'w-full p-2 border rounded' }}
-      {% if form.descricao.errors %}<p class="text-sm text-red-600">{{ form.descricao.errors }}</p>{% endif %}
+      <label for="{{ form.categoria.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.categoria.label }}</label>
+      {{ form.categoria|add_class:'w-full p-2 border rounded' }}
+      {% if form.categoria.errors %}<p class="text-sm text-red-600">{{ form.categoria.errors }}</p>{% endif %}
     </div>
     <div class="flex justify-end gap-3 border-t pt-4">
       <a href="{% url 'empresas:tags_list' %}" class="px-4 py-2 text-sm border rounded">{% translate 'Cancelar' %}</a>

--- a/empresas/templates/empresas/tags_list.html
+++ b/empresas/templates/empresas/tags_list.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load i18n %}
+{% load i18n custom_filters %}
 {% block title %}{% translate 'Produtos e Serviços' %}{% endblock %}
 {% block content %}
 <section class="max-w-6xl mx-auto px-4 py-10 space-y-6">


### PR DESCRIPTION
## Resumo
- Corrige formulário de empresa para exibir campos do modelo, incluindo CNPJ, tags e endereço.
- Atualiza formulário de tags para usar campo de categoria e carrega filtros customizados.
- Ajusta templates de contato e listagem de tags para carregar filtros customizados utilizados pelos campos do formulário.

## Testes
- `pytest empresas -q`


------
https://chatgpt.com/codex/tasks/task_e_688bd73a8a2c8325acd56ff40b18a947