### PR TITLE
feat: enhance dashboard filtering and export

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -9,12 +9,13 @@ A view base aceita os seguintes parâmetros via query string:
 - `periodo`: `mensal`, `trimestral`, `semestral`, `anual`.
 - `escopo`: `auto`, `global`, `organizacao`, `nucleo`, `evento`.
 - `organizacao_id`, `nucleo_id`, `evento_id`: identificadores para filtragem.
-- `metricas`: lista separada por vírgula com métricas desejadas (ex.: `num_users,num_eventos`).
+- `metricas`: múltiplos valores permitidos (ex.: `metricas=num_users&metricas=num_eventos`).
+- `data_inicio`, `data_fim`: limites opcionais de datas no formato ISO `YYYY-MM-DD`.
 
 Exemplo:
 
 ```
-/dashboard/admin/?periodo=anual&escopo=organizacao&organizacao_id=1&metricas=num_users,num_eventos
+/dashboard/admin/?periodo=anual&escopo=organizacao&organizacao_id=1&metricas=num_users&metricas=num_eventos
 ```
 
 ## Exportação de métricas
@@ -26,7 +27,7 @@ Usuários root, admin e coordenador podem exportar as métricas atuais:
 /dashboard/export/?formato=pdf&periodo=mensal&escopo=global
 ```
 
-O arquivo gerado inclui `total` e `crescimento` de cada métrica.
+O arquivo gerado inclui `total` e a variação percentual calculada como `(valor_atual - valor_anterior) / max(valor_anterior, 1) * 100`.
 
 ## Configurações salvas
 
@@ -47,4 +48,4 @@ Exemplo de JSON armazenado:
 }
 ```
 
-O cache das métricas expira em 5 minutos. Para invalidar manualmente, utilize o comando `python manage.py clear_cache` ou limpe o backend configurado.
+O cache das métricas expira em 5 minutos e utiliza a chave `dashboard-<id>-<escopo>-<json dos filtros>`. Para invalidar manualmente, utilize o comando `python manage.py clear_cache` ou limpe o backend configurado.

--- a/dashboard/models.py
+++ b/dashboard/models.py
@@ -28,7 +28,11 @@ class DashboardConfig(models.Model):
     created_at = models.DateTimeField(auto_now_add=True)
 
     def clean(self):
-        if self.publico and self.user.user_type not in {UserType.ROOT, UserType.ADMIN}:
+        if (
+            self.publico
+            and self.user_id
+            and self.user.user_type not in {UserType.ROOT, UserType.ADMIN}
+        ):
             raise ValidationError({"publico": "Somente admins podem tornar público"})
 
     def __str__(self) -> str:  # pragma: no cover - simples

--- a/dashboard/services.py
+++ b/dashboard/services.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+import json
 from typing import Dict, Optional, Tuple
 
 from dateutil.relativedelta import relativedelta
@@ -167,16 +168,16 @@ class DashboardMetricsService:
         """Return dashboard metrics, cached for 5 minutes."""
         inicio, fim = DashboardService.get_period_range(periodo, inicio, fim)
 
-        cache_parts = [
-            str(user.pk),
-            periodo,
-            inicio.isoformat(),
-            fim.isoformat(),
-            escopo,
-        ]
-        for k in sorted(filters.keys()):
-            cache_parts.append(f"{k}:{filters[k]}")
-        cache_key = "dashboard_metrics_" + "_".join(cache_parts)
+        cache_filters = {
+            "periodo": periodo,
+            "inicio": inicio.isoformat(),
+            "fim": fim.isoformat(),
+            **filters,
+        }
+        cache_key = (
+            f"dashboard-{user.id}-{escopo}-"
+            f"{json.dumps(cache_filters, sort_keys=True)}"
+        )
         cached = cache.get(cache_key)
         if cached:
             return cached

--- a/dashboard/templates/dashboard/admin.html
+++ b/dashboard/templates/dashboard/admin.html
@@ -8,6 +8,8 @@
 <main class="max-w-7xl mx-auto px-4 py-10" role="main" aria-label="Dashboard">
   <h1 class="text-3xl font-semibold text-neutral-900 text-center mb-10">{% trans "Dashboard Administrativo" %}</h1>
 
+  {% include 'dashboard/partials/filters_form.html' %}
+
   <div hx-get="{% url 'dashboard:metrics-partial' %}" hx-trigger="load, every 10s" hx-target="#metrics" hx-swap="innerHTML">
     {% include 'dashboard/partials/metrics_list.html' %}
   </div>

