### PR TITLE
Refatora configuracoes de conta

### DIFF
--- a/configuracoes/README.md
+++ b/configuracoes/README.md
@@ -13,6 +13,7 @@ automaticamente após o cadastro. O modelo herda de
 - `receber_notificacoes_whatsapp` e `frequencia_notificacoes_whatsapp`
 - `idioma`
 - `tema`
+- `hora_notificacao_diaria`, `hora_notificacao_semanal` e `dia_semana_notificacao`
 
 ## Atualização via serviço
 
@@ -34,3 +35,28 @@ As preferências são expostas na interface na aba **Preferências** dentro de
 `/configuracoes/` e também pela API em `configuracoes/api/`.
 Para consultar registros removidos logicamente utilize o manager
 `ConfiguracaoConta.all_objects`.
+
+### API
+
+```
+GET /configuracoes/api/
+```
+
+Resposta:
+
+```json
+{
+  "receber_notificacoes_email": true,
+  "frequencia_notificacoes_email": "imediata",
+  "receber_notificacoes_whatsapp": false,
+  "frequencia_notificacoes_whatsapp": "diaria",
+  "idioma": "pt-BR",
+  "tema": "claro",
+  "hora_notificacao_diaria": "08:00:00",
+  "hora_notificacao_semanal": "08:00:00",
+  "dia_semana_notificacao": 0
+}
+```
+
+Use `PATCH /configuracoes/api/` para atualizar campos específicos. Consulte a
+documentação OpenAPI gerada para exemplos completos.

--- a/configuracoes/api.py
+++ b/configuracoes/api.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import time
+
+from drf_spectacular.utils import OpenApiExample, extend_schema
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from . import metrics
 from .models import ConfiguracaoConta
 from .serializers import ConfiguracaoContaSerializer
 from .services import get_configuracao_conta
@@ -15,20 +19,70 @@ class ConfiguracaoContaAPIView(APIView):
     def get_object(self) -> ConfiguracaoConta:
         return get_configuracao_conta(self.request.user)
 
+    @extend_schema(
+        responses=ConfiguracaoContaSerializer,
+        examples=[
+            OpenApiExample(
+                "Exemplo",
+                value={
+                    "receber_notificacoes_email": True,
+                    "frequencia_notificacoes_email": "imediata",
+                    "receber_notificacoes_whatsapp": False,
+                    "frequencia_notificacoes_whatsapp": "diaria",
+                    "idioma": "pt-BR",
+                    "tema": "claro",
+                    "hora_notificacao_diaria": "08:00:00",
+                    "hora_notificacao_semanal": "08:00:00",
+                    "dia_semana_notificacao": 0,
+                },
+            )
+        ],
+    )
     def get(self, request):
+        start = time.monotonic()
         serializer = ConfiguracaoContaSerializer(self.get_object())
-        return Response(serializer.data)
+        resp = Response(serializer.data)
+        metrics.config_api_latency_seconds.labels(method="GET").observe(time.monotonic() - start)
+        return resp
 
+    @extend_schema(
+        request=ConfiguracaoContaSerializer,
+        responses=ConfiguracaoContaSerializer,
+        examples=[
+            OpenApiExample(
+                "Atualização completa",
+                request_only=True,
+                value={"tema": "escuro", "idioma": "en-US"},
+            )
+        ],
+    )
     def put(self, request):
+        start = time.monotonic()
         obj = self.get_object()
         serializer = ConfiguracaoContaSerializer(obj, data=request.data)
         serializer.is_valid(raise_exception=True)
         serializer.save()
-        return Response(serializer.data)
+        resp = Response(serializer.data)
+        metrics.config_api_latency_seconds.labels(method="PUT").observe(time.monotonic() - start)
+        return resp
 
+    @extend_schema(
+        request=ConfiguracaoContaSerializer,
+        responses=ConfiguracaoContaSerializer,
+        examples=[
+            OpenApiExample(
+                "Atualização parcial",
+                request_only=True,
+                value={"receber_notificacoes_email": False},
+            )
+        ],
+    )
     def patch(self, request):
+        start = time.monotonic()
         obj = self.get_object()
         serializer = ConfiguracaoContaSerializer(obj, data=request.data, partial=True)
         serializer.is_valid(raise_exception=True)
         serializer.save()
-        return Response(serializer.data)
+        resp = Response(serializer.data)
+        metrics.config_api_latency_seconds.labels(method="PATCH").observe(time.monotonic() - start)
+        return resp

