### PR TITLE
feat(dashboard): optimize metrics queries and cache

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -48,7 +48,7 @@ Exemplo de JSON armazenado:
 }
 ```
 
-O cache das métricas expira em 5 minutos e utiliza a chave `dashboard-<id>-<escopo>-<json dos filtros>`. Para invalidar manualmente, utilize o comando `python manage.py clear_cache` ou limpe o backend configurado.
+O cache das métricas expira em 5 minutos e utiliza a chave `dashboard-<escopo>-<json dos filtros>`, permitindo reutilização entre usuários com o mesmo escopo e filtros. Para invalidar manualmente, utilize o comando `python manage.py clear_cache` ou limpe o backend configurado.
 
 ## Modelos e persistência
 

--- a/tests/dashboard/test_services.py
+++ b/tests/dashboard/test_services.py
@@ -116,6 +116,19 @@ def test_get_metrics_cache_differentiates(admin_user):
     assert metrics1["num_users"]["total"] < metrics2["num_users"]["total"]
 
 
+def test_get_metrics_cache_shared_between_users(admin_user, django_assert_num_queries):
+    other = User.objects.create_user(
+        email="same@example.com",
+        username="same",
+        password="x",
+        user_type=UserType.ADMIN,
+        organizacao=admin_user.organizacao,
+    )
+    DashboardMetricsService.get_metrics(admin_user, escopo="organizacao", organizacao_id=admin_user.organizacao_id)
+    with django_assert_num_queries(0):
+        DashboardMetricsService.get_metrics(other, escopo="organizacao", organizacao_id=admin_user.organizacao_id)
+
+
 def test_get_metrics_permission_denied(cliente_user, admin_user):
     with pytest.raises(PermissionError):
         DashboardMetricsService.get_metrics(


### PR DESCRIPTION
## Summary
- optimize growth calculation to use single aggregate query
- cache dashboard metrics by scope/filters for reuse across users
- document shared cache key and add regression test

## Testing
- `ruff check dashboard/services.py tests/dashboard/test_services.py`
- `black dashboard/services.py tests/dashboard/test_services.py`
- `isort dashboard/services.py tests/dashboard/test_services.py`
- `pytest tests/dashboard/test_services.py::test_get_metrics_cache_shared_between_users -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'reportlab')*


------
https://chatgpt.com/codex/tasks/task_e_6893884c2edc83259433fe67c6caa015