### PR TITLE
feat(chat): add search and history pagination

### DIFF
--- a/chat/static/chat/js/chat_socket.js
+++ b/chat/static/chat/js/chat_socket.js
@@ -163,13 +163,14 @@
         if(historyUrl){
             fetch(historyUrl).then(r=>r.json()).then(data=>{
                 const frag = document.createDocumentFragment();
-                data.messages.forEach(m=>{
+                const ordered = data.messages.slice().reverse();
+                ordered.forEach(m=>{
                     const div = renderMessage(m.remetente, m.tipo, m.conteudo, null, m.id, m.pinned_at, m.reactions, m.user_reactions);
                     frag.appendChild(div);
                 });
                 messages.appendChild(frag);
-                if(data.messages.length){
-                    oldestId = data.messages[0].id;
+                if(ordered.length){
+                    oldestId = ordered[0].id;
                 }
                 historyEnd = !data.has_more;
                 scrollToBottom();
@@ -186,12 +187,13 @@
                     const first = messages.firstChild;
                     const prevHeight = messages.scrollHeight;
                     const frag = document.createDocumentFragment();
-                    data.messages.forEach(m=>{
+                    const ordered = data.messages.slice().reverse();
+                    ordered.forEach(m=>{
                         const div = renderMessage(m.remetente, m.tipo, m.conteudo, null, m.id, m.pinned_at, m.reactions, m.user_reactions);
                         frag.appendChild(div);
                     });
                     messages.insertBefore(frag, first);
-                    oldestId = data.messages[0].id;
+                    oldestId = ordered[0].id;
                     const newHeight = messages.scrollHeight;
                     messages.scrollTop = newHeight - prevHeight;
                 }else{
@@ -202,7 +204,7 @@
         }
 
         messages.addEventListener('scroll', ()=>{
-            if(messages.scrollTop === 0){
+            if(messages.scrollTop < 50){
                 loadPrevious();
             }
         });
@@ -220,8 +222,8 @@
             }else if(tipo === 'file'){
                 content = `<div class="chat-file"><a href="${conteudo}" target="_blank">📎 Baixar arquivo</a></div>`;
             }
-            div.innerHTML = `<div><strong>${remetente}</strong>: ${content}</div><ul class="reactions flex gap-2 ml-2"></ul><div class="reaction-container relative"><button type="button" class="reaction-btn" aria-haspopup="true" aria-label="Adicionar reação">😊</button><div class="reaction-menu hidden absolute bg-white border rounded p-1 flex gap-1" role="menu"><button type="button" class="react-option" data-emoji="👍" aria-label="Adicionar reação 👍">👍</button><button type="button" class="react-option" data-emoji="😂" aria-label="Adicionar reação 😂">😂</button><button type="button" class="react-option" data-emoji="❤️" aria-label="Adicionar reação ❤️">❤️</button><button type="button" class="react-option" data-emoji="😮" aria-label="Adicionar reação 😮">😮</button></div></div>`;
-            if(id){ div.dataset.id = id; }
+            div.innerHTML = `<div><strong>${remetente}</strong>: ${content}</div><ul class="reactions flex gap-2 ml-2"></ul><div class="reaction-container relative"><button type="button" class="reaction-btn" aria-haspopup="true" aria-expanded="false" aria-label="Adicionar reação">😊</button><ul class="reaction-menu hidden absolute bg-white border rounded p-1 flex gap-1" role="menu"><li><button type="button" class="react-option" data-emoji="😊" aria-label="Adicionar reação 😊">😊</button></li><li><button type="button" class="react-option" data-emoji="👍" aria-label="Adicionar reação 👍">👍</button></li><li><button type="button" class="react-option" data-emoji="😂" aria-label="Adicionar reação 😂">😂</button></li><li><button type="button" class="react-option" data-emoji="❤️" aria-label="Adicionar reação ❤️">❤️</button></li><li><button type="button" class="react-option" data-emoji="😮" aria-label="Adicionar reação 😮">😮</button></li></ul></div>`;
+            if(id){ div.dataset.id = id; div.dataset.messageId = id; }
             if(isAdmin && id){
                 const btn = document.createElement('button');
                 btn.classList.add('pin-toggle');

--- a/chat/templates/chat/conversation_detail.html
+++ b/chat/templates/chat/conversation_detail.html
@@ -38,6 +38,23 @@
       </div>
     </header>
 
+    <form id="search-form" data-channel="{{ conversation.id }}" class="mb-4 flex flex-wrap items-end gap-2" aria-label="{% trans 'Buscar mensagens' %}">
+      <label for="search-q" class="sr-only">{% trans 'Buscar mensagens' %}</label>
+      <input type="search" id="search-q" name="q" class="flex-1 border rounded p-2" placeholder="{% trans 'Buscar' %}" />
+      <input type="date" name="desde" class="border rounded p-2" />
+      <input type="date" name="ate" class="border rounded p-2" />
+      <select name="tipo" class="border rounded p-2">
+        <option value="">{% trans 'Todos' %}</option>
+        <option value="text">{% trans 'Texto' %}</option>
+        <option value="image">{% trans 'Imagem' %}</option>
+        <option value="video">{% trans 'Vídeo' %}</option>
+        <option value="file">{% trans 'Arquivo' %}</option>
+      </select>
+      <button type="submit" class="bg-primary text-white px-4 py-2 rounded">{% trans 'Buscar' %}</button>
+    </form>
+    <p id="search-feedback" class="text-sm text-neutral-500 mb-2 hidden"></p>
+    <div id="search-results" class="mb-4 space-y-2"></div>
+
     {% if pinned_messages %}
       <section id="pinned" class="mb-4 space-y-2" aria-label="{% trans 'Mensagens fixadas' %}">
         <h3 class="flex items-center gap-1 text-sm font-semibold text-neutral-600"><span>📌</span>{% trans 'Mensagens fixadas' %}</h3>
@@ -82,6 +99,62 @@
 <script>
   document.addEventListener('DOMContentLoaded', function(){
     if(window.HubXChatRoom){HubXChatRoom.init(document.getElementById('chat-container'));}
+    const searchForm = document.getElementById('search-form');
+    const results = document.getElementById('search-results');
+    const feedback = document.getElementById('search-feedback');
+    let nextUrl = null;
+    function render(data, append){
+      if(!append){ results.innerHTML=''; }
+      if(data.results.length === 0 && !append){
+        feedback.textContent = '{% trans "Nenhum resultado encontrado." %}';
+        feedback.classList.remove('hidden');
+        nextUrl = null;
+        return;
+      }
+      feedback.classList.add('hidden');
+      const ul = append ? results.querySelector('ul') : document.createElement('ul');
+      if(!append){ ul.className = 'divide-y'; }
+      data.results.forEach(m=>{
+        const li = document.createElement('li');
+        li.innerHTML = `<button type="button" class="w-full text-left p-2 hover:bg-neutral-100" data-id="${m.id}"><span class="font-semibold">${m.remetente}</span> <time class="text-xs text-neutral-500">${new Date(m.created).toLocaleString()}</time> - ${m.conteudo.substring(0,80)}</button>`;
+        ul.appendChild(li);
+      });
+      if(!append){ results.appendChild(ul); }
+      if(data.next){
+        nextUrl = data.next;
+        const more = document.createElement('button');
+        more.id = 'search-more';
+        more.className = 'text-blue-600 hover:underline mt-2';
+        more.textContent = '{% trans "Carregar mais" %}';
+        results.appendChild(more);
+      }else{
+        nextUrl = null;
+      }
+    }
+    searchForm.addEventListener('submit', function(e){
+      e.preventDefault();
+      const params = new URLSearchParams(new FormData(searchForm));
+      fetch(`/api/chat/channels/${searchForm.dataset.channel}/messages/search/?${params.toString()}`)
+        .then(r=>r.json())
+        .then(data=>render(data,false));
+    });
+    results.addEventListener('click', function(e){
+      const btn = e.target.closest('button[data-id]');
+      if(btn){
+        const id = btn.dataset.id;
+        const msg = document.querySelector(`[data-message-id="${id}"], [data-id="${id}"]`);
+        if(msg){
+          msg.classList.add('bg-yellow-100');
+          msg.scrollIntoView({behavior:'smooth', block:'center'});
+          setTimeout(()=>msg.classList.remove('bg-yellow-100'),2000);
+        }
+      } else if(e.target.id === 'search-more' && nextUrl){
+        fetch(nextUrl).then(r=>r.json()).then(data=>{
+          e.target.remove();
+          render(data,true);
+        });
+      }
+    });
   });
 </script>
 {% endblock %}

--- a/chat/templates/chat/partials/message.html
+++ b/chat/templates/chat/partials/message.html
@@ -39,6 +39,9 @@
           role="menu"
         >
           <li>
+            <button type="button" class="react-option" data-emoji="😊" aria-label="{% trans 'Reagir com 😊' %}">😊</button>
+          </li>
+          <li>
             <button type="button" class="react-option" data-emoji="👍" aria-label="{% trans 'Reagir com 👍' %}">👍</button>
           </li>
           <li>


### PR DESCRIPTION
## Summary
- add accessible reaction menu and reactions list
- implement search form and dynamic results
- support paginated history loading and before filter

## Testing
- `ruff check chat/api_views.py tests/chat/test_api_views.py`
- `pytest tests/chat/test_api_views.py::test_history_before_returns_previous_desc tests/chat/test_api_views.py::test_history_before_accepts_timestamp tests/chat/test_api_views.py::test_search_messages_date_range -q`

------
https://chatgpt.com/codex/tasks/task_e_68929e4014d48325bb20f7edf799ed87