--- a/configuracoes/forms.py
+++ b/configuracoes/forms.py
@@ -18,6 +18,9 @@ class ConfiguracaoContaForm(forms.ModelForm):
             "frequencia_notificacoes_whatsapp",
             "idioma",
             "tema",
+            "hora_notificacao_diaria",
+            "hora_notificacao_semanal",
+            "dia_semana_notificacao",
         )
         widgets = {
             "receber_notificacoes_email": forms.CheckboxInput(),
@@ -26,10 +29,16 @@ class ConfiguracaoContaForm(forms.ModelForm):
             "frequencia_notificacoes_whatsapp": forms.Select(),
             "idioma": forms.Select(),
             "tema": forms.Select(),
+            "hora_notificacao_diaria": forms.TimeInput(format="%H:%M"),
+            "hora_notificacao_semanal": forms.TimeInput(format="%H:%M"),
+            "dia_semana_notificacao": forms.Select(),
         }
         help_texts = {
             "frequencia_notificacoes_email": _("Aplicável apenas se notificações por e-mail estiverem ativas."),
             "frequencia_notificacoes_whatsapp": _("Aplicável apenas se notificações por WhatsApp estiverem ativas."),
+            "hora_notificacao_diaria": _("Horário para envio das notificações diárias."),
+            "hora_notificacao_semanal": _("Horário para envio das notificações semanais."),
+            "dia_semana_notificacao": _("Dia da semana para notificações semanais."),
         }
 
     def clean(self) -> dict[str, object]:

--- a/configuracoes/metrics.py
+++ b/configuracoes/metrics.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from prometheus_client import Counter, Summary  # type: ignore
+
+config_cache_hits_total = Counter(
+    "configuracao_conta_cache_hits_total", "Total de hits de cache para configurações de conta"
+)
+config_cache_misses_total = Counter(
+    "configuracao_conta_cache_misses_total", "Total de misses de cache para configurações de conta"
+)
+config_get_latency_seconds = Summary(
+    "configuracao_conta_get_latency_seconds", "Latência para obter configuração de conta"
+)
+config_api_latency_seconds = Summary(
+    "configuracao_conta_api_latency_seconds", "Latência das requisições da API de ConfiguracaoConta", ["method"]
+)

--- a/configuracoes/migrations/0006_remove_tema_escuro_add_schedule.py
+++ b/configuracoes/migrations/0006_remove_tema_escuro_add_schedule.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from datetime import time
+
+from django.db import migrations, models
+
+
+def migrate_tema(apps, schema_editor):
+    Config = apps.get_model('configuracoes', 'ConfiguracaoConta')
+    for config in Config.objects.all():
+        if getattr(config, 'tema_escuro', False):
+            config.tema = 'escuro'
+            config.save(update_fields=['tema'])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('configuracoes', '0005_configuracaoconta_deleted_and_more'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='configuracaoconta',
+            name='hora_notificacao_diaria',
+            field=models.TimeField(default=time(8, 0), help_text='Horário para envio de notificações diárias'),
+        ),
+        migrations.AddField(
+            model_name='configuracaoconta',
+            name='hora_notificacao_semanal',
+            field=models.TimeField(default=time(8, 0), help_text='Horário para envio de notificações semanais'),
+        ),
+        migrations.AddField(
+            model_name='configuracaoconta',
+            name='dia_semana_notificacao',
+            field=models.PositiveSmallIntegerField(default=0, help_text='Dia da semana para notificações semanais'),
+        ),
+        migrations.RunPython(migrate_tema),
+        migrations.RemoveField(
+            model_name='configuracaoconta',
+            name='tema_escuro',
+        ),
+    ]

--- a/configuracoes/models.py
+++ b/configuracoes/models.py
@@ -1,5 +1,8 @@
+from datetime import time
+
 from django.conf import settings
 from django.db import models
+from django.utils.translation import gettext_lazy as _
 from django_extensions.db.models import TimeStampedModel
 
 from core.models import SoftDeleteManager, SoftDeleteModel
@@ -20,6 +23,16 @@ TEMA_CHOICES = [
     ("claro", "Claro"),
     ("escuro", "Escuro"),
     ("automatico", "Automático"),
+]
+
+DIAS_SEMANA_CHOICES = [
+    (0, _("Segunda")),
+    (1, _("Terça")),
+    (2, _("Quarta")),
+    (3, _("Quinta")),
+    (4, _("Sexta")),
+    (5, _("Sábado")),
+    (6, _("Domingo")),
 ]
 
 
