### PR TITLE
feat: improve configuracoes i18n and monitoring

### DIFF
--- a/configuracoes/README.md
+++ b/configuracoes/README.md
@@ -60,3 +60,18 @@ Resposta:
 
 Use `PATCH /configuracoes/api/` para atualizar campos específicos. Consulte a
 documentação OpenAPI gerada para exemplos completos.
+
+## Testes e traduções
+
+Para executar a suíte de testes deste app:
+
+```bash
+pytest tests/configuracoes -q
+```
+
+Para gerar e compilar as traduções (inglês e espanhol):
+
+```bash
+python manage.py makemessages -l en -l es
+python manage.py compilemessages
+```

--- a/configuracoes/locale/en/LC_MESSAGES/django.po
+++ b/configuracoes/locale/en/LC_MESSAGES/django.po
@@ -3,207 +3,244 @@
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-05 20:46-0300\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"POT-Creation-Date: 2025-08-06 10:38-0300\n"
+"PO-Revision-Date: 2025-08-06 10:38-0300\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"Language-Team: English\n"
+"Language: en\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
 #: forms.py:37
 msgid "Aplicável apenas se notificações por e-mail estiverem ativas."
-msgstr ""
+msgstr "Only applicable if email notifications are enabled."
 
 #: forms.py:38
 msgid "Aplicável apenas se notificações por WhatsApp estiverem ativas."
-msgstr ""
+msgstr "Only applicable if WhatsApp notifications are enabled."
 
 #: forms.py:39
 msgid "Horário para envio das notificações diárias."
-msgstr ""
+msgstr "Time to send daily notifications."
 
 #: forms.py:40
 msgid "Horário para envio das notificações semanais."
-msgstr ""
+msgstr "Time to send weekly notifications."
 
 #: forms.py:41
 msgid "Dia da semana para notificações semanais."
-msgstr ""
+msgstr "Day of the week for weekly notifications."
 
 #: forms.py:56
 msgid "Obrigatório para frequência diária."
-msgstr ""
+msgstr "Required for daily frequency."
 
 #: forms.py:59 forms.py:61
 msgid "Obrigatório para frequência semanal."
-msgstr ""
+msgstr "Required for weekly frequency."
+
+#: models.py:11
+msgid "Imediata"
+msgstr "Immediate"
+
+#: models.py:12
+msgid "Diária"
+msgstr "Daily"
+
+#: models.py:13
+msgid "Semanal"
+msgstr "Weekly"
+
+#: models.py:17
+msgid "Português"
+msgstr "Portuguese"
+
+#: models.py:18
+msgid "English"
+msgstr "English"
+
+#: models.py:19
+msgid "Español"
+msgstr "Spanish"
+
+#: models.py:23
+msgid "Claro"
+msgstr "Light"
+
+#: models.py:24
+msgid "Escuro"
+msgstr "Dark"
+
+#: models.py:25
+msgid "Automático"
+msgstr "Automatic"
 
 #: models.py:29
 msgid "Segunda"
-msgstr ""
+msgstr "Monday"
 
 #: models.py:30
 msgid "Terça"
-msgstr ""
+msgstr "Tuesday"
 
 #: models.py:31
 msgid "Quarta"
-msgstr ""
+msgstr "Wednesday"
 
 #: models.py:32
 msgid "Quinta"
-msgstr ""
+msgstr "Thursday"
 
 #: models.py:33
 msgid "Sexta"
-msgstr ""
+msgstr "Friday"
 
 #: models.py:34
 msgid "Sábado"
-msgstr ""
+msgstr "Saturday"
 
 #: models.py:35
 msgid "Domingo"
-msgstr ""
+msgstr "Sunday"
 
 #: models.py:61
 msgid "Horário para envio de notificações diárias"
-msgstr ""
+msgstr "Time to send daily notifications"
 
 #: models.py:65
 msgid "Horário para envio de notificações semanais"
-msgstr ""
+msgstr "Time to send weekly notifications"
 
 #: models.py:70
 msgid "Dia da semana para notificações semanais"
-msgstr ""
+msgstr "Weekday for weekly notifications"
 
 #: templates/configuracoes/configuracoes.html:4
 msgid "Configurações da Conta"
-msgstr ""
+msgstr "Account Settings"
 
 #: templates/configuracoes/configuracoes.html:8
 msgid "Configurações"
