### PR TITLE
Improve 2FA UX and accessibility

### DIFF
--- a/accounts/templates/login/login.html
+++ b/accounts/templates/login/login.html
@@ -4,15 +4,15 @@
 {% block title %}Entrar - HubX{% endblock %}
 
 {% block content %}
-<div class="bg-muted min-h-screen flex items-center justify-center px-4">
-  <div class="bg-white p-8 rounded-2xl shadow max-w-md w-full mx-auto">
-    <h1 class="text-2xl font-bold text-center text-gray-900 mb-1">Bem-vindo de volta</h1>
+<main class="bg-muted min-h-screen flex items-center justify-center px-4">
+  <div class="bg-white p-8 rounded-2xl shadow max-w-md w-full mx-auto" role="dialog" aria-labelledby="login-title">
+    <h1 id="login-title" class="text-2xl font-bold text-center text-gray-900 mb-1">Bem-vindo de volta</h1>
     <p class="text-center text-sm text-gray-600 mb-6">
       Entre para acessar sua conta e conectar-se à sua rede
     </p>
 
     {% if form.non_field_errors %}
-      <div class="text-red-600 text-sm mb-4">{{ form.non_field_errors }}</div>
+      <div class="text-red-600 text-sm mb-4" role="alert">{{ form.non_field_errors }}</div>
     {% endif %}
 
     <form method="post" action="{% url 'accounts:login' %}" class="space-y-5">
@@ -24,9 +24,11 @@
                placeholder="Digite seu e-mail"
                data-check-url="{% url 'accounts:check_2fa' %}"
                class="w-full p-3 border border-gray-300 rounded-lg text-sm placeholder-gray-400 shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
-               required>
+               required
+               aria-describedby="email-error"
+               {% if form.email.errors %}aria-invalid="true"{% endif %}>
         {% if form.email.errors %}
-          <div class="text-red-600 text-xs mt-1">{{ form.email.errors }}</div>
+          <div id="email-error" class="text-red-600 text-xs mt-1" role="alert">{{ form.email.errors }}</div>
         {% endif %}
       </div>
       <div>
@@ -34,9 +36,11 @@
         <input type="password" id="id_password" name="password"
                placeholder="Digite sua senha"
                class="w-full p-3 border border-gray-300 rounded-lg text-sm placeholder-gray-400 shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
-               required>
+               required
+               aria-describedby="password-error"
+               {% if form.password.errors %}aria-invalid="true"{% endif %}>
         {% if form.password.errors %}
-          <div class="text-red-600 text-xs mt-1">{{ form.password.errors }}</div>
+          <div id="password-error" class="text-red-600 text-xs mt-1" role="alert">{{ form.password.errors }}</div>
         {% endif %}
       </div>
       <div id="totp-field" style="display:none">
@@ -44,9 +48,11 @@
         <input type="text" id="id_totp" name="totp"
                value="{{ form.totp.value|default_if_none:'' }}"
                placeholder="Código 2FA"
-               class="w-full p-3 border border-gray-300 rounded-lg text-sm placeholder-gray-400 shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent">
+               class="w-full p-3 border border-gray-300 rounded-lg text-sm placeholder-gray-400 shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
+               aria-describedby="totp-error"
+               {% if form.totp.errors %}aria-invalid="true"{% endif %}>
         {% if form.totp.errors %}
-          <div class="text-red-600 text-xs mt-1">{{ form.totp.errors }}</div>
+          <div id="totp-error" class="text-red-600 text-xs mt-1" role="alert">{{ form.totp.errors }}</div>
         {% endif %}
       </div>
       <button type="submit"
@@ -73,7 +79,7 @@
       </a>
     </div>
   </div>
-</div>
+</main>
 <script>
   const emailInput = document.getElementById('id_email');
   const totpField = document.getElementById('totp-field');

--- a/accounts/templates/perfil/informacoes_pessoais.html
+++ b/accounts/templates/perfil/informacoes_pessoais.html
@@ -1,11 +1,7 @@
 {% extends 'perfil/perfil.html' %}
 {% load static %}
 
-{% block title %}Informações Pessoais | HubX
-<div class="mt-6 text-center">
-  <a href="{% url 'accounts:perfil' %}" class="text-sm text-primary hover:underline">← Voltar</a>
-</div>
-{% endblock %}
+{% block title %}Informações Pessoais | HubX{% endblock %}
 
 {% block perfil_content %}
 <div class="max-w-3xl mx-auto">

--- a/accounts/templates/perfil/notificacoes.html
+++ b/accounts/templates/perfil/notificacoes.html
@@ -1,11 +1,7 @@
 {% extends 'perfil/perfil.html' %}
 {% load static %}
 
-{% block title %}Preferências de Notificação | HubX
-<div class="mt-6 text-center">
-  <a href="{% url 'accounts:perfil' %}" class="text-sm text-primary hover:underline">← Voltar</a>
-</div>
-{% endblock %}
+{% block title %}Preferências de Notificação | HubX{% endblock %}
 
 {% block perfil_content %}
 <div class="max-w-3xl mx-auto">

--- a/accounts/templates/perfil/perfil.html
+++ b/accounts/templates/perfil/perfil.html
@@ -23,11 +23,20 @@
       <button class="text-sm text-primary hover:underline">Alterar foto</button>
     </div>
 
