### PR TITLE
docs: padroniza TimeStampedModel e SoftDeleteModel nos requisitos

### DIFF
--- a/.requisitos/accounts/REQ-ACCOUNTS-001.md
+++ b/.requisitos/accounts/REQ-ACCOUNTS-001.md
@@ -68,6 +68,10 @@ O App Accounts gerencia todo o ciclo de vida de contas de usuário no sistema Hu
   - Descrição: Suportar 1000 cadastros por hora  
   - Métrica/Meta: escalonamento automático  
 
+
+- **RNF-04**: Todos os modelos deste app devem herdar de `TimeStampedModel` para timestamps automáticos (`created` e `modified`), garantindo consistência e evitando campos manuais.
+- **RNF-05**: Quando houver necessidade de exclusão lógica, os modelos devem implementar `SoftDeleteModel` (ou mixin equivalente), evitando remoções físicas e padronizando os campos `deleted` e `deleted_at`.
+
 ## 5. Casos de Uso
 
 ### UC‑01 – Criar Conta
@@ -96,13 +100,13 @@ O App Accounts gerencia todo o ciclo de vida de contas de usuário no sistema Hu
 - Perfis de usuário seguem lógica: root, admin, associado, nucleado, coordenador, convidado.
 
 ## 7. Modelo de Dados
+*Nota:* Todos os modelos herdam de `TimeStampedModel` (campos `created` e `modified`) e utilizam `SoftDeleteModel` para exclusão lógica quando necessário. Assim, campos de timestamp e exclusão lógica não são listados individualmente.
 - **Account**  
   - id: UUID  
   - email: EmailField, único  
   - password_hash: string  
   - is_active: boolean  
   - last_login: datetime  
-  - created_at, updated_at: datetime  
 
 - **Profile**  
   - user: FK → Account.id  
@@ -153,13 +157,12 @@ Feature: Gerenciamento de contas
 - **RF‑09** – Suporte a autenticação em duas etapas (2FA) opcional com códigos TOTP.  
 
 ### Requisitos Não‑Funcionais Adicionais
-- **RNF‑04** – Segurança reforçada: tokens de recuperação e confirmação devem ter entropia ≥ 128 bits e expirar em 24 horas.  
-- **RNF‑05** – Logs de tentativas de login e eventos de segurança devem ser armazenados com carimbo de data/hora e IP.  
+- **RNF-06** – Segurança reforçada: tokens de recuperação e confirmação devem ter entropia ≥ 128 bits e expirar em 24 horas.  
+- **RNF-07** – Logs de tentativas de login e eventos de segurança devem ser armazenados com carimbo de data/hora e IP.  
 
 ### Modelo de Dados Adicional
 - `failed_login_attempts: integer` – contador de falhas consecutivas.  
 - `lock_expires_at: datetime` – data/hora em que o bloqueio por falhas expira.  
-- `deleted_at: datetime` – marca soft delete da conta.  
 - `two_factor_enabled: boolean` – indica se 2FA está habilitado.  
 - `two_factor_secret: string` – chave secreta TOTP (criptografada).  
 

--- a/.requisitos/agenda/REQ-AGENDA-001.md
+++ b/.requisitos/agenda/REQ-AGENDA-001.md
@@ -84,6 +84,10 @@ Gerenciar todo o ciclo de vida de Eventos no Hubx: criação, edição e exclus�
   - Descrição: Logs e histórico de alterações para eventos, inscrições e briefings.  
   - Métrica/Meta: 100% dos eventos críticos registrados
 
+
+- **RNF‑05**: Todos os modelos deste app devem herdar de `TimeStampedModel` para timestamps automáticos (`created` e `modified`), garantindo consistência e evitando campos manuais.
+- **RNF‑06**: Quando houver necessidade de exclusão lógica, os modelos devem implementar `SoftDeleteModel` (ou mixin equivalente), evitando remoções físicas e padronizando os campos `deleted` e `deleted_at`.
+
 ## 5. Casos de Uso
 
 ### UC‑01 – Criar Evento
@@ -119,6 +123,7 @@ Gerenciar todo o ciclo de vida de Eventos no Hubx: criação, edição e exclus�
 - Briefing segue fluxo de estados: rascunho → orçamentado → aprovado/recusado.
 
 ## 7. Modelo de Dados
