### PR TITLE
feat: chat templates e websocket básico

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,7 @@ para visualizar categorias e interações.
 
 ## 📡 Chat (WebSocket)
 
-O módulo de chat registra mensagens trocadas entre usuários.  
-Ao abrir uma conversa, as últimas 20 mensagens são carregadas automaticamente do banco de dados (`Mensagem`), mantendo o histórico.
+O módulo de chat registra mensagens trocadas entre usuários. Acesse `/chat/` para ver os canais disponíveis agrupados por contexto. Ao abrir um canal, as mensagens são exibidas em tempo real via WebSocket com HTMX. Se o JavaScript estiver desativado o envio ainda funciona, mas a página será recarregada.
 
 Para que o WebSocket funcione:
 
@@ -117,6 +116,10 @@ Para rodar manualmente com `daphne`:
 ```bash
 daphne Hubx.asgi:application -b 0.0.0.0 -p 8000
 ```
+
+### Produção
+
+Em produção defina `ALLOWED_HOSTS` com o domínio usado e configure o proxy para aceitar conexões `wss://`. O endpoint do WebSocket segue o padrão `/ws/chat/<id>/`.
 
 ---
 

--- a/chat/static/chat/chat.js
+++ b/chat/static/chat/chat.js
@@ -1,0 +1,46 @@
+(function () {
+  function scrollToBottom(list) {
+    list.scrollTop = list.scrollHeight;
+  }
+
+  function init() {
+    const form = document.getElementById('message-form');
+    const list = document.getElementById('message-list');
+    if (!form || !list) return;
+    const channelId = form.dataset.channel;
+    const scheme = window.location.protocol === 'https:' ? 'wss' : 'ws';
+    const socketUrl = scheme + '://' + window.location.host + '/ws/chat/' + channelId + '/';
+    let socket = new WebSocket(socketUrl);
+
+    socket.onmessage = function (e) {
+      const data = JSON.parse(e.data);
+      if (!data.id) return;
+      fetch('/chat/partials/message/' + data.id + '/')
+        .then((r) => r.text())
+        .then((html) => {
+          list.insertAdjacentHTML('beforeend', html);
+          scrollToBottom(list);
+        });
+    };
+
+    socket.onclose = function () {
+      setTimeout(init, 1000);
+    };
+
+    form.addEventListener('submit', function (e) {
+      e.preventDefault();
+      const tipo = form.querySelector('[name="tipo"]').value;
+      const conteudo = form.querySelector('[name="conteudo"]').value.trim();
+      if (socket.readyState === WebSocket.OPEN && tipo === 'text' && conteudo) {
+        socket.send(JSON.stringify({ tipo: 'text', conteudo: conteudo }));
+        form.reset();
+      } else {
+        form.submit();
+      }
+    });
+
+    scrollToBottom(list);
+  }
+
+  document.addEventListener('DOMContentLoaded', init);
+})();

--- a/chat/templates/chat/conversation_detail.html
+++ b/chat/templates/chat/conversation_detail.html
@@ -1,42 +1,37 @@
 {% extends "chat/base_chat.html" %}
-{% load i18n widget_tweaks %}
+{% load i18n static widget_tweaks %}
 
 {% block title %}{{ conversation.titulo }}{% endblock %}
 
 {% block chat_content %}
-<main class="max-w-4xl mx-auto p-4">
-  <header class="mb-4">
-    <h2 class="text-lg font-semibold">{{ conversation.titulo }}</h2>
-    <p class="text-sm text-gray-500">
-      {% trans "Participantes" %}:
-      {% for p in conversation.participants.all %}
-        {{ p.user.username }}{% if not forloop.last %}, {% endif %}
-      {% endfor %}
-    </p>
+<main class="max-w-4xl mx-auto h-screen flex flex-col p-4">
+  <header class="mb-4 flex items-center gap-3">
+    {% if conversation.imagem %}
+      <img src="{{ conversation.imagem.url }}" alt="" class="w-12 h-12 rounded-full" />
+    {% endif %}
+    <div class="flex-1">
+      <h2 class="text-lg font-semibold">{{ conversation.titulo }}</h2>
+      {% if conversation.descricao %}
+        <p class="text-sm text-neutral-500">{{ conversation.descricao }}</p>
+      {% endif %}
+    </div>
   </header>
 
-  <div id="messages" class="overflow-y-auto h-[calc(100vh-15rem)] space-y-4 mb-4">
+  <section id="message-list" class="flex-1 overflow-y-auto space-y-4 mb-4" aria-live="polite">
     {% for m in mensagens %}
       {% include "chat/partials/message.html" with m=m %}
     {% empty %}
       <p class="text-neutral-500">{% trans "Nenhuma mensagem." %}</p>
     {% endfor %}
