### PR TITLE
feat(chat): improve realtime templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,9 @@ para visualizar categorias e interações.
 
 ## 📡 Chat (WebSocket)
 
-O módulo de chat registra mensagens trocadas entre usuários. Acesse `/chat/` para ver os canais disponíveis agrupados por contexto. Ao abrir um canal, as mensagens são exibidas em tempo real via WebSocket com HTMX. Se o JavaScript estiver desativado o envio ainda funciona, mas a página será recarregada.
+O módulo de chat registra mensagens trocadas entre usuários. Acesse `/chat/` para ver os canais disponíveis agrupados por contexto (privado, núcleo, evento, organização). Cada item exibe o número de mensagens não lidas e o preview da última mensagem. Ao abrir um canal é possível visualizar mensagens fixadas, reagir com emojis e enviar anexos. A interface usa HTMX + WebSocket e possui *fallback* para quando o JavaScript está desabilitado.
+
+![Demonstração do chat](docs/chat-demo.png)
 
 Para que o WebSocket funcione:
 
@@ -118,8 +120,14 @@ daphne Hubx.asgi:application -b 0.0.0.0 -p 8000
 ```
 
 ### Produção
+Em produção defina `ALLOWED_HOSTS` com o domínio usado e configure o proxy para aceitar conexões `wss://`. O endpoint do WebSocket segue o padrão `/ws/chat/<id>/`. Exemplo de configuração no `settings.py`:
 
-Em produção defina `ALLOWED_HOSTS` com o domínio usado e configure o proxy para aceitar conexões `wss://`. O endpoint do WebSocket segue o padrão `/ws/chat/<id>/`.
+```python
+ALLOWED_HOSTS = ["seu-dominio.com"]
+CSRF_TRUSTED_ORIGINS = ["https://seu-dominio.com"]
+```
+
+Certifique-se também de liberar o esquema `wss://` no servidor ou proxy reverso.
 
 ---
 

--- a/chat/forms.py
+++ b/chat/forms.py
@@ -9,6 +9,15 @@ User = get_user_model()
 
 
 class NovaConversaForm(forms.ModelForm):
+    contexto_tipo = forms.ChoiceField(
+        choices=ChatChannel.CONTEXT_CHOICES,
+        label=_("Tipo de contexto"),
+    )
+    contexto_id = forms.UUIDField(
+        required=False,
+        label=_("Contexto"),
+        widget=s2forms.Select2Widget,
+    )
     participants = forms.ModelMultipleChoiceField(
         queryset=User.objects.none(),
         widget=s2forms.Select2MultipleWidget,
@@ -20,10 +29,17 @@ class NovaConversaForm(forms.ModelForm):
         required=False,
         label=_("Descrição"),
     )
+    imagem = forms.ImageField(required=False, label=_("Imagem"))
 
     class Meta:
         model = ChatChannel
-        fields = ["titulo", "descricao"]
+        fields = [
+            "contexto_tipo",
+            "contexto_id",
+            "titulo",
+            "descricao",
+            "imagem",
+        ]
 
     def __init__(self, *args, user=None, **kwargs):
         super().__init__(*args, **kwargs)

