### PR TITLE
feat(discussao): add search and async notifications

### DIFF
--- a/Hubx/settings.py
+++ b/Hubx/settings.py
@@ -63,6 +63,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "django.contrib.postgres",
     # ‑‑‑‑ Terceiros (third‑party) ‑‑‑‑
     "rest_framework",
     "rest_framework.authtoken",

--- a/discussao/apps.py
+++ b/discussao/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class DiscussaoConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "discussao"
+
+    def ready(self) -> None:  # pragma: no cover - import side effects
+        from . import signals  # noqa: F401

--- a/discussao/migrations/0010_search_indexes.py
+++ b/discussao/migrations/0010_search_indexes.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from django.db import migrations
+
+
+def create_indexes(apps, schema_editor) -> None:
+    if schema_editor.connection.vendor != "postgresql":
+        return
+    schema_editor.execute(
+        """
+        CREATE INDEX IF NOT EXISTS discussao_topico_search_idx
+        ON discussao_topicodiscussao USING GIN (to_tsvector('portuguese', titulo || ' ' || conteudo));
+        """
+    )
+    schema_editor.execute(
+        """
+        CREATE INDEX IF NOT EXISTS discussao_resposta_search_idx
+        ON discussao_respostadiscussao USING GIN (to_tsvector('portuguese', conteudo));
+        """
+    )
+
+
+def drop_indexes(apps, schema_editor) -> None:
+    if schema_editor.connection.vendor != "postgresql":
+        return
+    schema_editor.execute("DROP INDEX IF EXISTS discussao_topico_search_idx;")
+    schema_editor.execute("DROP INDEX IF EXISTS discussao_resposta_search_idx;")
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("discussao", "0009_tag_deleted_tag_deleted_at"),
+    ]
+
+    operations = [migrations.RunPython(create_indexes, reverse_code=drop_indexes)]

--- a/discussao/signals.py
+++ b/discussao/signals.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from django.core.cache import cache
+from django.db.models.signals import post_delete, post_save
+from django.dispatch import receiver
+
+from .models import RespostaDiscussao, TopicoDiscussao
+
+
+@receiver([post_save, post_delete], sender=TopicoDiscussao)
+@receiver([post_save, post_delete], sender=RespostaDiscussao)
+def clear_discussao_cache(**_kwargs):
+    cache.clear()

--- a/discussao/tasks.py
+++ b/discussao/tasks.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from celery import shared_task
+
+from notificacoes.services.notificacoes import enviar_para_usuario
+
+from .models import RespostaDiscussao
+
+
+@shared_task(autoretry_for=(Exception,), retry_backoff=True)
+def notificar_nova_resposta(resposta_id: int) -> None:
+    resposta = RespostaDiscussao.objects.select_related("topico", "topico__autor", "autor").get(
+        pk=resposta_id
+    )
+    topico = resposta.topico
+    if resposta.autor_id != topico.autor_id:
+        try:
+            enviar_para_usuario(
+                topico.autor,
+                "discussao_nova_resposta",
+                {"topico": topico.titulo, "autor": resposta.autor.get_full_name() or resposta.autor.username},
+            )
+        except ValueError:
+            pass
+
+
+@shared_task(autoretry_for=(Exception,), retry_backoff=True)
+def notificar_melhor_resposta(resposta_id: int) -> None:
+    resposta = RespostaDiscussao.objects.select_related("autor", "topico").get(pk=resposta_id)
+    try:
+        enviar_para_usuario(
+            resposta.autor,
+            "discussao_melhor_resposta",
+            {"topico": resposta.topico.titulo},
+        )
+    except ValueError:
+        pass

--- a/discussao/templates/discussao/comentario_item.html
+++ b/discussao/templates/discussao/comentario_item.html
@@ -11,7 +11,7 @@
       </form>
     {% endif %}
     {% if (user == topico.autor or user.get_tipo_usuario in ['admin','root']) and not topico.melhor_resposta %}
-      <form method="post" action="{% url 'discussao:topico_resolver' topico.categoria.slug topico.slug %}">
+      <form hx-post="{% url 'discussao:topico_resolver' topico.categoria.slug topico.slug %}" hx-target="#topico-resolver" hx-swap="outerHTML" hx-indicator="#resolver-indicator" hx-on:afterRequest="document.getElementById('resolved-badge').classList.toggle('hidden')">
         {% csrf_token %}
         <input type="hidden" name="melhor_resposta" value="{{ comentario.id }}" />
         <button type="submit" class="text-green-600 text-xs">{% trans "Marcar como resolvido" %}</button>

--- a/discussao/templates/discussao/resolver_button.html
+++ b/discussao/templates/discussao/resolver_button.html
@@ -1,0 +1,13 @@
+{% load i18n %}
+{% if topico.resolvido %}
+  <form hx-post="{% url 'discussao:topico_resolver' topico.categoria.slug topico.slug %}" hx-target="#topico-resolver" hx-swap="outerHTML" hx-indicator="#resolver-indicator" hx-on:afterRequest="document.getElementById('resolved-badge').classList.toggle('hidden')">
+    {% csrf_token %}
+    <button type="submit" class="text-sm text-green-600" aria-label="{% trans 'Desmarcar resolução' %}">{% trans "Desmarcar resolução" %}</button>
+  </form>
+{% else %}
+  <form hx-post="{% url 'discussao:topico_resolver' topico.categoria.slug topico.slug %}" hx-target="#topico-resolver" hx-swap="outerHTML" hx-indicator="#resolver-indicator" hx-on:afterRequest="document.getElementById('resolved-badge').classList.toggle('hidden')">
+    {% csrf_token %}
+    <button type="submit" class="text-sm text-green-600" aria-label="{% trans 'Marcar como resolvido' %}">{% trans "Marcar como resolvido" %}</button>
+  </form>
+{% endif %}
+<span id="resolver-indicator" class="htmx-indicator text-xs">{% trans "Carregando..." %}</span>

