### PR TITLE
Add briefing creation and status management

### DIFF
--- a/agenda/forms.py
+++ b/agenda/forms.py
@@ -134,6 +134,13 @@ class BriefingEventoForm(forms.ModelForm):
         ]
 
 
+class BriefingEventoCreateForm(BriefingEventoForm):
+    """Formulário de criação que inclui o evento associado."""
+
+    class Meta(BriefingEventoForm.Meta):
+        fields = ["evento", *BriefingEventoForm.Meta.fields]
+
+
 class ParceriaEventoForm(forms.ModelForm):
     class Meta:
         model = ParceriaEvento

--- a/agenda/templates/agenda/briefing_form.html
+++ b/agenda/templates/agenda/briefing_form.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+{% load i18n %}
+{% block title %}{% if object %}{% trans "Editar Briefing" %}{% else %}{% trans "Novo Briefing" %}{% endif %} | Hubx{% endblock %}
+
+{% block content %}
+<section class="max-w-screen-xl mx-auto pt-8 px-6 lg:px-8">
+  <h1 class="text-2xl font-bold text-neutral-900 mb-6">
+    {% if object %}{% trans "Editar Briefing" %}{% else %}{% trans "Novo Briefing" %}{% endif %}
+  </h1>
+  <form method="post" class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 space-y-6">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <div class="flex justify-end gap-3 pt-4 border-t border-neutral-100">
+      <a href="{% url 'agenda:briefing_list' %}" class="btn-secondary" aria-label="{% trans 'Cancelar' %}">{% trans 'Cancelar' %}</a>
+      <button type="submit" class="btn-primary" aria-label="{% trans 'Salvar' %}">{% trans 'Salvar' %}</button>
+    </div>
+  </form>
+</section>
+{% endblock %}

--- a/agenda/templates/agenda/briefing_list.html
+++ b/agenda/templates/agenda/briefing_list.html
@@ -5,8 +5,12 @@
 
 {% block content %}
 <section id="briefing-container" class="max-w-7xl mx-auto px-4 py-10">
-  <header class="mb-6">
+  <header class="mb-6 flex items-center justify-between">
     <h1 class="text-2xl font-bold text-neutral-900">{% trans "Briefings de Eventos" %}</h1>
+    <a
+      href="{% url 'agenda:briefing_criar' %}"
+      class="btn-primary"
+    >{% trans "Novo Briefing" %}</a>
   </header>
 
   {% if messages %}
@@ -63,13 +67,41 @@
               <td class="px-4 py-2">{{ briefing.cronograma_resumido }}</td>
               <td class="px-4 py-2">{{ briefing.conteudo_programatico }}</td>
               <td class="px-4 py-2">{{ briefing.observacoes }}</td>
-              <td class="px-4 py-2">
+              <td class="px-4 py-2 space-x-2">
                 <a
                   href="{% url 'agenda:briefing_editar' briefing.pk %}"
                   class="text-blue-600 hover:underline"
+                >{% trans "Editar" %}</a>
+                <form
+                  method="post"
+                  action="{% url 'agenda:briefing_status' briefing.pk 'orcamentado' %}"
+                  class="inline"
                 >
-                  {% trans "Editar" %}
-                </a>
+                  {% csrf_token %}
+                  <button type="submit" class="text-green-600 hover:underline">
+                    {% trans "Orçar" %}
+                  </button>
+                </form>
+                <form
+                  method="post"
+                  action="{% url 'agenda:briefing_status' briefing.pk 'aprovado' %}"
+                  class="inline"
+                >
+                  {% csrf_token %}
+                  <button type="submit" class="text-primary hover:underline">
+                    {% trans "Aprovar" %}
+                  </button>
+                </form>
+                <form
+                  method="post"
+                  action="{% url 'agenda:briefing_status' briefing.pk 'recusado' %}"
+                  class="inline"
+                >
+                  {% csrf_token %}
+                  <button type="submit" class="text-red-600 hover:underline">
+                    {% trans "Recusar" %}
+                  </button>
+                </form>
               </td>
             </tr>
           {% empty %}

--- a/agenda/urls.py
+++ b/agenda/urls.py
@@ -2,7 +2,9 @@ from django.urls import path
 
 from . import views
 from .views import (
+    BriefingEventoCreateView,
     BriefingEventoListView,
+    BriefingEventoStatusView,
     BriefingEventoUpdateView,
     EventoCreateView,
     EventoDeleteView,
@@ -54,8 +56,18 @@ urlpatterns = [
     path("materiais/", MaterialDivulgacaoEventoListView.as_view(), name="material_list"),
     path("briefings/", BriefingEventoListView.as_view(), name="briefing_list"),
     path(
+        "briefing/novo/",
+        BriefingEventoCreateView.as_view(),
+        name="briefing_criar",
+    ),
+    path(
         "briefing/<int:pk>/editar/",
         BriefingEventoUpdateView.as_view(),
         name="briefing_editar",
+    ),
+    path(
+        "briefing/<int:pk>/status/<str:status>/",
+        BriefingEventoStatusView.as_view(),
+        name="briefing_status",
     ),
 ]

--- a/tests/agenda/test_briefing.py
+++ b/tests/agenda/test_briefing.py
@@ -1,0 +1,33 @@
+import pytest
+from unittest.mock import patch
+from django.urls import reverse
+
+from accounts.factories import UserFactory
+from organizacoes.factories import OrganizacaoFactory
+from accounts.models import UserType
+from agenda.factories import EventoFactory
+from agenda.models import BriefingEvento
+
+
+@pytest.mark.django_db
+def test_briefing_status_updates(client):
+    org = OrganizacaoFactory()
+    user = UserFactory(user_type=UserType.ADMIN, organizacao=org)
+    client.force_login(user)
+    evento = EventoFactory(organizacao=org, coordenador=user)
+    briefing = BriefingEvento.objects.create(
+        evento=evento,
+        objetivos="obj",
+        publico_alvo="pub",
+        requisitos_tecnicos="req",
+    )
+    url = reverse("agenda:briefing_status", args=[briefing.pk, "aprovado"])
+    with patch("agenda.views.notificar_briefing_status.delay") as mock_delay:
+        response = client.post(url)
+    assert response.status_code == 302
+    briefing.refresh_from_db()
+    assert briefing.status == "aprovado"
+    assert briefing.avaliado_por == user
+    assert briefing.avaliado_em is not None
+    assert briefing.aprovado_em is not None
+    mock_delay.assert_called_once_with(briefing.pk, "aprovado")


### PR DESCRIPTION
## Summary
- allow creating briefings and change their status with audit trail
- notify coordinators when briefing status changes
- add regression test for briefing status flow

## Testing
- `pytest tests/agenda/test_briefing.py -q`
- `pytest -q` *(fails: test_view_benchmark, test_password_reset_clears_lock, FeedPublicPrivateTests::test_nucleo_post_only_with_filter, test_metrics_dashboard, test_exportar_relatorio)*

------
https://chatgpt.com/codex/tasks/task_e_68914ab7ae6c832592136340c9cf30c0