### PR TITLE
feat: sync theme without reload

### DIFF
--- a/configuracoes/templates/configuracoes/partials/preferencias.html
+++ b/configuracoes/templates/configuracoes/partials/preferencias.html
@@ -76,3 +76,19 @@
     toggleFields();
   })();
 </script>
+{% if updated_preferences %}
+<script>
+  (function () {
+    const tema = "{{ preferencias_form.instance.tema }}";
+    const idioma = "{{ preferencias_form.instance.idioma }}";
+    localStorage.setItem('tema', tema);
+    document.cookie = `tema=${tema};path=/`;
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const theme = tema === 'automatico' ? (prefersDark ? 'escuro' : 'claro') : tema;
+    document.documentElement.classList.toggle('dark', theme === 'escuro');
+    localStorage.setItem('idioma', idioma);
+    document.cookie = `django_language=${idioma};path=/`;
+    document.documentElement.setAttribute('lang', idioma);
+  })();
+</script>
+{% endif %}

--- a/configuracoes/views.py
+++ b/configuracoes/views.py
@@ -87,6 +87,8 @@ class ConfiguracoesView(LoginRequiredMixin, View):
             "two_factor_enabled": self.get_two_factor_enabled(),
             "redes_conectadas": request.user.redes_sociais or {},
         }
+        if tab == "preferencias" and form.is_valid():
+            context["updated_preferences"] = True
         template = (
             f"configuracoes/partials/{tab}.html"
             if request.headers.get("HX-Request")
@@ -97,9 +99,4 @@ class ConfiguracoesView(LoginRequiredMixin, View):
             tema = form.instance.tema
             response.set_cookie("tema", tema)
             response.set_cookie("django_language", form.instance.idioma)
-            response.headers["HX-Refresh"] = "true"
-            messages.info(
-                request,
-                _("Preferências atualizadas. As mudanças serão aplicadas no próximo carregamento."),
-            )
         return response

--- a/tests/configuracoes/test_views.py
+++ b/tests/configuracoes/test_views.py
@@ -51,7 +51,9 @@ def test_view_post_atualiza_preferencias(admin_client, admin_user):
     assert admin_user.configuracao.receber_notificacoes_email is False
     assert resp.cookies["tema"].value == "escuro"
     assert resp.cookies["django_language"].value == "pt-BR"
-    assert resp.headers["HX-Refresh"] == "true"
+    content = resp.content.decode()
+    assert 'const tema = "escuro"' in content
+    assert "localStorage.setItem('tema', tema)" in content
 
 
 try:


### PR DESCRIPTION
## Summary
- sync theme and language preferences without requiring HX refresh
- update template to persist preferences to localStorage and cookies
- adjust preference tests to verify new behaviour

## Testing
- `pytest` *(fails: tests/accounts/test_password_reset_unlocks.py::test_password_reset_clears_lock, tests/feed/test_feed.py::FeedPublicPrivateTests::test_nucleo_post_only_with_filter)*

------
https://chatgpt.com/codex/tasks/task_e_68927d71e91c8325ad86b5a9c0771360