### PR TITLE
feat(agenda): enforce scope and audit logs

### DIFF
--- a/agenda/migrations/0013_eventolog_briefing_fields.py
+++ b/agenda/migrations/0013_eventolog_briefing_fields.py
@@ -1,0 +1,58 @@
+from django.db import migrations, models
+import django.db.models.deletion
+from django.conf import settings
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("agenda", "0012_remove_inscricaoevento_avaliacao"),
+        ("accounts", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="EventoLog",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("deleted", models.BooleanField(default=False)),
+                ("deleted_at", models.DateTimeField(blank=True, null=True)),
+                ("created", models.DateTimeField(auto_now_add=True)),
+                ("modified", models.DateTimeField(auto_now=True)),
+                ("acao", models.CharField(max_length=50)),
+                ("detalhes", models.JSONField(blank=True, default=dict)),
+                ("evento", models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name="logs", to="agenda.evento")),
+                ("usuario", models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, to=settings.AUTH_USER_MODEL)),
+            ],
+            options={"ordering": ["-created"]},
+        ),
+        migrations.AddField(
+            model_name="briefingevento",
+            name="coordenadora_aprovou",
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AddField(
+            model_name="briefingevento",
+            name="prazo_limite_resposta",
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="briefingevento",
+            name="recusado_por",
+            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name="briefings_recusados", to=settings.AUTH_USER_MODEL),
+        ),
+        migrations.AddField(
+            model_name="historicalbriefingevento",
+            name="coordenadora_aprovou",
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AddField(
+            model_name="historicalbriefingevento",
+            name="prazo_limite_resposta",
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="historicalbriefingevento",
+            name="recusado_por",
+            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name="+historical_briefings_recusados", to=settings.AUTH_USER_MODEL),
+        ),
+    ]

--- a/agenda/serializers.py
+++ b/agenda/serializers.py
@@ -7,6 +7,7 @@ from validate_docbr import CNPJ
 from .models import (
     BriefingEvento,
     Evento,
+    EventoLog,
     InscricaoEvento,
     MaterialDivulgacaoEvento,
     ParceriaEvento,
@@ -30,7 +31,19 @@ class EventoSerializer(serializers.ModelSerializer):
         request = self.context["request"]
         validated_data["organizacao"] = request.user.organizacao
         validated_data["coordenador"] = request.user
-        return super().create(validated_data)
+        instance = super().create(validated_data)
+        EventoLog.objects.create(
+            evento=instance, usuario=request.user, acao="evento_criado"
+        )
+        return instance
+
+    def update(self, instance, validated_data):
+        request = self.context["request"]
+        instance = super().update(instance, validated_data)
+        EventoLog.objects.create(
+            evento=instance, usuario=request.user, acao="evento_atualizado"
+        )
+        return instance
 
 
 class InscricaoEventoSerializer(serializers.ModelSerializer):
@@ -131,6 +144,9 @@ class BriefingEventoSerializer(serializers.ModelSerializer):
             "orcamento_enviado_em",
             "aprovado_em",
             "recusado_em",
+            "coordenadora_aprovou",
+            "recusado_por",
+            "prazo_limite_resposta",
             "avaliado_por",
             "avaliado_em",
             "created",

--- a/tests/agenda/test_briefing.py
+++ b/tests/agenda/test_briefing.py
@@ -6,7 +6,7 @@ from accounts.factories import UserFactory
 from organizacoes.factories import OrganizacaoFactory
 from accounts.models import UserType
 from agenda.factories import EventoFactory
-from agenda.models import BriefingEvento
+from agenda.models import BriefingEvento, EventoLog
 
 
 @pytest.mark.django_db
@@ -30,4 +30,6 @@ def test_briefing_status_updates(client):
     assert briefing.avaliado_por == user
     assert briefing.avaliado_em is not None
     assert briefing.aprovado_em is not None
+    assert briefing.coordenadora_aprovou is True
+    assert EventoLog.objects.filter(evento=evento, acao="briefing_aprovado").exists()
     mock_delay.assert_called_once_with(briefing.pk, "aprovado")

--- a/tests/agenda/test_eventolog.py
+++ b/tests/agenda/test_eventolog.py
@@ -1,0 +1,16 @@
+import pytest
+
+from accounts.factories import UserFactory
+from organizacoes.factories import OrganizacaoFactory
+from agenda.factories import EventoFactory
+from agenda.models import InscricaoEvento, EventoLog
+
+
+@pytest.mark.django_db
+def test_inscricao_confirmacao_gera_log():
+    org = OrganizacaoFactory()
+    user = UserFactory(organizacao=org)
+    evento = EventoFactory(organizacao=org, coordenador=user)
+    inscricao = InscricaoEvento.objects.create(user=user, evento=evento)
+    inscricao.confirmar_inscricao()
+    assert EventoLog.objects.filter(evento=evento, acao="inscricao_confirmada", usuario=user).exists()

--- a/tests/agenda/test_feedback.py
+++ b/tests/agenda/test_feedback.py
@@ -35,12 +35,13 @@ def evento_passado(organizacao, usuario):
 
 
 @pytest.fixture
-def usuario(client):
+def usuario(client, organizacao):
     user = User.objects.create_user(
         username="cliente",
         email="cliente@example.com",
         password="12345",
         user_type=UserType.NUCLEADO,
+        organizacao=organizacao,
     )
     client.force_login(user)
     return user

--- a/tests/agenda/test_inscricoes.py
+++ b/tests/agenda/test_inscricoes.py
@@ -52,12 +52,13 @@ def evento(organizacao, usuario_logado):
 
 
 @pytest.fixture
-def usuario_comum(client):
+def usuario_comum(client, organizacao):
     user = User.objects.create_user(
         username="comum",
         email="comum@example.com",
         password="12345",
         user_type=UserType.NUCLEADO,
+        organizacao=organizacao,
     )
     client.force_login(user)
     return user


### PR DESCRIPTION
## Summary
- add structured EventoLog and log event/briefing/inscription actions
- restrict agenda views and APIs to user's organization or nuclei
- finish briefing approval/denial workflow with new fields

## Testing
- `pytest tests/agenda`

------
https://chatgpt.com/codex/tasks/task_e_68915bc4a0988325bdf0d310558d7d12