-  </div>
+  </section>
 
-  <form
-    method="post"
-    enctype="multipart/form-data"
-    class="flex gap-2"
-    hx-post="."
-    hx-target="#messages"
-    hx-swap="beforeend"
-    hx-on:afterSwap="this.reset()"
-  >
+  <form id="message-form" data-channel="{{ conversation.id }}" class="mt-auto flex items-end gap-2" hx-post="/api/chat/channels/{{ conversation.id }}/messages/" hx-target="#message-list" hx-swap="beforeend" hx-on:afterSwap="this.reset(); document.getElementById('message-list').scrollTop = document.getElementById('message-list').scrollHeight;" aria-label="{% trans 'Enviar mensagem' %}">
     {% csrf_token %}
-    {{ form.tipo }}
-    {{ form.arquivo }}
+    {{ form.tipo|add_class:"border rounded p-2" }}
+    {{ form.arquivo|add_class:"hidden" }}
     {{ form.conteudo|add_class:"flex-1 border rounded p-2" }}
-    <button class="bg-primary text-white px-4 py-2 rounded hover:bg-primary/90" type="submit">{% trans "Enviar" %}</button>
+    <button type="submit" class="bg-primary text-white px-4 py-2 rounded hover:bg-primary/90 focus:outline-none focus:ring" aria-label="{% trans 'Enviar mensagem' %}">{% trans "Enviar" %}</button>
   </form>
+  <script src="{% static 'chat/chat.js' %}"></script>
 </main>
 {% endblock %}

--- a/chat/templates/chat/conversation_list.html
+++ b/chat/templates/chat/conversation_list.html
@@ -9,39 +9,46 @@
     <h1 class="text-xl font-semibold">{% trans "Minhas conversas" %}</h1>
     <a
       href="{% url 'chat:nova_conversa' %}"
-      class="bg-primary text-white px-4 py-2 rounded hover:bg-primary/90"
+      class="bg-primary text-white px-4 py-2 rounded hover:bg-primary/90 focus:outline-none focus:ring"
+      aria-label="{% trans 'Nova conversa' %}"
     >
       {% trans "Nova conversa" %}
     </a>
   </div>
-  <ul role="list" class="bg-white divide-y divide-gray-200 rounded-lg">
-    {% for conv in conversas %}
-      <li>
-        <a
-          href="{{ conv.get_absolute_url }}"
-          class="flex items-center justify-between py-2 px-4 hover:bg-gray-100"
-        >
-          <div>
-            <p class="font-medium">{{ conv.titulo|default:conv.id }}</p>
-            {% if conv.last_message_text %}
-              <p class="text-sm text-gray-500">
-                {{ conv.last_message_text|truncatechars:50 }}
-              </p>
-            {% endif %}
-          </div>
-          {% if conv.last_message_at %}
-            <time
-              datetime="{{ conv.last_message_at|date:'c' }}"
-              class="text-xs text-gray-400"
-            >
-              {{ conv.last_message_at|date:'d/m H:i' }}
-            </time>
-          {% endif %}
-        </a>
-      </li>
-    {% empty %}
-      <li class="py-2 px-4 text-gray-500">{% trans "Nenhuma conversa." %}</li>
-    {% endfor %}
-  </ul>
+  {% for tipo, canais in grupos.items %}
+    <section class="mb-6">
+      <h2 class="text-sm font-semibold text-neutral-500 mb-2">
+        {% if tipo == 'privado' %}{% trans "Privado" %}{% elif tipo == 'nucleo' %}{% trans "Núcleo" %}{% elif tipo == 'evento' %}{% trans "Evento" %}{% elif tipo == 'organizacao' %}{% trans "Organização" %}{% else %}{{ tipo }}{% endif %}
+      </h2>
+      <nav aria-label="{% trans 'Lista de conversas' %}">
+        <ul role="list" class="bg-white divide-y divide-gray-200 rounded-lg">
+        {% for conv in canais %}
+          <li>
+            <a href="{{ conv.get_absolute_url }}" class="flex items-center justify-between py-2 px-4 hover:bg-gray-100 focus:outline-none focus:ring">
+              <div class="flex items-center gap-3">
+                {% if conv.imagem %}
+                  <img src="{{ conv.imagem.url }}" alt="" class="w-8 h-8 rounded-full" />
+                {% endif %}
+                <div>
+                  <p class="font-medium">{{ conv.titulo|default:conv.id }}</p>
+                  {% if conv.last_message_text %}
+                    <p class="text-sm text-gray-500">{{ conv.last_message_text|truncatechars:50 }}</p>
+                  {% endif %}
+                </div>
+              </div>
+              <div class="text-right">
+                {% if conv.last_message_at %}
+                  <time datetime="{{ conv.last_message_at|date:'c' }}" class="block text-xs text-gray-400">{{ conv.last_message_at|date:'d/m H:i' }}</time>
+                {% endif %}
+              </div>
+            </a>
+          </li>
+        {% empty %}
+          <li class="py-2 px-4 text-gray-500">{% trans "Nenhuma conversa." %}</li>
+        {% endfor %}
+        </ul>
+      </nav>
+    </section>
+  {% endfor %}
 </main>
 {% endblock %}

