### PR TITLE
feat: add upload service and post validations

### DIFF
--- a/feed/README.md
+++ b/feed/README.md
@@ -17,7 +17,22 @@ Endpoints under `/api/feed/` provide CRUD access to posts, comments, likes and m
 Deleting a post performs a *soft delete* (`deleted=True`). Media URLs are exposed via
 `image_url`, `pdf_url` and `video_url` fields.
 
+Exemplo de listagem filtrada:
+
+```bash
+curl /api/feed/posts/?tags=django&date_from=2025-01-01
+```
+
+Cada post pode conter **apenas um** tipo de mídia (imagem, vídeo ou PDF).
+Uploads são enviados ao S3 com tentativas de reenvio em caso de falha.
+
+Posts contendo palavras proibidas são marcados para moderação e só aparecem
+após aprovação.
+
 ## Comments and Likes
 
 `/api/feed/comments/` and `/api/feed/likes/` allow creating and removing comments and likes
 for posts. Authentication is required for all endpoints.
+
+Integração com S3 requer credenciais com permissão de `s3:PutObject` e
+`s3:GetObject` no *bucket* configurado em `AWS_STORAGE_BUCKET_NAME`.

--- a/feed/apps.py
+++ b/feed/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class FeedConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "feed"
+
+    def ready(self) -> None:  # pragma: no cover - importa sinais
+        from . import signals  # noqa: F401

--- a/feed/services.py
+++ b/feed/services.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import mimetypes
+import uuid
+from typing import IO
+
+import boto3
+from botocore.exceptions import ClientError
+from django.conf import settings
+from django.core.exceptions import ValidationError
+
+
+def upload_media(file: IO[bytes]) -> str:
+    """Upload media to S3 with simple retry logic.
+
+    Returns the generated presigned URL.
+    """
+    content_type = getattr(file, "content_type", None) or mimetypes.guess_type(file.name)[0]
+    size = getattr(file, "size", 0)
+    ext = (file.name or "").lower()
+
+    limits = {
+        "image": 5 * 1024 * 1024,
+        "video": 20 * 1024 * 1024,
+        "pdf": 10 * 1024 * 1024,
+    }
+    kind = "image"
+    if content_type:
+        if content_type.startswith("video/"):
+            kind = "video"
+        elif content_type == "application/pdf" or ext.endswith(".pdf"):
+            kind = "pdf"
+    if size > limits[kind]:
+        raise ValidationError("Arquivo maior que o permitido")
+
+    bucket = getattr(settings, "AWS_STORAGE_BUCKET_NAME", "")
+    key = f"feed/{uuid.uuid4()}-{file.name}"
+    if bucket:
+        client = boto3.client("s3")
+        for attempt in range(3):
+            try:
+                file.seek(0)
+                client.upload_fileobj(file, bucket, key)
+                break
+            except ClientError:
+                if attempt == 2:
+                    raise
+        return client.generate_presigned_url("get_object", Params={"Bucket": bucket, "Key": key}, ExpiresIn=3600)
+    # Sem S3 configurado, retorna caminho gerado
+    return key

--- a/feed/signals.py
+++ b/feed/signals.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from notificacoes.services.notificacoes import enviar_para_usuario
+
+from .models import Comment, Like
+
+
+@receiver(post_save, sender=Like)
+def notificar_like(sender, instance, created, **kwargs):
+    if created:
+        try:
+            enviar_para_usuario(instance.post.autor, "feed_like", {"post_id": str(instance.post.id)})
+        except Exception:
+            pass
+
+
+@receiver(post_save, sender=Comment)
+def notificar_comment(sender, instance, created, **kwargs):
+    if created:
+        try:
+            enviar_para_usuario(instance.post.autor, "feed_comment", {"post_id": str(instance.post.id)})
+        except Exception:
+            pass

--- a/feed/views.py
+++ b/feed/views.py
@@ -16,6 +16,7 @@ from nucleos.models import Nucleo
 
 from .forms import CommentForm, LikeForm, PostForm
 from .models import Like, ModeracaoPost, Post
+from .services import upload_media
 
 
 @login_required
@@ -122,6 +123,10 @@ class NovaPostagemView(LoginRequiredMixin, CreateView):
         return context
 
     def form_valid(self, form):
