### PR TITLE
Refatora templates de listas com HTMX e Tailwind

### DIFF
--- a/agenda/templates/agenda/briefing_list.html
+++ b/agenda/templates/agenda/briefing_list.html
@@ -4,7 +4,7 @@
 {% block title %}{% trans "Briefings" %} | Hubx{% endblock %}
 
 {% block content %}
-<section class="max-w-7xl mx-auto px-4 py-10">
+<section id="briefing-container" class="max-w-7xl mx-auto px-4 py-10">
   <header class="mb-6">
     <h1 class="text-2xl font-bold text-neutral-900">{% trans "Briefings de Eventos" %}</h1>
   </header>
@@ -16,6 +16,27 @@
       {% endfor %}
     </div>
   {% endif %}
+
+  <form
+    hx-get="{% url 'agenda:briefing_list' %}"
+    hx-target="#briefing-container"
+    hx-push-url="true"
+    class="mb-6 flex gap-2"
+  >
+    <input
+      type="text"
+      name="q"
+      value="{{ request.GET.q }}"
+      placeholder="{% trans 'Buscar por evento' %}"
+      class="w-full rounded-md border-gray-300 px-3 py-2"
+    />
+    <button
+      type="submit"
+      class="rounded-md bg-primary px-4 py-2 text-white hover:bg-primary/90"
+    >
+      {% trans "Filtrar" %}
+    </button>
+  </form>
 
   <main>
     <div class="overflow-x-auto bg-white border border-neutral-200 rounded-2xl shadow-sm">
@@ -29,6 +50,7 @@
             <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Cronograma Resumido" %}</th>
             <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Conteúdo Programático" %}</th>
             <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Observações" %}</th>
+            <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Ações" %}</th>
           </tr>
         </thead>
         <tbody class="divide-y divide-neutral-200">
@@ -41,15 +63,27 @@
               <td class="px-4 py-2">{{ briefing.cronograma_resumido }}</td>
               <td class="px-4 py-2">{{ briefing.conteudo_programatico }}</td>
               <td class="px-4 py-2">{{ briefing.observacoes }}</td>
+              <td class="px-4 py-2">
+                <a
+                  href="{% url 'agenda:briefing_editar' briefing.pk %}"
+                  class="text-blue-600 hover:underline"
+                >
+                  {% trans "Editar" %}
+                </a>
+              </td>
             </tr>
           {% empty %}
             <tr>
-              <td colspan="7" class="px-4 py-4 text-center text-neutral-500">{% trans "Nenhum briefing encontrado." %}</td>
+              <td colspan="8" class="px-4 py-4 text-center text-neutral-500">{% trans "Nenhum briefing encontrado." %}</td>
             </tr>
           {% endfor %}
         </tbody>
       </table>
     </div>
   </main>
+
+  <footer class="mt-6 text-right">
+    <a href="{% url 'agenda:calendario' %}" class="text-sm text-blue-600 hover:underline">{% trans "Voltar à agenda" %}</a>
+  </footer>
 </section>
 {% endblock %}

--- a/agenda/templates/agenda/inscricao_list.html
+++ b/agenda/templates/agenda/inscricao_list.html
@@ -4,7 +4,7 @@
 {% block title %}{% trans "Inscrições" %} | Hubx{% endblock %}
 
 {% block content %}
-<section class="max-w-7xl mx-auto px-4 py-10">
+<section id="inscricao-container" class="max-w-7xl mx-auto px-4 py-10">
   <header class="mb-6">
     <h1 class="text-2xl font-bold text-neutral-900">{% trans "Lista de Inscrições" %}</h1>
   </header>
@@ -16,6 +16,27 @@
       {% endfor %}
     </div>
   {% endif %}
