### PR TITLE
feat: add feed metrics dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Inclui também geração de dados de teste e suporte a interface moderna com Tai
 - Serviço central de notificações assíncronas
 - Automação de inadimplências e API para lançamentos financeiros
 - Denúncia e moderação básica de posts do feed
+- Dashboard com métricas do feed e gráficos interativos
 
 ### Limitações de Design
 

--- a/dashboard/api_urls.py
+++ b/dashboard/api_urls.py
@@ -1,9 +1,13 @@
+from django.urls import path
 from rest_framework.routers import DefaultRouter
 
 from .api import DashboardFilterViewSet, DashboardViewSet
+from .api_views import FeedMetricsView
 
 router = DefaultRouter()
 router.register(r"dashboard/filters", DashboardFilterViewSet, basename="dashboard-filter")
 router.register(r"dashboard", DashboardViewSet, basename="dashboard")
 
-urlpatterns = router.urls
+urlpatterns = router.urls + [
+    path("feed/metrics/", FeedMetricsView.as_view(), name="feed-metrics"),
+]

--- a/dashboard/api_views.py
+++ b/dashboard/api_views.py
@@ -1,0 +1,44 @@
+"""API views for dashboard-related endpoints."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from rest_framework import permissions
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from .services import get_feed_counts, get_top_authors, get_top_tags
+
+
+class CanViewMetrics(permissions.BasePermission):
+    """Permissão para acesso às métricas do dashboard."""
+
+    def has_permission(self, request: Request, view: APIView) -> bool:  # pragma: no cover - simples
+        return request.user.has_perm("dashboard.view_metrics")
+
+
+class FeedMetricsView(APIView):
+    """Retorna métricas do feed para o dashboard."""
+
+    permission_classes = [permissions.IsAuthenticated, CanViewMetrics]
+
+    def get(self, request: Request, *args, **kwargs) -> Response:
+        org = request.query_params.get("organizacao")
+        inicio_str = request.query_params.get("inicio")
+        fim_str = request.query_params.get("fim")
+        try:
+            inicio = datetime.fromisoformat(inicio_str) if inicio_str else None
+        except ValueError:
+            return Response({"detail": "data_inicio inválida"}, status=400)
+        try:
+            fim = datetime.fromisoformat(fim_str) if fim_str else None
+        except ValueError:
+            return Response({"detail": "data_fim inválida"}, status=400)
+
+        counts = get_feed_counts(org, inicio, fim)
+        tags = get_top_tags(org, inicio, fim)
+        authors = get_top_authors(org, inicio, fim)
+        return Response({"counts": counts, "top_tags": tags, "top_authors": authors})
+

--- a/dashboard/templates/dashboard/admin.html
+++ b/dashboard/templates/dashboard/admin.html
@@ -24,6 +24,39 @@
 
   <div hx-get="{% url 'dashboard:notificacoes-partial' %}" hx-trigger="load, every 10s" hx-target="#notifications" hx-swap="innerHTML"></div>
 
+  <section class="my-8" aria-labelledby="feed-metrics-title">
+    <h2 id="feed-metrics-title" class="text-xl font-semibold mb-4">{% trans "Métricas do Feed" %}</h2>
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+      <canvas id="feed-type-chart" aria-label="{% trans 'Posts por tipo' %}" role="img"></canvas>
+      <canvas id="feed-tag-chart" aria-label="{% trans 'Top tags' %}" role="img"></canvas>
+      <canvas id="feed-author-chart" aria-label="{% trans 'Top autores' %}" role="img"></canvas>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script>
+      document.addEventListener('DOMContentLoaded', function () {
+        fetch('{% url "dashboard_api:feed-metrics" %}')
+          .then(r => r.json())
+          .then(data => {
+            const tipoCtx = document.getElementById('feed-type-chart');
+            new Chart(tipoCtx, {
+              type: 'bar',
+              data: {labels: Object.keys(data.counts.posts_by_type), datasets: [{data: Object.values(data.counts.posts_by_type)}]},
+            });
+            const tagCtx = document.getElementById('feed-tag-chart');
+            new Chart(tagCtx, {
+              type: 'bar',
+              data: {labels: data.top_tags.map(t => t.tag), datasets: [{data: data.top_tags.map(t => t.total)}]},
+            });
+            const authorCtx = document.getElementById('feed-author-chart');
+            new Chart(authorCtx, {
+              type: 'bar',
+              data: {labels: data.top_authors.map(a => a.autor), datasets: [{data: data.top_authors.map(a => a.total)}]},
+            });
+          });
+      });
+    </script>
+  </section>
+
   <section class="mb-8">
     <h2 class="text-xl font-semibold mb-4">{% trans "Ações Rápidas" %}</h2>
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">

--- a/tests/dashboard/test_feed_metrics.py
+++ b/tests/dashboard/test_feed_metrics.py
@@ -1,0 +1,57 @@
+import pytest
+from django.contrib.auth.models import ContentType, Permission
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from accounts.factories import UserFactory
+from dashboard.models import DashboardConfig
+from dashboard.services import get_feed_counts, get_top_authors, get_top_tags
+from feed.factories import PostFactory
+from feed.models import Tag
+
+pytestmark = pytest.mark.django_db
+
+
+def _grant_perm(user):
+    ct = ContentType.objects.get_for_model(DashboardConfig)
+    perm, _ = Permission.objects.get_or_create(
+        codename="view_metrics", name="Can view metrics", content_type=ct
+    )
+    user.user_permissions.add(perm)
+
+
+def test_get_feed_counts(admin_user):
+    PostFactory(autor=admin_user, organizacao=admin_user.organizacao, tipo_feed="global")
+    data = get_feed_counts(organizacao=admin_user.organizacao_id)
+    assert data["total_posts"] == 1
+    assert data["posts_by_type"]["global"] == 1
+
+
+def test_get_top_tags(admin_user):
+    tag = Tag.objects.create(nome="django")
+    post = PostFactory(autor=admin_user, organizacao=admin_user.organizacao)
+    post.tags.add(tag)
+    tags = get_top_tags(organizacao=admin_user.organizacao_id)
+    assert tags[0]["tag"] == "django"
+    assert tags[0]["total"] == 1
+
+
+def test_get_top_authors(admin_user):
+    other = UserFactory(organizacao=admin_user.organizacao)
+    PostFactory.create_batch(2, autor=admin_user, organizacao=admin_user.organizacao)
+    PostFactory(autor=other, organizacao=admin_user.organizacao)
+    authors = get_top_authors(organizacao=admin_user.organizacao_id, limite=1)
+    assert authors[0]["autor_id"] == admin_user.id
+
+
+def test_feed_metrics_view(admin_user):
+    _grant_perm(admin_user)
+    PostFactory(autor=admin_user, organizacao=admin_user.organizacao)
+    client = APIClient()
+    client.force_authenticate(user=admin_user)
+    url = reverse("dashboard_api:feed-metrics")
+    resp = client.get(url)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "counts" in body and "top_tags" in body
+


### PR DESCRIPTION
## Summary
- add services to compute feed post metrics with caching
- expose feed metrics API and update admin dashboard with charts
- document feed metrics in README

## Testing
- `python manage.py makemigrations --check` *(fails: index name 'idx_lanc_centro_conta_status_venc' cannot be longer than 30 characters)*
- `python manage.py migrate --noinput` *(fails: index name 'idx_lanc_centro_conta_status_venc' cannot be longer than 30 characters)*
- `ruff check dashboard/services.py dashboard/api_views.py dashboard/api_urls.py tests/dashboard/test_feed_metrics.py`
- `mypy --strict dashboard/services.py dashboard/api_views.py dashboard/api_urls.py tests/dashboard/test_feed_metrics.py` *(fails: missing type parameters and other typing issues across project)*
- `pytest tests/dashboard/test_feed_metrics.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6893a7cea0f88325a133d9e4acf9dba2