### PR TITLE
feat(chat): add modal for message editing

### DIFF
--- a/chat/templates/chat/conversation_detail.html
+++ b/chat/templates/chat/conversation_detail.html
@@ -64,6 +64,16 @@
     </form>
   </div>
   <div id="modal"></div>
+  <dialog id="edit-modal" class="p-4 rounded max-w-md w-full">
+    <form method="dialog" class="space-y-2">
+      <label for="edit-input" class="sr-only">{% trans 'Editar mensagem' %}</label>
+      <textarea id="edit-input" class="w-full border rounded p-2" rows="3"></textarea>
+      <div class="flex justify-end gap-2">
+        <button type="button" id="edit-cancel" class="px-3 py-1 border rounded" aria-label="{% trans 'Cancelar edição' %}">{% trans 'Cancelar' %}</button>
+        <button type="submit" id="edit-save" class="px-3 py-1 bg-primary text-white rounded" aria-label="{% trans 'Salvar mensagem editada' %}">{% trans 'Salvar' %}</button>
+      </div>
+    </form>
+  </dialog>
 </main>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- replace prompt-based editing with accessible modal in conversation view
- add JavaScript helpers for modal-based message edits

## Testing
- `pytest` *(fails: tests/accounts/test_password_reset_unlocks.py::test_password_reset_clears_lock - assert 200 == 302, tests/feed/test_feed.py::FeedPublicPrivateTests::test_nucleo_post_only_with_filter - AssertionError: 1 != 0, tests/configuracoes/test_views.py::test_view_benchmark)*

------
https://chatgpt.com/codex/tasks/task_e_689252090e5c8325b111327b9e131529