-msgstr ""
+msgstr "Settings"
 
 #: templates/configuracoes/configuracoes.html:16
 msgid "Seções de Configuração"
-msgstr ""
+msgstr "Settings Sections"
 
 #: templates/configuracoes/configuracoes.html:17
 msgid "Informações Pessoais"
-msgstr ""
+msgstr "Personal Information"
 
 #: templates/configuracoes/configuracoes.html:18
 msgid "Segurança"
-msgstr ""
+msgstr "Security"
 
 #: templates/configuracoes/configuracoes.html:19
 msgid "Conexões Sociais"
-msgstr ""
+msgstr "Social Connections"
 
 #: templates/configuracoes/configuracoes.html:20
 msgid "Preferências"
-msgstr ""
+msgstr "Preferences"
 
 #: templates/configuracoes/partials/informacoes.html:15
 #: templates/configuracoes/partials/preferencias.html:58
 #: templates/configuracoes/partials/seguranca.html:27
 msgid "Salvar Alterações"
-msgstr ""
+msgstr "Save Changes"
 
 #: templates/configuracoes/partials/preferencias.html:9
 msgid "Receber notificações por e-mail"
-msgstr ""
+msgstr "Receive email notifications"
 
 #: templates/configuracoes/partials/preferencias.html:19
 msgid "Receber notificações por WhatsApp"
-msgstr ""
+msgstr "Receive WhatsApp notifications"
 
 #: templates/configuracoes/partials/preferencias.html:25
 msgid "Funcionalidade de WhatsApp em desenvolvimento"
-msgstr ""
+msgstr "WhatsApp feature under development"
 
 #: templates/configuracoes/partials/preferencias.html:28
 msgid "Horário diário"
-msgstr ""
+msgstr "Daily time"
 
 #: templates/configuracoes/partials/preferencias.html:35
 msgid "Horário semanal"
-msgstr ""
+msgstr "Weekly time"
 
 #: templates/configuracoes/partials/preferencias.html:42
 msgid "Dia da semana"
-msgstr ""
+msgstr "Day of the week"
 
 #: templates/configuracoes/partials/preferencias.html:49
 msgid "Idioma"
-msgstr ""
+msgstr "Language"
 
 #: templates/configuracoes/partials/preferencias.html:51
 #, python-format
 msgid "Idioma atual: %(LANGUAGE_CODE)s"
-msgstr ""
+msgstr "Current language: %(LANGUAGE_CODE)s"
 
 #: templates/configuracoes/partials/preferencias.html:54
 msgid "Tema"
-msgstr ""
+msgstr "Theme"
 
 #: templates/configuracoes/partials/redes.html:3
 msgid "Contas conectadas"
-msgstr ""
+msgstr "Connected accounts"
 
 #: templates/configuracoes/partials/redes.html:15
 msgid "Desconectar"
-msgstr ""
+msgstr "Disconnect"
 
 #: templates/configuracoes/partials/redes.html:22
 msgid "Nenhuma conta conectada."
-msgstr ""
+msgstr "No account connected."
 
 #: templates/configuracoes/partials/redes.html:26
 msgid "Conectar nova conta"
-msgstr ""
+msgstr "Connect new account"
 
 #: templates/configuracoes/partials/seguranca.html:34
 msgid "Autenticação em duas etapas"
-msgstr ""
+msgstr "Two-factor authentication"
 
 #: templates/configuracoes/partials/seguranca.html:38
 msgid "2FA está habilitado para sua conta."
-msgstr ""
+msgstr "2FA is enabled for your account."
 
 #: templates/configuracoes/partials/seguranca.html:44
 msgid "Desativar 2FA"
-msgstr ""
+msgstr "Disable 2FA"
 
 #: templates/configuracoes/partials/seguranca.html:48
 msgid "2FA não está habilitado."
-msgstr ""
+msgstr "2FA is not enabled."
 
 #: templates/configuracoes/partials/seguranca.html:54
 msgid "Ativar 2FA"
-msgstr ""
+msgstr "Enable 2FA"
 
-#: views.py:67
+#: views.py:76
 msgid "Conta desconectada."
-msgstr ""
+msgstr "Account disconnected."
 
-#: views.py:69
+#: views.py:78
 msgid "Rede social não encontrada."
-msgstr ""
+msgstr "Social network not found."
 
