### PR TITLE
feat(nucleos): add slug and toggle active

### DIFF
--- a/nucleos/README.md
+++ b/nucleos/README.md
@@ -1,0 +1,22 @@
+# Núcleos
+
+Views principais:
+
+- `nucleos:list` – lista núcleos ativos com busca por nome ou *slug*.
+- `nucleos:create` – criação de núcleo vinculado à organização do usuário.
+- `nucleos:update` – edição de dados básicos do núcleo.
+- `nucleos:toggle_active` – inativa ou reativa um núcleo.
+- `nucleos:exportar_membros` – exporta membros em CSV.
+
+Fluxo de participação:
+
+1. Usuário solicita participação (`participacao_solicitar`).
+2. Coordenadores/Admins aprovam ou recusam (`participacao_decidir`).
+3. Status possíveis: `pendente`, `aprovado`, `recusado` (um usuário por núcleo).
+
+Permissões:
+
+- Administradores e superadmins podem criar/editar/excluir.
+- Coordenadores podem gerenciar membros e inativar núcleos.
+- Todas as views exigem autenticação.
+

--- a/nucleos/forms.py
+++ b/nucleos/forms.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from django import forms
 from django.contrib.auth import get_user_model
 from django.utils.translation import gettext_lazy as _
+import bleach
 
 from .models import CoordenadorSuplente, Nucleo, ParticipacaoNucleo
 
@@ -12,7 +13,11 @@ User = get_user_model()
 class NucleoForm(forms.ModelForm):
     class Meta:
         model = Nucleo
-        fields = ["organizacao", "nome", "descricao", "avatar", "cover"]
+        fields = ["nome", "slug", "descricao", "avatar", "cover"]
+
+    def clean_descricao(self):
+        descricao = self.cleaned_data.get("descricao", "")
+        return bleach.clean(descricao)
 
 
 class NucleoSearchForm(forms.Form):

--- a/nucleos/migrations/0004_nucleo_slug_inativa.py
+++ b/nucleos/migrations/0004_nucleo_slug_inativa.py
@@ -1,0 +1,29 @@
+import uuid
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("nucleos", "0003_nucleo_membros"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="nucleo",
+            name="slug",
+            field=models.SlugField(max_length=255, unique=True, default=uuid.uuid4),
+        ),
+        migrations.AddField(
+            model_name="nucleo",
+            name="inativa",
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AddField(
+            model_name="nucleo",
+            name="inativada_em",
+            field=models.DateTimeField(null=True, blank=True),
+        ),
+    ]
+

--- a/nucleos/services.py
+++ b/nucleos/services.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+from django.contrib.auth import get_user_model
+
+from .models import Nucleo, ParticipacaoNucleo
+
+User = get_user_model()
+
+
+def criar_participacoes_membros(nucleo: Nucleo, membros: Iterable[User]) -> list[ParticipacaoNucleo]:
+    """Cria participações aprovadas para a lista de membros fornecida."""
+    participacoes: list[ParticipacaoNucleo] = []
+    for user in membros:
+        part, _ = ParticipacaoNucleo.objects.get_or_create(nucleo=nucleo, user=user)
+        part.status = "aprovado"
+        part.save(update_fields=["status"])
+        participacoes.append(part)
+    return participacoes
+

--- a/nucleos/templates/nucleos/detail.html
+++ b/nucleos/templates/nucleos/detail.html
@@ -10,7 +10,10 @@
   {% endif %}
   <div class="flex items-center gap-4 mt-4">
     {% if object.avatar %}<img src="{{ object.avatar.url }}" class="w-16 h-16 rounded-full" />{% endif %}
-    <h1 class="text-2xl font-bold">{{ object.nome }}</h1>
+    <div>
+      <h1 class="text-2xl font-bold">{{ object.nome }}</h1>
+      <p class="text-sm text-gray-500">{{ object.slug }}</p>
+    </div>
   </div>
 
   <h2 class="mt-6 font-semibold">{% trans 'Membros' %}</h2>
@@ -50,6 +53,11 @@
 
   <div class="mt-6">
     <a href="{% url 'nucleos:exportar_membros' object.pk %}" class="text-blue-600">{% trans 'Exportar membros (CSV)' %}</a>
