### PR TITLE
feat(chat): adicionar serviços e consumer para canais

### DIFF
--- a/chat/api.py
+++ b/chat/api.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from django.contrib.auth import get_user_model
 
-from .models import ChatMessage, ChatNotification
+from .models import ChatChannel, ChatMessage, ChatNotification, ChatParticipant
+from .services import adicionar_reacao, enviar_mensagem
 
 User = get_user_model()
 
@@ -10,29 +11,35 @@ User = get_user_model()
 def get_user(pk: int):
     try:
         return User.objects.get(pk=pk)
-    except User.DoesNotExist:  # pragma: no cover - simple fallback
+    except User.DoesNotExist:  # pragma: no cover - fallback
         return None
 
 
 def create_message(**kwargs):
-    print("✅ Entrou em create_message com dados:")
-    for k, v in kwargs.items():
-        print(f"   {k}: {v}")
-    """Create a chat message and return it."""
-    return ChatMessage.objects.create(**kwargs)
+    """Wrapper para enviar_mensagem com resolução de IDs."""
+    channel = kwargs.get("channel")
+    if not channel and "channel_id" in kwargs:
+        channel = ChatChannel.objects.get(pk=kwargs["channel_id"])
+    remetente = kwargs.get("remetente")
+    if not remetente and "remetente_id" in kwargs:
+        remetente = User.objects.get(pk=kwargs["remetente_id"])
+    tipo = kwargs.get("tipo", "text")
+    conteudo = kwargs.get("conteudo", "")
+    arquivo = kwargs.get("arquivo")
+    return enviar_mensagem(
+        canal=channel,
+        remetente=remetente,
+        tipo=tipo,
+        conteudo=conteudo,
+        arquivo=arquivo,
+    )
 
 
-def notify_users(recipient_ids, message: ChatMessage) -> None:
-    """Create notifications for a list of recipients."""
-    for uid in recipient_ids:
-        ChatNotification.objects.create(
-            usuario_id=uid,
-            mensagem=message,
-        )
+def notify_users(channel: ChatChannel, message: ChatMessage) -> None:
+    """Cria ChatNotification para participantes do canal."""
+    for participant in ChatParticipant.objects.filter(channel=channel).exclude(user=message.remetente):
+        ChatNotification.objects.create(usuario=participant.user, mensagem=message)
 
 
 def add_reaction(message: ChatMessage, emoji: str) -> None:
-    reactions = message.reactions
-    reactions[emoji] = reactions.get(emoji, 0) + 1
-    message.reactions = reactions
-    message.save(update_fields=["reactions"])
+    adicionar_reacao(message, emoji)

--- a/chat/routing.py
+++ b/chat/routing.py
@@ -1,7 +1,7 @@
 from django.urls import re_path
 
-from . import consumers
+from .consumers import ChatConsumer
 
 websocket_urlpatterns = [
-    re_path(r"^ws/chat/(?P<dest_id>\d+)/$", consumers.ChatConsumer.as_asgi()),
+    re_path(r"ws/chat/(?P<channel_id>[0-9a-f-]+)/$", ChatConsumer.as_asgi()),
 ]

--- a/chat/services.py
+++ b/chat/services.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from typing import Iterable, Optional
+
+from django.contrib.auth import get_user_model
+from django.utils import timezone
+
+from .models import ChatChannel, ChatMessage, ChatParticipant
+
+User = get_user_model()
+
+
+def criar_canal(
+    criador: User,
+    contexto_tipo: str,
+    contexto_id: Optional[str],
+    titulo: Optional[str],
+    descricao: Optional[str],
+    participantes: Iterable[User],
+) -> ChatChannel:
+    """Cria um ``ChatChannel`` e adiciona participantes.
+
+    O ``criador`` sempre será ``is_owner`` e ``is_admin``.
+    ``contexto_tipo`` define o escopo da conversa. Validações
+    adicionais de permissão serão implementadas futuramente.
+    """
+    canal = ChatChannel.objects.create(
+        contexto_tipo=contexto_tipo,
+        contexto_id=contexto_id,
+        titulo=titulo or "",
+        descricao=descricao or "",
+    )
+    ChatParticipant.objects.create(channel=canal, user=criador, is_owner=True, is_admin=True)
+    for user in participantes:
+        if user != criador:
+            ChatParticipant.objects.get_or_create(channel=canal, user=user)
+    return canal
+
+
+def enviar_mensagem(
+    canal: ChatChannel,
+    remetente: User,
+    tipo: str,
+    conteudo: str = "",
+    arquivo=None,
+) -> ChatMessage:
+    """Salva uma nova mensagem no canal.
+
+    Verifica se ``remetente`` participa do canal e se o ``tipo``
+    requer um arquivo.
+    """
+    if not ChatParticipant.objects.filter(channel=canal, user=remetente).exists():
+        raise PermissionError("Usuário não participa do canal.")
+    if tipo in {"image", "video", "file"} and not arquivo:
+        raise ValueError("Arquivo obrigatório para este tipo de mensagem.")
+    msg = ChatMessage.objects.create(
+        channel=canal,
+        remetente=remetente,
+        tipo=tipo,
+        conteudo=conteudo,
+        arquivo=arquivo,
+        timestamp=timezone.now(),
+    )
+    return msg
+
+
+def adicionar_reacao(mensagem: ChatMessage, emoji: str) -> None:
+    """Incrementa a contagem de ``emoji`` na mensagem."""
+    reactions = mensagem.reactions or {}
+    reactions[emoji] = reactions.get(emoji, 0) + 1
+    mensagem.reactions = reactions
+    mensagem.save(update_fields=["reactions"])

