### PR TITLE
Restrict public dashboard filters and improve metrics error handling

### DIFF
--- a/dashboard/forms.py
+++ b/dashboard/forms.py
@@ -27,7 +27,8 @@ class DashboardFilterForm(forms.ModelForm):
     def save(self, user, filtros_data, commit: bool = True):
         instance: DashboardFilter = super().save(commit=False)
         instance.user = user
-        instance.filtros = filtros_data
+        allowed = {"metricas", "organizacao_id", "nucleo_id", "evento_id", "data_inicio", "data_fim"}
+        instance.filtros = {k: v for k, v in filtros_data.items() if k in allowed}
         if commit:
             instance.save()
         return instance

--- a/dashboard/models.py
+++ b/dashboard/models.py
@@ -23,6 +23,10 @@ class DashboardFilter(SoftDeleteModel, TimeStampedModel):
     def __str__(self) -> str:  # pragma: no cover - simple representation
         return self.nome
 
+    def clean(self):
+        if self.publico and self.user_id and self.user.user_type not in {UserType.ROOT, UserType.ADMIN}:
+            raise ValidationError({"publico": "Somente admins podem tornar público"})
+
 
 class DashboardConfig(SoftDeleteModel, TimeStampedModel):
     objects = SoftDeleteManager()

--- a/dashboard/services.py
+++ b/dashboard/services.py
@@ -169,6 +169,16 @@ class DashboardMetricsService:
         valid_periodos = {"mensal", "trimestral", "semestral", "anual"}
         if periodo not in valid_periodos:
             raise ValueError("Período inválido")