--- a/chat/templates/chat/partials/message.html
+++ b/chat/templates/chat/partials/message.html
@@ -1,10 +1,35 @@
 {% load i18n %}
-<div class="{% if m.remetente_id == user.id %}text-right{% endif %}">
-  <article class="inline-block px-3 py-2 rounded-lg {% if m.remetente_id == user.id %}bg-blue-100{% else %}bg-gray-100{% endif %}">
-    <header class="text-xs text-gray-500">
-      <time datetime="{{ m.timestamp|date:'c' }}">{{ m.timestamp|date:'d/m H:i' }}</time>
-      – <span>{{ m.remetente.username }}</span>
+<article role="article" class="flex gap-2 p-2 rounded-lg bg-gray-50">
+  <div class="flex-shrink-0">
+    {% if m.remetente.profile.avatar %}
+      <img src="{{ m.remetente.profile.avatar.url }}" alt="" class="w-8 h-8 rounded-full" />
+    {% else %}
+      <span class="inline-block w-8 h-8 rounded-full bg-gray-300 text-sm flex items-center justify-center">{{ m.remetente.username|first|upper }}</span>
+    {% endif %}
+  </div>
+  <div class="flex-1">
+    <header class="flex items-center gap-2 text-xs text-gray-500">
+      <span class="font-semibold text-gray-700">{{ m.remetente.username }}</span>
+      <time datetime="{{ m.timestamp|date:'c' }}">{{ m.timestamp|date:"d/m/Y H:i" }}</time>
+      {% if m.hidden_at %}<span class="text-red-500">{% trans "Oculta" %}</span>{% endif %}
     </header>
-    <p>{{ m.conteudo }}</p>
-  </article>
-</div>
+    <div class="mt-1">
+      {% if m.tipo == 'text' %}
+        <p>{{ m.conteudo|linebreaksbr }}</p>
+      {% elif m.tipo == 'image' %}
+        <img src="{{ m.arquivo.url }}" alt="" class="max-w-xs rounded" />
+      {% elif m.tipo == 'video' %}
+        <video src="{{ m.arquivo.url }}" controls class="max-w-xs"></video>
+      {% elif m.tipo == 'file' %}
+        <a href="{{ m.arquivo.url }}" class="text-primary underline">{{ m.arquivo.name }}</a>
+      {% endif %}
+    </div>
+    {% if m.reactions %}
+      <ul class="flex gap-2 mt-2">
+        {% for emoji, count in m.reactions.items %}
+          <li class="text-sm">{{ emoji }} {{ count }}</li>
+        {% endfor %}
+      </ul>
+    {% endif %}
+  </div>
+</article>

--- a/chat/urls.py
+++ b/chat/urls.py
@@ -7,5 +7,10 @@ app_name = "chat"
 urlpatterns = [
     path("", views.conversation_list, name="conversation_list"),
     path("nova/", views.nova_conversa, name="nova_conversa"),
+    path(
+        "partials/message/<uuid:message_id>/",
+        views.message_partial,
+        name="message_partial",
+    ),
     path("<uuid:channel_id>/", views.conversation_detail, name="conversation_detail"),
 ]

--- a/chat/views.py
+++ b/chat/views.py
@@ -95,3 +95,9 @@ def conversation_detail(request, channel_id):
         "chat/conversation_detail.html",
         {"conversation": conversation, "mensagens": mensagens, "form": form},
     )
+
+
+@login_required
+def message_partial(request, message_id):
+    message = get_object_or_404(ChatMessage.objects.select_related("remetente"), pk=message_id)
+    return render(request, "chat/partials/message.html", {"m": message})


### PR DESCRIPTION
## Summary
- implementar listagem de canais agrupados
- adicionar detalhe de conversa com mensagens em tempo real
- criar template parcial e script JS para WebSocket

## Testing
- `ruff check chat/urls.py chat/views.py`
- `black chat/urls.py chat/views.py`
- `pytest` *(falha: Reverse for 'mensagem-...' not found; async tests not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_688e12e83bb0832594bfc8c41d00a2fc