--- a/tests/chat/test_consumers.py
+++ b/tests/chat/test_consumers.py
@@ -1,0 +1,59 @@
+import os
+
+import pytest
+from channels.db import database_sync_to_async
+from channels.testing import WebsocketCommunicator
+
+from chat.models import ChatMessage
+from chat.services import criar_canal
+from Hubx.asgi import application
+
+os.environ.setdefault("DJANGO_ALLOW_ASYNC_UNSAFE", "true")
+
+pytestmark = pytest.mark.django_db(transaction=True)
+
+
+@pytest.fixture(autouse=True)
+def in_memory_channel_layer(settings):
+    settings.CHANNEL_LAYERS = {"default": {"BACKEND": "channels.layers.InMemoryChannelLayer"}}
+
+
+@pytest.mark.asyncio
+async def test_consumer_connect_send_message_and_reaction(admin_user, coordenador_user):
+    canal = await database_sync_to_async(criar_canal)(
+        criador=admin_user,
+        contexto_tipo="privado",
+        contexto_id=None,
+        titulo="Privado",
+        descricao="",
+        participantes=[coordenador_user],
+    )
+    communicator = WebsocketCommunicator(application, f"/ws/chat/{canal.id}/")
+    communicator.scope["user"] = admin_user
+    connected, _ = await communicator.connect()
+    assert connected
+    await communicator.send_json_to({"tipo": "text", "conteudo": "olá"})
+    response = await communicator.receive_json_from()
+    assert response["conteudo"] == "olá"
+    msg = await database_sync_to_async(ChatMessage.objects.get)(pk=response["id"])
+    await communicator.send_json_to({"tipo": "reaction", "mensagem_id": str(msg.id), "emoji": "👍"})
+    response2 = await communicator.receive_json_from()
+    assert response2["reactions"]["👍"] == 1
+    await communicator.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_consumer_rejects_non_participant(admin_user, associado_user):
+    canal = await database_sync_to_async(criar_canal)(
+        criador=admin_user,
+        contexto_tipo="privado",
+        contexto_id=None,
+        titulo="Privado",
+        descricao="",
+        participantes=[],
+    )
+    communicator = WebsocketCommunicator(application, f"/ws/chat/{canal.id}/")
+    communicator.scope["user"] = associado_user
+    connected, _ = await communicator.connect()
+    assert connected is False
+    await communicator.disconnect()

--- a/tests/chat/test_services.py
+++ b/tests/chat/test_services.py
@@ -1,0 +1,54 @@
+import pytest
+from django.contrib.auth import get_user_model
+
+from chat.models import ChatParticipant
+from chat.services import adicionar_reacao, criar_canal, enviar_mensagem
+
+User = get_user_model()
+
+pytestmark = pytest.mark.django_db
+
+
+def test_criar_canal_adiciona_participantes(admin_user, coordenador_user):
+    canal = criar_canal(
+        criador=admin_user,
+        contexto_tipo="privado",
+        contexto_id=None,
+        titulo="Privado",
+        descricao="",
+        participantes=[coordenador_user],
+    )
+    participantes = ChatParticipant.objects.filter(channel=canal)
+    assert participantes.count() == 2
+    owner = participantes.get(user=admin_user)
+    assert owner.is_owner and owner.is_admin
+
+
+def test_enviar_mensagem_valida_participacao(admin_user, coordenador_user, associado_user):
+    canal = criar_canal(
+        criador=admin_user,
+        contexto_tipo="privado",
+        contexto_id=None,
+        titulo="Privado",
+        descricao="",
+        participantes=[coordenador_user],
+    )
+    msg = enviar_mensagem(canal, admin_user, "text", conteudo="oi")
+    assert msg.conteudo == "oi"
+    with pytest.raises(PermissionError):
+        enviar_mensagem(canal, associado_user, "text", conteudo="ola")
+
+
+def test_adicionar_reacao_incrementa(admin_user, coordenador_user):
+    canal = criar_canal(
+        criador=admin_user,
+        contexto_tipo="privado",
+        contexto_id=None,
+        titulo="Privado",
+        descricao="",
+        participantes=[coordenador_user],
+    )
+    msg = enviar_mensagem(canal, admin_user, "text", conteudo="oi")
+    adicionar_reacao(msg, "👍")
+    msg.refresh_from_db()
+    assert msg.reactions["👍"] == 1


### PR DESCRIPTION
## Resumo
- introduz módulo `chat.services` com criação de canais, envio de mensagens e reações
- reescreve `ChatConsumer` e `routing` para operar por canal
- integra serviços nas views e adiciona testes de WebSocket

## Testes
- `ruff check chat/services.py chat/api.py chat/consumers.py chat/routing.py chat/views.py tests/chat/test_services.py tests/chat/test_consumers.py`
- `black chat/services.py chat/api.py chat/consumers.py chat/routing.py chat/views.py tests/chat/test_services.py tests/chat/test_consumers.py`
- `pytest tests/chat/test_consumers.py tests/chat/test_services.py tests/chat/test_views.py tests/chat/test_models.py`


------
https://chatgpt.com/codex/tasks/task_e_688d5928769c8325931122ee70d1eaa7