### PR TITLE
feat(chat): add unpin and notifications websocket

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ O módulo expõe métricas Prometheus em `/metrics`, incluindo `chat_mensagens_s
 Para que o WebSocket funcione:
 
 1. Instale o pacote `daphne` (já listado em `requirements.txt`).
-2. Rode o servidor com:
+2. Execute um servidor Redis local em `localhost:6379`.
+3. Rode o servidor com:
 
 ```bash
 python manage.py runserver
@@ -136,6 +137,20 @@ CSRF_TRUSTED_ORIGINS = ["https://seu-dominio.com"]
 ```
 
 Certifique-se também de liberar o esquema `wss://` no servidor ou proxy reverso.
+
+### Tasks de exportação
+
+As exportações de histórico são processadas de forma assíncrona. Para
+acompanhar o progresso e gerar os arquivos é necessário executar um
+worker Celery apontando para o mesmo Redis:
+
+```bash
+celery -A Hubx worker -l INFO
+```
+
+Os arquivos gerados ficarão disponíveis em `media/chat_exports/` e o
+endpoint `/api/chat/channels/<id>/export/` aceita os parâmetros
+`inicio`, `fim` e `tipos` para filtrar o conteúdo exportado.
 
 ---
 

--- a/chat/api_urls.py
+++ b/chat/api_urls.py
@@ -1,10 +1,16 @@
 from django.urls import path
 from rest_framework.routers import DefaultRouter
 
-from .api_views import ChatChannelViewSet, ChatMessageViewSet, ModeracaoViewSet
+from .api_views import (
+    ChatChannelViewSet,
+    ChatMessageViewSet,
+    ChatNotificationViewSet,
+    ModeracaoViewSet,
+)
 
 router = DefaultRouter()
 router.register(r"channels", ChatChannelViewSet, basename="chat-channel")
+router.register(r"notificacoes", ChatNotificationViewSet, basename="chat-notificacao")
 router.register(r"moderacao/messages", ModeracaoViewSet, basename="chat-moderacao")
 
 chat_message_list = ChatMessageViewSet.as_view({"get": "list", "post": "create"})
@@ -17,6 +23,7 @@ chat_message_detail = ChatMessageViewSet.as_view(
     }
 )
 chat_message_pin = ChatMessageViewSet.as_view({"post": "pin"})
+chat_message_unpin = ChatMessageViewSet.as_view({"post": "unpin"})
 chat_message_react = ChatMessageViewSet.as_view({"post": "react"})
 chat_message_flag = ChatMessageViewSet.as_view({"post": "flag"})
 
