### PR TITLE
Refactor chat to websocket history

### DIFF
--- a/chat/static/chat/js/chat_socket.js
+++ b/chat/static/chat/js/chat_socket.js
@@ -121,6 +121,24 @@
                 });
                 div.appendChild(btn);
             }
+            if(id && (remetente === currentUser || isAdmin) && tipo === 'text'){
+                const edit = document.createElement('button');
+                edit.className = 'edit-msg ml-2 text-xs text-blue-600';
+                edit.textContent = 'Editar';
+                edit.addEventListener('click', ()=>{
+                    const novo = prompt('Editar mensagem', conteudo);
+                    if(!novo || novo === conteudo) return;
+                    fetch(`/api/chat/channels/${destinatarioId}/messages/${id}/`,{
+                        method:'PATCH',
+                        headers:{'Content-Type':'application/json','X-CSRFToken':csrfToken},
+                        body: JSON.stringify({conteudo: novo})
+                    }).then(r=>r.ok?r.json():Promise.reject())
+                      .then(data=>{
+                        renderMessage(data.remetente, data.tipo, data.conteudo, div, data.id, data.pinned_at, data.reactions);
+                      });
+                });
+                div.appendChild(edit);
+            }
             renderReactions(div,reactions);
             setupReactionMenu(div,id);
             return div;

--- a/chat/templates/chat/conversation_detail.html
+++ b/chat/templates/chat/conversation_detail.html
@@ -12,7 +12,7 @@
     data-csrf-token="{{ csrf_token }}"
     data-is-admin="{{ is_admin|yesno:'true,false' }}"
     data-upload-url="{% url 'chat_api:chat-upload' %}"
-    data-history-url=""
+    data-history-url="{{ history_url }}"
     class="flex flex-col h-full"
   >
     <header class="mb-4 flex items-center justify-between gap-3">

--- a/tests/chat/test_api_views.py
+++ b/tests/chat/test_api_views.py
@@ -74,6 +74,19 @@ def test_send_and_list_messages(api_client: APIClient, admin_user, coordenador_u
     assert resp.json()["count"] >= 1
 
 
+def test_history_endpoint_returns_messages(api_client: APIClient, admin_user):
+    channel = ChatChannel.objects.create(contexto_tipo="privado")
+    ChatParticipant.objects.create(channel=channel, user=admin_user)
+    ChatMessage.objects.create(channel=channel, remetente=admin_user, tipo="text", conteudo="a")
+    ChatMessage.objects.create(channel=channel, remetente=admin_user, tipo="text", conteudo="b")
+    api_client.force_authenticate(admin_user)
+    url = reverse("chat_api:chat-channel-messages-history", args=[channel.id])
+    resp = api_client.get(url)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["messages"]) == 2
+
+
 def test_messages_permission_denied_for_non_participant(api_client: APIClient, admin_user, coordenador_user):
     channel = ChatChannel.objects.create(contexto_tipo="privado")
     ChatParticipant.objects.create(channel=channel, user=admin_user)


### PR DESCRIPTION
## Summary
- remove HTMX/NovaMensagemForm flow from conversation detail and rely on WebSocket component
- add channel message history API endpoint and expose in template
- allow inline message edits via new front-end handler

## Testing
- `pytest tests/chat/test_api_views.py::test_history_endpoint_returns_messages -q`
- `pytest tests/chat/test_views.py::test_conversation_detail_denies_non_participant -q`


------
https://chatgpt.com/codex/tasks/task_e_68923eb332308325832269b86e5c6f92