### PR TITLE
Implement caching, search, and notifications for feed

### DIFF
--- a/Hubx/settings.py
+++ b/Hubx/settings.py
@@ -63,6 +63,8 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "django.contrib.postgres",
+    "django_prometheus",
     # ‑‑‑‑ Terceiros (third‑party) ‑‑‑‑
     "rest_framework",
     "rest_framework.authtoken",
@@ -91,6 +93,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    "django_prometheus.middleware.PrometheusBeforeMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "silk.middleware.SilkyMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
@@ -102,6 +105,7 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "simple_history.middleware.HistoryRequestMiddleware",
     "dashboard.middleware.DashboardTimingMiddleware",
+    "django_prometheus.middleware.PrometheusAfterMiddleware",
 ]
 
 ROOT_URLCONF = "Hubx.urls"
@@ -140,6 +144,25 @@ DATABASES = {
         "ATOMIC_REQUESTS": True,
     }
 }
+
+CACHE_URL = os.getenv("CACHE_URL")
+if CACHE_URL:
+    CACHES = {
+        "default": {
+            "BACKEND": "django_redis.cache.RedisCache",
+            "LOCATION": CACHE_URL,
+            "OPTIONS": {
+                "CLIENT_CLASS": "django_redis.client.DefaultClient",
+            },
+        }
+    }
+else:  # pragma: no cover - fallback para testes sem Redis
+    CACHES = {
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "hubx",
+        }
+    }
 
 # Password validation
 AUTH_PASSWORD_VALIDATORS = [

--- a/Hubx/urls.py
+++ b/Hubx/urls.py
@@ -87,6 +87,7 @@ urlpatterns = [
         "api/agenda/",
         include(("agenda.api_urls", "agenda_api"), namespace="agenda_api"),
     ),
+    path("", include("django_prometheus.urls")),
 ]
 
 # Arquivos de mídia em desenvolvimento

--- a/feed/README.md
+++ b/feed/README.md
@@ -13,6 +13,10 @@ Endpoints under `/api/feed/` provide CRUD access to posts, comments, likes and m
 - `tags`: comma separated tag ids or names
 - `date_from` / `date_to`: ISO dates limiting creation date
 - `q`: full text search in content or tag names
+- `page`: pagination page
+
+Listings are cached for 60 seconds per usuário e parâmetros de busca. Qualquer criação,
+edição ou remoção de post limpa o cache automaticamente.
 
 Deleting a post performs a *soft delete* (`deleted=True`). Media URLs are exposed via
 `image_url`, `pdf_url` and `video_url` fields.
@@ -28,6 +32,19 @@ Uploads são enviados ao S3 com tentativas de reenvio em caso de falha.
 
 Posts contendo palavras proibidas são marcados para moderação e só aparecem
 após aprovação.
+
+### Busca
+
+O parâmetro `q` aceita múltiplos termos. Os termos separados por espaço usam o
+operador lógico **AND**. Para buscas com **OR**, separe termos com `|`. Em
+ambientes PostgreSQL a busca usa `SearchVector` com rank e ordenação por
+relevância.
+
+### Notificações
+
+Após a criação de um post, uma tarefa Celery envia notificações para usuários da
+mesma organização. Métricas Prometheus acompanham a quantidade de posts e
+notificações enviadas.
 
 ## Comments and Likes
 

--- a/feed/migrations/0009_search_indexes.py
+++ b/feed/migrations/0009_search_indexes.py
@@ -1,0 +1,19 @@
+from django.db import migrations
+from django.contrib.postgres.indexes import GinIndex
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("feed", "0008_alter_post_conteudo"),
+    ]
+
+    operations = [
+        migrations.AddIndex(
+            model_name="post",
+            index=GinIndex(fields=["conteudo"], name="post_conteudo_gin"),
+        ),
+        migrations.AddIndex(
+            model_name="tag",
+            index=GinIndex(fields=["nome"], name="tag_nome_gin"),
+        ),
+    ]

--- a/feed/models.py
+++ b/feed/models.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import uuid
-from pathlib import Path
 
 from django.conf import settings
 from django.contrib.auth import get_user_model