@@ -43,7 +56,19 @@ class ConfiguracaoConta(TimeStampedModel, SoftDeleteModel):
     )
     idioma = models.CharField(max_length=5, choices=IDIOMA_CHOICES, default="pt-BR")
     tema = models.CharField(max_length=10, choices=TEMA_CHOICES, default="claro")
-    tema_escuro = models.BooleanField(default=False, help_text="Obsoleto; use 'tema'")
+    hora_notificacao_diaria = models.TimeField(
+        default=time(8, 0),
+        help_text=_("Horário para envio de notificações diárias"),
+    )
+    hora_notificacao_semanal = models.TimeField(
+        default=time(8, 0),
+        help_text=_("Horário para envio de notificações semanais"),
+    )
+    dia_semana_notificacao = models.PositiveSmallIntegerField(
+        choices=DIAS_SEMANA_CHOICES,
+        default=0,
+        help_text=_("Dia da semana para notificações semanais"),
+    )
 
     objects = SoftDeleteManager()
     all_objects = models.Manager()

--- a/configuracoes/serializers.py
+++ b/configuracoes/serializers.py
@@ -15,4 +15,7 @@ class ConfiguracaoContaSerializer(serializers.ModelSerializer):
             "frequencia_notificacoes_whatsapp",
             "idioma",
             "tema",
+            "hora_notificacao_diaria",
+            "hora_notificacao_semanal",
+            "dia_semana_notificacao",
         ]

--- a/configuracoes/services.py
+++ b/configuracoes/services.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import time
 from typing import Any
 
+import sentry_sdk
 from django.core.cache import cache
 
 from accounts.models import User
 
+from . import metrics
 from .models import ConfiguracaoConta
 
 CACHE_KEY = "configuracao_conta:{id}"
@@ -13,15 +16,26 @@ CACHE_KEY = "configuracao_conta:{id}"
 
 def get_configuracao_conta(usuario: User) -> ConfiguracaoConta:
     """Obtém configurações do cache ou do banco com chave única por usuário."""
+    start = time.monotonic()
     key = CACHE_KEY.format(id=usuario.id)
     config = cache.get(key)
     if config is None:
-        config, _ = ConfiguracaoConta.all_objects.get_or_create(user_id=usuario.id, defaults={"user": usuario})
-        if config.deleted:
-            config.deleted = False
-            config.deleted_at = None
-            config.save(update_fields=["deleted", "deleted_at"])
-        cache.set(key, config)
+        metrics.config_cache_misses_total.inc()
+        try:
+            config, _ = ConfiguracaoConta.all_objects.get_or_create(
+                user_id=usuario.id, defaults={"user": usuario}
+            )
+            if config.deleted:
+                config.deleted = False
+                config.deleted_at = None
+                config.save(update_fields=["deleted", "deleted_at"])
+            cache.set(key, config)
+        except Exception as exc:  # pragma: no cover - falha de infraestrutura
+            sentry_sdk.capture_exception(exc)
+            raise
+    else:
+        metrics.config_cache_hits_total.inc()
+    metrics.config_get_latency_seconds.observe(time.monotonic() - start)
     return config
 
 

--- a/configuracoes/tasks.py
+++ b/configuracoes/tasks.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 import logging
+import os
 from datetime import timedelta
 
+import sentry_sdk
 from celery import shared_task
 from django.db import models
 from django.utils import timezone
+from twilio.base.exceptions import TwilioRestException  # type: ignore
+from twilio.rest import Client  # type: ignore
 
 from agenda.models import Evento
 from chat.models import ChatNotification
@@ -19,7 +23,8 @@ logger = logging.getLogger(__name__)
 
 def _send_for_frequency(frequency: str) -> None:
     delta = timedelta(days=1 if frequency == "diaria" else 7)
-    since = timezone.now() - delta
+    now = timezone.localtime()
+    since = now - delta
     configs = ConfiguracaoConta.objects.select_related("user").filter(
         (
             models.Q(frequencia_notificacoes_email=frequency, receber_notificacoes_email=True)
@@ -29,6 +34,17 @@ def _send_for_frequency(frequency: str) -> None:
             )
         )
     )