-#: views.py:80
+#: views.py:89
 msgid "Alterações salvas com sucesso."
-msgstr ""
+msgstr "Changes saved successfully."
 
-#: views.py:82
+#: views.py:91
 msgid "Corrija os erros abaixo."
-msgstr ""
+msgstr "Please correct the errors below."
+

--- a/configuracoes/locale/es/LC_MESSAGES/django.po
+++ b/configuracoes/locale/es/LC_MESSAGES/django.po
@@ -3,208 +3,244 @@
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-05 20:46-0300\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"POT-Creation-Date: 2025-08-06 10:38-0300\n"
+"PO-Revision-Date: 2025-08-06 10:38-0300\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"Language-Team: Spanish\n"
+"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? "
-"1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
+
 #: forms.py:37
 msgid "Aplicável apenas se notificações por e-mail estiverem ativas."
-msgstr ""
+msgstr "Aplicable solo si las notificaciones por correo electrónico están activas."
 
 #: forms.py:38
 msgid "Aplicável apenas se notificações por WhatsApp estiverem ativas."
-msgstr ""
+msgstr "Aplicable solo si las notificaciones por WhatsApp están activas."
 
 #: forms.py:39
 msgid "Horário para envio das notificações diárias."
-msgstr ""
+msgstr "Horario para envío de notificaciones diarias."
 
 #: forms.py:40
 msgid "Horário para envio das notificações semanais."
-msgstr ""
+msgstr "Horario para envío de notificaciones semanales."
 
 #: forms.py:41
 msgid "Dia da semana para notificações semanais."
-msgstr ""
+msgstr "Día de la semana para notificaciones semanales."
 
 #: forms.py:56
 msgid "Obrigatório para frequência diária."
-msgstr ""
+msgstr "Obligatorio para frecuencia diaria."
 
 #: forms.py:59 forms.py:61
 msgid "Obrigatório para frequência semanal."
-msgstr ""
+msgstr "Obligatorio para frecuencia semanal."
+
+#: models.py:11
+msgid "Imediata"
+msgstr "Inmediata"
+
+#: models.py:12
+msgid "Diária"
+msgstr "Diaria"
+
+#: models.py:13
+msgid "Semanal"
+msgstr "Semanal"
+
+#: models.py:17
+msgid "Português"
+msgstr "Portugués"
+
+#: models.py:18
+msgid "English"
+msgstr "Inglés"
+
+#: models.py:19
+msgid "Español"
+msgstr "Español"
+
+#: models.py:23
+msgid "Claro"
+msgstr "Claro"
+
+#: models.py:24
+msgid "Escuro"
+msgstr "Oscuro"
+
+#: models.py:25
+msgid "Automático"
+msgstr "Automático"
 
 #: models.py:29
 msgid "Segunda"
-msgstr ""
+msgstr "Lunes"
 
 #: models.py:30
 msgid "Terça"
-msgstr ""
+msgstr "Martes"
 
 #: models.py:31
 msgid "Quarta"
-msgstr ""
+msgstr "Miércoles"
 
 #: models.py:32
 msgid "Quinta"
-msgstr ""
+msgstr "Jueves"
 
 #: models.py:33
 msgid "Sexta"
-msgstr ""
+msgstr "Viernes"
 
 #: models.py:34
 msgid "Sábado"
-msgstr ""
+msgstr "Sábado"
 
 #: models.py:35
 msgid "Domingo"
-msgstr ""
+msgstr "Domingo"
 
 #: models.py:61
 msgid "Horário para envio de notificações diárias"
-msgstr ""
+msgstr "Horario para envío de notificaciones diarias"
 
 #: models.py:65
 msgid "Horário para envio de notificações semanais"
-msgstr ""
+msgstr "Horario para envío de notificaciones semanales"
 
 #: models.py:70
 msgid "Dia da semana para notificações semanais"
-msgstr ""
+msgstr "Día de la semana para notificaciones semanales"
 
 #: templates/configuracoes/configuracoes.html:4
 msgid "Configurações da Conta"
-msgstr ""
+msgstr "Configuraciones de la cuenta"
 
 #: templates/configuracoes/configuracoes.html:8
 msgid "Configurações"
-msgstr ""
+msgstr "Configuraciones"
 
 #: templates/configuracoes/configuracoes.html:16
 msgid "Seções de Configuração"
