### PR TITLE
feat: improve chat reactions and history

### DIFF
--- a/chat/static/chat/css/chat.css
+++ b/chat/static/chat/css/chat.css
@@ -199,15 +199,6 @@
     background: rgba(0, 255, 65, 0.2);
 }
 
-.chat-media-thumb {
-    max-width: 120px;
-    max-height: 120px;
-    width: 100%;
-    border-radius: 8px;
-    margin-top: 4px;
-    display: block;
-}
-
 .chat-file {
     background: #f5f5f5;
     padding: 6px 10px;

--- a/chat/static/chat/js/chat_socket.js
+++ b/chat/static/chat/js/chat_socket.js
@@ -90,6 +90,7 @@
                 Object.entries(reactions).forEach(([emoji,count])=>{
                     const li = document.createElement('li');
                     li.className = 'text-sm';
+                    li.dataset.emoji = emoji;
                     if(userReactions && userReactions.includes(emoji)){
                         li.classList.add('font-bold');
                     }
@@ -102,6 +103,7 @@
         function setupReactionMenu(div, id){
             const btn = div.querySelector('.reaction-btn');
             const menu = div.querySelector('.reaction-menu');
+            const list = div.querySelector('.reactions');
             if(!btn || !menu || !id) return;
             function closeMenu(){
                 menu.classList.add('hidden');
@@ -148,6 +150,21 @@
                   });
                 closeMenu();
             });
+            if(list){
+                list.addEventListener('click', e=>{
+                    const li = e.target.closest('li');
+                    if(!li) return;
+                    const emoji = li.dataset.emoji;
+                    fetch(`/api/chat/channels/${destinatarioId}/messages/${id}/react/`,{
+                        method:'POST',
+                        headers:{'X-CSRFToken':csrfToken,'Content-Type':'application/json'},
+                        body: JSON.stringify({emoji})
+                    }).then(r=>r.ok?r.json():Promise.reject())
+                      .then(data=>{
+                        renderReactions(div, data.reactions, data.user_reactions);
+                      });
+                });
+            }
         }
 
         function scrollToBottom(){ messages.scrollTop = messages.scrollHeight; }
@@ -219,13 +236,13 @@
             if(pinned){ div.classList.add('pinned'); }
             let content = conteudo;
             if(tipo === 'image'){
-                content = `<img src="${conteudo}" alt="imagem" class="chat-media-thumb">`;
+                content = `<img src="${conteudo}" alt="imagem" class="w-full max-w-xs h-auto rounded">`;
             }else if(tipo === 'video'){
-                content = `<video src="${conteudo}" controls class="chat-media-thumb"></video>`;
+                content = `<video src="${conteudo}" controls class="w-full max-w-xs h-auto" aria-label="${t('videoPlayer','Player de vídeo')}"></video>`;
             }else if(tipo === 'file'){
                 content = `<div class="chat-file"><a href="${conteudo}" target="_blank">📎 Baixar arquivo</a></div>`;
             }