--- a/dashboard/templates/dashboard/cliente.html
+++ b/dashboard/templates/dashboard/cliente.html
@@ -8,6 +8,8 @@
 <main class="max-w-7xl mx-auto px-4 py-10" role="main" aria-label="Dashboard">
   <h1 class="text-3xl font-semibold text-neutral-900 text-center mb-10">{% trans "Dashboard Cliente" %}</h1>
 
+  {% include 'dashboard/partials/filters_form.html' %}
+
   <div hx-get="{% url 'dashboard:metrics-partial' %}" hx-trigger="load, every 10s" hx-target="#metrics" hx-swap="innerHTML">
     {% include 'dashboard/partials/metrics_list.html' %}
   </div>

--- a/dashboard/templates/dashboard/config_form.html
+++ b/dashboard/templates/dashboard/config_form.html
@@ -1,0 +1,20 @@
+{% extends 'base.html' %}
+{% load i18n %}
+{% block title %}{% trans 'Salvar filtros' %}{% endblock %}
+{% block content %}
+<main class="max-w-md mx-auto p-4" role="main">
+  <h1 class="text-2xl font-semibold mb-4">{% trans 'Salvar filtros' %}</h1>
+  <form method="post" class="space-y-4" aria-label="{% trans 'Formulário de configuração do dashboard' %}">
+    {% csrf_token %}
+    <div>
+      <label for="id_nome" class="block text-sm font-medium text-neutral-700">{% trans 'Nome' %}</label>
+      {{ form.nome }}
+    </div>
+    <div class="flex items-center gap-2">
+      {{ form.publico }}
+      <label for="id_publico" class="text-sm text-neutral-700">{% trans 'Público' %}</label>
+    </div>
+    <button type="submit" class="px-4 py-2 bg-primary-600 text-white rounded focus:outline-none focus:ring" aria-label="{% trans 'Salvar configuração' %}">{% trans 'Salvar' %}</button>
+  </form>
+</main>
+{% endblock %}

--- a/dashboard/templates/dashboard/config_list.html
+++ b/dashboard/templates/dashboard/config_list.html
@@ -1,0 +1,18 @@
+{% extends 'base.html' %}
+{% load i18n %}
+{% block title %}{% trans 'Configurações salvas' %}{% endblock %}
+{% block content %}
+<main class="max-w-2xl mx-auto p-4" role="main">
+  <h1 class="text-2xl font-semibold mb-4">{% trans 'Configurações salvas' %}</h1>
+  <ul class="space-y-2">
+    {% for cfg in object_list %}
+      <li class="flex justify-between items-center p-2 bg-white rounded shadow">
+        <span>{{ cfg.nome }}</span>
+        <a href="{% url 'dashboard:config-apply' cfg.pk %}" class="text-primary-600 underline" aria-label="{% trans 'Aplicar configuração' %}">{% trans 'Aplicar' %}</a>
+      </li>
+    {% empty %}
+      <li>{% trans 'Nenhuma configuração salva.' %}</li>
+    {% endfor %}
+  </ul>
+</main>
+{% endblock %}

--- a/dashboard/templates/dashboard/gerente.html
+++ b/dashboard/templates/dashboard/gerente.html
@@ -8,6 +8,8 @@
 <main class="max-w-7xl mx-auto px-4 py-10" role="main" aria-label="Dashboard">
   <h1 class="text-3xl font-semibold text-neutral-900 text-center mb-10">{% trans "Dashboard Gerente" %}</h1>
 
+  {% include 'dashboard/partials/filters_form.html' %}
+
   <div hx-get="{% url 'dashboard:metrics-partial' %}" hx-trigger="load, every 10s" hx-target="#metrics" hx-swap="innerHTML">
     {% include 'dashboard/partials/metrics_list.html' %}
   </div>

--- a/dashboard/templates/dashboard/partials/chart.html
+++ b/dashboard/templates/dashboard/partials/chart.html
@@ -1,7 +1,7 @@
 {% load i18n %}
