### PR TITLE
feat(empresas): sanitize tag names and add form tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,4 @@
 ## [Unreleased]
 - fix: ajusta rotas e permite importação de despesas com valores negativos
 - feat: adiciona métricas Prometheus e APIs de logs no módulo financeiro
+- feat(empresas): sanitiza nomes de tags e adiciona testes de formulário

--- a/empresas/README.md
+++ b/empresas/README.md
@@ -26,3 +26,13 @@ Exemplos:
 Cada alteração relevante gera um registro no histórico, acessível somente por administradores e pelo proprietário da empresa. CNPJs são mascarados exibindo apenas os quatro últimos dígitos.
 
 Usuários autenticados podem avaliar uma empresa com nota de 1 a 5. O proprietário recebe notificação quando uma nova avaliação é criada.
+
+## Arquitetura
+
+```mermaid
+graph TD
+    Empresa -->|possui| ContatoEmpresa
+    Empresa -->|usa| Tag
+    Empresa -->|recebe| AvaliacaoEmpresa
+    AvaliacaoEmpresa -->|gera| Post
+```

--- a/empresas/forms.py
+++ b/empresas/forms.py
@@ -8,6 +8,11 @@ from validate_docbr import CNPJ
 from .models import AvaliacaoEmpresa, ContatoEmpresa, Empresa, Tag
 
 
+def sanitize_tag_name(name: str) -> str:
+    """Remove caracteres potencialmente perigosos de nomes de tags."""
+    return re.sub(r"[^\w\s-]", "", name).strip()
+
+
 class EmpresaForm(forms.ModelForm):
     tags_field = forms.CharField(required=False, label="Tags")
 
@@ -57,7 +62,10 @@ class EmpresaForm(forms.ModelForm):
         tags_names = [tag.strip() for tag in self.cleaned_data.get("tags_field", "").split(",") if tag.strip()]
         tags = []
         for name in tags_names:
-            tag, _ = Tag.objects.get_or_create(nome=name)
+            clean_name = sanitize_tag_name(name)
+            if not clean_name:
+                continue
+            tag, _ = Tag.objects.get_or_create(nome=clean_name)
             tags.append(tag)
         if commit:
             instance.tags.set(tags)

--- a/empresas/tests/test_forms.py
+++ b/empresas/tests/test_forms.py
@@ -1,0 +1,18 @@
+import pytest
+
+from empresas.forms import EmpresaForm
+from empresas.factories import EmpresaFactory
+from empresas.models import Tag
+
+
+@pytest.mark.django_db
+def test_tags_are_sanitized():
+    empresa = EmpresaFactory()
+    form = EmpresaForm(instance=empresa)
+    data = form.initial
+    data["tags_field"] = "Tag<script>, outro!@#"
+    form = EmpresaForm(data, instance=empresa)
+    assert form.is_valid()
+    form.save()
+    assert Tag.objects.filter(nome="Tagscript").exists()
+    assert Tag.objects.filter(nome="outro").exists()


### PR DESCRIPTION
## Summary
- sanitize tag names on empresa form to avoid unsafe characters
- add unit test ensuring tag sanitization
- document empresas module architecture with mermaid diagram

## Testing
- `pytest empresas/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68952a5bb32883259ce7acadd79f83f6