### PR TITLE
feat(discussao): add topic resolution and response editing

### DIFF
--- a/discussao/README.md
+++ b/discussao/README.md
@@ -1,0 +1,34 @@
+# Módulo Discussão
+
+Este app provê fórum simples com categorias, tópicos e respostas.
+
+## Endpoints principais
+
+| Método | Caminho | Descrição |
+|--------|--------|-----------|
+| GET | `/discussao/` | lista categorias |
+| POST | `/discussao/categorias/novo/` | cria categoria (admin) |
+| GET/POST | `/discussao/<categoria>/novo/` | cria tópico |
+| POST | `/discussao/<categoria>/<topico>/resolver/` | marca tópico como resolvido |
+| POST | `/discussao/<categoria>/<topico>/responder/` | cria resposta |
+| POST | `/discussao/comentario/<id>/editar/` | edita resposta |
+
+## Casos de uso
+
+- **UC-01** criar categorias.
+- **UC-02** listar tópicos com filtros e busca.
+- **UC-03** criar/editar tópicos.
+- **UC-04** responder tópicos e editar respostas.
+- **UC-05** votar em tópicos e respostas.
+- **UC-06** marcar resolução e melhor resposta.
+- **UC-07** filtrar por tags e texto.
+
+## Regras de negócio
+
+* Apenas membros da organização podem participar.
+* Autor ou administrador podem editar e resolver tópicos/respostas.
+
+## Moderação
+
+Moderadores podem sinalizar conteúdo impróprio e revisar no `DiscussionModerationLog`.
+

--- a/discussao/urls.py
+++ b/discussao/urls.py
@@ -8,10 +8,12 @@ from .views import (
     InteracaoView,
     RespostaCreateView,
     RespostaDeleteView,
+    RespostaUpdateView,
     TopicoCreateView,
     TopicoDeleteView,
     TopicoDetailView,
     TopicoListView,
+    TopicoMarkResolvedView,
     TopicoUpdateView,
 )
 
@@ -20,13 +22,23 @@ urlpatterns = [
     path("categorias/novo/", CategoriaCreateView.as_view(), name="categoria_criar"),
     path("categorias/<slug:slug>/editar/", CategoriaUpdateView.as_view(), name="categoria_editar"),
     path("categorias/<slug:slug>/remover/", CategoriaDeleteView.as_view(), name="categoria_remover"),
+    path(
+        "comentario/<int:pk>/editar/",
+        RespostaUpdateView.as_view(),
+        name="resposta_editar",
+    ),
+    path(
+        "comentario/<int:pk>/remover/",
+        RespostaDeleteView.as_view(),
+        name="delete_comment",
+    ),
     path("<slug:categoria_slug>/", TopicoListView.as_view(), name="topicos"),
+    path("<slug:categoria_slug>/novo/", TopicoCreateView.as_view(), name="topico_criar"),
     path(
         "<slug:categoria_slug>/<slug:topico_slug>/",
         TopicoDetailView.as_view(),
         name="topico_detalhe",
     ),
-    path("<slug:categoria_slug>/novo/", TopicoCreateView.as_view(), name="topico_criar"),
     path(
         "<slug:categoria_slug>/<slug:topico_slug>/editar/",
         TopicoUpdateView.as_view(),
@@ -43,9 +55,9 @@ urlpatterns = [
         name="resposta_criar",
     ),
     path(
-        "comentario/<int:pk>/remover/",
-        RespostaDeleteView.as_view(),
-        name="delete_comment",
+        "<slug:categoria_slug>/<slug:topico_slug>/resolver/",
+        TopicoMarkResolvedView.as_view(),
+        name="topico_resolver",
     ),
     path(
         "interacao/<int:content_type_id>/<int:object_id>/<str:acao>/",

--- a/tests/discussao/test_factories.py
+++ b/tests/discussao/test_factories.py
@@ -1,0 +1,16 @@
+import pytest
+
+from discussao.factories import (
+    CategoriaDiscussaoFactory,
+    RespostaDiscussaoFactory,
+    TopicoDiscussaoFactory,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+def test_factories_create_objects():
+    categoria = CategoriaDiscussaoFactory()
+    topico = TopicoDiscussaoFactory(categoria=categoria)
+    resposta = RespostaDiscussaoFactory(topico=topico)
+    assert resposta.topico == topico and topico.categoria == categoria


### PR DESCRIPTION
## Summary
- allow searching topics by title or content
- enable editing responses and marking topics as resolved
- document discussao endpoints and use cases

## Testing
- `pytest --cov=discussao tests/discussao -q`


------
https://chatgpt.com/codex/tasks/task_e_688e3c51f9708325b869643e7188663d