### PR TITLE
Refatora templates do módulo financeiro e adiciona testes HTMX

### DIFF
--- a/docs/financeiro.md
+++ b/docs/financeiro.md
@@ -99,6 +99,29 @@ Resposta:
 }
 ```
 
+## Interface Web
+
+### Importar Pagamentos
+
+1. Acesse **Financeiro → Importar**.
+2. Escolha um arquivo `.csv` ou `.xlsx` e selecione **Pré-visualizar**. O envio é feito via HTMX e a pré-visualização aparece abaixo do formulário.
+3. Erros de validação são exibidos na região de mensagens. Quando não houver problemas, o botão **Confirmar Importação** é habilitado.
+4. Ao confirmar, a tarefa roda em segundo plano. Futuras integrações com o módulo de Notificações avisarão sobre erros encontrados.
+
+### Centros de Custo
+
+1. Em **Financeiro → Centros de Custo** use o botão **Novo Centro** para abrir o formulário no modal.
+2. Preencha nome, tipo e vínculos com organização, núcleo ou evento e salve. A tabela é atualizada automaticamente.
+3. Utilize as ações **Editar** ou **Excluir** de cada linha para gerenciar registros existentes.
+
+### Relatórios
+
+1. Acesse **Financeiro → Relatórios**.
+2. Defina filtros de centro, núcleo e período e clique em **Gerar Relatório** para obter o saldo e a série temporal.
+3. Use **Exportar CSV** ou **Exportar XLSX** para baixar os dados com os filtros aplicados.
+
+> **Nota:** Todos os formulários utilizam rótulos associados, suporte a teclado e regiões `aria-live` para mensagens, atendendo às diretrizes WCAG 2.1 AA.
+
 ## Inadimplências
 
 `GET /api/financeiro/inadimplencias/`

--- a/financeiro/templates/financeiro/centro_form.html
+++ b/financeiro/templates/financeiro/centro_form.html
@@ -1,17 +1,39 @@
 {% load i18n %}
-<form hx-post="/api/financeiro/centros/" hx-target="#lista-centros" class="p-4 bg-white rounded shadow max-w-md" aria-live="assertive">
+<form id="centro-form"
+      {% if centro %}
+        hx-put="/api/financeiro/centros/{{ centro.id }}/"
+      {% else %}
+        hx-post="/api/financeiro/centros/"
+      {% endif %}
+      hx-target="#centros-list"
+      hx-on="htmx:afterRequest: htmx.ajax('GET', '/financeiro/centros/', '#centros-list'); document.getElementById('modal').innerHTML='';"
+      class="p-4 bg-white rounded shadow max-w-md space-y-4" aria-live="assertive">
   {% csrf_token %}
-  <div class="mb-2">
+  <div>
     <label for="id_nome" class="block text-sm font-medium">{{ _('Nome') }}</label>
-    <input id="id_nome" name="nome" class="border p-2 w-full" required />
+    <input id="id_nome" name="nome" type="text" class="border p-2 w-full" required {% if centro %}value="{{ centro.nome }}"{% endif %} {% if form and form.nome.errors %}aria-invalid="true"{% endif %} />
+    {% if form and form.nome.errors %}<p class="text-red-600 text-sm" aria-live="polite">{{ form.nome.errors }}</p>{% endif %}
   </div>
-  <div class="mb-2">
+  <div>
     <label for="id_tipo" class="block text-sm font-medium">{{ _('Tipo') }}</label>
-    <select id="id_tipo" name="tipo" class="border p-2 w-full">
-      <option value="organizacao">{{ _('Organização') }}</option>
-      <option value="nucleo">{{ _('Núcleo') }}</option>
-      <option value="evento">{{ _('Evento') }}</option>
+    <select id="id_tipo" name="tipo" class="border p-2 w-full" required {% if form and form.tipo.errors %}aria-invalid="true"{% endif %}>
+      <option value="organizacao"{% if centro and centro.tipo == 'organizacao' %} selected{% endif %}>{{ _('Organização') }}</option>
+      <option value="nucleo"{% if centro and centro.tipo == 'nucleo' %} selected{% endif %}>{{ _('Núcleo') }}</option>
+      <option value="evento"{% if centro and centro.tipo == 'evento' %} selected{% endif %}>{{ _('Evento') }}</option>
     </select>
+    {% if form and form.tipo.errors %}<p class="text-red-600 text-sm" aria-live="polite">{{ form.tipo.errors }}</p>{% endif %}
+  </div>
+  <div>
+    <label for="id_organizacao" class="block text-sm font-medium">{{ _('Organização') }}</label>
+    <input id="id_organizacao" name="organizacao" class="border p-2 w-full" {% if centro and centro.organizacao %}value="{{ centro.organizacao }}"{% endif %} />
+  </div>
+  <div>
+    <label for="id_nucleo" class="block text-sm font-medium">{{ _('Núcleo') }}</label>
+    <input id="id_nucleo" name="nucleo" class="border p-2 w-full" {% if centro and centro.nucleo %}value="{{ centro.nucleo }}"{% endif %} />
+  </div>
+  <div>
+    <label for="id_evento" class="block text-sm font-medium">{{ _('Evento') }}</label>
+    <input id="id_evento" name="evento" class="border p-2 w-full" {% if centro and centro.evento %}value="{{ centro.evento }}"{% endif %} />
   </div>
   <button type="submit" class="bg-green-600 text-white px-4 py-2 rounded">{{ _('Salvar') }}</button>
 </form>

--- a/financeiro/templates/financeiro/centros_list.html
+++ b/financeiro/templates/financeiro/centros_list.html
@@ -4,14 +4,54 @@
 {% block title %}{{ _('Centros de Custo') }}{% endblock %}
 
 {% block content %}
-<main class="p-4 max-w-4xl mx-auto">
-  <h1 class="text-2xl font-semibold mb-4">{{ _('Centros de Custo') }}</h1>
-  <div class="mb-4">
-    <button id="novo-centro" class="bg-blue-600 text-white px-4 py-2 rounded" hx-get="/financeiro/centros/form/" hx-target="#modal">
+<main class="p-4 max-w-5xl mx-auto">
+  <header class="flex items-center justify-between mb-4">
+    <h1 class="text-2xl font-semibold">{{ _('Centros de Custo') }}</h1>
+    <button class="bg-blue-600 text-white px-4 py-2 rounded" hx-get="/financeiro/centro/new/" hx-target="#modal" hx-trigger="click">
       {{ _('Novo Centro') }}
     </button>
-  </div>
-  <div id="lista-centros" hx-get="/api/financeiro/centros/" hx-trigger="load" hx-target="this" aria-live="polite"></div>
+  </header>
+  <section id="centros-list" class="overflow-x-auto" aria-live="polite">
+    <table class="min-w-full divide-y divide-gray-200">
+      <thead class="bg-gray-50">
+        <tr>
+          <th scope="col" class="px-3 py-2 text-left text-xs font-medium text-gray-500">{{ _('Nome') }}</th>
+          <th scope="col" class="px-3 py-2 text-left text-xs font-medium text-gray-500">{{ _('Tipo') }}</th>
+          <th scope="col" class="px-3 py-2 text-left text-xs font-medium text-gray-500">{{ _('Organização/Núcleo/Evento') }}</th>
+          <th scope="col" class="px-3 py-2 text-left text-xs font-medium text-gray-500">{{ _('Saldo') }}</th>
+          <th scope="col" class="px-3 py-2 text-right text-xs font-medium text-gray-500">{{ _('Ações') }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for c in centros %}
+        <tr class="divide-x divide-gray-200">
+          <td class="px-3 py-2">{{ c.nome }}</td>
+          <td class="px-3 py-2">{{ c.get_tipo_display }}</td>
+          <td class="px-3 py-2">
+            {% if c.organizacao %}{{ c.organizacao }}{% elif c.nucleo %}{{ c.nucleo }}{% elif c.evento %}{{ c.evento }}{% endif %}
+          </td>
+          <td class="px-3 py-2">{{ c.saldo }}</td>
+          <td class="px-3 py-2 text-right space-x-2">
+            <button class="text-primary underline" hx-get="/financeiro/centro/{{ c.id }}/edit/" hx-target="#modal" hx-trigger="click">{{ _('Editar') }}</button>
+            <button class="text-red-600 underline" hx-delete="/api/financeiro/centros/{{ c.id }}/" hx-target="closest tr" hx-confirm="{{ _('Tem certeza?') }}">{{ _('Excluir') }}</button>
+          </td>
+        </tr>
+        {% empty %}
+        <tr>
+          <td colspan="5" class="px-3 py-2 text-center text-sm text-gray-500">{{ _('Nenhum centro encontrado.') }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    <div class="mt-4 flex justify-between">
+      {% if prev %}
+        <button class="px-3 py-1 text-sm bg-gray-200 rounded" hx-get="?offset={{ prev }}" hx-target="#centros-list" hx-trigger="click" hx-swap="outerHTML">{{ _('Anterior') }}</button>
+      {% endif %}
+      {% if next %}
+        <button class="px-3 py-1 text-sm bg-gray-200 rounded ml-auto" hx-get="?offset={{ next }}" hx-target="#centros-list" hx-trigger="click" hx-swap="outerHTML">{{ _('Próximo') }}</button>
+      {% endif %}
+    </div>
+  </section>
   <div id="modal" class="mt-4" aria-live="assertive"></div>
 </main>
 {% endblock %}

--- a/financeiro/templates/financeiro/importar_pagamentos.html
+++ b/financeiro/templates/financeiro/importar_pagamentos.html
@@ -4,26 +4,41 @@
 {% block title %}{{ _('Importar Pagamentos') }}{% endblock %}
 
 {% block content %}
-<section class="max-w-3xl mx-auto p-4">
-  <h1 class="text-2xl font-semibold mb-4">{{ _('Importar Pagamentos') }}</h1>
-  <form id="upload-form" method="post" enctype="multipart/form-data"
-        hx-post="/api/financeiro/importar-pagamentos/" hx-target="#preview" hx-swap="none"
-        hx-on="htmx:afterRequest: renderPreview(event)"
-        class="space-y-4 border p-4 rounded-lg bg-white">
-    {% csrf_token %}
-    <label for="file" class="block text-sm font-medium text-gray-700">{{ _('Arquivo') }}</label>
-    <input id="file" type="file" name="file" accept=".csv,.xlsx" class="block w-full border p-2 rounded" required />
-    <button type="submit" class="bg-primary text-white px-4 py-2 rounded">{{ _('Pré-visualizar') }}</button>
-  </form>
-  <div id="preview" class="mt-6" aria-live="polite"></div>
-  <div id="messages" class="mt-4" aria-live="polite"></div>
-  <input type="hidden" id="confirm-id" name="id" />
-  <div class="mt-4 flex items-center gap-2">
-    <button id="confirm-btn" disabled hx-post="/api/financeiro/importar-pagamentos/confirmar/" hx-target="#messages" hx-include="#confirm-id" hx-indicator="#loading" class="bg-secondary text-white px-4 py-2 rounded">
-      {{ _('Confirmar Importação') }}
+<main class="max-w-3xl mx-auto p-4">
+  <section>
+    <h1 class="text-2xl font-semibold mb-4">{{ _('Importar Pagamentos') }}</h1>
+    <form id="upload-form" method="post" enctype="multipart/form-data" class="space-y-4 border p-4 rounded-lg bg-white">
+      {% csrf_token %}
+      <label for="file" class="block text-sm font-medium text-gray-700">{{ _('Arquivo') }}</label>
+      <input id="file" type="file" name="file" accept=".csv,.xlsx" class="block w-full border p-2 rounded" required />
+    </form>
+    <button id="preview-btn"
+            class="mt-2 bg-primary text-white px-4 py-2 rounded"
+            hx-post="/api/financeiro/importar-pagamentos/"
+            hx-target="#preview"
+            hx-trigger="change from:#file"
+            hx-include="#upload-form"
+            hx-on="htmx:afterRequest: renderPreview(event)">
+      {{ _('Pré-visualizar') }}
     </button>
-    <span id="loading" class="htmx-indicator text-sm">{{ _('Processando...') }}</span>
-  </div>
+    <div id="preview" class="mt-6" aria-live="polite"></div>
+    <div id="messages" class="mt-4 text-sm" aria-live="polite"></div>
+    <form id="confirm-form">
+      {% csrf_token %}
+      <input type="hidden" id="confirm-id" name="id" />
+    </form>
+    <div class="mt-4 flex items-center gap-2">
+      <button id="confirm-btn" disabled
+              hx-post="/api/financeiro/importar-pagamentos/confirmar/"
+              hx-target="#messages"
+              hx-include="#confirm-form"
+              hx-indicator="#loading"
+              class="bg-secondary text-white px-4 py-2 rounded">
+        {{ _('Confirmar Importação') }}
+      </button>
+      <span id="loading" class="htmx-indicator text-sm">{{ _('Processando...') }}</span>
+    </div>
+  </section>
   <script>
     function renderPreview(evt) {
       const preview = document.getElementById('preview');
@@ -33,23 +48,24 @@
       try {
         const data = JSON.parse(evt.detail.xhr.response);
         if (data.preview && data.preview.length) {
-          const rows = data.preview.map(r => `<tr><td class=\"px-2 py-1\">${r.centro_custo}</td><td class=\"px-2 py-1\">${r.conta_associado || ''}</td><td class=\"px-2 py-1\">${r.tipo}</td><td class=\"px-2 py-1\">${r.valor}</td><td class=\"px-2 py-1\">${r.data_lancamento}</td></tr>`).join('');
-          preview.innerHTML = `<table class=\"min-w-full divide-y divide-gray-200\"><thead><tr><th class=\"px-2 py-1 text-left text-xs font-medium text-gray-500\">{{ _('Centro de Custo') }}</th><th class=\"px-2 py-1 text-left text-xs font-medium text-gray-500\">{{ _('Conta') }}</th><th class=\"px-2 py-1 text-left text-xs font-medium text-gray-500\">{{ _('Tipo') }}</th><th class=\"px-2 py-1 text-left text-xs font-medium text-gray-500\">{{ _('Valor') }}</th><th class=\"px-2 py-1 text-left text-xs font-medium text-gray-500\">{{ _('Data') }}</th></tr></thead><tbody>${rows}</tbody></table>`;
+          const rows = data.preview.map(r => `<tr><td class="px-2 py-1">${r.centro_custo}</td><td class="px-2 py-1">${r.conta_associado || ''}</td><td class="px-2 py-1">${r.tipo}</td><td class="px-2 py-1">${r.valor}</td><td class="px-2 py-1">${r.data_lancamento}</td></tr>`).join('');
+          preview.innerHTML = `<table class="min-w-full divide-y divide-gray-200"><thead><tr><th class="px-2 py-1 text-left text-xs font-medium text-gray-500">{{ _('Centro de Custo') }}</th><th class="px-2 py-1 text-left text-xs font-medium text-gray-500">{{ _('Conta') }}</th><th class="px-2 py-1 text-left text-xs font-medium text-gray-500">{{ _('Tipo') }}</th><th class="px-2 py-1 text-left text-xs font-medium text-gray-500">{{ _('Valor') }}</th><th class="px-2 py-1 text-left text-xs font-medium text-gray-500">{{ _('Data') }}</th></tr></thead><tbody>${rows}</tbody></table>`;
           document.getElementById('confirm-id').value = data.id;
           document.getElementById('confirm-btn').disabled = false;
         }
         if (data.erros && data.erros.length) {
-          messages.innerHTML = `<ul class=\"list-disc text-red-600 pl-5\">${data.erros.map(e => `<li>${e}</li>`).join('')}</ul>`;
+          messages.innerHTML = `<ul class="list-disc text-red-600 pl-5">${data.erros.map(e => `<li>${e}</li>`).join('')}</ul>`;
           if (!data.preview || !data.preview.length) {
             document.getElementById('confirm-btn').disabled = true;
           }
         }
       } catch (e) {
-        messages.textContent = 'Erro ao processar pré-visualização';
+        messages.textContent = '{{ _('Erro ao processar pré-visualização') }}';
+        document.getElementById('confirm-btn').disabled = true;
       }
     }
   </script>