+*Nota:* Todos os modelos herdam de `TimeStampedModel` (campos `created` e `modified`) e utilizam `SoftDeleteModel` para exclusão lógica quando necessário. Assim, campos de timestamp e exclusão lógica não são listados individualmente.
 
 - **Evento**  
   - id: UUID  
@@ -127,7 +132,6 @@ Gerenciar todo o ciclo de vida de Eventos no Hubx: criação, edição e exclus�
   - organizacao: FK → Organizacao.id  
   - nucleo: FK opcional → Nucleo.id  
   - status: enum('ativo','concluido','cancelado')  
-  - created_at, updated_at: datetime
 
 - **InscricaoEvento**  
   - user: FK → User.id  
@@ -184,8 +188,8 @@ Feature: Gestão de Eventos
 - **RF‑10** – Definir número máximo de participantes e lista de espera automática quando lotado.  
 
 ### Requisitos Não‑Funcionais Adicionais
-- **RNF‑05** – Geração de QRCode deve ocorrer em ≤ 100 ms.  
-- **RNF‑06** – Processos de orçamento devem ser rastreados com logs auditáveis.  
+- **RNF‑07** – Geração de QRCode deve ocorrer em ≤ 100 ms.  
+- **RNF‑08** – Processos de orçamento devem ser rastreados com logs auditáveis.  
 
 ### Modelo de Dados Adicional
 - `InscricaoEvento`: adicionar `qrcode_url: URLField`, `check_in_realizado_em: datetime`.  

--- a/.requisitos/chat/REQ-CHAT-001.md
+++ b/.requisitos/chat/REQ-CHAT-001.md
@@ -66,6 +66,10 @@ O App Chat deve permitir comunicação em tempo real via WebSocket e interface v
   - Descrição: Código modular e documentado  
   - Métrica/Meta: Cobertura ≥ 90 %  
 
+
+- **RNF‑03**: Todos os modelos deste app devem herdar de `TimeStampedModel` para timestamps automáticos (`created` e `modified`), garantindo consistência e evitando campos manuais.
+- **RNF‑04**: Quando houver necessidade de exclusão lógica, os modelos devem implementar `SoftDeleteModel` (ou mixin equivalente), evitando remoções físicas e padronizando os campos `deleted` e `deleted_at`.
+
 ## 5. Casos de Uso
 
 ### UC‑01 – Comunicação em Tempo Real
@@ -87,12 +91,12 @@ O App Chat deve permitir comunicação em tempo real via WebSocket e interface v
 2. Sistema gera arquivo JSON/CSV com todas as mensagens do canal.
 
 ## 6. Modelo de Dados
+*Nota:* Todos os modelos herdam de `TimeStampedModel` (campos `created` e `modified`) e utilizam `SoftDeleteModel` para exclusão lógica quando necessário. Assim, campos de timestamp e exclusão lógica não são listados individualmente.
 
 - **ChatChannel**  
   - id: UUID  
   - tipo: enum('privado','nucleo','evento','organizacao')  
   - context_id: UUID  
-  - created_at: datetime  
 
 - **Mensagem**  
   - id: UUID  
@@ -107,7 +111,6 @@ O App Chat deve permitir comunicação em tempo real via WebSocket e interface v
   - usuario: FK → User.id  
   - mensagem: FK → Mensagem.id  
   - lida: boolean  
-  - created_at: datetime  
 
 ## 7. Regras de Negócio
 - Usuário deve estar autenticado e ter vínculo com o contexto.  
@@ -143,8 +146,8 @@ Feature: Chat em tempo real
 - **RF‑09** – Sistema de reação (emoji) nas mensagens para aumentar engajamento.  
 
 ### Requisitos Não‑Funcionais Adicionais
-- **RNF‑03** – Escalabilidade para suportar 10 000 conexões WebSocket simultâneas.  
-- **RNF‑04** – Históricos exportados devem incluir metadados (remetente, timestamp, tipo) e ser gerados em ≤ 500 ms.  
+- **RNF‑05** – Escalabilidade para suportar 10 000 conexões WebSocket simultâneas.  
+- **RNF‑06** – Históricos exportados devem incluir metadados (remetente, timestamp, tipo) e ser gerados em ≤ 500 ms.  
 
 ### Modelo de Dados Adicional
 - Em `Mensagem`, adicionar `pinned_at: datetime` (opcional) e `reactions: JSONField` (mapeamento emoji→contagem).  

