### PR TITLE
feat(chat): add message edit history restoration

### DIFF
--- a/chat/api_urls.py
+++ b/chat/api_urls.py
@@ -27,6 +27,7 @@ chat_message_pin = ChatMessageViewSet.as_view({"post": "pin"})
 chat_message_unpin = ChatMessageViewSet.as_view({"post": "unpin"})
 chat_message_react = ChatMessageViewSet.as_view({"post": "react"})
 chat_message_flag = ChatMessageViewSet.as_view({"post": "flag"})
+chat_message_restore = ChatMessageViewSet.as_view({"post": "restore"})
 chat_message_search = ChatMessageViewSet.as_view({"get": "search"})
 
 urlpatterns = router.urls + [
@@ -56,6 +57,11 @@ urlpatterns = router.urls + [
         name="chat-channel-message-react",
     ),
     path(
+        "channels/<uuid:channel_pk>/messages/<uuid:pk>/restore/",
+        chat_message_restore,
+        name="chat-channel-message-restore",
+    ),
+    path(
         "channels/<uuid:channel_pk>/messages/<uuid:pk>/flag/",
         chat_message_flag,
         name="chat-channel-message-flag",
@@ -72,4 +78,3 @@ urlpatterns = router.urls + [
     ),
     path("upload/", UploadArquivoAPIView.as_view(), name="chat-upload"),
 ]
-

--- a/chat/templates/chat/historico_edicoes.html
+++ b/chat/templates/chat/historico_edicoes.html
@@ -2,7 +2,8 @@
 {% load i18n %}
 
 {% block chat_content %}
-<h2 class="text-xl font-semibold mb-4">{% trans "Histórico de edições" %}</h2>
+<h2 class="text-xl font-semibold mb-2">{% trans "Histórico de edições" %}</h2>
+<p class="mb-4 text-sm text-gray-700">{{ message.conteudo|linebreaksbr }}</p>
 <form method="get" class="mb-4 flex gap-2 items-end">
   <div>
     <label for="inicio" class="block text-sm">{% trans "Início" %}</label>
@@ -24,6 +25,18 @@
       <div class="mt-1">
         {{ log.previous_content|linebreaksbr }}
       </div>
+      <form
+        method="post"
+        class="mt-2"
+        hx-post="/api/chat/channels/{{ channel.id }}/messages/{{ message.id }}/restore/"
+        hx-swap="none"
+      >
+        {% csrf_token %}
+        <input type="hidden" name="log_id" value="{{ log.id }}" />
+        <button type="submit" class="px-2 py-1 text-xs bg-primary text-white rounded">
+          {% trans "Restaurar" %}
+        </button>
+      </form>
     </li>
   {% empty %}
     <li>{% trans "Nenhum registro" %}</li>

--- a/chat/templates/chat/partials/message.html
+++ b/chat/templates/chat/partials/message.html
@@ -65,7 +65,7 @@
           📌
         </button>
         <button
-          hx-get="{% url 'chat:historico_edicoes' m.channel_id %}?message={{ m.id }}"
+          hx-get="{% url 'chat:historico_edicoes' m.channel_id m.id %}"
           hx-target="#modal"
           class="text-xs text-neutral-600"
           aria-label="{% trans 'Histórico de edições' %}"

--- a/chat/urls.py
+++ b/chat/urls.py
@@ -19,7 +19,7 @@ urlpatterns = [
         name="exportar_modal",
     ),
     path(
-        "<uuid:channel_id>/historico/",
+        "<uuid:channel_id>/mensagens/<uuid:message_id>/historico/",
         views.historico_edicoes,
         name="historico_edicoes",
     ),

--- a/tests/chat/test_views.py
+++ b/tests/chat/test_views.py
@@ -1,8 +1,7 @@
 import pytest
-from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
 
-from chat.models import ChatChannel, ChatParticipant, ChatMessage, ChatModerationLog
+from chat.models import ChatChannel, ChatMessage, ChatModerationLog, ChatParticipant
 
 pytestmark = pytest.mark.django_db
 
@@ -59,10 +58,8 @@ def test_historico_edicoes_view(client, admin_user):
     channel = ChatChannel.objects.create(titulo="H", contexto_tipo="privado")
     ChatParticipant.objects.create(channel=channel, user=admin_user, is_admin=True)
     msg = ChatMessage.objects.create(channel=channel, remetente=admin_user, conteudo="a")
-    ChatModerationLog.objects.create(message=msg, action="edit", moderator=admin_user, previous_content="b")
+    log = ChatModerationLog.objects.create(message=msg, action="edit", moderator=admin_user, previous_content="b")
     client.force_login(admin_user)
-    resp = client.get(reverse("chat:historico_edicoes", args=[channel.id]))
+    resp = client.get(reverse("chat:historico_edicoes", args=[channel.id, msg.id]))
     assert resp.status_code == 200
-    assert "logs" in resp.context
-
-
+    assert list(resp.context["logs"]) == [log]


### PR DESCRIPTION
## Summary
- show edit history for individual messages
- allow moderators to restore messages from history
- support restore via API endpoint and new tests

## Testing
- `pytest tests/chat/test_views.py::test_historico_edicoes_view tests/chat/test_api_views.py::test_restore_message -q`


------
https://chatgpt.com/codex/tasks/task_e_689359a9c4dc8325bba8a54632b352ea