+        if isinstance(inicio, str):
+            try:
+                inicio = datetime.fromisoformat(inicio)
+            except ValueError:
+                raise ValueError("data_inicio inválida")
+        if isinstance(fim, str):
+            try:
+                fim = datetime.fromisoformat(fim)
+            except ValueError:
+                raise ValueError("data_fim inválida")
         inicio, fim = DashboardService.get_period_range(periodo, inicio, fim)
 
         cache_filters = {

--- a/dashboard/templates/dashboard/admin.html
+++ b/dashboard/templates/dashboard/admin.html
@@ -8,6 +8,8 @@
 <main class="max-w-7xl mx-auto px-4 py-10" role="main" aria-label="Dashboard">
   <h1 class="text-3xl font-semibold text-neutral-900 text-center mb-10">{% trans "Dashboard Administrativo" %}</h1>
 
+  {% include 'dashboard/partials/messages.html' %}
+
   {% include 'dashboard/partials/filters_form.html' %}
 
   <div hx-get="{% url 'dashboard:metrics-partial' %}" hx-trigger="load, every 10s" hx-target="#metrics" hx-swap="innerHTML">

--- a/dashboard/templates/dashboard/cliente.html
+++ b/dashboard/templates/dashboard/cliente.html
@@ -8,6 +8,8 @@
 <main class="max-w-7xl mx-auto px-4 py-10" role="main" aria-label="Dashboard">
   <h1 class="text-3xl font-semibold text-neutral-900 text-center mb-10">{% trans "Dashboard Cliente" %}</h1>
 
+  {% include 'dashboard/partials/messages.html' %}
+
   {% include 'dashboard/partials/filters_form.html' %}
 
   <div hx-get="{% url 'dashboard:metrics-partial' %}" hx-trigger="load, every 10s" hx-target="#metrics" hx-swap="innerHTML">

--- a/dashboard/templates/dashboard/config_list.html
+++ b/dashboard/templates/dashboard/config_list.html
@@ -4,6 +4,7 @@
 {% block content %}
 <main class="max-w-2xl mx-auto p-4" role="main">
   <h1 class="text-2xl font-semibold mb-4">{% trans 'Configurações salvas' %}</h1>
+  {% include 'dashboard/partials/messages.html' %}
   <ul class="space-y-2">
     {% for cfg in object_list %}
       <li class="flex justify-between items-center p-2 bg-white rounded shadow">

--- a/dashboard/templates/dashboard/filter_list.html
+++ b/dashboard/templates/dashboard/filter_list.html
@@ -4,6 +4,7 @@
 {% block content %}
 <main class="max-w-2xl mx-auto p-4" role="main">
   <h1 class="text-2xl font-semibold mb-4">{% trans 'Filtros salvos' %}</h1>
+  {% include 'dashboard/partials/messages.html' %}
   <ul class="space-y-2">
     {% for f in object_list %}
       <li class="flex justify-between items-center p-2 bg-white rounded shadow">

--- a/dashboard/templates/dashboard/gerente.html
+++ b/dashboard/templates/dashboard/gerente.html
@@ -8,6 +8,8 @@
 <main class="max-w-7xl mx-auto px-4 py-10" role="main" aria-label="Dashboard">
   <h1 class="text-3xl font-semibold text-neutral-900 text-center mb-10">{% trans "Dashboard Gerente" %}</h1>
 
+  {% include 'dashboard/partials/messages.html' %}
+
   {% include 'dashboard/partials/filters_form.html' %}
 
   <div hx-get="{% url 'dashboard:metrics-partial' %}" hx-trigger="load, every 10s" hx-target="#metrics" hx-swap="innerHTML">

--- a/dashboard/templates/dashboard/partials/messages.html
+++ b/dashboard/templates/dashboard/partials/messages.html
@@ -1,0 +1,8 @@
+{% load i18n %}
+{% if messages %}
+<div id="messages" hx-swap-oob="true" class="mb-4">
+  {% for message in messages %}
+    <div class="bg-red-100 text-red-800 p-2 rounded" role="alert">{{ message }}</div>
+  {% endfor %}
+</div>
+{% endif %}

--- a/dashboard/templates/dashboard/partials/metric_card.html
+++ b/dashboard/templates/dashboard/partials/metric_card.html
@@ -2,7 +2,7 @@
 <div class="p-4 bg-white rounded-lg shadow" aria-label="{{ title }}">
   <div class="flex items-center justify-between">
     <h3 class="text-sm font-medium text-neutral-700">{{ title }}</h3>
-    {% if icon %}<i class="fa-solid {{ icon }} text-primary-600"></i>{% endif %}
+    {% if icon %}<i class="fa-solid {{ icon }} text-primary-600" aria-label="{{ title }}"></i>{% endif %}
   </div>
   <p class="text-3xl font-bold text-neutral-900" id="{{ id }}">{{ value }}</p>
 </div>

--- a/dashboard/templates/dashboard/root.html
+++ b/dashboard/templates/dashboard/root.html
@@ -8,6 +8,8 @@
 <main class="max-w-7xl mx-auto px-4 py-10" role="main" aria-label="Dashboard">
   <h1 class="text-3xl font-semibold text-neutral-900 text-center mb-10">{% trans "Dashboard Root" %}</h1>
 
+  {% include 'dashboard/partials/messages.html' %}
+
   {% include 'dashboard/partials/filters_form.html' %}
 
   <div hx-get="{% url 'dashboard:metrics-partial' %}" hx-trigger="load, every 10s" hx-target="#metrics" hx-swap="innerHTML">

--- a/tests/dashboard/test_models.py
+++ b/tests/dashboard/test_models.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+from django.core.exceptions import ValidationError
 
 from dashboard.models import DashboardFilter
 
@@ -23,3 +24,9 @@ def test_soft_delete(admin_user):
     deleted = DashboardFilter.all_objects.get(id=filtro_id)
     assert deleted.deleted is True
     assert deleted.deleted_at is not None
+
+
+def test_non_admin_cannot_save_public_filter(cliente_user):
+    filtro = DashboardFilter(user=cliente_user, nome="f1", filtros={}, publico=True)
+    with pytest.raises(ValidationError):
+        filtro.full_clean()

--- a/tests/dashboard/test_services.py
+++ b/tests/dashboard/test_services.py
@@ -126,3 +126,8 @@ def test_get_metrics_permission_denied(cliente_user, admin_user):
 def test_get_metrics_invalid_period(admin_user):
     with pytest.raises(ValueError):
         DashboardMetricsService.get_metrics(admin_user, periodo="xxx")
+
+
+def test_get_metrics_invalid_date(admin_user):
+    with pytest.raises(ValueError):
+        DashboardMetricsService.get_metrics(admin_user, inicio="bad-date")

--- a/tests/dashboard/test_templates.py
+++ b/tests/dashboard/test_templates.py
@@ -1,0 +1,26 @@
+import pytest
+from django.urls import reverse
+
+from dashboard.views import METRICAS_INFO
+from dashboard.services import DashboardMetricsService
+
+pytestmark = pytest.mark.django_db
+
+
+def test_metricas_info_used_in_context(client, admin_user):
+    client.force_login(admin_user)
+    resp = client.get(reverse("dashboard:admin"))
+    expected = [{"key": k, "label": v["label"]} for k, v in METRICAS_INFO.items()]
+    assert resp.context["metricas_disponiveis"] == expected
+
+
+def test_error_message_rendered(client, admin_user, monkeypatch):
+    client.force_login(admin_user)
+
+    def boom(user, **kwargs):
+        raise ValueError("boom")
+
+    monkeypatch.setattr(DashboardMetricsService, "get_metrics", boom)
+    resp = client.get(reverse("dashboard:metrics-partial"), HTTP_HX_REQUEST="true")
+    assert resp.status_code == 400
+    assert "boom" in resp.content.decode()

--- a/tests/dashboard/test_views.py
+++ b/tests/dashboard/test_views.py
@@ -50,7 +50,6 @@ def test_view_mixins():
     assert issubclass(ClienteDashboardView, ClienteRequiredMixin)
 
 
-
 def test_root_dashboard_view(client, root_user):
     client.force_login(root_user)
     resp = client.get(reverse("dashboard:root"))
@@ -118,6 +117,12 @@ def test_base_view_accepts_params(monkeypatch, client, admin_user):
     assert resp.context["chart_data"] == [1]
 
 
+def test_invalid_date_returns_400(client, admin_user):
+    client.force_login(admin_user)
+    resp = client.get(reverse("dashboard:admin"), {"data_inicio": "xx"})
+    assert resp.status_code == 400
+
+
 def test_export_view_csv(monkeypatch, client, admin_user):
     client.force_login(admin_user)
 
@@ -166,9 +171,12 @@ def test_forbidden_dashboard_views(client, cliente_user):
 
 def test_config_save_and_apply(client, admin_user, gerente_user):
     client.force_login(admin_user)
-    url = reverse("dashboard:config-create") + "?periodo=mensal&escopo=organizacao&organizacao_id=" + str(
-        admin_user.organizacao_id
-    ) + "&metricas=num_users"
+    url = (
+        reverse("dashboard:config-create")
+        + "?periodo=mensal&escopo=organizacao&organizacao_id="
+        + str(admin_user.organizacao_id)
+        + "&metricas=num_users"
+    )
     resp = client.post(url, {"nome": "cfg", "publico": True})
     assert resp.status_code == 302
     cfg = DashboardConfig.objects.get(nome="cfg")
@@ -196,4 +204,3 @@ def test_filter_save_and_apply(client, admin_user, gerente_user):
     resp = client.get(reverse("dashboard:filter-apply", args=[filtro.pk]))
     assert resp.status_code == 302
     assert "metricas=num_users" in resp["Location"]
-


### PR DESCRIPTION
## Summary
- Validate `DashboardFilter` to restrict public filters to admin roles and accept only whitelisted fields in filter form
- Centralize metric metadata, handle invalid dates gracefully, and surface HTMX error messages
- Add accessibility labels for metric icons and expose message area in dashboard templates

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6893669e040483259cf8a5261b6585f1