### PR TITLE
feat(accounts): refine registration and login flows

### DIFF
--- a/accounts/signals.py
+++ b/accounts/signals.py
@@ -1,10 +1,8 @@
 from django.contrib.auth import get_user_model
 from django.db.models.signals import post_save
 from django.dispatch import receiver
-from django.utils import timezone
 
-from .models import AccountToken, NotificationSettings
-from .tasks import send_confirmation_email
+from .models import NotificationSettings
 
 User = get_user_model()
 
@@ -17,10 +15,3 @@ def create_notification_settings(sender, instance, created, **kwargs):
         if instance.user_type in {"root", "admin"}:
             instance.is_staff = True
             instance.save(update_fields=["is_staff"])
-        if not instance.is_active:
-            token = AccountToken.objects.create(
-                usuario=instance,
-                tipo=AccountToken.Tipo.EMAIL_CONFIRMATION,
-                expires_at=timezone.now() + timezone.timedelta(hours=24),
-            )
-            send_confirmation_email.delay(token.id)

--- a/accounts/templates/accounts/resend_confirmation.html
+++ b/accounts/templates/accounts/resend_confirmation.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+{% load i18n %}
+{% block title %}{% trans "Reenviar confirmação" %}{% endblock %}
+{% block content %}
+<section class="max-w-md mx-auto px-4 py-12 text-center">
+  <div class="rounded-2xl border border-neutral-200 bg-white p-8 shadow-sm">
+    <h1 class="mb-4 text-2xl font-bold text-neutral-900">{% trans "Reenviar confirmação" %}</h1>
+    <form method="post" class="space-y-4">
+      {% csrf_token %}
+      <input type="email" name="email" required class="w-full p-3 border border-gray-300 rounded-lg" placeholder="{% trans 'Seu e-mail' %}">
+      <button type="submit" class="w-full bg-primary text-white py-2 rounded-lg">{% trans "Enviar" %}</button>
+    </form>
+  </div>
+</section>
+{% endblock %}

--- a/accounts/templates/login/login.html
+++ b/accounts/templates/login/login.html
@@ -18,14 +18,14 @@
     <form method="post" action="{% url 'accounts:login' %}" class="space-y-5">
       {% csrf_token %}
       <div>
-        <label for="id_username" class="block mb-1 text-sm font-medium text-gray-700">Usuário</label>
-        <input type="text" id="id_username" name="username"
-               value="{{ form.username.value|default_if_none:'' }}"
+        <label for="id_email" class="block mb-1 text-sm font-medium text-gray-700">Email</label>
+        <input type="email" id="id_email" name="email"
+               value="{{ form.email.value|default_if_none:'' }}"
                placeholder="Digite seu e-mail"
                class="w-full p-3 border border-gray-300 rounded-lg text-sm placeholder-gray-400 shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
                required>
-        {% if form.username.errors %}
-          <div class="text-red-600 text-xs mt-1">{{ form.username.errors }}</div>
+        {% if form.email.errors %}
+          <div class="text-red-600 text-xs mt-1">{{ form.email.errors }}</div>
         {% endif %}
       </div>
       <div>
@@ -38,9 +38,15 @@
           <div class="text-red-600 text-xs mt-1">{{ form.password.errors }}</div>
         {% endif %}
       </div>
-      <div class="flex items-center gap-2 text-sm text-gray-600">
-        <input type="checkbox" id="remember" name="remember" class="accent-primary">
-        <label for="remember">Lembrar-me neste dispositivo</label>
+      <div>
+        <label for="id_totp" class="block mb-1 text-sm font-medium text-gray-700">TOTP</label>
+        <input type="text" id="id_totp" name="totp"
+               value="{{ form.totp.value|default_if_none:'' }}"
+               placeholder="Código 2FA (se habilitado)"
+               class="w-full p-3 border border-gray-300 rounded-lg text-sm placeholder-gray-400 shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent">
+        {% if form.totp.errors %}
+          <div class="text-red-600 text-xs mt-1">{{ form.totp.errors }}</div>
+        {% endif %}
       </div>
       <button type="submit"
               class="w-full bg-primary text-white py-3 px-4 rounded-xl font-semibold text-sm shadow hover:bg-primary/90 transition">
@@ -48,10 +54,15 @@
       </button>
     </form>
 
