### PR TITLE
feat: integrate sentry and improve chat accessibility

### DIFF
--- a/Hubx/settings.py
+++ b/Hubx/settings.py
@@ -16,12 +16,21 @@ from decimal import Decimal
 from pathlib import Path
 
 from celery.schedules import crontab
+import sentry_sdk
+from sentry_sdk.integrations.django import DjangoIntegration
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
 # Versão do HTMX utilizada nos templates
 HTMX_VERSION = "1.9.12"
+
+sentry_sdk.init(
+    dsn=os.getenv("SENTRY_DSN"),
+    integrations=[DjangoIntegration()],
+    traces_sample_rate=float(os.getenv("SENTRY_TRACES_SAMPLE_RATE", "0.0")),
+    profiles_sample_rate=float(os.getenv("SENTRY_PROFILES_SAMPLE_RATE", "0.0")),
+)
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/5.2/howto/deployment/checklist/

--- a/chat/static/chat/js/chat_socket.js
+++ b/chat/static/chat/js/chat_socket.js
@@ -105,18 +105,20 @@
             }else if(tipo === 'file'){
                 content = `<div class="chat-file"><a href="${conteudo}" target="_blank">📎 Baixar arquivo</a></div>`;
             }
-            div.innerHTML = `<div><strong>${remetente}</strong>: ${content}</div><ul class="reactions flex gap-2 ml-2"></ul><div class="reaction-menu hidden absolute bg-white border rounded p-1 flex gap-1"><button type="button" class="react-option" data-emoji="👍">👍</button><button type="button" class="react-option" data-emoji="😂">😂</button><button type="button" class="react-option" data-emoji="❤️">❤️</button><button type="button" class="react-option" data-emoji="😮">😮</button></div>`;
+            div.innerHTML = `<div><strong>${remetente}</strong>: ${content}</div><ul class="reactions flex gap-2 ml-2"></ul><div class="reaction-menu hidden absolute bg-white border rounded p-1 flex gap-1" role="menu"><button type="button" class="react-option" data-emoji="👍" aria-label="Adicionar reação 👍">👍</button><button type="button" class="react-option" data-emoji="😂" aria-label="Adicionar reação 😂">😂</button><button type="button" class="react-option" data-emoji="❤️" aria-label="Adicionar reação ❤️">❤️</button><button type="button" class="react-option" data-emoji="😮" aria-label="Adicionar reação 😮">😮</button></div>`;
             if(id){ div.dataset.id = id; }
             if(isAdmin && id){
                 const btn = document.createElement('button');
                 btn.classList.add('pin-toggle');
                 btn.textContent = pinned ? 'Desafixar' : 'Fixar';
+                btn.setAttribute('aria-label', pinned ? 'Desafixar mensagem' : 'Fixar mensagem');
                 btn.addEventListener('click', ()=>{
                     const action = div.classList.contains('pinned') ? 'unpin' : 'pin';
                     fetch(`/api/chat/channels/${destinatarioId}/messages/${id}/${action}/`,{method:'POST',headers:{'X-CSRFToken':csrfToken}})
                         .then(r=>r.json()).then(data=>{
                             div.classList.toggle('pinned', !!data.pinned_at);
                             btn.textContent = data.pinned_at ? 'Desafixar' : 'Fixar';
+                            btn.setAttribute('aria-label', data.pinned_at ? 'Desafixar mensagem' : 'Fixar mensagem');
                         });
                 });
                 div.appendChild(btn);
@@ -125,6 +127,7 @@
                 const edit = document.createElement('button');
                 edit.className = 'edit-msg ml-2 text-xs text-blue-600';
                 edit.textContent = 'Editar';
+                edit.setAttribute('aria-label','Editar mensagem');
                 edit.addEventListener('click', ()=>{
                     const novo = prompt('Editar mensagem', conteudo);
                     if(!novo || novo === conteudo) return;

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,3 +10,4 @@ bleach==6.2.0
 twilio==9.2.3
 WeasyPrint==61.2
 django-silk==5.1.0
+sentry-sdk==2.34.1


### PR DESCRIPTION
## Summary
- enable Sentry APM with configurable sampling
- improve chat controls with ARIA labels
- test message history date filtering

## Testing
- `pytest tests/chat/test_api_views.py::test_history_endpoint_filters_by_date -q`


------
https://chatgpt.com/codex/tasks/task_e_6892460fd80883258bce624b8a4c3225