-msgstr ""
+msgstr "Secciones de configuración"
 
 #: templates/configuracoes/configuracoes.html:17
 msgid "Informações Pessoais"
-msgstr ""
+msgstr "Información personal"
 
 #: templates/configuracoes/configuracoes.html:18
 msgid "Segurança"
-msgstr ""
+msgstr "Seguridad"
 
 #: templates/configuracoes/configuracoes.html:19
 msgid "Conexões Sociais"
-msgstr ""
+msgstr "Conexiones sociales"
 
 #: templates/configuracoes/configuracoes.html:20
 msgid "Preferências"
-msgstr ""
+msgstr "Preferencias"
 
 #: templates/configuracoes/partials/informacoes.html:15
 #: templates/configuracoes/partials/preferencias.html:58
 #: templates/configuracoes/partials/seguranca.html:27
 msgid "Salvar Alterações"
-msgstr ""
+msgstr "Guardar cambios"
 
 #: templates/configuracoes/partials/preferencias.html:9
 msgid "Receber notificações por e-mail"
-msgstr ""
+msgstr "Recibir notificaciones por correo electrónico"
 
 #: templates/configuracoes/partials/preferencias.html:19
 msgid "Receber notificações por WhatsApp"
-msgstr ""
+msgstr "Recibir notificaciones por WhatsApp"
 
 #: templates/configuracoes/partials/preferencias.html:25
 msgid "Funcionalidade de WhatsApp em desenvolvimento"
-msgstr ""
+msgstr "Funcionalidad de WhatsApp en desarrollo"
 
 #: templates/configuracoes/partials/preferencias.html:28
 msgid "Horário diário"
-msgstr ""
+msgstr "Horario diario"
 
 #: templates/configuracoes/partials/preferencias.html:35
 msgid "Horário semanal"
-msgstr ""
+msgstr "Horario semanal"
 
 #: templates/configuracoes/partials/preferencias.html:42
 msgid "Dia da semana"
-msgstr ""
+msgstr "Día de la semana"
 
 #: templates/configuracoes/partials/preferencias.html:49
 msgid "Idioma"
-msgstr ""
+msgstr "Idioma"
 
 #: templates/configuracoes/partials/preferencias.html:51
 #, python-format
 msgid "Idioma atual: %(LANGUAGE_CODE)s"
-msgstr ""
+msgstr "Idioma actual: %(LANGUAGE_CODE)s"
 
 #: templates/configuracoes/partials/preferencias.html:54
 msgid "Tema"
-msgstr ""
+msgstr "Tema"
 
 #: templates/configuracoes/partials/redes.html:3
 msgid "Contas conectadas"
-msgstr ""
+msgstr "Cuentas conectadas"
 
 #: templates/configuracoes/partials/redes.html:15
 msgid "Desconectar"
-msgstr ""
+msgstr "Desconectar"
 
 #: templates/configuracoes/partials/redes.html:22
 msgid "Nenhuma conta conectada."
-msgstr ""
+msgstr "Ninguna cuenta conectada."
 
 #: templates/configuracoes/partials/redes.html:26
 msgid "Conectar nova conta"
-msgstr ""
+msgstr "Conectar nueva cuenta"
 
 #: templates/configuracoes/partials/seguranca.html:34
 msgid "Autenticação em duas etapas"
-msgstr ""
+msgstr "Autenticación de dos factores"
 
 #: templates/configuracoes/partials/seguranca.html:38
 msgid "2FA está habilitado para sua conta."
-msgstr ""
+msgstr "El 2FA está habilitado para su cuenta."
 
 #: templates/configuracoes/partials/seguranca.html:44
 msgid "Desativar 2FA"
-msgstr ""
+msgstr "Desactivar 2FA"
 
 #: templates/configuracoes/partials/seguranca.html:48
 msgid "2FA não está habilitado."
-msgstr ""
+msgstr "El 2FA no está habilitado."
 
 #: templates/configuracoes/partials/seguranca.html:54
 msgid "Ativar 2FA"
-msgstr ""
+msgstr "Activar 2FA"
 
-#: views.py:67
+#: views.py:76
 msgid "Conta desconectada."
-msgstr ""
+msgstr "Cuenta desconectada."
 
-#: views.py:69
+#: views.py:78
 msgid "Rede social não encontrada."