--- a/.requisitos/configuracoes/REQ-CONFIGURACOES_CONTA-001.md
+++ b/.requisitos/configuracoes/REQ-CONFIGURACOES_CONTA-001.md
@@ -57,6 +57,10 @@ O App de Configurações de Conta permite que cada usuário personalize suas pre
   - Descrição: Garantia de relação 1:1 sem duplicatas.
   - Métrica/Meta: 0 falhas em testes de unicidade.
 
+
+- **RNF‑03**: Todos os modelos deste app devem herdar de `TimeStampedModel` para timestamps automáticos (`created` e `modified`), garantindo consistência e evitando campos manuais.
+- **RNF‑04**: Quando houver necessidade de exclusão lógica, os modelos devem implementar `SoftDeleteModel` (ou mixin equivalente), evitando remoções físicas e padronizando os campos `deleted` e `deleted_at`.
+
 ## 5. Casos de Uso
 
 ### UC‑01 – Configurar Notificações por Email
@@ -81,14 +85,13 @@ O App de Configurações de Conta permite que cada usuário personalize suas pre
 - Preferências independentes de permissões.
 
 ## 7. Modelo de Dados
+*Nota:* Todos os modelos herdam de `TimeStampedModel` (campos `created` e `modified`) e utilizam `SoftDeleteModel` para exclusão lógica quando necessário. Assim, campos de timestamp e exclusão lógica não são listados individualmente.
 
 - **ConfiguracoesConta**  
   - user: OneToOneField(User, on_delete=CASCADE, related_name='configuracoes')  
   - receber_notificacoes_email: BooleanField(default=True)  
   - receber_notificacoes_whatsapp: BooleanField(default=False)  
   - tema_escuro: BooleanField(default=False)  
-  - created_at: datetime  
-  - updated_at: datetime  
 
 ## 8. Critérios de Aceite (Gherkin)
 ```gherkin

--- a/.requisitos/dashboard/REQ-DASHBOARD-001.md
+++ b/.requisitos/dashboard/REQ-DASHBOARD-001.md
@@ -57,6 +57,10 @@ Oferecer visualizações dinâmicas e personalizadas de métricas, estatísticas
   - Descrição: Código modular e estruturado para herança.  
   - Métrica/Meta: Cobertura ≥ 90 %  
 
+
+- **RNF‑03**: Todos os modelos deste app devem herdar de `TimeStampedModel` para timestamps automáticos (`created` e `modified`), garantindo consistência e evitando campos manuais.
+- **RNF‑04**: Quando houver necessidade de exclusão lógica, os modelos devem implementar `SoftDeleteModel` (ou mixin equivalente), evitando remoções físicas e padronizando os campos `deleted` e `deleted_at`.
+
 ## 5. Fluxo de Usuário / Caso de Uso
 ```mermaid
 flowchart TD
@@ -78,6 +82,7 @@ flowchart TD
   - **convidado**: sem acesso.
 
 ## 7. Modelo de Dados
+*Nota:* Todos os modelos herdam de `TimeStampedModel` (campos `created` e `modified`) e utilizam `SoftDeleteModel` para exclusão lógica quando necessário. Assim, campos de timestamp e exclusão lógica não são listados individualmente.
 Reaproveita modelos existentes:  
 - Usuário (`User`),  
 - Organização (`Organization`),  
@@ -109,5 +114,5 @@ Feature: Acesso ao Dashboard
 - **RF‑07** – Permitir que usuários salvem e compartilhem filtros e configurações de dashboards.  
 
 ### Requisitos Não‑Funcionais Adicionais
-- **RNF‑03** – As consultas de métricas devem ser cacheadas com invalidação automática a cada 5 minutos.  
-- **RNF‑04** – O componente de visualização deve seguir princípios de acessibilidade (WCAG 2.1).  
+- **RNF‑05** – As consultas de métricas devem ser cacheadas com invalidação automática a cada 5 minutos.  
+- **RNF‑06** – O componente de visualização deve seguir princípios de acessibilidade (WCAG 2.1).  