--- a/feed/tasks.py
+++ b/feed/tasks.py
@@ -1,9 +1,21 @@
 from __future__ import annotations
 
 from celery import shared_task
+from django.contrib.auth import get_user_model
+from django.core.cache import cache
+from prometheus_client import Counter, Histogram
+
+from notificacoes.services.notificacoes import enviar_para_usuario
 
 from .models import Post
-from notificacoes.services.notificacoes import enviar_para_usuario
+
+POSTS_CREATED = Counter("feed_posts_created_total", "Total de posts criados")
+NOTIFICATIONS_SENT = Counter(
+    "feed_notifications_sent_total", "Total de notificações de novos posts"
+)
+NOTIFICATION_LATENCY = Histogram(
+    "feed_notification_latency_seconds", "Latência do envio de notificações"
+)
 
 
 @shared_task
@@ -17,3 +29,23 @@ def notificar_autor_sobre_interacao(post_id: str, tipo: str) -> None:
         enviar_para_usuario(post.autor, event, {"post_id": str(post.id)})
     except Exception:  # pragma: no cover - melhor esforço
         pass
+
+
+@shared_task
+def notify_new_post(post_id: str) -> None:
+    # garante idempotência: apenas primeira execução envia
+    if not cache.add(f"notify_post_{post_id}", True, 3600):
+        return
+    try:
+        post = Post.objects.get(id=post_id)
+    except Post.DoesNotExist:  # pragma: no cover - simples
+        return
+    User = get_user_model()
+    users = User.objects.filter(organizacao=post.organizacao).exclude(id=post.autor_id)
+    with NOTIFICATION_LATENCY.time():
+        for user in users:
+            try:
+                enviar_para_usuario(user, "feed_new_post", {"post_id": str(post.id)})
+                NOTIFICATIONS_SENT.inc()
+            except Exception:  # pragma: no cover - melhor esforço
+                pass

--- a/feed/tests/test_cache.py
+++ b/feed/tests/test_cache.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from django.core.cache import cache
+from django.db import connection
+from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
+from rest_framework.test import APIClient
+
+from accounts.factories import UserFactory
+from feed.factories import PostFactory
+from organizacoes.factories import OrganizacaoFactory
+
+
+class FeedCacheTest(TestCase):
+    def setUp(self) -> None:
+        org = OrganizacaoFactory()
+        self.user = UserFactory(organizacao=org)
+        self.client = APIClient()
+        self.client.force_authenticate(self.user)
+        cache.clear()
+
+    def _get_ids(self, data) -> list[str]:
+        results = data["results"] if isinstance(data, dict) else data
+        return [item["id"] for item in results]
+
+    def test_cache_miss_and_hit(self) -> None:
+        PostFactory(autor=self.user, conteudo="primeiro")
+        with CaptureQueriesContext(connection) as ctx1:
+            res1 = self.client.get("/api/feed/posts/")
+            self.assertEqual(res1.status_code, 200)
+            self.assertGreater(len(ctx1), 0)
+        with CaptureQueriesContext(connection) as ctx2:
+            res2 = self.client.get("/api/feed/posts/")
+            self.assertEqual(res2.status_code, 200)
+            self.assertLess(len(ctx2), len(ctx1))
+            self.assertEqual(self._get_ids(res1.data), self._get_ids(res2.data))
+
+    def test_cache_invalidation(self) -> None:
+        first = PostFactory(autor=self.user, conteudo="a")
+        self.client.get("/api/feed/posts/")
+        PostFactory(autor=self.user, conteudo="b")  # sinal limpa cache
+        res = self.client.get("/api/feed/posts/")
+        ids = self._get_ids(res.data)
+        self.assertIn(str(first.id), ids)
+        self.assertEqual(len(ids), 2)
+

