### PR TITLE
feat(discussao): add websocket updates

### DIFF
--- a/Hubx/asgi.py
+++ b/Hubx/asgi.py
@@ -11,6 +11,7 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "Hubx.settings")
 django.setup()  # Deve vir antes de qualquer importação que acesse models
 
 import chat.routing  # Agora é seguro importar  # noqa: E402
+import discussao.routing  # noqa: E402
 import notificacoes.routing  # noqa: E402
 
 application = ProtocolTypeRouter(
@@ -20,6 +21,7 @@ application = ProtocolTypeRouter(
             URLRouter(
                 chat.routing.websocket_urlpatterns
                 + notificacoes.routing.websocket_urlpatterns
+                + discussao.routing.websocket_urlpatterns
             )
         ),
     }

--- a/discussao/apps.py
+++ b/discussao/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class DiscussaoConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "discussao"
+
+    def ready(self) -> None:  # pragma: no cover - import side effects
+        from . import signals  # noqa: F401

--- a/discussao/consumers.py
+++ b/discussao/consumers.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from channels.db import database_sync_to_async
+from channels.generic.websocket import AsyncJsonWebsocketConsumer
+
+from .models import TopicoDiscussao
+
+
+class DiscussionConsumer(AsyncJsonWebsocketConsumer):
+    async def connect(self) -> None:  # pragma: no cover - connection handled in tests
+        user = self.scope.get("user")
+        topico_id = self.scope["url_route"]["kwargs"].get("topico_id")
+        if not user or not user.is_authenticated:
+            await self.close()
+            return
+        exists = await database_sync_to_async(
+            TopicoDiscussao.objects.filter(pk=topico_id).exists
+        )()
+        if not exists:
+            await self.close()
+            return
+        self.group_name = f"discussao_{topico_id}"
+        await self.channel_layer.group_add(self.group_name, self.channel_name)
+        await self.accept()
+
+    async def disconnect(self, code: int) -> None:  # pragma: no cover - simple
+        if hasattr(self, "group_name"):
+            await self.channel_layer.group_discard(self.group_name, self.channel_name)
+
+    async def discussion_event(self, event: dict) -> None:
+        await self.send_json(event)

--- a/discussao/routing.py
+++ b/discussao/routing.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from django.urls import re_path
+
+from .consumers import DiscussionConsumer
+
+websocket_urlpatterns = [
+    re_path(r"ws/discussao/(?P<topico_id>\d+)/", DiscussionConsumer.as_asgi()),
+]

--- a/discussao/signals.py
+++ b/discussao/signals.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from asgiref.sync import async_to_sync
+from channels.layers import get_channel_layer
+from django.db.models.signals import post_delete, post_save
+from django.dispatch import receiver
+
+from .models import InteracaoDiscussao, RespostaDiscussao
+
+
+def _send_event(group: str, event: dict) -> None:
+    layer = get_channel_layer()
+    async_to_sync(layer.group_send)(group, {"type": "discussion.event", **event})
+
+
+@receiver(post_save, sender=RespostaDiscussao)
+def resposta_created(sender, instance: RespostaDiscussao, created: bool, **kwargs) -> None:
+    if not created:
+        return
+    _send_event(
+        f"discussao_{instance.topico_id}",
+        {
+            "event": "nova_resposta",
+            "topico_id": instance.topico_id,
+            "resposta_id": instance.id,
+            "conteudo": instance.conteudo[:100],
+        },
+    )
+
+
+@receiver([post_save, post_delete], sender=InteracaoDiscussao)
+def interacao_changed(sender, instance: InteracaoDiscussao, **kwargs) -> None:
+    obj = instance.content_object
+    if hasattr(obj, "topico_id"):
+        topico_id = getattr(obj, "topico_id", obj.id)
+    else:
+        topico_id = obj.id
+    _send_event(
+        f"discussao_{topico_id}",
+        {
+            "event": "atualizacao_votos",
+            "objeto": obj.__class__.__name__,
+            "objeto_id": obj.id,
+            "score": getattr(obj, "score", 0),
+        },
+    )

--- a/discussao/templates/discussao/topico_detail.html
+++ b/discussao/templates/discussao/topico_detail.html
@@ -72,6 +72,21 @@
       </form>
     {% endif %}
   </section>
+  <script>
+    (function(){
+      const scheme = window.location.protocol === 'https:' ? 'wss' : 'ws';
+      const ws = new WebSocket(`${scheme}://${window.location.host}/ws/discussao/{{ topico.id }}/`);
+      ws.onmessage = function(e){
+        const data = JSON.parse(e.data);
+        if(data.event === 'nova_resposta'){
+          htmx.ajax('GET', window.location.href, {target:'#lista-comentarios', swap:'innerHTML'});
+        } else if(data.event === 'atualizacao_votos' && data.objeto === 'TopicoDiscussao'){
+          const el = document.getElementById('topic-score');
+          if(el){ el.innerText = data.score; }
+        }
+      };
+    })();
+  </script>
 </article>
 {% endblock %}
 {% endif %}

--- a/tests/discussao/test_consumers.py
+++ b/tests/discussao/test_consumers.py
@@ -1,0 +1,30 @@
+import asyncio
+
+import pytest
+from channels.db import database_sync_to_async
+from channels.testing import WebsocketCommunicator
+
+from discussao.factories import RespostaDiscussaoFactory, TopicoDiscussaoFactory
+from Hubx.asgi import application
+
+pytestmark = pytest.mark.django_db(transaction=True)
+
+
+@pytest.fixture(autouse=True)
+def in_memory_channel_layer(settings):
+    settings.CHANNEL_LAYERS = {"default": {"BACKEND": "channels.layers.InMemoryChannelLayer"}}
+
+
+def test_consumer_receives_new_response(admin_user):
+    async def inner():
+        topico = await database_sync_to_async(TopicoDiscussaoFactory.create)(autor=admin_user)
+        communicator = WebsocketCommunicator(application, f"/ws/discussao/{topico.id}/")
+        communicator.scope["user"] = admin_user
+        connected, _ = await communicator.connect()
+        assert connected
+        await database_sync_to_async(RespostaDiscussaoFactory.create)(topico=topico, autor=admin_user, conteudo="ola")
+        event = await communicator.receive_json_from()
+        assert event["event"] == "nova_resposta"
+        await communicator.disconnect()
+
+    asyncio.run(inner())


### PR DESCRIPTION
## Summary
- enable channels routing for discussão
- broadcast events for new replies and votes
- connect topic detail page to websocket
- add consumer test

## Testing
- `ruff check discussao/consumers.py discussao/routing.py discussao/signals.py discussao/apps.py Hubx/asgi.py tests/discussao/test_consumers.py`
- `mypy --strict discussao/consumers.py discussao/routing.py discussao/signals.py tests/discussao/test_consumers.py Hubx/asgi.py` *(fails: missing stubs and type annotations in unrelated modules)*
- `pytest tests/discussao/test_consumers.py`
- `pytest tests/discussao` *(fails: redis connection errors in several tests)*

------
https://chatgpt.com/codex/tasks/task_e_6893c284911c83258896ad407c5326ac