--- a/.requisitos/discussao/REQ-DISCUSSAO-001.md
+++ b/.requisitos/discussao/REQ-DISCUSSAO-001.md
@@ -71,6 +71,10 @@ O App Discussão fornece um fórum colaborativo organizado por categorias, permi
   - Descrição: As ações de criação, edição e exclusão devem validar permissões.
   - Métrica/Meta: 0 acessos indevidos em testes de penetração.
 
+
+- **RNF‑04**: Todos os modelos deste app devem herdar de `TimeStampedModel` para timestamps automáticos (`created` e `modified`), garantindo consistência e evitando campos manuais.
+- **RNF‑05**: Quando houver necessidade de exclusão lógica, os modelos devem implementar `SoftDeleteModel` (ou mixin equivalente), evitando remoções físicas e padronizando os campos `deleted` e `deleted_at`.
+
 ## 5. Casos de Uso
 
 ### UC‑01 – Gerenciar Categorias
@@ -103,6 +107,7 @@ O App Discussão fornece um fórum colaborativo organizado por categorias, permi
 - Respostas devem herdar contexto organizacional do tópico.
 
 ## 7. Modelo de Dados
+*Nota:* Todos os modelos herdam de `TimeStampedModel` (campos `created` e `modified`) e utilizam `SoftDeleteModel` para exclusão lógica quando necessário. Assim, campos de timestamp e exclusão lógica não são listados individualmente.
 
 - **Categoria**  
   - id: UUID  
@@ -116,7 +121,6 @@ O App Discussão fornece um fórum colaborativo organizado por categorias, permi
   - autor: FK → User.id  
   - titulo: string  
   - conteudo: text  
-  - created_at, updated_at: datetime  
   - resolved: boolean  
 
 - **Resposta**  
@@ -124,7 +128,6 @@ O App Discussão fornece um fórum colaborativo organizado por categorias, permi
   - topico: FK → Topico.id  
   - autor: FK → User.id  
   - conteudo: text  
-  - created_at: datetime  
 
 - **Voto**  
   - id: UUID  
@@ -132,7 +135,6 @@ O App Discussão fornece um fórum colaborativo organizado por categorias, permi
   - item_id: UUID  
   - user: FK → User.id  
   - vote: integer (1 ou -1)  
-  - created_at: datetime  
 
 ## 8. Critérios de Aceite (Gherkin)
 ```gherkin
@@ -167,12 +169,12 @@ Feature: Fórum de Discussão
 - **RF‑09** – Permitir fechar e reabrir tópicos para novas respostas.  
 
 ### Requisitos Não‑Funcionais Adicionais
-- **RNF‑04** – Prover campo “motivo de edição” para rastrear alterações.  
+- **RNF‑06** – Prover campo “motivo de edição” para rastrear alterações.  
 
 ### Modelo de Dados Adicional
 - `Topico`: adicionar `melhor_resposta: FK → Resposta.id (opcional)` e `tags: M2M → Tag`.  
 - `Resposta`: adicionar `editado_em: datetime`, `motivo_edicao: text`.  
-- Nova entidade `Tag`: `id`, `nome`, `created_at`.  
+- Nova entidade `Tag`: `id`, `nome`, ``.  
 
 ### Regras de Negócio Adicionais
 - Apenas o autor ou admin pode marcar “melhor resposta”.  

--- a/.requisitos/empresas/REQ-EMPRESAS-001.md
+++ b/.requisitos/empresas/REQ-EMPRESAS-001.md
@@ -69,6 +69,10 @@ O App Empresas gerencia o cadastro, consulta, atualização e remoção de empre
   - Descrição: Código modular e documentado para fácil extensão.
   - Métrica/Meta: Cobertura de testes ≥ 90 %.
 
+
+- **RNF‑04**: Todos os modelos deste app devem herdar de `TimeStampedModel` para timestamps automáticos (`created` e `modified`), garantindo consistência e evitando campos manuais.
+- **RNF‑05**: Quando houver necessidade de exclusão lógica, os modelos devem implementar `SoftDeleteModel` (ou mixin equivalente), evitando remoções físicas e padronizando os campos `deleted` e `deleted_at`.
+
 ## 5. Casos de Uso
 
 ### UC‑01 – Listar Empresas
@@ -100,6 +104,7 @@ O App Empresas gerencia o cadastro, consulta, atualização e remoção de empre
 - Apenas usuário responsável ou admin pode editar/excluir.
 
 ## 7. Modelo de Dados
+*Nota:* Todos os modelos herdam de `TimeStampedModel` (campos `created` e `modified`) e utilizam `SoftDeleteModel` para exclusão lógica quando necessário. Assim, campos de timestamp e exclusão lógica não são listados individualmente.
 
 - **Empresa**  
   - id: UUID  
@@ -114,13 +119,11 @@ O App Empresas gerencia o cadastro, consulta, atualização e remoção de empre
   - descricao: TextField (opcional)  
   - palavras_chave: CharField  
   - tags: M2M → Tag  
-  - created_at, updated_at: datetime  
 
 - **Tag**  
   - id: UUID  
   - nome: string (unique)  
   - categoria: enum('prod','serv')  
-  - created_at, updated_at: datetime  
 
 ## 8. Critérios de Aceite (Gherkin)
 ```gherkin
