### PR TITLE
Add HTMX modal for nucleus participation requests

### DIFF
--- a/nucleos/templates/nucleos/detail.html
+++ b/nucleos/templates/nucleos/detail.html
@@ -65,13 +65,11 @@
     {% endif %}
   </div>
 
-  {% if request.user.user_type != 'admin' and request.user.user_type != 'coordenador' %}
-  <div class="mt-4">
-    <form hx-post="{% url 'nucleos_api:nucleo-solicitar' object.pk %}" hx-on="htmx:afterRequest: this.outerHTML='<p class=\'text-green-600\'>{% trans 'Solicitação enviada' %}</p>'">
-      {% csrf_token %}
-      <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">{% trans 'Solicitar participação' %}</button>
-    </form>
-  </div>
-  {% endif %}
-</section>
-{% endblock %}
+    {% if mostrar_solicitar and request.user.user_type not in ('admin','coordenador') %}
+    <div class="mt-4">
+      <button id="solicitar-btn" type="button" class="px-4 py-2 bg-blue-600 text-white rounded" hx-get="{% url 'nucleos:solicitar_modal' object.pk %}" hx-target="#modal">{% trans 'Solicitar participação' %}</button>
+    </div>
+    {% endif %}
+    <div id="modal"></div>
+  </section>
+  {% endblock %}

--- a/nucleos/templates/nucleos/solicitar_modal.html
+++ b/nucleos/templates/nucleos/solicitar_modal.html
@@ -1,0 +1,13 @@
+{% load i18n %}
+<div class="p-4 bg-white rounded shadow max-w-md">
+  <h2 class="text-lg font-semibold mb-4">{% trans 'Confirmar solicitação de participação?' %}</h2>
+  <form hx-post="{% url 'nucleos_api:nucleo-solicitar' nucleo.pk %}"
+        hx-swap="none"
+        hx-on="htmx:afterRequest: document.getElementById('solicitar-btn').outerHTML='<p class=\'text-green-600\'>{% trans 'Solicitação enviada' %}</p>'; document.getElementById('modal').innerHTML='';">
+    {% csrf_token %}
+    <div class="flex justify-end gap-2">
+      <button type="button" class="px-3 py-1 border rounded" hx-on="click: document.getElementById('modal').innerHTML=''">{% trans 'Cancelar' %}</button>
+      <button type="submit" class="px-3 py-1 bg-blue-600 text-white rounded">{% trans 'Confirmar' %}</button>
+    </div>
+  </form>
+</div>

--- a/nucleos/urls.py
+++ b/nucleos/urls.py
@@ -10,6 +10,11 @@ urlpatterns = [
     path("<int:pk>/", views.NucleoDetailView.as_view(), name="detail"),
     path("<int:pk>/editar/", views.NucleoUpdateView.as_view(), name="update"),
     path("<int:pk>/remover/", views.NucleoDeleteView.as_view(), name="delete"),
+    path(
+        "<int:pk>/solicitar/confirmar/",
+        views.SolicitarParticipacaoModalView.as_view(),
+        name="solicitar_modal",
+    ),
     path("<int:pk>/participar/", views.ParticipacaoCreateView.as_view(), name="participacao_solicitar"),
     path(
         "<int:pk>/participacao/<int:participacao_id>/decidir/",

--- a/nucleos/views.py
+++ b/nucleos/views.py
@@ -8,7 +8,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.db.models import Q
 from django.http import HttpResponse
-from django.shortcuts import get_object_or_404, redirect
+from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse_lazy
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
@@ -132,7 +132,15 @@ class NucleoDetailView(GerenteRequiredMixin, LoginRequiredMixin, DetailView):
         if self.request.user.user_type in {UserType.ADMIN, UserType.COORDENADOR}:
             ctx["membros_pendentes"] = nucleo.participacoes.filter(status="pendente")
             ctx["suplentes"] = nucleo.coordenadores_suplentes.all()
+        part = nucleo.participacoes.filter(user=self.request.user).first()
+        ctx["mostrar_solicitar"] = not part or part.status == "recusado"
         return ctx
+
+
+class SolicitarParticipacaoModalView(LoginRequiredMixin, View):
+    def get(self, request, pk):
+        nucleo = get_object_or_404(Nucleo, pk=pk, deleted=False, inativa=False)
+        return render(request, "nucleos/solicitar_modal.html", {"nucleo": nucleo})
 
 
 class ParticipacaoCreateView(LoginRequiredMixin, View):


### PR DESCRIPTION
## Summary
- add context flag and modal endpoint to confirm nucleus participation requests
- provide HTMX modal template and trigger from nucleus detail view

## Testing
- `pytest tests/nucleos/test_api.py::test_solicitar_aprovar_recusar tests/nucleos/test_api.py::test_expiracao_automatica -q`

------
https://chatgpt.com/codex/tasks/task_e_6894f9f11f0c8325974265e12551e01d