-    <!-- Navegação horizontal -->
-    <nav class="flex flex-wrap justify-center gap-4 mt-6 border-t pt-4 text-sm font-medium text-gray-600">
-      <a href="{% url 'accounts:perfil' %}" class="hover:text-primary transition">🏠 Home</a>
-      <a href="{% url 'accounts:conexoes' %}" class="hover:text-primary transition">👥 Conexões</a>
-      <a href="{% url 'accounts:midias' %}" class="hover:text-primary transition">🖼️ Mídias</a>
+    <!-- Abas de navegação -->
+    <nav class="mt-6 border-b flex space-x-4 text-sm font-medium text-gray-600" role="tablist">
+      <a href="{% url 'accounts:informacoes_pessoais' %}"
+         class="px-3 py-2 -mb-px border-b-2 {% if request.resolver_match.url_name == 'informacoes_pessoais' %}border-primary text-primary{% else %}border-transparent hover:text-primary{% endif %}"
+         role="tab"
+         aria-selected="{% if request.resolver_match.url_name == 'informacoes_pessoais' %}true{% else %}false{% endif %}">Informações Pessoais</a>
+      <a href="{% url 'accounts:seguranca' %}"
+         class="px-3 py-2 -mb-px border-b-2 {% if request.resolver_match.url_name == 'seguranca' %}border-primary text-primary{% else %}border-transparent hover:text-primary{% endif %}"
+         role="tab"
+         aria-selected="{% if request.resolver_match.url_name == 'seguranca' %}true{% else %}false{% endif %}">Segurança</a>
+      <a href="{% url 'accounts:notificacoes' %}"
+         class="px-3 py-2 -mb-px border-b-2 {% if request.resolver_match.url_name == 'notificacoes' %}border-primary text-primary{% else %}border-transparent hover:text-primary{% endif %}"
+         role="tab"
+         aria-selected="{% if request.resolver_match.url_name == 'notificacoes' %}true{% else %}false{% endif %}">Notificações</a>
     </nav>
 
     <!-- Bloco dinâmico para subpáginas -->
@@ -35,13 +44,6 @@
       {% block perfil_content %}
       {% endblock %}
     </div>
-
-    <!-- Rodapé com menus adicionais -->
-    <footer class="mt-8 pt-4 border-t flex flex-col sm:flex-row justify-center items-center gap-4 text-sm text-gray-500">
-      <a href="{% url 'accounts:redes_sociais' %}" class="hover:text-primary transition">🌐 Redes Sociais</a>
-      <a href="{% url 'accounts:seguranca' %}" class="hover:text-primary transition">🔒 Segurança</a>
-      <a href="{% url 'accounts:notificacoes' %}" class="hover:text-primary transition">🔔 Notificações</a>
-    </footer>
 
   </div>
 </div>

--- a/accounts/templates/perfil/redes_sociais.html
+++ b/accounts/templates/perfil/redes_sociais.html
@@ -1,11 +1,7 @@
 {% extends 'perfil/perfil.html' %}
 {% load static %}
 
-{% block title %}Redes Sociais | HubX
-<div class="mt-6 text-center">
-  <a href="{% url 'accounts:perfil' %}" class="text-sm text-primary hover:underline">← Voltar</a>
-</div>
-{% endblock %}
+{% block title %}Redes Sociais | HubX{% endblock %}
 
 {% block perfil_content %}
 <div class="max-w-3xl mx-auto">

--- a/accounts/templates/perfil/seguranca.html
+++ b/accounts/templates/perfil/seguranca.html
@@ -1,11 +1,7 @@
 {% extends 'perfil/perfil.html' %}
 {% load static %}
 
-{% block title %}Segurança da Conta | HubX
-<div class="mt-6 text-center">
-  <a href="{% url 'accounts:perfil' %}" class="text-sm text-primary hover:underline">← Voltar</a>
-</div>
-{% endblock %}
+{% block title %}Segurança da Conta | HubX{% endblock %}
 
 {% block perfil_content %}
 <div class="max-w-3xl mx-auto">

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1,6 +1,6 @@
+import base64
 import os
 import uuid
-import base64
 from io import BytesIO
 
 import pyotp
@@ -9,9 +9,9 @@ from django.contrib import messages
 from django.contrib.auth import get_user_model, login, logout, update_session_auth_hash
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.forms import PasswordChangeForm, SetPasswordForm
-from django.contrib.auth.password_validation import validate_password
 from django.contrib.auth.hashers import make_password
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.contrib.auth.password_validation import validate_password
 from django.core.exceptions import ValidationError
 from django.core.files.base import ContentFile, File
 from django.core.files.storage import default_storage
@@ -161,7 +161,7 @@ def disable_2fa(request):
         code = request.POST.get("code")
         if code and pyotp.TOTP(request.user.two_factor_secret).verify(code):
             user = request.user
-            user.two_factor_secret = ""
+            user.two_factor_secret = None
             user.two_factor_enabled = False
             user.save(update_fields=["two_factor_secret", "two_factor_enabled"])
             messages.success(request, _("Verificação em duas etapas desativada."))


### PR DESCRIPTION
## Summary
- refine 2FA disabling to clear secret and add regression test
- reorganize profile section into tabbed navigation
- enhance login form accessibility with ARIA attributes

## Testing
- `ruff check accounts/views.py tests/accounts/test_two_factor.py`
- `bandit accounts/views.py`
- `pytest tests/accounts/test_two_factor.py tests/accounts/test_bcrypt_config.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68914588b3cc8325850d5fe81f7c4ead