### PR TITLE
feat(chat): add accessible reaction menu markup

### DIFF
--- a/chat/templates/chat/partials/message.html
+++ b/chat/templates/chat/partials/message.html
@@ -31,17 +31,26 @@
           type="button"
           class="reaction-btn"
           aria-haspopup="true"
+          aria-expanded="false"
           aria-label="{% trans 'Adicionar reação' %}"
         >😊</button>
-        <div
+        <ul
           class="reaction-menu hidden absolute bg-white border rounded p-1 flex gap-1"
           role="menu"
         >
-          <button type="button" class="react-option" data-emoji="👍" aria-label="{% trans 'Reagir com 👍' %}">👍</button>
-          <button type="button" class="react-option" data-emoji="😂" aria-label="{% trans 'Reagir com 😂' %}">😂</button>
-          <button type="button" class="react-option" data-emoji="❤️" aria-label="{% trans 'Reagir com ❤️' %}">❤️</button>
-          <button type="button" class="react-option" data-emoji="😮" aria-label="{% trans 'Reagir com 😮' %}">😮</button>
-        </div>
+          <li>
+            <button type="button" class="react-option" data-emoji="👍" aria-label="{% trans 'Reagir com 👍' %}">👍</button>
+          </li>
+          <li>
+            <button type="button" class="react-option" data-emoji="😂" aria-label="{% trans 'Reagir com 😂' %}">😂</button>
+          </li>
+          <li>
+            <button type="button" class="react-option" data-emoji="❤️" aria-label="{% trans 'Reagir com ❤️' %}">❤️</button>
+          </li>
+          <li>
+            <button type="button" class="react-option" data-emoji="😮" aria-label="{% trans 'Reagir com 😮' %}">😮</button>
+          </li>
+        </ul>
       </div>
       {% if is_admin %}
         <button


### PR DESCRIPTION
## Summary
- ensure server-rendered messages include reaction button with expandable menu

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'reportlab'; assert 200 == 302; AssertionError: 1 != 0)*

------
https://chatgpt.com/codex/tasks/task_e_689281a2251883259bf0143da9fcfd7e