-    <div class="text-center mt-6">
+    <div class="text-center mt-6 space-y-2">
       <a href="{% url 'accounts:password_reset' %}" class="text-sm text-primary hover:underline">
         Esqueceu sua senha?
       </a>
+      <div>
+        <a href="{% url 'accounts:resend_confirmation' %}" class="text-sm text-primary hover:underline">
+          Reenviar confirmação de e-mail
+        </a>
+      </div>
     </div>
 
     <div class="text-center mt-4 text-sm text-gray-600">

--- a/accounts/templates/register/registro_pendente.html
+++ b/accounts/templates/register/registro_pendente.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+{% load i18n %}
+{% block title %}{% trans "Confirme seu e-mail" %}{% endblock %}
+{% block content %}
+<section class="max-w-md mx-auto px-4 py-12 text-center">
+  <div class="rounded-2xl border border-neutral-200 bg-white p-8 shadow-sm">
+    <h1 class="mb-4 text-2xl font-bold text-neutral-900">{% trans "Quase lá!" %}</h1>
+    <p class="text-neutral-600">{% trans "Conta criada. Confirme seu e-mail em até 24 horas para ativá-la." %}</p>
+  </div>
+</section>
+{% endblock %}

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -11,6 +11,8 @@ urlpatterns = [
     path("", views.login_view, name="root_login"),
     # Registro de usuário
     path("register/", views.register_view, name="register"),
+    path("register/pending/", views.registro_pendente, name="registro_pendente"),
+    path("resend-confirmation/", views.resend_confirmation, name="resend_confirmation"),
     path("password_reset/", views.password_reset, name="password_reset"),
     path(
         "password_reset/<str:code>/",

--- a/tests/accounts/test_user_registration.py
+++ b/tests/accounts/test_user_registration.py
@@ -1,0 +1,42 @@
+import pytest
+from django.contrib.auth import get_user_model
+from django.utils import timezone
+
+from accounts.forms import CustomUserCreationForm
+from accounts.models import AccountToken
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+def test_user_creation_creates_inactive_and_token():
+    form = CustomUserCreationForm(
+        data={
+            "email": "new@example.com",
+            "cpf": "12345678901",
+            "password1": "StrongPass1!",
+            "password2": "StrongPass1!",
+        }
+    )
+    assert form.is_valid(), form.errors
+    user = form.save()
+    assert not user.is_active
+    assert user.failed_login_attempts == 0
+    assert user.lock_expires_at is None
+    token = AccountToken.objects.get(usuario=user, tipo=AccountToken.Tipo.EMAIL_CONFIRMATION)
+    assert token.expires_at > timezone.now()
+
+
+@pytest.mark.django_db
+def test_user_creation_unique_email():
+    User.objects.create_user(email="dup@example.com", username="dup", password="pass")
+    form = CustomUserCreationForm(
+        data={
+            "email": "dup@example.com",
+            "cpf": "12345678901",
+            "password1": "StrongPass1!",
+            "password2": "StrongPass1!",
+        }
+    )
+    assert not form.is_valid()
+    assert "email" in form.errors

--- a/tests/test_accounts_auth.py
+++ b/tests/test_accounts_auth.py
@@ -1,5 +1,4 @@
 from django.contrib.auth import get_user_model
-from django.db import IntegrityError
 from django.test import Client, TestCase
 from django.urls import reverse
 
@@ -22,7 +21,7 @@ class AuthTests(TestCase):
         )
         resp = self.client.post(
             reverse("accounts:login"),
-            {"username": "alpha@example.com", "password": "pass"},
+            {"email": "alpha@example.com", "password": "pass"},
         )
         self.assertEqual(resp.status_code, 302)
         self.assertEqual(resp.url, "/accounts/perfil/")


### PR DESCRIPTION
## Summary
- enforce unique email and confirm via token on registration
- add custom email login form with optional 2FA
- provide resend confirmation flow and registration notice

## Testing
- `pytest` *(fails: dashboard tests: metrics cache, admin view invokes service methods, root dashboard view, admin dashboard view, gerente dashboard view, cliente dashboard view)*
- `pytest tests/test_accounts_auth.py`


------
https://chatgpt.com/codex/tasks/task_e_688bfd860c148325a4c266fb32333906