### PR TITLE
feat(configuracoes): adicionar fixtures de exemplo

### DIFF
--- a/configuracoes/README.md
+++ b/configuracoes/README.md
@@ -61,6 +61,18 @@ Resposta:
 Use `PATCH /configuracoes/api/` para atualizar campos específicos. Consulte a
 documentação OpenAPI gerada para exemplos completos.
 
+## Fixtures de exemplo
+
+Para demonstrar diferentes combinações de preferências é possível carregar os
+dados de `configuracoes/fixtures/configuracoes_exemplo.json`:
+
+```bash
+python manage.py loaddata configuracoes/fixtures/configuracoes_exemplo.json
+```
+
+Isso criará alguns registros de `ConfiguracaoConta` com valores variados para
+testes e desenvolvimento.
+
 ## Testes e traduções
 
 Para executar a suíte de testes deste app:

--- a/configuracoes/fixtures/configuracoes_exemplo.json
+++ b/configuracoes/fixtures/configuracoes_exemplo.json
@@ -1,0 +1,56 @@
+[
+  {
+    "model": "configuracoes.configuracaoconta",
+    "pk": 1,
+    "fields": {
+      "user": 1,
+      "receber_notificacoes_email": true,
+      "frequencia_notificacoes_email": "imediata",
+      "receber_notificacoes_whatsapp": false,
+      "frequencia_notificacoes_whatsapp": "imediata",
+      "receber_notificacoes_push": true,
+      "frequencia_notificacoes_push": "imediata",
+      "idioma": "pt-BR",
+      "tema": "claro",
+      "hora_notificacao_diaria": "08:00:00",
+      "hora_notificacao_semanal": "08:00:00",
+      "dia_semana_notificacao": 0
+    }
+  },
+  {
+    "model": "configuracoes.configuracaoconta",
+    "pk": 2,
+    "fields": {
+      "user": 2,
+      "receber_notificacoes_email": true,
+      "frequencia_notificacoes_email": "diaria",
+      "receber_notificacoes_whatsapp": true,
+      "frequencia_notificacoes_whatsapp": "semanal",
+      "receber_notificacoes_push": false,
+      "frequencia_notificacoes_push": "imediata",
+      "idioma": "en-US",
+      "tema": "escuro",
+      "hora_notificacao_diaria": "09:30:00",
+      "hora_notificacao_semanal": "10:00:00",
+      "dia_semana_notificacao": 2
+    }
+  },
+  {
+    "model": "configuracoes.configuracaoconta",
+    "pk": 3,
+    "fields": {
+      "user": 3,
+      "receber_notificacoes_email": false,
+      "frequencia_notificacoes_email": "semanal",
+      "receber_notificacoes_whatsapp": true,
+      "frequencia_notificacoes_whatsapp": "diaria",
+      "receber_notificacoes_push": true,
+      "frequencia_notificacoes_push": "semanal",
+      "idioma": "es-ES",
+      "tema": "automatico",
+      "hora_notificacao_diaria": "07:00:00",
+      "hora_notificacao_semanal": "11:00:00",
+      "dia_semana_notificacao": 5
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- add sample fixtures for account configuration combinations
- document fixture loading in README

## Testing
- `mypy --strict configuracoes` *(fails: Class cannot subclass "ModelForm" ... )*
- `pytest` *(fails: 43 errors during collection: missing modules and other errors)*


------
https://chatgpt.com/codex/tasks/task_e_689528f85f648325a829401aca3c2a04