### PR TITLE
feat: async discussion notifications

### DIFF
--- a/discussao/api.py
+++ b/discussao/api.py
@@ -154,6 +154,7 @@ class TopicoViewSet(viewsets.ModelViewSet):
         return Response(serializer.data)
 
 
+@method_decorator(cache_page(60), name="list")
 class RespostaViewSet(viewsets.ModelViewSet):
     queryset = RespostaDiscussao.objects.select_related("autor", "topico").all()
     serializer_class = RespostaDiscussaoSerializer

--- a/discussao/tasks.py
+++ b/discussao/tasks.py
@@ -2,20 +2,48 @@ from __future__ import annotations
 
 from celery import shared_task  # type: ignore
 
+from notificacoes.services.notificacoes import enviar_para_usuario
+
 from .models import RespostaDiscussao
 
 
 @shared_task(autoretry_for=(Exception,), retry_backoff=True)
 def notificar_nova_resposta(resposta_id: int) -> None:
     try:
-        RespostaDiscussao.objects.select_related("topico", "topico__autor").get(id=resposta_id)
+        resposta = (
+            RespostaDiscussao.objects.select_related("topico", "topico__autor", "autor")
+            .prefetch_related("topico__respostas__autor")
+            .get(id=resposta_id)
+        )
     except RespostaDiscussao.DoesNotExist:  # pragma: no cover - segurança
         return
+
+    topico = resposta.topico
+    destinatarios = {topico.autor, *(r.autor for r in topico.respostas.all())}
+    destinatarios.discard(resposta.autor)
+    for user in destinatarios:
+        try:
+            enviar_para_usuario(
+                user,
+                "discussao_nova_resposta",
+                {"topico": topico, "resposta": resposta},
+            )
+        except ValueError:  # pragma: no cover - template ausente
+            continue
 
 
 @shared_task(autoretry_for=(Exception,), retry_backoff=True)
 def notificar_melhor_resposta(resposta_id: int) -> None:
     try:
-        RespostaDiscussao.objects.select_related("autor").get(id=resposta_id)
+        resposta = RespostaDiscussao.objects.select_related("autor", "topico").get(id=resposta_id)
     except RespostaDiscussao.DoesNotExist:  # pragma: no cover - segurança
+        return
+
+    try:
+        enviar_para_usuario(
+            resposta.autor,
+            "discussao_melhor_resposta",
+            {"topico": resposta.topico, "resposta": resposta},
+        )
+    except ValueError:  # pragma: no cover - template ausente
         return

--- a/tests/discussao/test_tasks.py
+++ b/tests/discussao/test_tasks.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from discussao.models import RespostaDiscussao, TopicoDiscussao
+from discussao.tasks import notificar_melhor_resposta, notificar_nova_resposta
+
+
+def test_notificar_nova_resposta(monkeypatch, categoria, associado_user, admin_user, nucleado_user):
+    topico = TopicoDiscussao.objects.create(
+        categoria=categoria, titulo="T", conteudo="c", autor=associado_user, publico_alvo=0
+    )
+    RespostaDiscussao.objects.create(topico=topico, autor=admin_user, conteudo="a")
+    resposta = RespostaDiscussao.objects.create(topico=topico, autor=nucleado_user, conteudo="b")
+    chamados = []
+
+    def fake_enviar(user, codigo, ctx):
+        chamados.append(user)
+
+    monkeypatch.setattr("discussao.tasks.enviar_para_usuario", fake_enviar)
+    notificar_nova_resposta(resposta.id)
+    assert associado_user in chamados and admin_user in chamados and nucleado_user not in chamados
+
+
+def test_notificar_melhor_resposta(monkeypatch, categoria, associado_user, nucleado_user):
+    topico = TopicoDiscussao.objects.create(
+        categoria=categoria, titulo="T", conteudo="c", autor=associado_user, publico_alvo=0
+    )
+    resposta = RespostaDiscussao.objects.create(topico=topico, autor=nucleado_user, conteudo="b")
+    chamados = []
+
+    def fake_enviar(user, codigo, ctx):
+        chamados.append((user, codigo))
+
+    monkeypatch.setattr("discussao.tasks.enviar_para_usuario", fake_enviar)
+    notificar_melhor_resposta(resposta.id)
+    assert chamados == [(nucleado_user, "discussao_melhor_resposta")]


### PR DESCRIPTION
## Summary
- notify topic authors and participants when new answers or best answer selection occurs
- cache list action for responses API
- test discussion notification tasks

## Testing
- `ruff check discussao tests/discussao`
- `mypy discussao/tasks.py discussao/api.py tests/discussao/test_tasks.py` (fails: Cannot override class variable...)
- `pytest tests/discussao/test_tasks.py tests/discussao/test_api.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6893906d296083258456d79826e53285