### PR TITLE
feat(chat): add keyboard nav to reaction menu

### DIFF
--- a/chat/static/chat/js/chat_socket.js
+++ b/chat/static/chat/js/chat_socket.js
@@ -112,7 +112,21 @@
                 }
             });
             menu.addEventListener('keydown', e=>{
-                if(e.key === 'Escape'){ e.preventDefault(); closeMenu(); btn.focus(); }
+                const opts = Array.from(menu.querySelectorAll('.react-option'));
+                const idx = opts.indexOf(document.activeElement);
+                if(e.key === 'ArrowRight' || e.key === 'ArrowDown'){
+                    e.preventDefault();
+                    const next = opts[(idx + 1) % opts.length];
+                    next && next.focus();
+                } else if(e.key === 'ArrowLeft' || e.key === 'ArrowUp'){
+                    e.preventDefault();
+                    const prev = opts[(idx - 1 + opts.length) % opts.length];
+                    prev && prev.focus();
+                } else if(e.key === 'Escape'){
+                    e.preventDefault();
+                    closeMenu();
+                    btn.focus();
+                }
             });
             menu.addEventListener('click', e=>{
                 const opt = e.target.closest('.react-option');


### PR DESCRIPTION
## Summary
- support arrow-key navigation within reaction popover

## Testing
- `pytest` *(fails: tests/accounts/test_password_reset_unlocks.py::test_password_reset_clears_lock, tests/feed/test_feed.py::FeedPublicPrivateTests::test_nucleo_post_only_with_filter)*

------
https://chatgpt.com/codex/tasks/task_e_6892785f253883259b6b5c5166ef4c47