### PR TITLE
feat(chat): add message favorites

### DIFF
--- a/chat/api_urls.py
+++ b/chat/api_urls.py
@@ -5,6 +5,7 @@ from .api_views import (
     ChatChannelViewSet,
     ChatMessageViewSet,
     ChatNotificationViewSet,
+    ChatFavoriteViewSet,
     ModeracaoViewSet,
     UploadArquivoAPIView,
 )
@@ -13,6 +14,7 @@ router = DefaultRouter()
 router.register(r"channels", ChatChannelViewSet, basename="chat-channel")
 router.register(r"notificacoes", ChatNotificationViewSet, basename="chat-notificacao")
 router.register(r"moderacao/messages", ModeracaoViewSet, basename="chat-moderacao")
+router.register(r"favorites", ChatFavoriteViewSet, basename="chat-favorite")
 
 chat_message_list = ChatMessageViewSet.as_view({"get": "list", "post": "create"})
 chat_message_detail = ChatMessageViewSet.as_view(
@@ -29,6 +31,9 @@ chat_message_react = ChatMessageViewSet.as_view({"post": "react"})
 chat_message_flag = ChatMessageViewSet.as_view({"post": "flag"})
 chat_message_restore = ChatMessageViewSet.as_view({"post": "restore"})
 chat_message_search = ChatMessageViewSet.as_view({"get": "search"})
+chat_message_favorite = ChatMessageViewSet.as_view(
+    {"post": "favorite", "delete": "favorite"}
+)
 
 urlpatterns = router.urls + [
     path(
@@ -65,6 +70,11 @@ urlpatterns = router.urls + [
         "channels/<uuid:channel_pk>/messages/<uuid:pk>/flag/",
         chat_message_flag,
         name="chat-channel-message-flag",
+    ),
+    path(
+        "channels/<uuid:channel_pk>/messages/<uuid:pk>/favorite/",
+        chat_message_favorite,
+        name="chat-channel-message-favorite",
     ),
     path(
         "channels/<uuid:channel_pk>/messages/search/",

--- a/chat/migrations/0018_chatfavorite.py
+++ b/chat/migrations/0018_chatfavorite.py
@@ -1,0 +1,33 @@
+from django.db import migrations, models
+import django.db.models.deletion
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("chat", "0017_chatmessage_reply_to"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="ChatFavorite",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("created", models.DateTimeField(auto_now_add=True)),
+                ("modified", models.DateTimeField(auto_now=True)),
+                ("user", models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name="chat_favorites", to=settings.AUTH_USER_MODEL)),
+                ("message", models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name="favorited_by", to="chat.chatmessage")),
+            ],
+            options={
+                "verbose_name": "Favorito",
+                "verbose_name_plural": "Favoritos",
+                "unique_together": {("user", "message")},
+            },
+        ),
+        migrations.AddIndex(
+            model_name="chatfavorite",
+            index=models.Index(fields=["user", "message"], name="chatfav_user_msg_idx"),
+        ),
+    ]

--- a/chat/models.py
+++ b/chat/models.py
@@ -187,6 +187,23 @@ class ChatMessageFlag(TimeStampedModel):
         verbose_name_plural = "Sinalizações"
 
 
+class ChatFavorite(TimeStampedModel):
+    """Marcações pessoais de mensagens favoritas."""
+
+    user = models.ForeignKey(
+        User, on_delete=models.CASCADE, related_name="chat_favorites"
+    )
+    message = models.ForeignKey(
+        ChatMessage, on_delete=models.CASCADE, related_name="favorited_by"
+    )
+
+    class Meta:
+        unique_together = ("user", "message")
+        indexes = [models.Index(fields=["user", "message"])]
+        verbose_name = "Favorito"
+        verbose_name_plural = "Favoritos"
+
+
 class RelatorioChatExport(TimeStampedModel):
     channel = models.ForeignKey(ChatChannel, on_delete=models.CASCADE)
     formato = models.CharField(max_length=10)

--- a/tests/chat/test_favorites_api.py
+++ b/tests/chat/test_favorites_api.py
@@ -1,0 +1,40 @@
+import pytest
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from chat.models import ChatChannel, ChatMessage, ChatParticipant, ChatFavorite
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def api_client() -> APIClient:
+    return APIClient()
+
+
+def test_favorite_message_flow(api_client: APIClient, admin_user, coordenador_user):
+    channel = ChatChannel.objects.create(contexto_tipo="privado")
+    ChatParticipant.objects.create(channel=channel, user=admin_user)
+    ChatParticipant.objects.create(channel=channel, user=coordenador_user)
+    msg = ChatMessage.objects.create(
+        channel=channel,
+        remetente=coordenador_user,
+        tipo="text",
+        conteudo="ola",
+    )
+    api_client.force_authenticate(admin_user)
+    fav_url = f"/api/chat/channels/{channel.id}/messages/{msg.id}/favorite/"
+    resp = api_client.post(fav_url)
+    assert resp.status_code == 201
+    assert ChatFavorite.objects.filter(user=admin_user, message=msg).exists()
+
+    list_url = reverse("chat_api:chat-favorite-list")
+    resp = api_client.get(list_url)
+    assert resp.status_code == 200
+    results = resp.json()["results"]
+    assert str(channel.id) in results
+    assert results[str(channel.id)][0]["id"] == str(msg.id)
+
+    resp = api_client.delete(fav_url)
+    assert resp.status_code == 204
+    assert not ChatFavorite.objects.filter(user=admin_user, message=msg).exists()


### PR DESCRIPTION
## Summary
- allow users to mark/unmark chat messages as favorites
- list favorite messages grouped by channel via new endpoint

## Testing
- `pytest tests/chat/test_favorites_api.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6893a5074aac832597da60cd72d13493