--- a/discussao/templates/discussao/topico_detail.html
+++ b/discussao/templates/discussao/topico_detail.html
@@ -11,20 +11,13 @@
   <header class="mb-6 border-b border-neutral-200 pb-4">
     <h1 class="text-2xl font-bold text-neutral-900 mb-2">
       {{ topico.titulo }}
-      {% if topico.resolvido %}
-      <span class="ml-2 px-2 py-1 text-xs font-semibold bg-green-100 text-green-800 rounded">{% trans "Resolvido" %}</span>
-      {% endif %}
+      <span id="resolved-badge" class="ml-2 px-2 py-1 text-xs font-semibold bg-green-100 text-green-800 rounded {% if not topico.resolvido %}hidden{% endif %}">{% trans "Resolvido" %}</span>
     </h1>
     <p class="text-sm text-neutral-600">{% trans "Por" %} {{ topico.autor.get_full_name|default:topico.autor.username }} · {{ topico.created|date:"d/m/Y H:i" }}</p>
     {% if user == topico.autor or user.get_tipo_usuario in ['admin','root'] %}
-    <form method="post" action="{% url 'discussao:topico_resolver' topico.categoria.slug topico.slug %}" class="mt-2">
-      {% csrf_token %}
-      {% if topico.resolvido %}
-      <button type="submit" class="text-sm text-green-600">{% trans "Desmarcar resolução" %}</button>
-      {% else %}
-      <button type="submit" class="text-sm text-green-600">{% trans "Marcar como resolvido" %}</button>
-      {% endif %}
-    </form>
+    <div id="topico-resolver" class="mt-2">
+      {% include 'discussao/resolver_button.html' with topico=topico %}
+    </div>
     {% endif %}
     <div class="flex items-center space-x-1 mt-2">
       <button hx-post="{% url 'discussao:interacao' content_type_id topico.id 'up' %}" hx-swap="none" hx-on:afterRequest="document.getElementById('topic-score').innerText = event.detail.xhr.responseJSON.score">&#9650;</button>

--- a/discussao/templates/discussao/topicos_list.html
+++ b/discussao/templates/discussao/topicos_list.html
@@ -5,7 +5,7 @@
       <a href="{% url 'discussao:topico_detalhe' categoria.slug topico.slug %}" class="text-primary-600 hover:underline">{{ topico.titulo }}</a>
       <div class="mt-1 space-x-1">
         {% for tag in topico.tags.all %}
-        <a href="?tag={{ tag.nome }}" class="text-xs bg-neutral-100 px-2 py-0.5 rounded">{{ tag.nome }}</a>
+        <a hx-get="?tags={{ tag.nome }}" hx-target="#lista-topicos" hx-push-url="true" class="text-xs bg-neutral-100 px-2 py-0.5 rounded">{{ tag.nome }}</a>
         {% endfor %}
       </div>
     </td>
@@ -29,13 +29,16 @@
 {% block content %}
 <div class="max-w-6xl mx-auto px-4 py-10">
   <h1 class="text-2xl font-bold text-neutral-900 mb-6">{{ categoria.nome }}</h1>
-  <div class="mb-4 flex items-center gap-3">
-    <select name="ordenacao" id="ordenacao" class="form-select" hx-get="?" hx-target="#lista-topicos" hx-include="closest div">
+  <form id="filtros" class="mb-4 flex items-center gap-3" hx-get="?" hx-target="#lista-topicos" hx-push-url="true" hx-indicator="#lista-topicos-indicator" hx-trigger="change, keyup delay:500ms">
+    <input type="text" name="search" value="{{ request.GET.search }}" placeholder="{% trans 'Buscar' %}" class="form-input" />
+    <input type="text" name="tags" value="{{ tags|default:'' }}" placeholder="{% trans 'Tags (separadas por vírgula)' %}" class="form-input" />
+    <select name="ordenacao" class="form-select">
       <option value="recentes" {% if ordenacao == 'recentes' %}selected{% endif %}>{% trans "Mais recentes" %}</option>
       <option value="comentados" {% if ordenacao == 'comentados' %}selected{% endif %}>{% trans "Mais comentados" %}</option>
     </select>
     <a href="{% url 'discussao:topico_criar' categoria.slug %}" class="ml-auto bg-primary-600 hover:bg-primary-700 text-white font-semibold py-2 px-4 rounded-xl">{% trans "Novo T\u00f3pico" %}</a>
-  </div>
+    <div id="lista-topicos-indicator" class="htmx-indicator text-sm">{% trans "Carregando..." %}</div>
+  </form>
   <div class="overflow-x-auto bg-white border border-neutral-200 rounded-2xl shadow-sm">
     <table class="min-w-full divide-y divide-neutral-200 text-sm">
       <thead class="bg-neutral-50">


### PR DESCRIPTION
## Summary
- support full-text search and multi-tag filters in discussion API and views
- add async notification tasks for new replies and best answers
- enhance topic pages with HTMX for resolution actions and filters

## Testing
- `ruff check discussao tests/discussao Hubx/settings.py --fix`
- `mypy --strict discussao/api.py discussao/views.py discussao/tasks.py tests/discussao/test_api.py` *(fails: many missing type annotations across project)*
- `pytest tests/discussao -q`


------
https://chatgpt.com/codex/tasks/task_e_689387fdb2a483259e2076c89313dcc7