-msgstr ""
+msgstr "Red social no encontrada."
 
-#: views.py:80
+#: views.py:89
 msgid "Alterações salvas com sucesso."
-msgstr ""
+msgstr "Cambios guardados con éxito."
 
-#: views.py:82
+#: views.py:91
 msgid "Corrija os erros abaixo."
-msgstr ""
+msgstr "Corrija los errores a continuación."
+

--- a/configuracoes/models.py
+++ b/configuracoes/models.py
@@ -8,21 +8,21 @@ from django_extensions.db.models import TimeStampedModel
 from core.models import SoftDeleteManager, SoftDeleteModel
 
 NOTIFICACAO_FREQ_CHOICES = [
-    ("imediata", "Imediata"),
-    ("diaria", "Diária"),
-    ("semanal", "Semanal"),
+    ("imediata", _("Imediata")),
+    ("diaria", _("Diária")),
+    ("semanal", _("Semanal")),
 ]
 
 IDIOMA_CHOICES = [
-    ("pt-BR", "Português"),
-    ("en-US", "English"),
-    ("es-ES", "Español"),
+    ("pt-BR", _("Português")),
+    ("en-US", _("English")),
+    ("es-ES", _("Español")),
 ]
 
 TEMA_CHOICES = [
-    ("claro", "Claro"),
-    ("escuro", "Escuro"),
-    ("automatico", "Automático"),
+    ("claro", _("Claro")),
+    ("escuro", _("Escuro")),
+    ("automatico", _("Automático")),
 ]
 
 DIAS_SEMANA_CHOICES = [

--- a/prometheus/configuracoes_alerts.yml
+++ b/prometheus/configuracoes_alerts.yml
@@ -1,0 +1,10 @@
+groups:
+  - name: configuracoes
+    rules:
+      - alert: ConfiguracaoContaLatenciaAlta
+        expr: histogram_quantile(0.95, sum(rate(configuracao_conta_api_latency_seconds_bucket[5m])) by (le)) > 0.1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Latência p95 do endpoint de configurações acima de 100ms"

--- a/tests/configuracoes/test_performance.py
+++ b/tests/configuracoes/test_performance.py
@@ -1,23 +1,41 @@
 import statistics
 import time
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
+from django.test import Client
 from django.urls import reverse
+from django.db import connection
 
 from accounts.factories import UserFactory
 
 pytestmark = [pytest.mark.django_db, pytest.mark.urls("tests.configuracoes.urls")]
 
 
-def test_preferencias_view_p95_below_100ms(client):
+@pytest.mark.parametrize("workers", [1, 5])
+def test_preferencias_view_p95_below_100ms(workers: int) -> None:
+    if workers > 1 and connection.vendor == "sqlite":
+        pytest.skip("SQLite não suporta chamadas concorrentes confiáveis")
     user = UserFactory()
-    client.force_login(user)
+    base_client = Client()
+    base_client.force_login(user)
+    session_cookie = base_client.cookies.get("sessionid")
     url = reverse("configuracoes") + "?tab=preferencias"
-    tempos = []
-    for _ in range(20):
+
+    def request_view(_: int) -> float:
+        local_client = Client()
+        if session_cookie:
+            local_client.cookies["sessionid"] = session_cookie.value
         inicio = time.perf_counter()
-        resp = client.get(url)
+        resp = local_client.get(url)
         assert resp.status_code == 200
-        tempos.append(time.perf_counter() - inicio)
+        return time.perf_counter() - inicio
+
+    if workers == 1:
+        tempos = [request_view(i) for i in range(20)]
+    else:
+        with ThreadPoolExecutor(max_workers=workers) as executor:
+            tempos = list(executor.map(request_view, range(20)))
+
     p95 = statistics.quantiles(tempos, n=100, method="inclusive")[94]
     assert p95 < 0.1


### PR DESCRIPTION
## Summary
- localize `ConfiguracaoConta` choices and view messages
- add performance test harness for ConfiguracoesView
- expose Prometheus alert rule and docs

## Testing
- `pytest tests/configuracoes/test_performance.py::test_preferencias_view_p95_below_100ms -q`
- `pytest tests/configuracoes -q`
- `django-admin compilemessages --pythonpath .. --settings Hubx.settings`


------
https://chatgpt.com/codex/tasks/task_e_6893594a2cc48325ad0e53afa8960dc1