+
+  <form
+    hx-get="{% url 'agenda:inscricao_list' %}"
+    hx-target="#inscricao-container"
+    hx-push-url="true"
+    class="mb-6 flex gap-2"
+  >
+    <input
+      type="text"
+      name="q"
+      value="{{ request.GET.q }}"
+      placeholder="{% trans 'Buscar por usuário ou evento' %}"
+      class="w-full rounded-md border-gray-300 px-3 py-2"
+    />
+    <button
+      type="submit"
+      class="rounded-md bg-primary px-4 py-2 text-white hover:bg-primary/90"
+    >
+      {% trans "Filtrar" %}
+    </button>
+  </form>
 
   <main>
     <div class="overflow-x-auto bg-white border border-neutral-200 rounded-2xl shadow-sm">
@@ -30,6 +51,7 @@
             <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Valor Pago" %}</th>
             <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Método de Pagamento" %}</th>
             <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Observação" %}</th>
+            <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Ações" %}</th>
           </tr>
         </thead>
         <tbody class="divide-y divide-neutral-200">
@@ -43,15 +65,27 @@
               <td class="px-4 py-2">{{ inscricao.valor_pago }}</td>
               <td class="px-4 py-2">{{ inscricao.get_metodo_pagamento_display }}</td>
               <td class="px-4 py-2">{{ inscricao.observacao }}</td>
+              <td class="px-4 py-2">
+                <a
+                  href="{% url 'agenda:evento_detalhe' inscricao.evento.pk %}"
+                  class="text-blue-600 hover:underline"
+                >
+                  {% trans "Ver" %}
+                </a>
+              </td>
             </tr>
           {% empty %}
             <tr>
-              <td colspan="8" class="px-4 py-4 text-center text-neutral-500">{% trans "Nenhuma inscrição encontrada." %}</td>
+              <td colspan="9" class="px-4 py-4 text-center text-neutral-500">{% trans "Nenhuma inscrição encontrada." %}</td>
             </tr>
           {% endfor %}
         </tbody>
       </table>
     </div>
   </main>
+
+  <footer class="mt-6 text-right">
+    <a href="{% url 'agenda:calendario' %}" class="text-sm text-blue-600 hover:underline">{% trans "Voltar à agenda" %}</a>
+  </footer>
 </section>
 {% endblock %}

--- a/agenda/templates/agenda/material_list.html
+++ b/agenda/templates/agenda/material_list.html
@@ -4,7 +4,7 @@
 {% block title %}{% trans "Materiais de Divulgação" %} | Hubx{% endblock %}
 
 {% block content %}
-<section class="max-w-7xl mx-auto px-4 py-10">
+<section id="material-container" class="max-w-7xl mx-auto px-4 py-10">
   <header class="mb-6">
     <h1 class="text-2xl font-bold text-neutral-900">{% trans "Materiais de Divulgação" %}</h1>
   </header>
@@ -17,21 +17,65 @@
     </div>
   {% endif %}
 
+  <form
+    hx-get="{% url 'agenda:material_list' %}"
+    hx-target="#material-container"
+    hx-push-url="true"
+    class="mb-6 flex gap-2"
+  >
+    <input
+      type="text"
+      name="q"
+      value="{{ request.GET.q }}"
+      placeholder="{% trans 'Buscar por título' %}"
+      class="w-full rounded-md border-gray-300 px-3 py-2"
+    />
+    <button
+      type="submit"
+      class="rounded-md bg-primary px-4 py-2 text-white hover:bg-primary/90"
+    >
+      {% trans "Filtrar" %}
+    </button>
+  </form>
+
   <main>