@@ -153,11 +156,11 @@ Feature: Gestão de Empresas
 - **RF‑07** – Permitir avaliações e comentários sobre empresas (1–5 estrelas) para feedback.  
 
 ### Requisitos Não‑Funcionais Adicionais
-- **RNF‑04** – O histórico deve estar disponível para consulta por admins e atender requisitos de LGPD.  
+- **RNF‑06** – O histórico deve estar disponível para consulta por admins e atender requisitos de LGPD.  
 
 ### Modelo de Dados Adicional
 - Nova entidade `EmpresaChangeLog` com campos: id, empresa_id, usuario_id, campo_alterado, valor_antigo, valor_novo, alterado_em.  
-- Nova entidade `AvaliacaoEmpresa` com campos: id, empresa_id, usuario_id, nota (1–5), comentario, created_at.  
+- Nova entidade `AvaliacaoEmpresa` com campos: id, empresa_id, usuario_id, nota (1–5), comentario.  
 
 ### Regras de Negócio Adicionais
 - Somente usuários autenticados podem avaliar empresas; um único usuário avalia uma empresa uma vez.  

--- a/.requisitos/feed/REQ-FEED-001.md
+++ b/.requisitos/feed/REQ-FEED-001.md
@@ -73,6 +73,10 @@ O App Feed permite exibir e gerenciar publicações de texto e mídia, organizad
   - Descrição: Controle de acesso baseado em escopo e permissões  
   - Métrica/Meta: 0 acessos indevidos em testes de penetração  
 
+
+- **RNF‑04**: Todos os modelos deste app devem herdar de `TimeStampedModel` para timestamps automáticos (`created` e `modified`), garantindo consistência e evitando campos manuais.
+- **RNF‑05**: Quando houver necessidade de exclusão lógica, os modelos devem implementar `SoftDeleteModel` (ou mixin equivalente), evitando remoções físicas e padronizando os campos `deleted` e `deleted_at`.
+
 ## 5. Casos de Uso
 
 ### UC‑01 – Listar Feed
@@ -105,6 +109,7 @@ O App Feed permite exibir e gerenciar publicações de texto e mídia, organizad
 - Posts marcados como `deleted` não aparecem no feed.
 
 ## 7. Modelo de Dados
+*Nota:* Todos os modelos herdam de `TimeStampedModel` (campos `created` e `modified`) e utilizam `SoftDeleteModel` para exclusão lógica quando necessário. Assim, campos de timestamp e exclusão lógica não são listados individualmente.
 
 - **Post**  
   - id: UUID  
@@ -116,8 +121,6 @@ O App Feed permite exibir e gerenciar publicações de texto e mídia, organizad
   - conteudo: TextField  
   - image: ImageField (S3)  
   - pdf: FileField (S3)  