+    {% if request.user.user_type in ('admin','coordenador','root') %}
+    <form method="post" action="{% url 'nucleos:toggle_active' object.pk %}" class="inline">{% csrf_token %}
+      <button class="ml-2 text-orange-600">{% if object.inativa %}{% trans 'Reativar' %}{% else %}{% trans 'Inativar' %}{% endif %}</button>
+    </form>
+    {% endif %}
   </div>
 
   {% if request.user.user_type != 'admin' and request.user.user_type != 'coordenador' %}

--- a/nucleos/templates/nucleos/list.html
+++ b/nucleos/templates/nucleos/list.html
@@ -19,12 +19,15 @@
     <div class="border rounded p-4">
       <div class="flex items-center gap-3">
         {% if nucleo.avatar %}<img src="{{ nucleo.avatar.url }}" class="w-12 h-12 rounded-full" />{% endif %}
-        <h3 class="font-semibold">{{ nucleo.nome }}</h3>
+        <div>
+          <h3 class="font-semibold">{{ nucleo.nome }}</h3>
+          <p class="text-sm text-gray-500">{{ nucleo.slug }}</p>
+        </div>
       </div>
       <p class="text-sm mt-2">{% trans "Membros" %}: {{ nucleo.membros_aprovados.count }}</p>
       <div class="mt-2">
         <a href="{% url 'nucleos:detail' nucleo.pk %}" class="text-blue-600">{% trans 'Detalhes' %}</a>
-        {% if request.user.user_type == 'admin' or request.user.user_type == 'coordenador' %}
+        {% if request.user.user_type == 'admin' or request.user.user_type == 'coordenador' or request.user.user_type == 'root' %}
         <form method="post" action="{% url 'nucleos:delete' nucleo.pk %}" class="inline">{% csrf_token %}
           <button class="text-red-600 ml-2">{% trans 'Excluir' %}</button>
         </form>

--- a/nucleos/urls.py
+++ b/nucleos/urls.py
@@ -41,4 +41,9 @@ urlpatterns = [
         views.ExportarMembrosView.as_view(),
         name="exportar_membros",
     ),
+    path(
+        "<int:pk>/toggle-active/",
+        views.NucleoToggleActiveView.as_view(),
+        name="toggle_active",
+    ),
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ pytest>=7.0
 pre-commit>=3.6
 pytest-benchmark>=4.0
 prometheus-client==0.20.0
+bleach==6.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -120,3 +120,4 @@ websockets==15.0.1
 zope.interface==7.2
 prometheus-client==0.20.0
 sentry-sdk
+bleach==6.2.0

--- a/tests/chat/conftest.py
+++ b/tests/chat/conftest.py
@@ -31,7 +31,7 @@ def organizacao():
 
 @pytest.fixture
 def nucleo(organizacao):
-    return Nucleo.objects.create(nome="Nuc", organizacao=organizacao)
+    return Nucleo.objects.create(nome="Nuc", slug="nuc", organizacao=organizacao)
 
 
 @pytest.fixture

--- a/tests/discussao/conftest.py
+++ b/tests/discussao/conftest.py
@@ -22,7 +22,7 @@ def outra_organizacao(db):
 
 @pytest.fixture
 def nucleo(organizacao):
-    return Nucleo.objects.create(nome="Nucleo", organizacao=organizacao)
+    return Nucleo.objects.create(nome="Nucleo", slug="nucleo", organizacao=organizacao)
 
 
 @pytest.fixture

--- a/tests/discussao/test_forms.py
+++ b/tests/discussao/test_forms.py
@@ -60,7 +60,7 @@ def test_topico_form_validation(categoria, admin_user, nucleo, evento):
         }
     )
     assert form2.is_valid()
