### PR TITLE
Add audit log for partnership deletions

### DIFF
--- a/agenda/api.py
+++ b/agenda/api.py
@@ -116,7 +116,7 @@ class ParceriaEventoViewSet(OrganizacaoFilterMixin, viewsets.ModelViewSet):
             evento=instance.evento,
             usuario=self.request.user,
             acao="parceria_excluida",
-            detalhes={"empresa": str(instance.empresa_id)},
+            detalhes={"parceria": instance.pk, "empresa": str(instance.empresa_id)},
         )
         instance.soft_delete()
 

--- a/tests/agenda/test_audit.py
+++ b/tests/agenda/test_audit.py
@@ -59,6 +59,7 @@ def test_parceria_delete_gera_log(api_client: APIClient) -> None:
         evento=evento,
         usuario=user,
         acao="parceria_excluida",
+        detalhes__parceria=parceria.pk,
         detalhes__empresa=str(parceria.empresa_id),
     ).exists()
 


### PR DESCRIPTION
## Summary
- log `parceria_excluida` actions with partnership and company IDs
- test partnership deletion audit logging via API

## Testing
- `pytest tests/agenda/test_audit.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6891fde9fce883258dc4a4913c2fd78f