-    <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-      {% for material in materiais %}
-        <article class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-5 flex flex-col">
-          <h2 class="text-lg font-semibold text-neutral-900 mb-2">{{ material.titulo }}</h2>
-          <p class="text-sm text-neutral-600 mb-4">{{ material.descricao }}</p>
-          {% if material.imagem_thumb %}
-            <img src="{{ material.imagem_thumb.url }}" alt="{{ material.titulo }}" class="mb-4 rounded-xl object-cover">
-          {% endif %}
-          <a href="{{ material.arquivo.url }}" class="mt-auto text-sm text-blue-600 hover:underline">{% trans "Download" %}</a>
-        </article>
-      {% empty %}
-        <p class="text-neutral-500">{% trans "Nenhum material disponível." %}</p>
-      {% endfor %}
+    <div class="overflow-x-auto bg-white border border-neutral-200 rounded-2xl shadow-sm">
+      <table class="min-w-full divide-y divide-neutral-200 table-auto text-sm">
+        <thead class="bg-neutral-50">
+          <tr>
+            <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Título" %}</th>
+            <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Descrição" %}</th>
+            <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Arquivo" %}</th>
+            <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Ações" %}</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-neutral-200">
+          {% for material in materiais %}
+            <tr>
+              <td class="px-4 py-2">{{ material.titulo }}</td>
+              <td class="px-4 py-2">{{ material.descricao }}</td>
+              <td class="px-4 py-2">{{ material.arquivo.name }}</td>
+              <td class="px-4 py-2">
+                <a
+                  href="{{ material.arquivo.url }}"
+                  class="text-blue-600 hover:underline"
+                >
+                  {% trans "Download" %}
+                </a>
+              </td>
+            </tr>
+          {% empty %}
+            <tr>
+              <td colspan="4" class="px-4 py-4 text-center text-neutral-500">{% trans "Nenhum material disponível." %}</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
     </div>
   </main>
+
+  <footer class="mt-6 text-right">
+    <a href="{% url 'agenda:calendario' %}" class="text-sm text-blue-600 hover:underline">{% trans "Voltar à agenda" %}</a>
+  </footer>
 </section>
 {% endblock %}

