### PR TITLE
Add chat channel categories and filtering

### DIFF
--- a/chat/api_urls.py
+++ b/chat/api_urls.py
@@ -3,6 +3,7 @@ from rest_framework.routers import DefaultRouter
 
 from .api_views import (
     AtualizarChavePublicaView,
+    ChatChannelCategoryViewSet,
     ChatChannelViewSet,
     ChatFavoriteViewSet,
     ChatMessageViewSet,
@@ -14,6 +15,7 @@ from .api_views import (
 
 router = DefaultRouter()
 router.register(r"channels", ChatChannelViewSet, basename="chat-channel")
+router.register(r"categorias", ChatChannelCategoryViewSet, basename="chat-categoria")
 router.register(r"notificacoes", ChatNotificationViewSet, basename="chat-notificacao")
 router.register(r"moderacao/messages", ModeracaoViewSet, basename="chat-moderacao")
 router.register(r"favorites", ChatFavoriteViewSet, basename="chat-favorite")

--- a/chat/migrations/0024_chatchannelcategory.py
+++ b/chat/migrations/0024_chatchannelcategory.py
@@ -1,0 +1,56 @@
+from django.db import migrations, models
+import uuid
+import django.db.models.deletion
+import django_extensions.db.fields
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("chat", "0023_chatchannel_retencao_dias"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="ChatChannelCategory",
+            fields=[
+                (
+                    "created",
+                    django_extensions.db.fields.CreationDateTimeField(
+                        auto_now_add=True, verbose_name="created"
+                    ),
+                ),
+                (
+                    "modified",
+                    django_extensions.db.fields.ModificationDateTimeField(
+                        auto_now=True, verbose_name="modified"
+                    ),
+                ),
+                (
+                    "id",
+                    models.UUIDField(
+                        primary_key=True,
+                        default=uuid.uuid4,
+                        editable=False,
+                        serialize=False,
+                    ),
+                ),
+                ("nome", models.CharField(max_length=100, unique=True)),
+                ("descricao", models.TextField(blank=True)),
+            ],
+            options={
+                "verbose_name": "Categoria de Canal",
+                "verbose_name_plural": "Categorias de Canal",
+            },
+        ),
+        migrations.AddField(
+            model_name="chatchannel",
+            name="categoria",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="channels",
+                to="chat.chatchannelcategory",
+            ),
+        ),
+    ]

--- a/chat/models.py
+++ b/chat/models.py
@@ -12,6 +12,21 @@ from core.models import SoftDeleteManager, SoftDeleteModel
 User = get_user_model()
 
 
+class ChatChannelCategory(TimeStampedModel):
+    """Categoria para organização de canais de chat."""
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    nome = models.CharField(max_length=100, unique=True)
+    descricao = models.TextField(blank=True)
+
+    def __str__(self) -> str:  # pragma: no cover - simple
+        return self.nome
+
+    class Meta:
+        verbose_name = "Categoria de Canal"
+        verbose_name_plural = "Categorias de Canal"
+
+
 class ChatChannel(TimeStampedModel, SoftDeleteModel):
     CONTEXT_CHOICES = [
         ("privado", "Privado"),
@@ -31,6 +46,13 @@ class ChatChannel(TimeStampedModel, SoftDeleteModel):
         null=True,
         blank=True,
         help_text="Quantidade de dias para manter mensagens antes da remoção automática",
+    )
+    categoria = models.ForeignKey(
+        ChatChannelCategory,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="channels",
     )
 
     objects = SoftDeleteManager()

--- a/tests/chat/test_categories_api.py
+++ b/tests/chat/test_categories_api.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import pytest
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from chat.models import ChatChannel, ChatChannelCategory, ChatParticipant
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def api_client() -> APIClient:
+    return APIClient()
+
+
+def test_category_crud_permissions(api_client: APIClient, admin_user, associado_user):
+    url = reverse("chat_api:chat-categoria-list")
+    api_client.force_authenticate(associado_user)
+    resp = api_client.post(url, {"nome": "Geral"})
+    assert resp.status_code == 403
+
+    api_client.force_authenticate(admin_user)
+    resp = api_client.post(url, {"nome": "Geral"})
+    assert resp.status_code == 201
+    cat_id = resp.json()["id"]
+
+    detail = reverse("chat_api:chat-categoria-detail", args=[cat_id])
+    api_client.force_authenticate(associado_user)
+    resp = api_client.patch(detail, {"descricao": "x"})
+    assert resp.status_code == 403
+
+    api_client.force_authenticate(admin_user)
+    resp = api_client.patch(detail, {"descricao": "x"})
+    assert resp.status_code == 200
+
+
+def test_category_list_filter(api_client: APIClient, admin_user):
+    ChatChannelCategory.objects.create(nome="Suporte")
+    ChatChannelCategory.objects.create(nome="Financeiro")
+    api_client.force_authenticate(admin_user)
+    url = reverse("chat_api:chat-categoria-list")
+    resp = api_client.get(url, {"nome": "sup"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["nome"] == "Suporte"
+
+
+def test_channel_list_filter_by_categoria(api_client: APIClient, admin_user):
+    cat1 = ChatChannelCategory.objects.create(nome="Cat1")
+    cat2 = ChatChannelCategory.objects.create(nome="Cat2")
+    c1 = ChatChannel.objects.create(contexto_tipo="privado", categoria=cat1)
+    c2 = ChatChannel.objects.create(contexto_tipo="privado", categoria=cat2)
+    ChatParticipant.objects.create(channel=c1, user=admin_user)
+    ChatParticipant.objects.create(channel=c2, user=admin_user)
+    api_client.force_authenticate(admin_user)
+    url = reverse("chat_api:chat-channel-list")
+    resp = api_client.get(url, {"categoria": cat1.id})
+    assert resp.status_code == 200
+    ids = [c["id"] for c in resp.json()]
+    assert str(c1.id) in ids
+    assert str(c2.id) not in ids


### PR DESCRIPTION
## Summary
- add `ChatChannelCategory` model and link channels to categories
- expose CRUD API for categories and allow filtering channels by category
- test category permissions and channel filtering

## Testing
- `pytest tests/chat/test_categories_api.py -q`
- `pytest tests/chat/test_api_views.py::test_list_channels_returns_only_participated -q`


------
https://chatgpt.com/codex/tasks/task_e_6894e3d4ac6083258d0446bf1c5dad90