### PR TITLE
Add chat message retention policy

### DIFF
--- a/chat/README.md
+++ b/chat/README.md
@@ -98,6 +98,7 @@ reações, pins e moderação para todos os conectados.
 Arquivos JSON possuem uma lista de objetos com `id`, `remetente`,
 `tipo`, `conteudo` e `created`. No formato CSV, o cabeçalho segue a
 mesma estrutura. Mensagens ocultas por moderação são ignoradas.
+Mensagens removidas pela política de retenção não são incluídas nas exportações.
 
 ## Janela de chat flutuante
 

--- a/chat/admin.py
+++ b/chat/admin.py
@@ -12,7 +12,7 @@ from .models import (
 
 @admin.register(ChatChannel)
 class ChatChannelAdmin(admin.ModelAdmin):
-    list_display = ["titulo", "created"]
+    list_display = ["titulo", "retencao_dias", "created"]
 
 
 @admin.register(ChatMessage)

--- a/chat/api_urls.py
+++ b/chat/api_urls.py
@@ -37,6 +37,7 @@ chat_message_favorite = ChatMessageViewSet.as_view(
     {"post": "favorite", "delete": "favorite"}
 )
 chat_message_create_item = ChatMessageViewSet.as_view({"post": "criar_item"})
+chat_channel_config_retencao = ChatChannelViewSet.as_view({"patch": "config_retencao"})
 
 urlpatterns = router.urls + [
     path(
@@ -83,6 +84,11 @@ urlpatterns = router.urls + [
         "channels/<uuid:channel_pk>/messages/<uuid:pk>/criar-item/",
         chat_message_create_item,
         name="chat-channel-message-criar-item",
+    ),
+    path(
+        "canais/<uuid:pk>/config-retencao/",
+        chat_channel_config_retencao,
+        name="chat-channel-config-retencao",
     ),
     path(
         "channels/<uuid:channel_pk>/messages/search/",

--- a/chat/metrics.py
+++ b/chat/metrics.py
@@ -50,3 +50,8 @@ chat_tarefas_criadas_total = Counter(
     "chat_tarefas_criadas_total",
     "Total de tarefas criadas a partir de mensagens",
 )
+
+chat_mensagens_removidas_retencao_total = Counter(
+    "chat_mensagens_removidas_retencao_total",
+    "Total de mensagens removidas pela política de retenção",
+)

--- a/chat/migrations/0023_chatchannel_retencao_dias.py
+++ b/chat/migrations/0023_chatchannel_retencao_dias.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("chat", "0022_e2ee_fields"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="chatchannel",
+            name="retencao_dias",
+            field=models.PositiveIntegerField(
+                null=True,
+                blank=True,
+                help_text="Quantidade de dias para manter mensagens antes da remoção automática",
+            ),
+        ),
+    ]

--- a/chat/models.py
+++ b/chat/models.py
@@ -27,6 +27,11 @@ class ChatChannel(TimeStampedModel, SoftDeleteModel):
     descricao = models.TextField(blank=True)
     imagem = models.ImageField(upload_to="chat/avatars/", null=True, blank=True)
     e2ee_habilitado = models.BooleanField(default=False)
+    retencao_dias = models.PositiveIntegerField(
+        null=True,
+        blank=True,
+        help_text="Quantidade de dias para manter mensagens antes da remoção automática",
+    )
 
     objects = SoftDeleteManager()
     all_objects = models.Manager()
@@ -237,6 +242,7 @@ class ChatModerationLog(TimeStampedModel):
         ("remove", "Remover"),
         ("edit", "Editar"),
         ("create_item", "Criar item"),
+        ("retencao", "Retenção"),
     ]
 
     message = models.ForeignKey(ChatMessage, on_delete=models.CASCADE, related_name="moderations")

--- a/chat/serializers.py
+++ b/chat/serializers.py
@@ -24,6 +24,7 @@ class ChatChannelSerializer(serializers.ModelSerializer):
             "descricao",
             "imagem",
             "e2ee_habilitado",
+            "retencao_dias",
             "created",
             "modified",
         ]
@@ -53,6 +54,16 @@ class ChatChannelSerializer(serializers.ModelSerializer):
         if last_msg:
             data["ultima_mensagem"] = ChatMessageSerializer(last_msg, context=self.context).data
         return data
+
+
+class ChatRetentionSerializer(serializers.Serializer):
+    """Serializer para configuração de política de retenção."""
+
+    retencao_dias = serializers.IntegerField(
+        min_value=1,
+        max_value=365,
+        allow_null=True,
+    )
 
 
 class ChatMessageSerializer(serializers.ModelSerializer):

--- a/tests/chat/test_retencao.py
+++ b/tests/chat/test_retencao.py
@@ -1,0 +1,62 @@
+from datetime import timedelta
+
+import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from chat.models import ChatAttachment, ChatChannel, ChatMessage, ChatModerationLog, ChatParticipant
+from chat.tasks import aplicar_politica_retencao
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def api_client() -> APIClient:
+    return APIClient()
+
+
+def test_config_retencao_updates_value(api_client: APIClient, admin_user) -> None:
+    channel = ChatChannel.objects.create(contexto_tipo="privado")
+    ChatParticipant.objects.create(channel=channel, user=admin_user, is_admin=True)
+    api_client.force_authenticate(admin_user)
+    url = reverse("chat_api:chat-channel-config-retencao", args=[channel.pk])
+    resp = api_client.patch(url, {"retencao_dias": 30}, format="json")
+    assert resp.status_code == 200
+    channel.refresh_from_db()
+    assert channel.retencao_dias == 30
+
+
+def test_config_retencao_requires_admin(api_client: APIClient, admin_user, coordenador_user) -> None:
+    channel = ChatChannel.objects.create(contexto_tipo="privado")
+    ChatParticipant.objects.create(channel=channel, user=admin_user, is_admin=True)
+    ChatParticipant.objects.create(channel=channel, user=coordenador_user)
+    api_client.force_authenticate(coordenador_user)
+    url = reverse("chat_api:chat-channel-config-retencao", args=[channel.pk])
+    resp = api_client.patch(url, {"retencao_dias": 10}, format="json")
+    assert resp.status_code == 403
+
+
+def test_config_retencao_validation(api_client: APIClient, admin_user) -> None:
+    channel = ChatChannel.objects.create(contexto_tipo="privado")
+    ChatParticipant.objects.create(channel=channel, user=admin_user, is_admin=True)
+    api_client.force_authenticate(admin_user)
+    url = reverse("chat_api:chat-channel-config-retencao", args=[channel.pk])
+    resp = api_client.patch(url, {"retencao_dias": 400}, format="json")
+    assert resp.status_code == 400
+
+
+def test_aplicar_politica_retencao_remove_mensagens(admin_user) -> None:
+    channel = ChatChannel.objects.create(contexto_tipo="privado", retencao_dias=30)
+    ChatParticipant.objects.create(channel=channel, user=admin_user, is_admin=True)
+    old_time = timezone.now() - timedelta(days=40)
+    old_msg = ChatMessage.objects.create(channel=channel, remetente=admin_user, tipo="text", conteudo="old")
+    ChatMessage.objects.filter(pk=old_msg.pk).update(created=old_time)
+    att = ChatAttachment.objects.create(mensagem=old_msg, arquivo=SimpleUploadedFile("a.txt", b"a"))
+    new_msg = ChatMessage.objects.create(channel=channel, remetente=admin_user, tipo="text", conteudo="new")
+    aplicar_politica_retencao()
+    assert not ChatMessage.objects.filter(id=old_msg.id).exists()
+    assert ChatMessage.objects.filter(id=new_msg.id).exists()
+    assert not ChatAttachment.objects.filter(id=att.id).exists()
+    assert ChatModerationLog.objects.filter(message_id=old_msg.id, action="retencao").exists()


### PR DESCRIPTION
## Summary
- add `retencao_dias` to chat channels with API endpoint for admins to configure
- implement daily task `aplicar_politica_retencao` to purge old messages and log removals
- expose metric `chat_mensagens_removidas_retencao_total` and cover new behaviour with tests

## Testing
- `ruff check chat/admin.py chat/models.py chat/serializers.py chat/api_views.py chat/tasks.py chat/metrics.py tests/chat/test_retencao.py`
- `pytest tests/chat/test_retencao.py -q`
- `pytest tests/chat/test_api_views.py::test_list_channels_returns_only_participated -q`


------
https://chatgpt.com/codex/tasks/task_e_6894b9e06f548325a6d323cf3b10041f