+        for field in ["image", "pdf", "video"]:
+            file = form.cleaned_data.get(field)
+            if file:
+                setattr(form.instance, field, upload_media(file))
         form.instance.autor = self.request.user
         form.instance.organizacao = self.request.user.organizacao
         response = super().form_valid(form)
@@ -199,6 +204,10 @@ def post_update(request, pk):
                 files["image"] = file
         form = PostForm(request.POST, files, instance=post, user=request.user)
         if form.is_valid():
+            for field in ["image", "pdf", "video"]:
+                file = form.cleaned_data.get(field)
+                if file:
+                    setattr(form.instance, field, upload_media(file))
             form.instance.organizacao = request.user.organizacao
             form.save()
             if request.headers.get("HX-Request"):

--- a/tests/feed/test_serializer.py
+++ b/tests/feed/test_serializer.py
@@ -1,0 +1,17 @@
+import pytest
+
+from feed.api import PostSerializer
+
+
+@pytest.mark.django_db
+def test_serializer_requires_nucleo():
+    ser = PostSerializer(data={"tipo_feed": "nucleo", "conteudo": "x"})
+    assert not ser.is_valid()
+    assert "nucleo" in ser.errors
+
+
+@pytest.mark.django_db
+def test_serializer_requires_evento():
+    ser = PostSerializer(data={"tipo_feed": "evento", "conteudo": "x"})
+    assert not ser.is_valid()
+    assert "evento" in ser.errors

--- a/tests/feed/test_services.py
+++ b/tests/feed/test_services.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import boto3
+import pytest
+from botocore.exceptions import ClientError
+from django.core.exceptions import ValidationError
+from django.core.files.uploadedfile import SimpleUploadedFile
+
+from feed.services import upload_media
+
+
+@pytest.mark.django_db
+def test_upload_media_retries(monkeypatch, settings):
+    settings.AWS_STORAGE_BUCKET_NAME = "bucket"
+    file = SimpleUploadedFile("a.png", b"data", content_type="image/png")
+    client = Mock()
+    calls = {"n": 0}
+
+    def upload_fileobj(f, bucket, key):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise ClientError({"Error": {}}, "upload")
+
+    client.upload_fileobj = upload_fileobj
+    client.generate_presigned_url = lambda *a, **k: f"url/{k['Params']['Key']}"
+    monkeypatch.setattr(boto3, "client", lambda *a, **k: client)
+    url = upload_media(file)
+    assert url.startswith("url/")
+    assert calls["n"] == 3
+
+
+@pytest.mark.django_db
+def test_upload_media_invalid_size(settings):
+    settings.AWS_STORAGE_BUCKET_NAME = "bucket"
+    big = SimpleUploadedFile(
+        "a.pdf",
+        b"x" * (10 * 1024 * 1024 + 1),
+        content_type="application/pdf",
+    )
+    with pytest.raises(ValidationError):
+        upload_media(big)

--- a/tests/feed/test_signals.py
+++ b/tests/feed/test_signals.py
@@ -1,0 +1,21 @@
+from unittest.mock import patch
+
+import pytest
+
+from feed.models import Comment, Like, Post
+
+
+@patch("feed.signals.enviar_para_usuario")
+@pytest.mark.django_db
+def test_like_triggers_notification(mock_send, admin_user, organizacao):
+    post = Post.objects.create(autor=admin_user, organizacao=organizacao)
+    Like.objects.create(post=post, user=admin_user)
+    assert mock_send.called
+
+
+@patch("feed.signals.enviar_para_usuario")
+@pytest.mark.django_db
+def test_comment_triggers_notification(mock_send, admin_user, organizacao):
+    post = Post.objects.create(autor=admin_user, organizacao=organizacao)
+    Comment.objects.create(post=post, user=admin_user, texto="x")
+    assert mock_send.called


### PR DESCRIPTION
## Summary
- ensure posts validate required nucleo or evento and support resilient media upload
- notify post authors on new likes and comments
- document API usage and S3 requirements

## Testing
- `pytest tests/feed -q`


------
https://chatgpt.com/codex/tasks/task_e_688e493bf0dc8325b37b46709eb95d7f