--- a/agenda/urls.py
+++ b/agenda/urls.py
@@ -2,6 +2,8 @@ from django.urls import path
 
 from . import views
 from .views import (
+    BriefingEventoListView,
+    BriefingEventoUpdateView,
     EventoCreateView,
     EventoDeleteView,
     EventoDetailView,
@@ -9,6 +11,8 @@ from .views import (
     EventoRemoveInscritoView,
     EventoSubscribeView,
     EventoUpdateView,
+    InscricaoEventoListView,
+    MaterialDivulgacaoEventoListView,
 )
 
 app_name = "agenda"
@@ -46,4 +50,12 @@ urlpatterns = [
     path("api/eventos/<int:pk>/espera/", views.fila_espera, name="fila_espera"),
     path("api/parcerias/<int:pk>/avaliar/", views.avaliar_parceria, name="parceria_avaliar"),
     path("eventos_por_dia/", views.eventos_por_dia, name="eventos_por_dia"),
+    path("inscricoes/", InscricaoEventoListView.as_view(), name="inscricao_list"),
+    path("materiais/", MaterialDivulgacaoEventoListView.as_view(), name="material_list"),
+    path("briefings/", BriefingEventoListView.as_view(), name="briefing_list"),
+    path(
+        "briefing/<int:pk>/editar/",
+        BriefingEventoUpdateView.as_view(),
+        name="briefing_editar",
+    ),
 ]

--- a/core/templates/core/home.html
+++ b/core/templates/core/home.html
@@ -22,6 +22,7 @@
   </div>
 </header>
 
+<main>
 <section class="py-12 bg-gray-50">
   <div class="max-w-7xl mx-auto px-4 text-center">
     <h2 class="text-2xl font-bold text-neutral-900 mb-8">{% trans "Principais Funcionalidades" %}</h2>
@@ -58,7 +59,7 @@
       </div>
     </div>
   </div>
-</section>
+ </section>
 
 <section class="py-12">
   <div class="max-w-7xl mx-auto px-4">
@@ -69,7 +70,7 @@
     </div>
   </div>
 
-</section>
+ </section>
 
 {% if user.is_authenticated %}
 <section class="py-12 bg-gray-50">
@@ -81,4 +82,9 @@
   </div>
 </section>
 {% endif %}
+</main>
+
+<footer class="py-6 text-center text-sm text-neutral-500">
+  &copy; {{ now|date:"Y" }} Hubx
+</footer>
 {% endblock %}

--- a/organizacoes/forms.py
+++ b/organizacoes/forms.py
@@ -24,7 +24,7 @@ class OrganizacaoForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
-        base_cls = "w-full p-2 border rounded-lg"
+        base_cls = "mt-1 w-full rounded-md border-gray-300 p-2"
         for field in self.fields.values():
             existing = field.widget.attrs.get("class", "")
             field.widget.attrs["class"] = f"{existing} {base_cls}".strip()

--- a/organizacoes/templates/organizacoes/update.html
+++ b/organizacoes/templates/organizacoes/update.html
@@ -133,9 +133,12 @@
 
     <div class="flex justify-end gap-3 pt-4 border-t border-neutral-100">
       <a href="{% url 'organizacoes:list' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100">{% trans "Cancelar" %}</a>
-      <button type="submit" class="text-sm px-4 py-2 rounded-xl bg-primary-600 text-white hover:bg-primary-700">{% trans "Salvar" %}</button>
+      <button type="submit" class="text-sm px-4 py-2 rounded-xl bg-green-600 text-white hover:bg-green-700">{% trans "Salvar" %}</button>
     </div>
   </form>
   </main>
+  <footer class="mt-6 text-right">
+    <a href="{% url 'organizacoes:list' %}" class="text-sm text-blue-600 hover:underline">{% trans "Voltar à lista" %}</a>
+  </footer>
 </section>
 {% endblock %}

--- a/organizacoes/views.py
+++ b/organizacoes/views.py
@@ -2,6 +2,7 @@ from django.contrib import messages
 from django.contrib.auth import get_user_model
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.urls import reverse_lazy
+from django.utils.translation import gettext_lazy as _
 from django.views.generic import (
     CreateView,
     DeleteView,
@@ -59,7 +60,7 @@ class OrganizacaoCreateView(SuperadminRequiredMixin, LoginRequiredMixin, CreateV
     success_url = reverse_lazy("organizacoes:list")
 
     def form_valid(self, form):
-        messages.success(self.request, "Organização criada com sucesso.")
+        messages.success(self.request, _("Organização criada com sucesso."))
         return super().form_valid(form)
 
 
@@ -73,7 +74,7 @@ class OrganizacaoUpdateView(SuperadminRequiredMixin, LoginRequiredMixin, UpdateV
         return super().get_queryset()
 
     def form_valid(self, form):
-        messages.success(self.request, "Organização atualizada com sucesso.")
+        messages.success(self.request, _("Organização atualizada com sucesso."))
         return super().form_valid(form)
 
 
@@ -86,7 +87,7 @@ class OrganizacaoDeleteView(SuperadminRequiredMixin, LoginRequiredMixin, DeleteV
         return super().get_queryset()
 
     def delete(self, request, *args, **kwargs):
-        messages.success(self.request, "Organização removida.")
+        messages.success(self.request, _("Organização removida."))
         return super().delete(request, *args, **kwargs)
 
 


### PR DESCRIPTION
## Sumário
- refatora listagens de briefing, inscrição e materiais para tabelas semânticas
- adiciona busca dinâmica via HTMX
- ajusta home e formulário de organizações para layout semântico

## Testes
- `pytest` *(falhou: tests/dashboard/test_api.py::test_metrics_cache, tests/dashboard/test_integration.py::test_admin_view_invokes_service_methods, tests/dashboard/test_views.py::test_root_dashboard_view, tests/dashboard/test_views.py::test_admin_dashboard_view, tests/dashboard/test_views.py::test_gerente_dashboard_view, tests/dashboard/test_views.py::test_cliente_dashboard_view)*


------
https://chatgpt.com/codex/tasks/task_e_688bd9aa71d0832594006e3cc5000c99