-    outro = Nucleo.objects.create(nome="Outro", organizacao=categoria.organizacao)
+    outro = Nucleo.objects.create(nome="Outro", slug="outro", organizacao=categoria.organizacao)
     form3 = TopicoDiscussaoForm(
         data={
             "categoria": cat_nucleo.pk,

--- a/tests/discussao/test_views.py
+++ b/tests/discussao/test_views.py
@@ -90,7 +90,7 @@ def test_topico_create_success(client, admin_user, categoria):
 
 def test_topico_create_invalid_nucleo(client, admin_user, categoria, nucleo):
     cat = CategoriaDiscussao.objects.create(nome="N", organizacao=categoria.organizacao, nucleo=nucleo)
-    outro = Nucleo.objects.create(nome="Outro", organizacao=categoria.organizacao)
+    outro = Nucleo.objects.create(nome="Outro", slug="outro", organizacao=categoria.organizacao)
     client.force_login(admin_user)
     url = reverse("discussao:topico_criar", args=[cat.slug])
     resp = client.post(

--- a/tests/feed/conftest.py
+++ b/tests/feed/conftest.py
@@ -81,7 +81,7 @@ def nucleado_user(db, organizacao):
 
 @pytest.fixture
 def nucleo(db, organizacao, coordenador_user, nucleado_user):
-    n = Nucleo.objects.create(nome="N1", organizacao=organizacao)
+    n = Nucleo.objects.create(nome="N1", slug="n1", organizacao=organizacao)
     ParticipacaoNucleo.objects.create(user=nucleado_user, nucleo=n, is_coordenador=False)
     ParticipacaoNucleo.objects.create(user=coordenador_user, nucleo=n, is_coordenador=True)
     return n

--- a/tests/feed/test_feed.py
+++ b/tests/feed/test_feed.py
@@ -29,7 +29,7 @@ class FeedPublicPrivateTests(TestCase):
         # associar usuários à organização para que apareçam no feed
         self.user.organizacao = self.org
         self.user.save()
-        self.nucleo = Nucleo.objects.create(nome="N1", organizacao=self.org)
+        self.nucleo = Nucleo.objects.create(nome="N1", slug="n1", organizacao=self.org)
         self.nucleo.participacoes.create(user=self.user)
         self.client.force_login(self.user)
 

--- a/tests/nucleos/test_api.py
+++ b/tests/nucleos/test_api.py
@@ -71,7 +71,7 @@ def _auth(client, user):
 
 
 def test_solicitar_aprovar_recusar(api_client, admin_user, outro_user, organizacao):
-    nucleo = Nucleo.objects.create(nome="N1", organizacao=organizacao)
+    nucleo = Nucleo.objects.create(nome="N1", slug="n1", organizacao=organizacao)
     _auth(api_client, outro_user)
     url = reverse("nucleos_api:nucleo-participacoes", args=[nucleo.pk])
     resp = api_client.post(url)
@@ -94,7 +94,7 @@ def test_solicitar_aprovar_recusar(api_client, admin_user, outro_user, organizac
 
 
 def test_expiracao_automatica(api_client, outro_user, organizacao):
-    nucleo = Nucleo.objects.create(nome="N2", organizacao=organizacao)
+    nucleo = Nucleo.objects.create(nome="N2", slug="n2", organizacao=organizacao)
     part = ParticipacaoNucleo.objects.create(user=outro_user, nucleo=nucleo)
     ParticipacaoNucleo.objects.filter(pk=part.pk).update(data_solicitacao=timezone.now() - timedelta(days=31))
     expirar_solicitacoes_pendentes()
@@ -103,7 +103,7 @@ def test_expiracao_automatica(api_client, outro_user, organizacao):
 
 
 def test_designar_suplente(api_client, admin_user, coord_user, organizacao):
-    nucleo = Nucleo.objects.create(nome="N3", organizacao=organizacao)
+    nucleo = Nucleo.objects.create(nome="N3", slug="n3", organizacao=organizacao)
     _auth(api_client, admin_user)
     url = reverse("nucleos_api:nucleo-adicionar-suplente", args=[nucleo.pk])
     data = {
@@ -117,7 +117,7 @@ def test_designar_suplente(api_client, admin_user, coord_user, organizacao):
 
 
 def test_exportar_membros(api_client, admin_user, outro_user, organizacao):
-    nucleo = Nucleo.objects.create(nome="N4", organizacao=organizacao)
+    nucleo = Nucleo.objects.create(nome="N4", slug="n4", organizacao=organizacao)
     ParticipacaoNucleo.objects.create(user=outro_user, nucleo=nucleo, status="aprovado")
     _auth(api_client, admin_user)
     url = reverse("nucleos_api:nucleo-exportar-membros", args=[nucleo.pk])

--- a/tests/nucleos/test_forms.py
+++ b/tests/nucleos/test_forms.py
@@ -1,34 +1,17 @@
 import pytest
 
 from nucleos.forms import NucleoForm, NucleoSearchForm, SuplenteForm
-from organizacoes.models import Organizacao
 
 pytestmark = pytest.mark.django_db
 
 
-@pytest.fixture
-def organizacao():
-    return Organizacao.objects.create(nome="Org", cnpj="00.000.000/0001-00")
-
-
 def test_nucleo_form_fields():
     form = NucleoForm()
-    assert list(form.fields) == [
-        "organizacao",
-        "nome",
-        "descricao",
-        "avatar",
-        "cover",
-    ]
+    assert list(form.fields) == ["nome", "slug", "descricao", "avatar", "cover"]
 
 
-def test_membros_queryset_includes_all_users():
-    form = NucleoForm()
-    assert "organizacao" in form.fields
-
-
-def test_form_validation_errors(organizacao):
-    form = NucleoForm(data={"organizacao": organizacao.pk, "nome": ""})
+def test_form_validation_errors():
+    form = NucleoForm(data={"nome": "", "slug": ""})
     assert not form.is_valid()
     assert "nome" in form.errors
 

--- a/tests/nucleos/test_models.py
+++ b/tests/nucleos/test_models.py
@@ -36,7 +36,7 @@ def usuario(organizacao):
 
 
 def test_str_representation(organizacao):
-    nucleo = Nucleo.objects.create(nome="Núcleo Alpha", organizacao=organizacao)
+    nucleo = Nucleo.objects.create(nome="Núcleo Alpha", slug="alpha", organizacao=organizacao)
     assert str(nucleo) == "Núcleo Alpha"
 
 
@@ -46,6 +46,7 @@ def test_create_with_required_fields(media_root, organizacao):
     nucleo = Nucleo.objects.create(
         organizacao=organizacao,
         nome="Núcleo Teste",
+        slug="teste",
         descricao="Desc",
         avatar=avatar,
         cover=cover,
@@ -58,14 +59,14 @@ def test_create_with_required_fields(media_root, organizacao):
 
 
 def test_participacao_unique_constraint(organizacao, usuario):
-    nucleo = Nucleo.objects.create(nome="N1", organizacao=organizacao)
+    nucleo = Nucleo.objects.create(nome="N1", slug="n1", organizacao=organizacao)
     ParticipacaoNucleo.objects.create(user=usuario, nucleo=nucleo)
     with pytest.raises(IntegrityError):
         ParticipacaoNucleo.objects.create(user=usuario, nucleo=nucleo)
 
 
 def test_membros_aprovados_property(organizacao, usuario):
-    nucleo = Nucleo.objects.create(nome="N", organizacao=organizacao)
+    nucleo = Nucleo.objects.create(nome="N", slug="n", organizacao=organizacao)
     ParticipacaoNucleo.objects.create(user=usuario, nucleo=nucleo, status="pendente")
     u2 = get_user_model().objects.create_user(
         username="u2", email="u2@example.com", password="pass", user_type=UserType.NUCLEADO, organizacao=organizacao
@@ -81,6 +82,7 @@ def test_upload_cleanup(media_root, organizacao):
     nucleo = Nucleo.objects.create(
         organizacao=organizacao,
         nome="Cleanup",
+        slug="cleanup",
         avatar=avatar,
         cover=cover,
     )


### PR DESCRIPTION
## Summary
- add slug/inativacao fields and soft-delete helpers for Nucleos
- sanitize description and support member management utilities
- improve templates and add toggle-active view

## Testing
- `pytest tests/nucleos -q`


------
https://chatgpt.com/codex/tasks/task_e_688e60f06a208325bac47d82a8f545b6