### PR TITLE
Evita consulta no ready do app de notificações

### DIFF
--- a/notificacoes/apps.py
+++ b/notificacoes/apps.py
@@ -4,8 +4,6 @@ from django.apps import AppConfig
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
-from .services import metrics
-
 
 class NotificacoesConfig(AppConfig):
     default_auto_field = "django.db.models.AutoField"
@@ -23,19 +21,8 @@ class NotificacoesConfig(AppConfig):
         ]
         missing = [name for name in required if not getattr(settings, name, "")]
         if missing:
-            raise ImproperlyConfigured(
-                f"Missing notification settings: {', '.join(missing)}"
-            )
+            raise ImproperlyConfigured(f"Missing notification settings: {', '.join(missing)}")
 
-        from .models import NotificationTemplate
-        from . import signals
-
-        try:
-            metrics.templates_total.set(
-                NotificationTemplate.objects.filter(ativo=True).count()
-            )
-        except Exception:  # pragma: no cover - durante migrações
-            metrics.templates_total.set(0)
+        from . import signals  # garante registro de sinais
 
         signals.definir_template_default.send(sender=self.__class__)
-

--- a/notificacoes/services/metrics.py
+++ b/notificacoes/services/metrics.py
@@ -1,3 +1,5 @@
+"""Métricas Prometheus para o app de notificações."""
+
 from prometheus_client import Counter, Gauge  # type: ignore
 
 notificacoes_enviadas_total = Counter(
@@ -13,4 +15,3 @@ notificacoes_falhadas_total = Counter(
 )
 
 templates_total = Gauge("templates_total", "Total de templates ativos")
-

--- a/notificacoes/signals.py
+++ b/notificacoes/signals.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
 from django.conf import settings
-from django.db.models.signals import post_save
+from django.db.models.signals import post_migrate, post_save
 from django.dispatch import Signal, receiver
-from django.utils.translation import gettext_lazy as _
 
-from .models import UserNotificationPreference
-
+from .models import NotificationTemplate, UserNotificationPreference
+from .services import metrics
 
 # Signal para que outros módulos definam templates padrão
 definir_template_default = Signal()
@@ -18,3 +17,11 @@ def criar_preferencias_apos_usuario(sender, instance, created, **kwargs):
     if created:
         UserNotificationPreference.objects.get_or_create(user=instance)
 
+
+@receiver(post_migrate)
+def atualizar_templates_total(sender, **kwargs):
+    from django.apps import apps
+
+    if apps.is_installed("notificacoes"):
+        total = NotificationTemplate.objects.filter(ativo=True).count()
+        metrics.templates_total.set(total)

--- a/tests/notificacoes/test_signals.py
+++ b/tests/notificacoes/test_signals.py
@@ -1,0 +1,48 @@
+import pytest
+from django.apps import apps
+from django.db.models.signals import post_migrate
+
+from notificacoes.models import NotificationTemplate
+from notificacoes.services import metrics
+
+pytestmark = pytest.mark.django_db
+
+
+def test_atualizar_templates_total_atualiza_gauge() -> None:
+    before = NotificationTemplate.objects.filter(ativo=True).count()
+
+    NotificationTemplate.objects.create(
+        codigo="active",
+        assunto="Oi",
+        corpo="{{ nome }}",
+        canal="email",
+        ativo=True,
+    )
+    NotificationTemplate.objects.create(
+        codigo="inactive",
+        assunto="Oi",
+        corpo="{{ nome }}",
+        canal="email",
+        ativo=False,
+    )
+
+    metrics.templates_total.set(0)
+    app_config = apps.get_app_config("notificacoes")
+    post_migrate.send(
+        sender=app_config,
+        app_config=app_config,
+        verbosity=0,
+        interactive=False,
+        using="default",
+    )
+    assert metrics.templates_total._value.get() == before + 1
+
+    NotificationTemplate.objects.filter(codigo="active").delete()
+    post_migrate.send(
+        sender=app_config,
+        app_config=app_config,
+        verbosity=0,
+        interactive=False,
+        using="default",
+    )
+    assert metrics.templates_total._value.get() == before


### PR DESCRIPTION
## Resumo
- evita consultas ao banco durante `AppConfig.ready` e apenas registra sinais
- atualiza métrica `templates_total` em um receiver `post_migrate`
- cria teste cobrindo a atualização da métrica

## Testes
- `python manage.py check`
- `python manage.py migrate notificacoes`
- `pytest tests/notificacoes/test_signals.py`


------
https://chatgpt.com/codex/tasks/task_e_688d28c51a388325b93e4167aa552f86