--- a/feed/tests/test_notifications.py
+++ b/feed/tests/test_notifications.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from django.test import TestCase, override_settings
+from rest_framework.test import APIClient
+
+from accounts.factories import UserFactory
+from organizacoes.factories import OrganizacaoFactory
+
+
+@override_settings(CELERY_TASK_ALWAYS_EAGER=True)
+class FeedNotificationTest(TestCase):
+    def setUp(self) -> None:
+        org = OrganizacaoFactory()
+        self.user = UserFactory(organizacao=org)
+        self.other = UserFactory(organizacao=org)
+        self.client = APIClient()
+        self.client.force_authenticate(self.user)
+
+    @patch("feed.tasks.enviar_para_usuario")
+    def test_notify_new_post_once(self, enviar) -> None:
+        res = self.client.post(
+            "/api/feed/posts/",
+            {"conteudo": "ola", "tipo_feed": "global"},
+        )
+        self.assertEqual(res.status_code, 201)
+        post_id = res.data["id"]
+        self.assertEqual(enviar.call_count, 1)
+        from feed.tasks import notify_new_post
+
+        notify_new_post(post_id)
+        self.assertEqual(enviar.call_count, 1)  # idempotente
+

--- a/feed/tests/test_search.py
+++ b/feed/tests/test_search.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from django.test import TestCase
+from rest_framework.test import APIClient
+
+from accounts.factories import UserFactory
+from feed.factories import PostFactory
+from organizacoes.factories import OrganizacaoFactory
+
+
+class FeedSearchTest(TestCase):
+    def setUp(self) -> None:
+        org = OrganizacaoFactory()
+        self.user = UserFactory(organizacao=org)
+        self.client = APIClient()
+        self.client.force_authenticate(self.user)
+
+    def _ids(self, data) -> list[str]:
+        results = data["results"] if isinstance(data, dict) else data
+        return [item["id"] for item in results]
+
+    def test_simple_search(self) -> None:
+        p1 = PostFactory(autor=self.user, conteudo="abacate verde")
+        p2 = PostFactory(autor=self.user, conteudo="laranja doce")
+        res = self.client.get("/api/feed/posts/", {"q": "abacate"})
+        ids = self._ids(res.data)
+        self.assertIn(str(p1.id), ids)
+        self.assertNotIn(str(p2.id), ids)
+
+    def test_or_operator(self) -> None:
+        p1 = PostFactory(autor=self.user, conteudo="abacate verde")
+        p2 = PostFactory(autor=self.user, conteudo="laranja doce")
+        res = self.client.get("/api/feed/posts/", {"q": "abacate|laranja"})
+        ids = self._ids(res.data)
+        self.assertIn(str(p1.id), ids)
+        self.assertIn(str(p2.id), ids)
+

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,6 +6,8 @@ pytest>=7.0
 pre-commit>=3.6
 pytest-benchmark>=4.0
 prometheus-client==0.20.0
+django-redis==5.4.0
+django-prometheus==2.3.1
 bleach==6.2.0
 twilio==9.2.3
 WeasyPrint==61.2
@@ -15,4 +17,5 @@ django-storages==1.14.2
 pytest-axe==1.1.6
 axe-core-python==0.1.0
 playwright==1.54.0
+psycopg2-binary==2.9.9
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,6 +41,8 @@ django-simple-history==3.10.1
 django-stubs==5.2.2
 django-stubs-ext==5.2.2
 django-storages==1.14.2
+django-redis==5.4.0
+django-prometheus==2.3.1
 django-tailwind==4.0.1
 django-widget-tweaks==1.5.0
 djangorestframework==3.16.0
@@ -100,6 +102,7 @@ pytz==2025.2
 PyYAML==6.0.2
 qrcode==8.2
 redis==6.2.0
+psycopg2-binary==2.9.9
 referencing==0.36.2
 requests==2.32.4
 rich==14.0.0


### PR DESCRIPTION
## Summary
- configure Redis cache and Prometheus monitoring
- add per-user cached feed listings and full-text search
- notify organization members on new posts and expose metrics

## Testing
- `ruff check feed/api.py feed/views.py feed/models.py feed/signals.py feed/tests/test_cache.py feed/tests/test_search.py feed/tests/test_notifications.py Hubx/settings.py Hubx/urls.py`
- `mypy --strict feed/api.py feed/views.py feed/models.py feed/signals.py feed/tasks.py` *(fails: many missing type annotations in repository)*
- `pytest feed/tests/test_cache.py feed/tests/test_search.py feed/tests/test_notifications.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6893828c38d483259bc63d297f11ceab