@@ -35,6 +42,11 @@ urlpatterns = router.urls + [
         "channels/<uuid:channel_pk>/messages/<uuid:pk>/pin/",
         chat_message_pin,
         name="chat-channel-message-pin",
+    ),
+    path(
+        "channels/<uuid:channel_pk>/messages/<uuid:pk>/unpin/",
+        chat_message_unpin,
+        name="chat-channel-message-unpin",
     ),
     path(
         "channels/<uuid:channel_pk>/messages/<uuid:pk>/react/",

--- a/chat/consumers.py
+++ b/chat/consumers.py
@@ -103,3 +103,21 @@ class ChatConsumer(AsyncJsonWebsocketConsumer):
 
     async def chat_message(self, event):
         await self.send_json(event)
+
+
+class NotificationConsumer(AsyncJsonWebsocketConsumer):
+    async def connect(self):
+        user = self.scope["user"]
+        if not user or not user.is_authenticated:
+            await self.close()
+            return
+        self.group_name = f"notifications_{user.id}"
+        await self.channel_layer.group_add(self.group_name, self.channel_name)
+        await self.accept()
+
+    async def disconnect(self, code):
+        if hasattr(self, "group_name"):
+            await self.channel_layer.group_discard(self.group_name, self.channel_name)
+
+    async def chat_notification(self, event):
+        await self.send_json(event)

--- a/chat/routing.py
+++ b/chat/routing.py
@@ -1,7 +1,8 @@
 from django.urls import re_path
 
-from .consumers import ChatConsumer
+from .consumers import ChatConsumer, NotificationConsumer
 
 websocket_urlpatterns = [
     re_path(r"ws/chat/(?P<channel_id>[0-9a-f-]+)/$", ChatConsumer.as_asgi()),
+    re_path(r"ws/chat/notificacoes/$", NotificationConsumer.as_asgi()),
 ]

--- a/chat/static/chat/js/notifications_socket.js
+++ b/chat/static/chat/js/notifications_socket.js
@@ -1,0 +1,14 @@
+(function(){
+    function initCounter(elementId){
+        const el = document.getElementById(elementId);
+        if(!el) return;
+        const scheme = window.location.protocol === 'https:' ? 'wss://' : 'ws://';
+        const url = scheme + window.location.host + '/ws/chat/notificacoes/';
+        const socket = new WebSocket(url);
+        socket.onmessage = function(){
+            const current = parseInt(el.textContent || '0', 10);
+            el.textContent = current + 1;
+        };
+    }
+    window.ChatNotifications = {initCounter};
+})();

--- a/tests/chat/conftest.py
+++ b/tests/chat/conftest.py
@@ -24,6 +24,11 @@ def celery_eager(settings):
     settings.CELERY_TASK_EAGER_PROPAGATES = True
 
 
+@pytest.fixture(autouse=True)
+def in_memory_channel_layer(settings):
+    settings.CHANNEL_LAYERS = {"default": {"BACKEND": "channels.layers.InMemoryChannelLayer"}}
+
+
 @pytest.fixture
 def organizacao():
     return Organizacao.objects.create(nome="Org", cnpj="00.000.000/0001-00", slug="org")

--- a/tests/chat/test_consumers.py
+++ b/tests/chat/test_consumers.py
@@ -5,7 +5,7 @@ import pytest
 from channels.db import database_sync_to_async
 from channels.testing import WebsocketCommunicator
 
-from chat.models import ChatMessage
+from chat.models import ChatMessage, ChatNotification
 from chat.services import criar_canal
 from Hubx.asgi import application
 
@@ -43,6 +43,31 @@ def test_consumer_connect_send_message_and_reaction(admin_user, coordenador_user
         await communicator.send_json_to({"tipo": "reaction", "mensagem_id": str(msg.id), "emoji": "👍"})
         response2 = await communicator.receive_json_from()
         assert response2["reactions"]["👍"] == 1
+        await communicator.disconnect()
+
+    asyncio.run(inner())
+
+
+def test_consumer_send_file_url(admin_user, coordenador_user):
+    async def inner():
+        canal = await database_sync_to_async(criar_canal)(
+            criador=admin_user,
+            contexto_tipo="privado",
+            contexto_id=None,
+            titulo="Privado",
+            descricao="",
+            participantes=[coordenador_user],
+        )
+        communicator = WebsocketCommunicator(application, f"/ws/chat/{canal.id}/")
+        communicator.scope["user"] = admin_user
+        connected, _ = await communicator.connect()
+        assert connected
+        url = "https://example.com/a.png"
+        await communicator.send_json_to({"tipo": "image", "conteudo": url})
+        response = await communicator.receive_json_from()
+        assert response["conteudo"] == url
+        msg = await database_sync_to_async(ChatMessage.objects.get)(pk=response["id"])
+        assert msg.conteudo == url and not msg.arquivo
         await communicator.disconnect()
 
     asyncio.run(inner())
@@ -108,5 +133,34 @@ def test_flag_via_websocket_hides_message(admin_user):
         await comm2.disconnect()
         await comm3.disconnect()
         await comm4.disconnect()
+
+    asyncio.run(inner())
+
+
+def test_notification_consumer_receives(admin_user, coordenador_user):
+    async def inner():
+        canal = await database_sync_to_async(criar_canal)(
+            criador=admin_user,
+            contexto_tipo="privado",
+            contexto_id=None,
+            titulo="Privado",
+            descricao="",
+            participantes=[coordenador_user],
+        )
+        notif_comm = WebsocketCommunicator(application, "/ws/chat/notificacoes/")
+        notif_comm.scope["user"] = coordenador_user
+        connected, _ = await notif_comm.connect()
+        assert connected
+        chat_comm = WebsocketCommunicator(application, f"/ws/chat/{canal.id}/")
+        chat_comm.scope["user"] = admin_user
+        connected2, _ = await chat_comm.connect()
+        assert connected2
+        await chat_comm.send_json_to({"tipo": "text", "conteudo": "oi"})
+        await chat_comm.receive_json_from()  # ignore chat message event
+        notif = await notif_comm.receive_json_from()
+        assert notif["conteudo"] == "oi"
+        await chat_comm.disconnect()
+        await notif_comm.disconnect()
+        assert await database_sync_to_async(ChatNotification.objects.count)() == 1
 
     asyncio.run(inner())

--- a/tests/chat/test_services.py
+++ b/tests/chat/test_services.py
@@ -78,6 +78,22 @@ def test_enviar_mensagem_valida_participacao(admin_user, coordenador_user, assoc
         enviar_mensagem(canal, associado_user, "text", conteudo="ola")
 
 
+def test_enviar_mensagem_url_sem_arquivo(admin_user, coordenador_user):
+    canal = criar_canal(
+        criador=admin_user,
+        contexto_tipo="privado",
+        contexto_id=None,
+        titulo="Privado",
+        descricao="",
+        participantes=[coordenador_user],
+    )
+    url = "https://example.com/img.png"
+    msg = enviar_mensagem(canal, admin_user, "image", conteudo=url)
+    assert msg.conteudo == url and not msg.arquivo
+    with pytest.raises(ValueError):
+        enviar_mensagem(canal, admin_user, "image", conteudo="not-url")
+
+
 def test_adicionar_reacao_incrementa(admin_user, coordenador_user):
     canal = criar_canal(
         criador=admin_user,


### PR DESCRIPTION
## Summary
- allow sending attachment messages using URLs
- add pin/unpin endpoints and realtime notifications
- document websocket/exports setup

## Testing
- `pytest tests/chat/test_services.py tests/chat/test_api_views.py tests/chat/test_consumers.py tests/chat/test_tasks.py --cov=chat.services --cov=chat.api_views --cov=chat.api --cov=chat.consumers --cov-report=term -q`


------
https://chatgpt.com/codex/tasks/task_e_68921268e46c8325bfc5034741d6908e