-<div class="p-4 bg-white rounded-lg shadow">
-  <h2 class="text-xl font-semibold mb-4">{{ title }}</h2>
-  <canvas id="{{ chart_id }}" class="w-full h-64"></canvas>
+<div class="p-4 bg-white rounded-lg shadow" role="figure" aria-labelledby="{{ chart_id }}-title">
+  <h2 id="{{ chart_id }}-title" class="text-xl font-semibold mb-4">{{ title }}</h2>
+  <canvas id="{{ chart_id }}" class="w-full h-64" role="img" aria-label="{{ title }}"></canvas>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script>

--- a/dashboard/templates/dashboard/partials/filters_form.html
+++ b/dashboard/templates/dashboard/partials/filters_form.html
@@ -1,0 +1,58 @@
+{% load i18n %}
+<form method="get" class="mb-6 flex flex-wrap gap-4 items-end" aria-label="{% trans 'Filtros do dashboard' %}">
+  <div>
+    <label for="periodo" class="block text-sm font-medium text-neutral-700">{% trans 'Período' %}</label>
+    <select id="periodo" name="periodo" class="mt-1 block border-gray-300 rounded" aria-label="{% trans 'Selecionar período' %}">
+      <option value="mensal" {% if periodo == 'mensal' %}selected{% endif %}>{% trans 'Mensal' %}</option>
+      <option value="trimestral" {% if periodo == 'trimestral' %}selected{% endif %}>{% trans 'Trimestral' %}</option>
+      <option value="semestral" {% if periodo == 'semestral' %}selected{% endif %}>{% trans 'Semestral' %}</option>
+      <option value="anual" {% if periodo == 'anual' %}selected{% endif %}>{% trans 'Anual' %}</option>
+    </select>
+  </div>
+  <div>
+    <label for="escopo" class="block text-sm font-medium text-neutral-700">{% trans 'Escopo' %}</label>
+    <select id="escopo" name="escopo" class="mt-1 block border-gray-300 rounded" aria-label="{% trans 'Selecionar escopo' %}">
+      <option value="auto" {% if escopo == 'auto' %}selected{% endif %}>{% trans 'Automático' %}</option>
+      <option value="global" {% if escopo == 'global' %}selected{% endif %}>{% trans 'Global' %}</option>
+      <option value="organizacao" {% if escopo == 'organizacao' %}selected{% endif %}>{% trans 'Organização' %}</option>
+      <option value="nucleo" {% if escopo == 'nucleo' %}selected{% endif %}>{% trans 'Núcleo' %}</option>
+      <option value="evento" {% if escopo == 'evento' %}selected{% endif %}>{% trans 'Evento' %}</option>
+    </select>
+  </div>
+  <div>
+    <label for="organizacao_id" class="block text-sm font-medium text-neutral-700">{% trans 'Organização' %}</label>
+    <select id="organizacao_id" name="organizacao_id" class="mt-1 block border-gray-300 rounded" aria-label="{% trans 'Selecionar organização' %}"></select>
+  </div>
+  <div>
+    <label for="nucleo_id" class="block text-sm font-medium text-neutral-700">{% trans 'Núcleo' %}</label>
+    <select id="nucleo_id" name="nucleo_id" class="mt-1 block border-gray-300 rounded" aria-label="{% trans 'Selecionar núcleo' %}"></select>
+  </div>
+  <div>
+    <label for="evento_id" class="block text-sm font-medium text-neutral-700">{% trans 'Evento' %}</label>
+    <select id="evento_id" name="evento_id" class="mt-1 block border-gray-300 rounded" aria-label="{% trans 'Selecionar evento' %}"></select>
+  </div>
+  <div>
+    <label for="data_inicio" class="block text-sm font-medium text-neutral-700">{% trans 'Data início' %}</label>
+    <input type="date" id="data_inicio" name="data_inicio" value="{{ filtros.data_inicio }}" class="mt-1 border-gray-300 rounded" />
+  </div>
+  <div>
+    <label for="data_fim" class="block text-sm font-medium text-neutral-700">{% trans 'Data fim' %}</label>
+    <input type="date" id="data_fim" name="data_fim" value="{{ filtros.data_fim }}" class="mt-1 border-gray-300 rounded" />
+  </div>
+  <fieldset class="flex flex-col">
+    <legend class="text-sm font-medium text-neutral-700">{% trans 'Métricas' %}</legend>
+    <div class="flex flex-wrap gap-2 mt-1">
+      {% for m in metricas_disponiveis %}
+      <label class="flex items-center gap-1 text-sm">
+        <input type="checkbox" name="metricas" value="{{ m.key }}" {% if m.key in metricas_selecionadas %}checked{% endif %} class="border-gray-300 rounded" />
+        {{ m.label }}
+      </label>
+      {% endfor %}
+    </div>
+  </fieldset>
+  <div class="flex gap-2 mt-4">
+    <button type="submit" class="px-4 py-2 bg-primary-600 text-white rounded focus:outline-none focus:ring" aria-label="{% trans 'Aplicar filtros' %}">{% trans 'Filtrar' %}</button>
+    <a href="{% url 'dashboard:export' %}?{{ request.GET.urlencode }}" class="px-4 py-2 bg-neutral-200 text-neutral-800 rounded focus:outline-none focus:ring" aria-label="{% trans 'Exportar métricas' %}">{% trans 'Exportar' %}</a>
+    <a href="{% url 'dashboard:config-create' %}?{{ request.GET.urlencode }}" class="px-4 py-2 bg-neutral-200 text-neutral-800 rounded focus:outline-none focus:ring" aria-label="{% trans 'Salvar filtros' %}">{% trans 'Salvar filtros' %}</a>
+  </div>
+</form>

