### PR TITLE
Add task creation from chat messages

### DIFF
--- a/agenda/admin.py
+++ b/agenda/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from .models import BriefingEvento, Evento, InscricaoEvento, MaterialDivulgacaoEvento, ParceriaEvento
+from .models import BriefingEvento, Evento, InscricaoEvento, MaterialDivulgacaoEvento, ParceriaEvento, Tarefa
 
 
 @admin.register(Evento)
@@ -26,3 +26,8 @@ class MaterialDivulgacaoEventoAdmin(admin.ModelAdmin):
 @admin.register(BriefingEvento)
 class BriefingEventoAdmin(admin.ModelAdmin):
     list_display = ["evento", "objetivos"]
+
+
+@admin.register(Tarefa)
+class TarefaAdmin(admin.ModelAdmin):
+    list_display = ["titulo", "data_inicio", "data_fim", "status"]

--- a/agenda/migrations/0018_tarefa.py
+++ b/agenda/migrations/0018_tarefa.py
@@ -1,0 +1,60 @@
+from django.db import migrations, models
+import django.db.models.deletion
+import uuid
+from django.conf import settings
+from django.core.serializers.json import DjangoJSONEncoder
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('agenda', '0017_evento_mensagem_origem'),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('organizacoes', '0008_organizacaoatividadelog_organizacaochangelog_and_more'),
+        ('nucleos', '0006_convitenucleo'),
+        ('chat', '0023_chatchannel_retencao_dias'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Tarefa',
+            fields=[
+                ('created', models.DateTimeField(auto_now_add=True)),
+                ('modified', models.DateTimeField(auto_now=True)),
+                ('deleted', models.BooleanField(default=False)),
+                ('deleted_at', models.DateTimeField(blank=True, null=True)),
+                ('id', models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)),
+                ('titulo', models.CharField(max_length=150)),
+                ('descricao', models.TextField(blank=True)),
+                ('data_inicio', models.DateTimeField()),
+                ('data_fim', models.DateTimeField()),
+                ('status', models.CharField(choices=[('pendente', 'Pendente'), ('concluida', 'Concluída')], default='pendente', max_length=20)),
+                ('organizacao', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='organizacoes.organizacao')),
+                ('nucleo', models.ForeignKey(null=True, blank=True, on_delete=django.db.models.deletion.SET_NULL, to='nucleos.nucleo')),
+                ('mensagem_origem', models.ForeignKey(null=True, blank=True, on_delete=django.db.models.deletion.SET_NULL, related_name='tarefas', to='chat.chatmessage')),
+                ('responsavel', models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, related_name='tarefas_criadas', to=settings.AUTH_USER_MODEL)),
+            ],
+            options={
+                'verbose_name': 'Tarefa',
+                'verbose_name_plural': 'Tarefas',
+            },
+        ),
+        migrations.CreateModel(
+            name='TarefaLog',
+            fields=[
+                ('created', models.DateTimeField(auto_now_add=True)),
+                ('modified', models.DateTimeField(auto_now=True)),
+                ('deleted', models.BooleanField(default=False)),
+                ('deleted_at', models.DateTimeField(blank=True, null=True)),
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('acao', models.CharField(max_length=50)),
+                ('detalhes', models.JSONField(blank=True, default=dict, encoder=DjangoJSONEncoder)),
+                ('tarefa', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='logs', to='agenda.tarefa')),
+                ('usuario', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, to=settings.AUTH_USER_MODEL)),
+            ],
+            options={
+                'ordering': ['-created'],
+                'verbose_name': 'Log de Tarefa',
+                'verbose_name_plural': 'Logs de Tarefa',
+            },
+        ),
+    ]

--- a/agenda/templates/agenda/tarefa_detail.html
+++ b/agenda/templates/agenda/tarefa_detail.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>{{ object.titulo }}</h1>
+<p>{{ object.descricao }}</p>
+{% endblock %}

--- a/agenda/urls.py
+++ b/agenda/urls.py
@@ -19,6 +19,7 @@ from .views import (
     ParceriaEventoDeleteView,
     ParceriaEventoListView,
     ParceriaEventoUpdateView,
+    TarefaDetailView,
 )
 
 app_name = "agenda"
@@ -78,4 +79,5 @@ urlpatterns = [
         BriefingEventoStatusView.as_view(),
         name="briefing_status",
     ),
+    path("tarefa/<uuid:pk>/", TarefaDetailView.as_view(), name="tarefa_detalhe"),
 ]

--- a/agenda/views.py
+++ b/agenda/views.py
@@ -51,6 +51,8 @@ from .models import (
     Evento,
     EventoLog,
     FeedbackNota,
+    Tarefa,
+    TarefaLog,
     InscricaoEvento,
     MaterialDivulgacaoEvento,
     ParceriaEvento,
@@ -247,6 +249,22 @@ class EventoDetailView(LoginRequiredMixin, NoSuperadminMixin, GerenteRequiredMix
             .select_related("organizacao")
             .prefetch_related("inscricoes", "feedbacks")
         )
+
+
+class TarefaDetailView(LoginRequiredMixin, NoSuperadminMixin, GerenteRequiredMixin, DetailView):
+    model = Tarefa
+    template_name = "agenda/tarefa_detail.html"
+
+    def get_queryset(self):
+        qs = Tarefa.objects.select_related("organizacao")
+        user = self.request.user
+        if user.user_type == UserType.ROOT:
+            return qs
+        nucleo_ids = list(user.nucleos.values_list("id", flat=True))
+        filtro = Q(organizacao=user.organizacao)
+        if nucleo_ids:
+            filtro |= Q(nucleo__in=nucleo_ids)
+        return qs.filter(filtro)
 
 
 class EventoSubscribeView(LoginRequiredMixin, NoSuperadminMixin, View):

--- a/chat/api_views.py
+++ b/chat/api_views.py
@@ -470,7 +470,11 @@ class ChatMessageViewSet(viewsets.ModelViewSet):
             return Response(status=status.HTTP_403_FORBIDDEN)
         except (ValueError, NotImplementedError) as exc:
             return Response({"erro": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
-        link = reverse("agenda:evento_detalhe", args=[item.pk]) if request.data.get("tipo") == "evento" else ""
+        link = ""
+        if request.data.get("tipo") == "evento":
+            link = reverse("agenda:evento_detalhe", args=[item.pk])
+        elif request.data.get("tipo") == "tarefa":
+            link = reverse("agenda:tarefa_detalhe", args=[item.pk])
         return Response(
             {"id": str(item.pk), "titulo": item.titulo, "link": link},
             status=status.HTTP_201_CREATED,


### PR DESCRIPTION
## Summary
- introduce `Tarefa` model and logs
- allow `criar_item_de_mensagem` to create tasks
- expose task detail route and tests

## Testing
- `pytest tests/chat/test_api_views.py::test_criar_item_evento tests/chat/test_api_views.py::test_criar_item_evento_sem_permissao tests/chat/test_api_views.py::test_criar_item_evento_dados_invalidos tests/chat/test_api_views.py::test_criar_item_tarefa tests/chat/test_api_views.py::test_criar_item_tarefa_sem_permissao tests/chat/test_api_views.py::test_criar_item_tarefa_dados_invalidos -q`

------
https://chatgpt.com/codex/tasks/task_e_6894d83819f08325b9dde774b082b2c9