### PR TITLE
Avoid DB access during notificacoes startup

### DIFF
--- a/notificacoes/apps.py
+++ b/notificacoes/apps.py
@@ -5,7 +5,6 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
 
-from .services import metrics
 class NotificacoesConfig(AppConfig):
     default_auto_field = "django.db.models.AutoField"
     name = "notificacoes"
@@ -27,16 +26,6 @@ class NotificacoesConfig(AppConfig):
                 f"Missing notification settings: {', '.join(missing)}"
             )
 
-        from .models import NotificationTemplate
-        from . import signals
-
-        try:
-            metrics.templates_total.set(
-                NotificationTemplate.objects.filter(ativo=True).count()
-            )
-        except Exception:  # pragma: no cover - durante migrações
-            metrics.templates_total.set(0)
-
-        signals.definir_template_default.send(sender=self.__class__)
+        from . import signals  # noqa: F401
 
 

--- a/notificacoes/signals.py
+++ b/notificacoes/signals.py
@@ -1,14 +1,12 @@
 from __future__ import annotations
 
 from django.conf import settings
-
-from django.db.models.signals import post_save
+from django.db.models.signals import post_migrate, post_save
 from django.dispatch import Signal, receiver
 from django.utils.translation import gettext_lazy as _
 
-from .models import UserNotificationPreference
-from django.db.models.signals import post_migrate
-from django.dispatch import receiver
+from .models import NotificationTemplate, UserNotificationPreference
+from .services import metrics
 
 
 # Signal para que outros módulos definam templates padrão

--- a/tests/notificacoes/test_startup.py
+++ b/tests/notificacoes/test_startup.py
@@ -1,0 +1,26 @@
+import os
+import subprocess
+import sys
+
+
+
+def test_django_setup_without_db_warning() -> None:
+    env = os.environ.copy()
+    env["DJANGO_SETTINGS_MODULE"] = "Hubx.settings"
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import warnings, django; warnings.simplefilter('always'); django.setup()",
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert (
+        "Accessing the database during app initialization is discouraged"
+        not in proc.stderr
+    ), proc.stderr
+    assert proc.returncode == 0


### PR DESCRIPTION
## Summary
- avoid database queries in notificacoes AppConfig.ready
- update templates gauge only after migrations
- test that django.setup() emits no database-access warnings

## Testing
- `python manage.py check`
- `pytest tests/notificacoes -q`


------
https://chatgpt.com/codex/tasks/task_e_688d32a294bc8325ab10f8e60408e42f