+    if frequency == "diaria":
+        configs = configs.filter(
+            hora_notificacao_diaria__hour=now.hour,
+            hora_notificacao_diaria__minute=now.minute,
+        )
+    else:
+        configs = configs.filter(
+            dia_semana_notificacao=now.weekday(),
+            hora_notificacao_semanal__hour=now.hour,
+            hora_notificacao_semanal__minute=now.minute,
+        )
     for config in configs:
         counts = {
             "chat": ChatNotification.objects.filter(usuario=config.user, created__gte=since, lido=False).count(),
@@ -44,8 +60,19 @@ def _send_for_frequency(frequency: str) -> None:
 
 
 def enviar_notificacao_whatsapp(user, contexto):
-    """Stub para envio via WhatsApp."""
-    logger.info("WhatsApp não implementado para %s: %s", user, contexto)
+    message = (
+        "Resumo: chat={chat}, feed={feed}, eventos={eventos}".format(**contexto)
+    )
+    try:
+        client = Client(os.environ.get("TWILIO_ACCOUNT_SID"), os.environ.get("TWILIO_AUTH_TOKEN"))
+        client.messages.create(
+            body=message,
+            from_=os.environ.get("TWILIO_WHATSAPP_FROM"),
+            to=f"whatsapp:{user.whatsapp}",
+        )
+    except TwilioRestException as exc:  # pragma: no cover - falha externa
+        sentry_sdk.capture_exception(exc)
+        logger.exception("Falha ao enviar WhatsApp", extra={"user": user.id})
 
 
 @shared_task

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,4 @@ pre-commit>=3.6
 pytest-benchmark>=4.0
 prometheus-client==0.20.0
 bleach==6.2.0
+twilio==9.2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -118,6 +118,7 @@ types-requests==2.32.4.20250611
 typing_extensions==4.14.0
 tzdata==2025.2
 uritemplate==4.2.0
+twilio==9.2.3
 urllib3==2.5.0
 uvicorn==0.35.0
 validate_docbr==1.11.1

--- a/tests/configuracoes/test_forms.py
+++ b/tests/configuracoes/test_forms.py
@@ -16,6 +16,9 @@ def test_form_fields():
         "frequencia_notificacoes_whatsapp",
         "idioma",
         "tema",
+        "hora_notificacao_diaria",
+        "hora_notificacao_semanal",
+        "dia_semana_notificacao",
     ]
 
 
@@ -28,6 +31,9 @@ def test_form_valid_data(admin_user):
         "frequencia_notificacoes_whatsapp": "semanal",
         "idioma": "en-US",
         "tema": "escuro",
+        "hora_notificacao_diaria": "08:00",
+        "hora_notificacao_semanal": "09:00",
+        "dia_semana_notificacao": 1,
     }
     form = ConfiguracaoContaForm(data=data, instance=config)
     assert form.is_valid()
@@ -50,6 +56,9 @@ def test_form_boolean_coercion(admin_user):
         "frequencia_notificacoes_whatsapp": "imediata",
         "idioma": "pt-BR",
         "tema": "claro",
+        "hora_notificacao_diaria": "08:00",
+        "hora_notificacao_semanal": "08:00",
+        "dia_semana_notificacao": 0,
     }
     form = ConfiguracaoContaForm(data=data, instance=config)
     assert form.is_valid()

--- a/tests/configuracoes/test_models.py
+++ b/tests/configuracoes/test_models.py
@@ -23,6 +23,10 @@ def test_configuracao_valores_padrao(admin_user):
     assert config.frequencia_notificacoes_whatsapp == "imediata"
     assert config.idioma == "pt-BR"
     assert config.tema == "claro"
+    assert config.hora_notificacao_diaria.strftime("%H:%M") == "08:00"
+    assert config.hora_notificacao_semanal.strftime("%H:%M") == "08:00"
+    assert config.dia_semana_notificacao == 0
+    assert not hasattr(config, "tema_escuro")
 
 
 def test_configuracao_unica_por_usuario(admin_user):

--- a/tests/configuracoes/test_services.py
+++ b/tests/configuracoes/test_services.py
@@ -1,6 +1,7 @@
 import pytest
 from django.core.cache import cache
 
+from configuracoes import metrics
 from configuracoes.services import atualizar_preferencias_usuario, get_configuracao_conta
 
 pytestmark = pytest.mark.django_db
@@ -21,3 +22,13 @@ def test_get_configuracao_conta_recupera_soft_deleted(admin_user):
     recuperado = get_configuracao_conta(admin_user)
     assert recuperado.pk == config.pk
     assert recuperado.deleted is False