-</section>
+</main>
 
 {% endblock %}
 

--- a/financeiro/templates/financeiro/relatorios.html
+++ b/financeiro/templates/financeiro/relatorios.html
@@ -4,9 +4,9 @@
 {% block title %}{{ _('Relatórios Financeiros') }}{% endblock %}
 
 {% block content %}
-<section class="max-w-5xl mx-auto p-4 space-y-4">
+<main class="max-w-5xl mx-auto p-4 space-y-4">
   <h1 class="text-2xl font-semibold mb-2">{{ _('Relatórios') }}</h1>
-  <form id="relatorio-form" class="space-y-4" hx-get="/api/financeiro/relatorios/" hx-target="#relatorio" hx-swap="none" hx-on="htmx:afterRequest: renderRelatorio(event)">
+  <form id="relatorio-form" class="space-y-4">
     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
       <div>
         <label for="rel-centro" class="block text-sm font-medium text-gray-700">{{ _('Centro de Custo') }}</label>
@@ -37,7 +37,14 @@
         <input id="rel-periodo-final" type="month" name="periodo_final" class="mt-1 block w-full border rounded p-2" />
       </div>
     </div>
-    <button type="submit" class="bg-primary text-white px-4 py-2 rounded">{{ _('Gerar Relatório') }}</button>
+    <button type="button" id="gerar-relatorio" class="bg-primary text-white px-4 py-2 rounded"
+            hx-get="/api/financeiro/relatorios/"
+            hx-target="#relatorio"
+            hx-include="#relatorio-form"
+            hx-trigger="click"
+            hx-on="htmx:afterRequest: renderRelatorio(event)">
+      {{ _('Gerar Relatório') }}
+    </button>
   </form>
 
   <div id="relatorio" class="mt-6" aria-live="polite"></div>