-  - created_at, updated_at: datetime  
-  - deleted: boolean  
 
 ## 8. Critérios de Aceite (Gherkin)
 ```gherkin
@@ -155,7 +158,7 @@ Feature: Feed de Publicações
 
 ### Modelo de Dados Adicional
 - `Post`: adicionar `video: FileField` (opcional) e `tags: M2M → Tag`.  
-- Nova entidade `Tag` com campos: id, nome (único), created_at.  
+- Nova entidade `Tag` com campos: id, nome (único).  
 - Nova entidade `ModeracaoPost` com campos: id, post_id, status (`pendente`,`aprovado`,`rejeitado`), motivo, avaliado_por, avaliado_em.  
 
 ### Regras de Negócio Adicionais

--- a/.requisitos/financeiro/REQ-FINANCEIRO-001.md
+++ b/.requisitos/financeiro/REQ-FINANCEIRO-001.md
@@ -79,6 +79,10 @@ O módulo Financeiro do Hubx centraliza a gestão de receitas e despesas de núc
   - **Descrição**: Interfaces de dashboards devem ser responsivas e acessíveis (seguir padrões WCAG 2.1 nível AA).
   - **Métrica/Meta**: Aderência a auditoria de acessibilidade.
 
+
+- **RNF‑05**: Todos os modelos deste app devem herdar de `TimeStampedModel` para timestamps automáticos (`created` e `modified`), garantindo consistência e evitando campos manuais.
+- **RNF‑06**: Quando houver necessidade de exclusão lógica, os modelos devem implementar `SoftDeleteModel` (ou mixin equivalente), evitando remoções físicas e padronizando os campos `deleted` e `deleted_at`.
+
 ## 5. Casos de Uso
 
 ### UC‑01 – Importar Pagamentos
@@ -111,6 +115,7 @@ O módulo Financeiro do Hubx centraliza a gestão de receitas e despesas de núc
 - Lançamentos financeiros não podem ser excluídos; correções devem ser registradas como ajustes.
 
 ## 7. Modelo de Dados
+*Nota:* Todos os modelos herdam de `TimeStampedModel` (campos `created` e `modified`) e utilizam `SoftDeleteModel` para exclusão lógica quando necessário. Assim, campos de timestamp e exclusão lógica não são listados individualmente.
 
 - **CentroCusto**
   - id: UUID
@@ -120,13 +125,11 @@ O módulo Financeiro do Hubx centraliza a gestão de receitas e despesas de núc
   - nucleo: FK → Nucleo.id (opcional)
   - evento: FK → Evento.id (opcional)
   - saldo: decimal
-  - created_at, updated_at: datetime
 
 - **ContaAssociado**
   - id: UUID
   - user: FK → User.id
   - saldo: decimal
-  - created_at, updated_at: datetime
 
 - **LancamentoFinanceiro**
   - id: UUID

--- a/.requisitos/notificacoes/REQ-NOTIFICACOES-001.md
+++ b/.requisitos/notificacoes/REQ-NOTIFICACOES-001.md
@@ -98,6 +98,10 @@ Este documento descreve um novo app de notificações que padroniza templates, p
   - **Descrição**: Os logs devem permitir rastrear quem enviou, quando e por qual canal, atendendo requisitos da LGPD.
   - **Métrica/Meta**: Logs acessíveis por 5 anos.
 
+
+- **RNF‑07**: Todos os modelos deste app devem herdar de `TimeStampedModel` para timestamps automáticos (`created` e `modified`), garantindo consistência e evitando campos manuais.
+- **RNF‑08**: Quando houver necessidade de exclusão lógica, os modelos devem implementar `SoftDeleteModel` (ou mixin equivalente), evitando remoções físicas e padronizando os campos `deleted` e `deleted_at`.
+
 ## 5. Casos de Uso
 
 ### UC‑01 – Enviar Notificação Individual
@@ -136,6 +140,7 @@ Este documento descreve um novo app de notificações que padroniza templates, p
 - Os registros de preferências e logs devem manter **integridade referencial** com o modelo de usuário (`settings.AUTH_USER_MODEL`); a exclusão de usuários deve ser protegida.
 
 ## 7. Modelo de Dados
+*Nota:* Todos os modelos herdam de `TimeStampedModel` (campos `created` e `modified`) e utilizam `SoftDeleteModel` para exclusão lógica quando necessário. Assim, campos de timestamp e exclusão lógica não são listados individualmente.
 
 - **NotificationTemplate**
   - `id`: UUID.
@@ -144,7 +149,7 @@ Este documento descreve um novo app de notificações que padroniza templates, p
   - `corpo`: texto com placeholders.
   - `canal`: enum ('email','push','whatsapp','todos').
   - `ativo`: boolean.
-  - `created_at`, `updated_at`: datetime.
+  - ``, ``: datetime.
 
 - **UserNotificationPreference**
   - `id`: UUID.
@@ -152,7 +157,7 @@ Este documento descreve um novo app de notificações que padroniza templates, p
   - `email`: boolean.
   - `push`: boolean.
   - `whatsapp`: boolean.
-  - `created_at`, `updated_at`: datetime.
+  - ``, ``: datetime.
 
 - **NotificationLog**
   - `id`: UUID.
@@ -162,7 +167,7 @@ Este documento descreve um novo app de notificações que padroniza templates, p
   - `status`: enum ('ENVIADA','FALHA').
   - `data_envio`: datetime.
   - `erro`: texto (opcional).
-  - `created_at`, `updated_at`: datetime.
+  - ``, ``: datetime.
 
 ## 8. Critérios de Aceite (Gherkin)
 

--- a/.requisitos/nucleos/REQ-NUCLEOS-001.md
+++ b/.requisitos/nucleos/REQ-NUCLEOS-001.md
@@ -73,6 +73,10 @@ O App Núcleos gerencia a criação, edição, visualização e associação de 
   - Descrição: Código modular e testável seguindo DDD e Clean Architecture.
   - Métrica/Meta: Cobertura de testes ≥ 90 %.
 
+
+- **RNF‑04**: Todos os modelos deste app devem herdar de `TimeStampedModel` para timestamps automáticos (`created` e `modified`), garantindo consistência e evitando campos manuais.
+- **RNF‑05**: Quando houver necessidade de exclusão lógica, os modelos devem implementar `SoftDeleteModel` (ou mixin equivalente), evitando remoções físicas e padronizando os campos `deleted` e `deleted_at`.
+
 ## 5. Casos de Uso
 
 ### UC‑01 – Criar Núcleo
@@ -103,6 +107,7 @@ O App Núcleos gerencia a criação, edição, visualização e associação de 
 - Soft delete preserva histórico de associações.
 
 ## 7. Modelo de Dados
+*Nota:* Todos os modelos herdam de `TimeStampedModel` (campos `created` e `modified`) e utilizam `SoftDeleteModel` para exclusão lógica quando necessário. Assim, campos de timestamp e exclusão lógica não são listados individualmente.
 
 - **Núcleo**  
   - id: UUID  
@@ -111,7 +116,6 @@ O App Núcleos gerencia a criação, edição, visualização e associação de 
   - avatar: ImageField (S3)  
   - cover: ImageField (S3)  
   - organizacao: FK → Organizacao.id  
-  - created_at, updated_at: datetime  
 
 - **ParticipacaoNucleo**  
   - id: UUID  

--- a/.requisitos/organizacoes/REQ-ORGANIZACOES-001.md
+++ b/.requisitos/organizacoes/REQ-ORGANIZACOES-001.md
@@ -68,6 +68,10 @@ O App Organizações gerencia o ciclo de vida de entidades organizacionais no Hu
   - Descrição: Código testável e modular, seguindo DDD.
   - Métrica/Meta: Cobertura de testes ≥ 90 %.
 
+
+- **RNF‑04**: Todos os modelos deste app devem herdar de `TimeStampedModel` para timestamps automáticos (`created` e `modified`), garantindo consistência e evitando campos manuais.
+- **RNF‑05**: Quando houver necessidade de exclusão lógica, os modelos devem implementar `SoftDeleteModel` (ou mixin equivalente), evitando remoções físicas e padronizando os campos `deleted` e `deleted_at`.
+
 ## 5. Casos de Uso
 
 ### UC‑01 – Listar Organizações
@@ -99,6 +103,7 @@ O App Organizações gerencia o ciclo de vida de entidades organizacionais no Hu
 - Organizações marcadas como `deleted` não aparecem em buscas.
 
 ## 7. Modelo de Dados
+*Nota:* Todos os modelos herdam de `TimeStampedModel` (campos `created` e `modified`) e utilizam `SoftDeleteModel` para exclusão lógica quando necessário. Assim, campos de timestamp e exclusão lógica não são listados individualmente.
 
 - **Organizacao**  
   - id: UUID  
@@ -107,8 +112,6 @@ O App Organizações gerencia o ciclo de vida de entidades organizacionais no Hu
   - descricao: text (opcional)  
   - avatar: ImageField (S3, opcional)  
   - cover: ImageField (S3, opcional)  
-  - created_at, updated_at: datetime  
-  - deleted: boolean (default false)
 
 - **Relacionamentos**  
   - organizacao é ForeignKey em: User, Nucleo, Evento, Empresa, Post, CategoriaForum, TopicoForum, etc.
@@ -145,8 +148,8 @@ Feature: Gestão de Organizações
 - **RF‑08** – Manter histórico de alterações com controle de versões.  
 
 ### Requisitos Não‑Funcionais Adicionais
-- **RNF‑04** – Logs de alterações devem ser imutáveis e acessíveis apenas por usuários root.  
+- **RNF‑06** – Logs de alterações devem ser imutáveis e acessíveis apenas por usuários root.  
 
 ### Modelo de Dados Adicional
 - `Organizacao`: adicionar `inativa: boolean` e `inativada_em: datetime`.  
-- Nova entidade `OrganizacaoLog` com campos: id, organizacao_id, usuario_id, acao, dados_antigos, dados_novos, created_at.  
+- Nova entidade `OrganizacaoLog` com campos: id, organizacao_id, usuario_id, acao, dados_antigos, dados_novos.  

--- a/.requisitos/tokens/REQ-TOKENS-001.md
+++ b/.requisitos/tokens/REQ-TOKENS-001.md
@@ -68,6 +68,10 @@ O App Tokens gerencia a criação, validação e expiração de tokens de acesso
   - Descrição: Log de uso de tokens para auditoria.
   - Métrica/Meta: 100% dos eventos registrados.
 
+
+- **RNF‑04**: Todos os modelos deste app devem herdar de `TimeStampedModel` para timestamps automáticos (`created` e `modified`), garantindo consistência e evitando campos manuais.
+- **RNF‑05**: Quando houver necessidade de exclusão lógica, os modelos devem implementar `SoftDeleteModel` (ou mixin equivalente), evitando remoções físicas e padronizando os campos `deleted` e `deleted_at`.
+
 ## 5. Casos de Uso
 
 ### UC‑01 – Gerar Token
@@ -96,6 +100,7 @@ O App Tokens gerencia a criação, validação e expiração de tokens de acesso
 - Perfis sem permissão para geração devem receber erro 403.
 
 ## 7. Modelo de Dados
+*Nota:* Todos os modelos herdam de `TimeStampedModel` (campos `created` e `modified`) e utilizam `SoftDeleteModel` para exclusão lógica quando necessário. Assim, campos de timestamp e exclusão lógica não são listados individualmente.
 
 - **TokenAcesso**  
   - codigo: string (PK, unique, não editável)  
@@ -106,7 +111,6 @@ O App Tokens gerencia a criação, validação e expiração de tokens de acesso
   - usuario: FK → User.id (opcional)  
   - organizacao: FK → Organizacao.id  
   - nucleos: M2M → Nucleo.id (opcional)  
-  - created_at, updated_at: datetime  
 
 ## 8. Critérios de Aceite (Gherkin)
 ```gherkin
@@ -140,7 +144,7 @@ Feature: Gerenciamento de Tokens
 - **RF‑08** – Permitir revogação manual de tokens, alterando estado para `revogado`.  
 
 ### Requisitos Não‑Funcionais Adicionais
-- **RNF‑04** – Logs de uso e revogação devem ser criptografados e retidos por 1 ano para auditoria.  
+- **RNF‑06** – Logs de uso e revogação devem ser criptografados e retidos por 1 ano para auditoria.  
 
 ### Modelo de Dados Adicional
 - `TokenAcesso`: adicionar `ip_gerado: string`, `ip_utilizado: string`, `revogado_em: datetime`, `revogado_por: FK → User.id`.  


### PR DESCRIPTION
## Resumo
- exige TimeStampedModel e SoftDeleteModel em todos os modelos
- remove campos manuais de timestamp/exclusão nas modelagens

## Testes
- `npx markdownlint-cli '.requisitos/**/*.md'` *(aponta avisos de formatação já existentes)*

------
https://chatgpt.com/codex/tasks/task_e_689105aa15948325baa57d7dcc9a1131