+
+
+def test_metrics_cache(admin_user):
+    cache.clear()
+    metrics.config_cache_hits_total._value.set(0)  # reset
+    metrics.config_cache_misses_total._value.set(0)
+    get_configuracao_conta(admin_user)
+    assert metrics.config_cache_misses_total._value.get() == 1
+    get_configuracao_conta(admin_user)
+    assert metrics.config_cache_hits_total._value.get() == 1

--- a/tests/configuracoes/test_tasks.py
+++ b/tests/configuracoes/test_tasks.py
@@ -1,9 +1,15 @@
 from unittest.mock import patch
 
 import pytest
+from django.utils import timezone
+from freezegun import freeze_time
 
 from chat.models import ChatChannel, ChatMessage, ChatNotification
-from configuracoes.tasks import enviar_notificacoes_diarias, enviar_notificacoes_semanais
+from configuracoes.tasks import (
+    enviar_notificacao_whatsapp,
+    enviar_notificacoes_diarias,
+    enviar_notificacoes_semanais,
+)
 
 pytestmark = pytest.mark.django_db
 
@@ -14,10 +20,12 @@ def _criar_notificacao(user):
     ChatNotification.objects.create(usuario=user, mensagem=msg)
 
 
+@freeze_time("2024-01-01 08:00:00-03:00")
 @patch("configuracoes.tasks.enviar_para_usuario")
 def test_tarefa_diaria_envia_resumo(mock_enviar, admin_user):
     config = admin_user.configuracao
     config.frequencia_notificacoes_email = "diaria"
+    config.hora_notificacao_diaria = timezone.localtime().time()
     config.save()
     _criar_notificacao(admin_user)
     enviar_notificacoes_diarias()
@@ -27,22 +35,34 @@ def test_tarefa_diaria_envia_resumo(mock_enviar, admin_user):
     assert args[2]["chat"] == 1
 
 
+@freeze_time("2024-01-01 08:00:00-03:00")
 @patch("configuracoes.tasks.enviar_para_usuario")
 def test_tarefa_diaria_respeita_preferencia(mock_enviar, admin_user):
     config = admin_user.configuracao
     config.receber_notificacoes_email = False
     config.frequencia_notificacoes_email = "diaria"
+    config.hora_notificacao_diaria = timezone.localtime().time()
     config.save()
     _criar_notificacao(admin_user)
     enviar_notificacoes_diarias()
     mock_enviar.assert_not_called()
 
 
+@patch("configuracoes.tasks.Client")
+def test_enviar_notificacao_whatsapp(mock_client, admin_user):
+    instance = mock_client.return_value
+    enviar_notificacao_whatsapp(admin_user, {"chat": 1, "feed": 0, "eventos": 0})
+    instance.messages.create.assert_called_once()
+
+
+@freeze_time("2024-01-01 08:00:00-03:00")
 @patch("configuracoes.tasks.enviar_notificacao_whatsapp")
 def test_tarefa_semanal_whatsapp(mock_whatsapp, admin_user):
     config = admin_user.configuracao
     config.receber_notificacoes_whatsapp = True
     config.frequencia_notificacoes_whatsapp = "semanal"
+    config.hora_notificacao_semanal = timezone.localtime().time()
+    config.dia_semana_notificacao = timezone.localtime().weekday()
     config.save()
     _criar_notificacao(admin_user)
     enviar_notificacoes_semanais()

--- a/tests/configuracoes/test_views.py
+++ b/tests/configuracoes/test_views.py
@@ -37,6 +37,9 @@ def test_view_post_atualiza_preferencias(admin_client, admin_user):
         "frequencia_notificacoes_whatsapp": "semanal",
         "idioma": "pt-BR",
         "tema": "escuro",
+        "hora_notificacao_diaria": "08:00",
+        "hora_notificacao_semanal": "08:00",
+        "dia_semana_notificacao": 0,
         "tab": "preferencias",
     }
     resp = admin_client.post(url, data, HTTP_HX_REQUEST="true")


### PR DESCRIPTION
## Summary
- remove campo obsoleto `tema_escuro` e adiciona agendamento de notificações
- implementa envio de WhatsApp via Twilio com tratamento de erros
- instrumenta configuração de conta com métricas e documentação OpenAPI

## Testing
- `ruff check configuracoes tests/configuracoes`
- `pytest tests/configuracoes --cov=configuracoes -q`


------
https://chatgpt.com/codex/tasks/task_e_68912cef90048325bee611de6c966938