@@ -61,7 +68,7 @@
       }
     }
   </script>
-</section>
+</main>
 
 {% endblock %}
 

--- a/financeiro/tests/test_templates_htmx.py
+++ b/financeiro/tests/test_templates_htmx.py
@@ -1,0 +1,101 @@
+import csv
+import re
+from io import StringIO
+
+import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.urls import reverse
+from django.utils import timezone
+
+from accounts.factories import UserFactory
+from accounts.models import UserType
+from financeiro.models import CentroCusto, ContaAssociado
+
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def admin_user():
+    user = UserFactory()
+    user.user_type = UserType.ADMIN
+    user.save()
+    return user
+
+
+@pytest.fixture
+def client_logged(client, admin_user):
+    client.force_login(admin_user)
+    return client
+
+
+def test_importar_pagamentos_template_structure(client_logged):
+    resp = client_logged.get(reverse("financeiro:importar_pagamentos"))
+    assert resp.status_code == 200
+    html = resp.content.decode()
+    assert 'id="file"' in html
+    match = re.search(r'<button[^>]*id="confirm-btn"[^>]*>', html)
+    assert match and "disabled" in match.group(0)
+
+
+def _make_csv(rows: list[list[str]]) -> bytes:
+    buf = StringIO()
+    writer = csv.writer(buf)
+    writer.writerow(
+        [
+            "centro_custo_id",
+            "conta_associado_id",
+            "tipo",
+            "valor",
+            "data_lancamento",
+            "data_vencimento",
+            "status",
+        ]
+    )
+    writer.writerows(rows)
+    return buf.getvalue().encode()
+
+
+@pytest.fixture
+def api_client(admin_user):
+    from rest_framework.test import APIClient
+
+    client = APIClient()
+    client.force_authenticate(user=admin_user)
+    return client
+
+
+def test_fluxo_importacao_htmx(api_client, settings, admin_user):
+    settings.CELERY_TASK_ALWAYS_EAGER = True
+    centro = CentroCusto.objects.create(nome="C", tipo="organizacao")
+    conta = ContaAssociado.objects.create(user=admin_user)
+    now = timezone.now().isoformat()
+    rows = [[str(centro.id), str(conta.id), "aporte_interno", "10", now, now, "pago"]]
+    file = SimpleUploadedFile("data.csv", _make_csv(rows), content_type="text/csv")
+    url = reverse("financeiro_api:financeiro-importar-pagamentos")
+    resp = api_client.post(url, {"file": file}, format="multipart", HTTP_HX_REQUEST="true")
+    assert resp.status_code == 201
+    token = resp.data["id"]
+    confirm_url = reverse("financeiro_api:financeiro-confirmar-importacao")
+    resp2 = api_client.post(confirm_url, {"id": token}, HTTP_HX_REQUEST="true")
+    assert resp2.status_code == 202
+
+
+def test_centro_criacao_htmx(api_client):
+    resp = api_client.post(
+        "/api/financeiro/centros/",
+        {"nome": "N", "tipo": "organizacao"},
+        HTTP_HX_REQUEST="true",
+    )
+    assert resp.status_code == 201
+    assert CentroCusto.objects.filter(nome="N").exists()
+
+
+def test_centro_criacao_erro(api_client):
+    resp = api_client.post(
+        "/api/financeiro/centros/",
+        {"tipo": "organizacao"},
+        HTTP_HX_REQUEST="true",
+    )
+    assert resp.status_code == 400
+    assert "nome" in resp.data


### PR DESCRIPTION
## Summary
- refatora páginas de importação, centros de custo e relatórios com HTML semântico, HTMX e Tailwind
- adiciona formulário de centros de custo com validações acessíveis
- documenta novos fluxos de interface e inclui testes básicos de integração HTMX

## Testing
- `black financeiro/tests/test_templates_htmx.py`
- `make test` *(falhou: playwright._impl._errors.Error: BrowserType.launch: Executable doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_6894aebb6274832588555ea210abce92