--- a/chat/services.py
+++ b/chat/services.py
@@ -17,6 +17,7 @@ def criar_canal(
     titulo: Optional[str],
     descricao: Optional[str],
     participantes: Iterable[User],
+    imagem=None,
 ) -> ChatChannel:
     """Cria um ``ChatChannel`` e adiciona participantes.
 
@@ -29,6 +30,7 @@ def criar_canal(
         contexto_id=contexto_id,
         titulo=titulo or "",
         descricao=descricao or "",
+        imagem=imagem,
     )
     ChatParticipant.objects.create(channel=canal, user=criador, is_owner=True, is_admin=True)
     for user in participantes:

--- a/chat/static/chat/chat.js
+++ b/chat/static/chat/chat.js
@@ -15,12 +15,11 @@
     socket.onmessage = function (e) {
       const data = JSON.parse(e.data);
       if (!data.id) return;
-      fetch('/chat/partials/message/' + data.id + '/')
-        .then((r) => r.text())
-        .then((html) => {
-          list.insertAdjacentHTML('beforeend', html);
-          scrollToBottom(list);
-        });
+      htmx.ajax('GET', '/chat/partials/message/' + data.id + '/', {
+        target: list,
+        swap: 'beforeend'
+      });
+      scrollToBottom(list);
     };
 
     socket.onclose = function () {
@@ -37,7 +36,7 @@
       } else {
         form.submit();
       }
-    });
+      });
 
     scrollToBottom(list);
   }

--- a/chat/templates/chat/conversation_detail.html
+++ b/chat/templates/chat/conversation_detail.html
@@ -5,20 +5,36 @@
 
 {% block chat_content %}
 <main class="max-w-4xl mx-auto h-screen flex flex-col p-4">
-  <header class="mb-4 flex items-center gap-3">
-    {% if conversation.imagem %}
-      <img src="{{ conversation.imagem.url }}" alt="" class="w-12 h-12 rounded-full" />
-    {% endif %}
-    <div class="flex-1">
-      <h2 class="text-lg font-semibold">{{ conversation.titulo }}</h2>
-      {% if conversation.descricao %}
-        <p class="text-sm text-neutral-500">{{ conversation.descricao }}</p>
+  <header class="mb-4 flex items-center justify-between gap-3">
+    <div class="flex items-center gap-3">
+      {% if conversation.imagem %}
+        <img src="{{ conversation.imagem.url }}" alt="" class="w-12 h-12 rounded-full" />
+      {% endif %}
+      <div>
+        <h2 class="text-lg font-semibold">{{ conversation.titulo }}</h2>
+        {% if conversation.descricao %}
+          <p class="text-sm text-neutral-500">{{ conversation.descricao }}</p>
+        {% endif %}
+      </div>
+    </div>
+    <div class="flex items-center gap-2 text-sm text-neutral-600">
+      <span>{{ conversation.participants.count }} {% trans 'participantes' %}</span>
+      {% if not is_owner %}
+        <a href="#" class="text-red-600 hover:underline" aria-label="{% trans 'Sair do canal' %}">{% trans 'Sair' %}</a>
       {% endif %}
     </div>
   </header>
 
+  {% if pinned_messages %}
+    <section id="pinned" class="mb-4 space-y-2" aria-label="{% trans 'Mensagens fixadas' %}">
+      {% for m in pinned_messages %}
+        {% include "chat/partials/message.html" with m=m %}
+      {% endfor %}
+    </section>
+  {% endif %}
+
   <section id="message-list" class="flex-1 overflow-y-auto space-y-4 mb-4" aria-live="polite">
-    {% for m in mensagens %}
+    {% for m in messages %}
       {% include "chat/partials/message.html" with m=m %}
     {% empty %}
       <p class="text-neutral-500">{% trans "Nenhuma mensagem." %}</p>

--- a/chat/templates/chat/conversation_form.html
+++ b/chat/templates/chat/conversation_form.html
@@ -9,10 +9,31 @@
   <form method="post" enctype="multipart/form-data" class="space-y-4 bg-white rounded-lg p-4">
     {% csrf_token %}
     <div>
+      <label for="{{ form.contexto_tipo.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.contexto_tipo.label }}</label>
+      {{ form.contexto_tipo|add_class:"w-full p-2 border rounded"|attr:"hx-get:/chat/contextos/"|attr:"hx-target:#id_contexto_id"|attr:"hx-trigger:change" }}
+      {% if form.contexto_tipo.errors %}
+        <p class="text-red-500 text-sm">{{ form.contexto_tipo.errors }}</p>
+      {% endif %}
+    </div>
+    <div>
+      <label for="{{ form.contexto_id.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.contexto_id.label }}</label>
+      {{ form.contexto_id|add_class:"w-full p-2 border rounded" }}
+      {% if form.contexto_id.errors %}
+        <p class="text-red-500 text-sm">{{ form.contexto_id.errors }}</p>
+      {% endif %}
+    </div>
+    <div>
       <label for="{{ form.titulo.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.titulo.label }}</label>
       {{ form.titulo|add_class:"w-full p-2 border rounded" }}
       {% if form.titulo.errors %}
         <p class="text-red-500 text-sm">{{ form.titulo.errors }}</p>
+      {% endif %}
+    </div>
+    <div>
+      <label for="{{ form.imagem.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.imagem.label }}</label>
+      {{ form.imagem|add_class:"w-full p-2 border rounded" }}
+      {% if form.imagem.errors %}
+        <p class="text-red-500 text-sm">{{ form.imagem.errors }}</p>
       {% endif %}
     </div>
     <div>

--- a/chat/templates/chat/conversation_list.html
+++ b/chat/templates/chat/conversation_list.html
@@ -15,40 +15,45 @@
       {% trans "Nova conversa" %}
     </a>
   </div>
+  <aside aria-label="{% trans 'Canais de chat' %}">
   {% for tipo, canais in grupos.items %}
     <section class="mb-6">
       <h2 class="text-sm font-semibold text-neutral-500 mb-2">
         {% if tipo == 'privado' %}{% trans "Privado" %}{% elif tipo == 'nucleo' %}{% trans "Núcleo" %}{% elif tipo == 'evento' %}{% trans "Evento" %}{% elif tipo == 'organizacao' %}{% trans "Organização" %}{% else %}{{ tipo }}{% endif %}
       </h2>
-      <nav aria-label="{% trans 'Lista de conversas' %}">
-        <ul role="list" class="bg-white divide-y divide-gray-200 rounded-lg">
-        {% for conv in canais %}
-          <li>
-            <a href="{{ conv.get_absolute_url }}" class="flex items-center justify-between py-2 px-4 hover:bg-gray-100 focus:outline-none focus:ring">
-              <div class="flex items-center gap-3">
-                {% if conv.imagem %}
-                  <img src="{{ conv.imagem.url }}" alt="" class="w-8 h-8 rounded-full" />
-                {% endif %}
-                <div>
-                  <p class="font-medium">{{ conv.titulo|default:conv.id }}</p>
-                  {% if conv.last_message_text %}
-                    <p class="text-sm text-gray-500">{{ conv.last_message_text|truncatechars:50 }}</p>
+        <nav aria-label="{% trans 'Lista de conversas' %}">
+          <ul role="list" class="bg-white divide-y divide-gray-200 rounded-lg">
+          {% for conv in canais %}
+            <li>
+              <a href="{% url 'chat:conversation_detail' conv.id %}" class="flex items-center justify-between py-2 px-4 hover:bg-gray-100 focus:outline-none focus:ring">
+                <div class="flex items-center gap-3">
+                  {% if conv.imagem %}
+                    <img src="{{ conv.imagem.url }}" alt="" class="w-8 h-8 rounded-full" />
+                  {% endif %}
+                  <div>
+                    <p class="font-medium">{{ conv.titulo|default:conv.id }}</p>
+                    {% if conv.last_message_text %}
+                      <p class="text-sm text-gray-500">{{ conv.last_message_text|truncatechars:50 }}</p>
+                    {% endif %}
+                  </div>
+                </div>
+                <div class="text-right">
+                  {% if conv.unread_count %}
+                    <span class="inline-block bg-primary text-white text-xs px-2 py-0.5 rounded-full mr-2">{{ conv.unread_count }}</span>
+                  {% endif %}
+                  {% if conv.last_message_at %}
+                    <time datetime="{{ conv.last_message_at|date:'c' }}" class="block text-xs text-gray-400">{{ conv.last_message_at|date:'d/m H:i' }}</time>
                   {% endif %}
                 </div>
-              </div>
-              <div class="text-right">
-                {% if conv.last_message_at %}
-                  <time datetime="{{ conv.last_message_at|date:'c' }}" class="block text-xs text-gray-400">{{ conv.last_message_at|date:'d/m H:i' }}</time>
-                {% endif %}
-              </div>
-            </a>
-          </li>
-        {% empty %}
-          <li class="py-2 px-4 text-gray-500">{% trans "Nenhuma conversa." %}</li>
-        {% endfor %}
-        </ul>
-      </nav>
-    </section>
-  {% endfor %}
-</main>
-{% endblock %}
+              </a>
+            </li>
+          {% empty %}
+            <li class="py-2 px-4 text-gray-500">{% trans "Nenhuma conversa." %}</li>
+          {% endfor %}
+          </ul>
+        </nav>
+      </section>
+    {% endfor %}
+  </aside>
+  </main>
+  {% endblock %}

--- a/chat/templates/chat/partials/message.html
+++ b/chat/templates/chat/partials/message.html
@@ -11,6 +11,7 @@
     <header class="flex items-center gap-2 text-xs text-gray-500">
       <span class="font-semibold text-gray-700">{{ m.remetente.username }}</span>
       <time datetime="{{ m.timestamp|date:'c' }}">{{ m.timestamp|date:"d/m/Y H:i" }}</time>
+      {% if m.pinned_at %}<span class="text-primary" aria-label="{% trans 'Mensagem fixada' %}">📌</span>{% endif %}
       {% if m.hidden_at %}<span class="text-red-500">{% trans "Oculta" %}</span>{% endif %}
     </header>
     <div class="mt-1">
@@ -24,12 +25,33 @@
         <a href="{{ m.arquivo.url }}" class="text-primary underline">{{ m.arquivo.name }}</a>
       {% endif %}
     </div>
-    {% if m.reactions %}
-      <ul class="flex gap-2 mt-2">
-        {% for emoji, count in m.reactions.items %}
-          <li class="text-sm">{{ emoji }} {{ count }}</li>
-        {% endfor %}
-      </ul>
-    {% endif %}
+    <div class="mt-2 flex items-center gap-2">
+      <button
+        hx-post="/api/chat/channels/{{ m.channel_id }}/messages/{{ m.id }}/react/"
+        hx-vals='{"emoji":"👍"}'
+        class="text-xs text-neutral-600"
+        aria-label="{% trans 'Adicionar reação' %}"
+        type="button"
+      >
+        👍
+      </button>
+      {% if is_admin %}
+        <button
+          hx-post="/api/chat/channels/{{ m.channel_id }}/messages/{{ m.id }}/pin/"
+          class="text-xs text-neutral-600"
+          aria-label="{% trans 'Fixar mensagem' %}"
+          type="button"
+        >
+          📌
+        </button>
+      {% endif %}
+      {% if m.reactions %}
+        <ul class="flex gap-2 ml-2">
+          {% for emoji, count in m.reactions.items %}
+            <li class="text-sm">{{ emoji }} {{ count }}</li>
+          {% endfor %}
+        </ul>
+      {% endif %}
+    </div>
   </div>
 </article>

--- a/chat/views.py
+++ b/chat/views.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 from django.contrib import messages
 from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required
-from django.db.models import OuterRef, Subquery
+from django.db.models import Count, OuterRef, Subquery
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.translation import gettext_lazy as _
 
 from .forms import NovaConversaForm, NovaMensagemForm
-from .models import ChatChannel, ChatMessage
+from .models import ChatChannel, ChatMessage, ChatNotification
 from .services import criar_canal, enviar_mensagem
 
 User = get_user_model()
@@ -18,12 +18,19 @@ User = get_user_model()
 @login_required
 def conversation_list(request):
     last_msg = ChatMessage.objects.filter(channel=OuterRef("pk")).order_by("-timestamp")
+    unread = (
+        ChatNotification.objects.filter(usuario=request.user, mensagem__channel=OuterRef("pk"), lido=False)
+        .values("mensagem__channel")
+        .annotate(cnt=Count("id"))
+        .values("cnt")
+    )
     qs = (
         ChatChannel.objects.filter(participants__user=request.user)
         .prefetch_related("participants")
         .annotate(
             last_message_text=Subquery(last_msg.values("conteudo")[:1]),
             last_message_at=Subquery(last_msg.values("timestamp")[:1]),
+            unread_count=Subquery(unread),
         )
         .distinct()
     )
@@ -47,11 +54,12 @@ def nova_conversa(request):
         if form.is_valid():
             canal = criar_canal(
                 criador=request.user,
-                contexto_tipo="privado",
-                contexto_id=None,
+                contexto_tipo=form.cleaned_data.get("contexto_tipo"),
+                contexto_id=form.cleaned_data.get("contexto_id"),
                 titulo=form.cleaned_data.get("titulo"),
                 descricao=form.cleaned_data.get("descricao"),
                 participantes=form.cleaned_data.get("participants") or [],
+                imagem=form.cleaned_data.get("imagem"),
             )
             messages.success(request, _("Conversa criada com sucesso."))
             return redirect("chat:conversation_detail", channel_id=canal.pk)
@@ -68,6 +76,8 @@ def conversation_detail(request, channel_id):
         pk=channel_id,
         participants__user=request.user,
     )
+    is_admin = conversation.participants.filter(user=request.user, is_admin=True).exists()
+    is_owner = conversation.participants.filter(user=request.user, is_owner=True).exists()
     if request.method == "POST":
         form = NovaMensagemForm(request.POST, request.FILES)
         if form.is_valid():
@@ -80,7 +90,11 @@ def conversation_detail(request, channel_id):
             )
             msg.lido_por.add(request.user)
             if request.headers.get("HX-Request"):
-                return render(request, "chat/partials/message.html", {"m": msg})
+                return render(
+                    request,
+                    "chat/partials/message.html",
+                    {"m": msg, "is_admin": is_admin},
+                )
             messages.success(request, _("Mensagem enviada."))
             return redirect("chat:conversation_detail", channel_id=channel_id)
         messages.error(request, _("Erro ao enviar mensagem."))
@@ -89,15 +103,25 @@ def conversation_detail(request, channel_id):
         return redirect("chat:conversation_detail", channel_id=channel_id)
     else:
         form = NovaMensagemForm()
-    mensagens = conversation.messages.select_related("remetente").prefetch_related("lido_por")
+    qs = conversation.messages.select_related("remetente").prefetch_related("lido_por")
+    pinned = qs.filter(pinned_at__isnull=False)
+    mensagens = qs.filter(pinned_at__isnull=True)
     return render(
         request,
         "chat/conversation_detail.html",
-        {"conversation": conversation, "mensagens": mensagens, "form": form},
+        {
+            "conversation": conversation,
+            "messages": mensagens,
+            "pinned_messages": pinned,
+            "form": form,
+            "is_admin": is_admin,
+            "is_owner": is_owner,
+        },
     )
 
 
 @login_required
 def message_partial(request, message_id):
     message = get_object_or_404(ChatMessage.objects.select_related("remetente"), pk=message_id)
-    return render(request, "chat/partials/message.html", {"m": message})
+    is_admin = message.channel.participants.filter(user=request.user, is_admin=True).exists()
+    return render(request, "chat/partials/message.html", {"m": message, "is_admin": is_admin})

--- a/tests/chat/test_review.py
+++ b/tests/chat/test_review.py
@@ -14,7 +14,10 @@ def test_review_flagged_message(admin_user):
     msg = ChatMessage.objects.create(channel=conv, remetente=admin_user, conteudo="oi")
     ChatMessageFlag.objects.create(message=msg, user=admin_user)
     client.force_authenticate(admin_user)
-    url = reverse("chat_api:mensagem-moderate", args=[msg.pk])
+    url = reverse(
+        "chat_api:chat-messages-moderate",
+        kwargs={"channel_pk": conv.pk, "pk": msg.pk},
+    )
     resp = client.post(url, {"acao": "approve"})
     assert resp.status_code == 200
     msg.refresh_from_db()
@@ -28,6 +31,9 @@ def test_moderate_requires_permission(associado_user):
     msg = ChatMessage.objects.create(channel=conv, remetente=associado_user, conteudo="oi")
     ChatMessageFlag.objects.create(message=msg, user=associado_user)
     client.force_authenticate(associado_user)
-    url = reverse("chat_api:mensagem-moderate", args=[msg.pk])
+    url = reverse(
+        "chat_api:chat-messages-moderate",
+        kwargs={"channel_pk": conv.pk, "pk": msg.pk},
+    )
     resp = client.post(url, {"acao": "approve"})
     assert resp.status_code == 403

--- a/tests/chat/test_templates.py
+++ b/tests/chat/test_templates.py
@@ -1,0 +1,45 @@
+import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.urls import reverse
+
+from chat.models import ChatChannel, ChatMessage, ChatParticipant
+
+pytestmark = pytest.mark.django_db
+
+
+def _create_channel(user):
+    channel = ChatChannel.objects.create(contexto_tipo="privado")
+    ChatParticipant.objects.create(channel=channel, user=user)
+    return channel
+
+
+def test_message_partial_renders_media(client, admin_user, media_root):
+    channel = _create_channel(admin_user)
+    client.force_login(admin_user)
+    msg_text = ChatMessage.objects.create(channel=channel, remetente=admin_user, tipo="text", conteudo="oi")
+    resp_text = client.get(reverse("chat:message_partial", args=[msg_text.id]))
+    html = resp_text.content.decode()
+    assert "oi" in html
+
+    img = SimpleUploadedFile("i.png", b"data", content_type="image/png")
+    msg_img = ChatMessage.objects.create(channel=channel, remetente=admin_user, tipo="image", arquivo=img)
+    resp_img = client.get(reverse("chat:message_partial", args=[msg_img.id]))
+    assert "<img" in resp_img.content.decode()
+
+    vid = SimpleUploadedFile("v.mp4", b"data", content_type="video/mp4")
+    msg_vid = ChatMessage.objects.create(channel=channel, remetente=admin_user, tipo="video", arquivo=vid)
+    resp_vid = client.get(reverse("chat:message_partial", args=[msg_vid.id]))
+    assert "<video" in resp_vid.content.decode()
+
+    f = SimpleUploadedFile("f.txt", b"data")
+    msg_file = ChatMessage.objects.create(channel=channel, remetente=admin_user, tipo="file", arquivo=f)
+    resp_file = client.get(reverse("chat:message_partial", args=[msg_file.id]))
+    assert "<a href" in resp_file.content.decode()
+
+
+def test_conversation_detail_has_aria_labels(client, admin_user):
+    channel = _create_channel(admin_user)
+    client.force_login(admin_user)
+    resp = client.get(reverse("chat:conversation_detail", args=[channel.id]))
+    html = resp.content.decode()
+    assert 'aria-label="Enviar mensagem"' in html

--- a/tests/chat/test_views.py
+++ b/tests/chat/test_views.py
@@ -40,7 +40,7 @@ def test_nova_conversa_creates_conversation(client, admin_user, monkeypatch):
     monkeypatch.setattr(views, "NovaConversaForm", DummyForm)
 
     client.force_login(admin_user)
-    data = {"titulo": "Nova"}
+    data = {"titulo": "Nova", "contexto_tipo": "privado"}
     resp = client.post(reverse("chat:nova_conversa"), data=data)
     assert resp.status_code == 302
     assert ChatChannel.objects.filter(titulo="Nova").exists()


### PR DESCRIPTION
## Summary
- enhance chat channel list with unread counts and grouped display
- allow creating channels with context, image and participants
- render pinned messages, reactions and WebSocket updates on channel detail

## Testing
- `pytest tests/chat -q`


------
https://chatgpt.com/codex/tasks/task_e_688e1c1b21248325a0390240977aac3d