--- a/dashboard/templates/dashboard/partials/metrics_list.html
+++ b/dashboard/templates/dashboard/partials/metrics_list.html
@@ -1,11 +1,8 @@
 {% load i18n %}
 <section class="mb-8" id="metrics">
   <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-    {% include "dashboard/partials/metric_card.html" with title=_("Usuários") value=num_users.total icon="fa-users" id="num_users" %}
-    {% include "dashboard/partials/metric_card.html" with title=_("Organizações") value=num_organizacoes.total icon="fa-building" id="num_organizacoes" %}
-    {% include "dashboard/partials/metric_card.html" with title=_("Núcleos") value=num_nucleos.total icon="fa-users-rectangle" id="num_nucleos" %}
-    {% include "dashboard/partials/metric_card.html" with title=_("Empresas") value=num_empresas.total icon="fa-city" id="num_empresas" %}
-    {% include "dashboard/partials/metric_card.html" with title=_("Eventos") value=num_eventos.total icon="fa-calendar" id="num_eventos" %}
-    {% include "dashboard/partials/metric_card.html" with title=_("Posts") value=num_posts.total icon="fa-newspaper" id="num_posts" %}
+    {% for m in metrics_iter %}
+      {% include "dashboard/partials/metric_card.html" with title=m.label value=m.data.total icon=m.icon id=m.key %}
+    {% endfor %}
   </div>
 </section>

--- a/dashboard/templates/dashboard/root.html
+++ b/dashboard/templates/dashboard/root.html
@@ -8,6 +8,8 @@
 <main class="max-w-7xl mx-auto px-4 py-10" role="main" aria-label="Dashboard">
   <h1 class="text-3xl font-semibold text-neutral-900 text-center mb-10">{% trans "Dashboard Root" %}</h1>
 
+  {% include 'dashboard/partials/filters_form.html' %}
+
   <div hx-get="{% url 'dashboard:metrics-partial' %}" hx-trigger="load, every 10s" hx-target="#metrics" hx-swap="innerHTML">
     {% include 'dashboard/partials/metrics_list.html' %}
   </div>

--- a/tests/dashboard/test_benchmark.py
+++ b/tests/dashboard/test_benchmark.py
@@ -1,0 +1,16 @@
+import pytest
+from django.urls import reverse
+
+from dashboard.services import DashboardMetricsService
+
+pytest.importorskip("pytest_benchmark")
+pytestmark = pytest.mark.django_db
+
+
+def test_get_metrics_benchmark(benchmark, admin_user):
+    benchmark(DashboardMetricsService.get_metrics, admin_user)
+
+
+def test_dashboard_view_benchmark(benchmark, client, admin_user):
+    client.force_login(admin_user)
+    benchmark(lambda: client.get(reverse('dashboard:admin')))


### PR DESCRIPTION
## Summary
- add scoped metric filtering with support for date range and metric selection
- export dashboard metrics to CSV/PDF and save/share filter configs
- improve dashboard templates with accessible filter form and documentation

## Testing
- `python -m pytest tests/dashboard -q`
- `python -m mypy dashboard --strict` *(fails: Missing type parameters for generic type "DateTimeField" and 508 more errors)*

------
https://chatgpt.com/codex/tasks/task_e_688e32c5af188325a0bad1f72158e6a4