-            div.innerHTML = `<div><strong>${remetente}</strong>: ${content}</div><ul class="reactions flex gap-2 ml-2"></ul><div class="reaction-container relative"><button type="button" class="reaction-btn" aria-haspopup="true" aria-expanded="false" aria-label="${t('addReaction','Adicionar reação')}">😊</button><ul class="reaction-menu hidden absolute bg-white border rounded p-1 flex gap-1" role="menu"><li><button type="button" class="react-option" data-emoji="😊" aria-label="${t('reactWith','Reagir com')} 😊">😊</button></li><li><button type="button" class="react-option" data-emoji="👍" aria-label="${t('reactWith','Reagir com')} 👍">👍</button></li><li><button type="button" class="react-option" data-emoji="😂" aria-label="${t('reactWith','Reagir com')} 😂">😂</button></li><li><button type="button" class="react-option" data-emoji="❤️" aria-label="${t('reactWith','Reagir com')} ❤️">❤️</button></li><li><button type="button" class="react-option" data-emoji="😮" aria-label="${t('reactWith','Reagir com')} 😮">😮</button></li></ul></div>`;
+            div.innerHTML = `<div><strong>${remetente}</strong>: ${content}</div><ul class="reactions flex gap-2 ml-2"></ul><div class="reaction-container relative"><button type="button" class="reaction-btn" aria-haspopup="true" aria-expanded="false" aria-label="${t('addReaction','Adicionar reação')}">🙂</button><ul class="reaction-menu hidden absolute bg-white border rounded p-1 flex gap-1" role="menu"><li><button type="button" class="react-option" data-emoji="🙂" aria-label="${t('reactWith','Reagir com')} 🙂">🙂</button></li><li><button type="button" class="react-option" data-emoji="❤️" aria-label="${t('reactWith','Reagir com')} ❤️">❤️</button></li><li><button type="button" class="react-option" data-emoji="👍" aria-label="${t('reactWith','Reagir com')} 👍">👍</button></li><li><button type="button" class="react-option" data-emoji="😂" aria-label="${t('reactWith','Reagir com')} 😂">😂</button></li><li><button type="button" class="react-option" data-emoji="🎉" aria-label="${t('reactWith','Reagir com')} 🎉">🎉</button></li></ul></div>`;
             if(id){ div.dataset.id = id; div.dataset.messageId = id; }
             if(isAdmin && id){
                 const btn = document.createElement('button');

--- a/chat/static/chat/js/i18n.js
+++ b/chat/static/chat/js/i18n.js
@@ -1,0 +1,12 @@
+(function(){
+  const el = document.querySelector('[data-i18n]');
+  let texts = {};
+  if(el){
+    try{
+      texts = JSON.parse(el.dataset.i18n);
+    }catch(e){
+      texts = {};
+    }
+  }
+  window.chatTexts = texts;
+})();

--- a/chat/templates/chat/base_chat.html
+++ b/chat/templates/chat/base_chat.html
@@ -15,18 +15,7 @@
 
 {% block extra_js %}
 {{ block.super }}
-<script>
-window.chatTexts = {
-  addReaction: "{% trans 'Adicionar reação' %}",
-  reactWith: "{% trans 'Reagir com' %}",
-  pin: "{% trans 'Fixar' %}",
-  unpin: "{% trans 'Desafixar' %}",
-  pinMessage: "{% trans 'Fixar mensagem' %}",
-  unpinMessage: "{% trans 'Desafixar mensagem' %}",
-  edit: "{% trans 'Editar' %}",
-  uploadError: "{% trans 'Erro no upload' %}"
-};
-</script>
+<script src="{% static 'chat/js/i18n.js' %}"></script>
 <script src="{% static 'chat/js/chat_socket.js' %}"></script>
 <script src="{% static 'chat/js/notifications_socket.js' %}"></script>
 {% endblock %}

--- a/chat/templates/chat/conversation_detail.html
+++ b/chat/templates/chat/conversation_detail.html
@@ -5,6 +5,7 @@
 
 {% block chat_content %}
 <main class="max-w-4xl mx-auto h-screen flex flex-col p-4">
+  <div id="i18n-data" data-i18n='{"noResults": "{{ _("Nenhum resultado encontrado.")|escapejs }}", "loadMore": "{{ _("Carregar mais")|escapejs }}", "clear": "{{ _("Limpar")|escapejs }}", "addReaction": "{{ _("Adicionar reação")|escapejs }}", "reactWith": "{{ _("Reagir com")|escapejs }}", "pin": "{{ _("Fixar")|escapejs }}", "unpin": "{{ _("Desafixar")|escapejs }}", "pinMessage": "{{ _("Fixar mensagem")|escapejs }}", "unpinMessage": "{{ _("Desafixar mensagem")|escapejs }}", "edit": "{{ _("Editar")|escapejs }}", "uploadError": "{{ _("Erro no upload")|escapejs }}", "videoPlayer": "{{ _("Player de vídeo")|escapejs }}"}'></div>
   <div
     id="chat-container"
     data-dest-id="{{ conversation.id }}"
@@ -40,19 +41,20 @@
 
     <form id="search-form" data-channel="{{ conversation.id }}" class="mb-4 flex flex-wrap items-end gap-2" aria-label="{% trans 'Buscar mensagens' %}">
       <label for="search-q" class="sr-only">{% trans 'Buscar mensagens' %}</label>
-      <input type="search" id="search-q" name="q" class="flex-1 border rounded p-2" placeholder="{% trans 'Buscar' %}" />
-      <input type="date" name="desde" class="border rounded p-2" />
-      <input type="date" name="ate" class="border rounded p-2" />
-      <select name="tipo" class="border rounded p-2">
+      <input type="search" id="search-q" name="q" class="w-full sm:flex-1 border rounded p-2" placeholder="{% trans 'Buscar' %}" />
+      <input type="date" name="desde" class="w-full sm:w-auto border rounded p-2" />
+      <input type="date" name="ate" class="w-full sm:w-auto border rounded p-2" />
+      <select name="tipo" class="w-full sm:w-auto border rounded p-2">
         <option value="">{% trans 'Todos' %}</option>
         <option value="text">{% trans 'Texto' %}</option>
         <option value="image">{% trans 'Imagem' %}</option>
         <option value="video">{% trans 'Vídeo' %}</option>
         <option value="file">{% trans 'Arquivo' %}</option>
       </select>
-      <button type="submit" class="bg-primary text-white px-4 py-2 rounded">{% trans 'Buscar' %}</button>
+      <button type="submit" class="w-full sm:w-auto bg-primary text-white px-4 py-2 rounded">{% trans 'Buscar' %}</button>
+      <button type="button" id="search-clear" class="w-full sm:w-auto px-4 py-2 border rounded">{% trans 'Limpar' %}</button>
     </form>
-    <p id="search-feedback" class="text-sm text-neutral-500 mb-2 hidden"></p>
+    <p id="search-feedback" class="text-sm text-neutral-500 mb-2 hidden text-center"></p>
     <div id="search-results" class="mb-4 space-y-2"></div>
 
     {% if pinned_messages %}
@@ -99,14 +101,16 @@
 <script>
   document.addEventListener('DOMContentLoaded', function(){
     if(window.HubXChatRoom){HubXChatRoom.init(document.getElementById('chat-container'));}
+    const texts = window.chatTexts || {};
     const searchForm = document.getElementById('search-form');
     const results = document.getElementById('search-results');
     const feedback = document.getElementById('search-feedback');
+    const clearBtn = document.getElementById('search-clear');
     let nextUrl = null;
     function render(data, append){
       if(!append){ results.innerHTML=''; }
       if(data.results.length === 0 && !append){
-        feedback.textContent = '{% trans "Nenhum resultado encontrado." %}';
+        feedback.innerHTML = `<div class="text-center"><span class="block text-4xl">🔍</span>${texts.noResults || '{% trans "Nenhum resultado encontrado." %}'}</div>`;
         feedback.classList.remove('hidden');
         nextUrl = null;
         return;
@@ -125,7 +129,7 @@
         const more = document.createElement('button');
         more.id = 'search-more';
         more.className = 'text-blue-600 hover:underline mt-2';
-        more.textContent = '{% trans "Carregar mais" %}';
+        more.textContent = texts.loadMore || '{% trans "Carregar mais" %}';
         results.appendChild(more);
       }else{
         nextUrl = null;
@@ -137,6 +141,12 @@
       fetch(`/api/chat/channels/${searchForm.dataset.channel}/messages/search/?${params.toString()}`)
         .then(r=>r.json())
         .then(data=>render(data,false));
+    });
+    clearBtn.addEventListener('click', function(){
+      searchForm.reset();
+      results.innerHTML = '';
+      feedback.classList.add('hidden');
+      nextUrl = null;
     });
     results.addEventListener('click', function(e){
       const btn = e.target.closest('button[data-id]');

--- a/chat/templates/chat/historico_edicoes.html
+++ b/chat/templates/chat/historico_edicoes.html
@@ -4,7 +4,7 @@
 {% block chat_content %}
 <h2 class="text-xl font-semibold mb-2">{% trans "Histórico de edições" %}</h2>
 <p class="mb-4 text-sm text-gray-700">{{ message.conteudo|linebreaksbr }}</p>
-<form method="get" class="mb-4 flex gap-2 items-end">
+<form method="get" class="mb-4 flex flex-wrap gap-2 items-end">
   <div>
     <label for="inicio" class="block text-sm">{% trans "Início" %}</label>
     <input type="date" name="inicio" id="inicio" value="{{ request.GET.inicio }}" class="border px-2 py-1 rounded" />
@@ -14,44 +14,50 @@
     <input type="date" name="fim" id="fim" value="{{ request.GET.fim }}" class="border px-2 py-1 rounded" />
   </div>
   <button type="submit" class="px-3 py-1 bg-primary text-white rounded">{% trans "Filtrar" %}</button>
+  <button type="submit" name="export" value="csv" class="px-3 py-1 border rounded">{% trans "Exportar CSV" %}</button>
 </form>
-<ul class="space-y-2">
-  {% for log in logs %}
-    <li class="p-2 border rounded">
-      <div class="text-sm text-gray-600">
-        <time datetime="{{ log.created|date:'c' }}">{{ log.created|date:'d/m/Y H:i' }}</time>
-        — {{ log.moderator.username }}
-      </div>
-      <div class="mt-1">
-        {{ log.previous_content|linebreaksbr }}
-      </div>
-      <form
-        method="post"
-        class="mt-2"
-        hx-post="/api/chat/channels/{{ channel.id }}/messages/{{ message.id }}/restore/"
-        hx-swap="none"
-      >
-        {% csrf_token %}
-        <input type="hidden" name="log_id" value="{{ log.id }}" />
-        <button type="submit" class="px-2 py-1 text-xs bg-primary text-white rounded">
-          {% trans "Restaurar" %}
-        </button>
-      </form>
-    </li>
-  {% empty %}
-    <li>{% trans "Nenhum registro" %}</li>
-  {% endfor %}
-</ul>
+<div class="overflow-x-auto">
+  <table class="min-w-full text-sm">
+    <thead>
+      <tr class="text-left">
+        <th class="px-2 py-1">{% trans "Data" %}</th>
+        <th class="px-2 py-1">{% trans "Moderador" %}</th>
+        <th class="px-2 py-1">{% trans "Conteúdo anterior" %}</th>
+        <th class="px-2 py-1">{% trans "Ações" %}</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for log in logs %}
+      <tr class="border-t">
+        <td class="px-2 py-1"><time datetime="{{ log.created|date:'c' }}">{{ log.created|date:'d/m/Y H:i' }}</time></td>
+        <td class="px-2 py-1">{{ log.moderator.username }}</td>
+        <td class="px-2 py-1">{{ log.previous_content|linebreaksbr }}</td>
+        <td class="px-2 py-1">
+          <form method="post" hx-post="/api/chat/channels/{{ channel.id }}/messages/{{ message.id }}/restore/" hx-swap="none">
+            {% csrf_token %}
+            <input type="hidden" name="log_id" value="{{ log.id }}" />
+            <button type="submit" class="px-2 py-1 text-xs bg-primary text-white rounded">{% trans "Restaurar" %}</button>
+          </form>
+        </td>
+      </tr>
+      {% empty %}
+      <tr>
+        <td colspan="4" class="px-2 py-4 text-center text-neutral-500">{% trans "Nenhum registro" %}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
 {% if logs.has_other_pages %}
-<div class="mt-4 flex justify-between items-center">
+<div class="mt-4 flex justify-between items-center text-sm">
   {% if logs.has_previous %}
-    <a href="?page={{ logs.previous_page_number }}" class="text-sm">{% trans "Anterior" %}</a>
+    <a href="?page={{ logs.previous_page_number }}" class="text-blue-600 hover:underline">{% trans "Anterior" %}</a>
   {% else %}
     <span></span>
   {% endif %}
-  <span class="text-sm">{{ logs.number }}/{{ logs.paginator.num_pages }}</span>
+  <span>{{ logs.number }}/{{ logs.paginator.num_pages }}</span>
   {% if logs.has_next %}
-    <a href="?page={{ logs.next_page_number }}" class="text-sm">{% trans "Próxima" %}</a>
+    <a href="?page={{ logs.next_page_number }}" class="text-blue-600 hover:underline">{% trans "Próxima" %}</a>
   {% else %}
     <span></span>
   {% endif %}

--- a/chat/templates/chat/partials/message.html
+++ b/chat/templates/chat/partials/message.html
@@ -18,9 +18,9 @@
       {% if m.tipo == 'text' %}
         <p>{{ m.conteudo|linebreaksbr }}</p>
       {% elif m.tipo == 'image' %}
-        <img src="{{ m.arquivo.url }}" alt="" class="max-w-xs rounded" />
+        <img src="{{ m.arquivo.url }}" alt="" class="w-full max-w-xs h-auto rounded" />
       {% elif m.tipo == 'video' %}
-        <video src="{{ m.arquivo.url }}" controls class="max-w-xs"></video>
+        <video src="{{ m.arquivo.url }}" controls class="w-full max-w-xs h-auto" aria-label="{% trans 'Player de vídeo' %}"></video>
       {% elif m.tipo == 'file' %}
         <a href="{{ m.arquivo.url }}" class="text-primary underline">{{ m.arquivo.name }}</a>
       {% endif %}
@@ -33,13 +33,16 @@
           aria-haspopup="true"
           aria-expanded="false"
           aria-label="{% trans 'Adicionar reação' %}"
-        >😊</button>
+        >🙂</button>
         <ul
           class="reaction-menu hidden absolute bg-white border rounded p-1 flex gap-1"
           role="menu"
         >
           <li>
-            <button type="button" class="react-option" data-emoji="😊" aria-label="{% trans 'Reagir com 😊' %}">😊</button>
+            <button type="button" class="react-option" data-emoji="🙂" aria-label="{% trans 'Reagir com 🙂' %}">🙂</button>
+          </li>
+          <li>
+            <button type="button" class="react-option" data-emoji="❤️" aria-label="{% trans 'Reagir com ❤️' %}">❤️</button>
           </li>
           <li>
             <button type="button" class="react-option" data-emoji="👍" aria-label="{% trans 'Reagir com 👍' %}">👍</button>
@@ -48,10 +51,7 @@
             <button type="button" class="react-option" data-emoji="😂" aria-label="{% trans 'Reagir com 😂' %}">😂</button>
           </li>
           <li>
-            <button type="button" class="react-option" data-emoji="❤️" aria-label="{% trans 'Reagir com ❤️' %}">❤️</button>
-          </li>
-          <li>
-            <button type="button" class="react-option" data-emoji="😮" aria-label="{% trans 'Reagir com 😮' %}">😮</button>
+            <button type="button" class="react-option" data-emoji="🎉" aria-label="{% trans 'Reagir com 🎉' %}">🎉</button>
           </li>
         </ul>
       </div>

--- a/chat/views.py
+++ b/chat/views.py
@@ -6,6 +6,7 @@ from django.contrib.auth.decorators import login_required, user_passes_test
 from django.core.paginator import Paginator
 from django.db.models import Count, OuterRef, Subquery
 from django.http import HttpResponse
+import csv
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.dateparse import parse_date
 from django.utils.translation import gettext_lazy as _
@@ -129,6 +130,14 @@ def historico_edicoes(request, channel_id, message_id):
         dt = parse_date(fim)
         if dt:
             logs = logs.filter(created__date__lte=dt)
+    if request.GET.get("export") == "csv":
+        response = HttpResponse(content_type="text/csv")
+        response["Content-Disposition"] = "attachment; filename=historico_edicoes.csv"
+        writer = csv.writer(response)
+        writer.writerow(["created", "moderator", "previous_content"])
+        for log in logs:
+            writer.writerow([log.created.isoformat(), log.moderator.username, log.previous_content])
+        return response
     paginator = Paginator(logs, 20)
     page = paginator.get_page(request.GET.get("page"))
     return render(


### PR DESCRIPTION
## Summary
- enhance reaction menu and media responsiveness
- add edition history table with CSV export
- integrate i18n loader and search UI improvements

## Testing
- `python -m pytest tests/chat/test_views.py::test_historico_edicoes_export_csv -q`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689367138464832599a12dd595fbf810