### PR TITLE
feat(feed): add AI moderation

### DIFF
--- a/feed/application/moderar_ai.py
+++ b/feed/application/moderar_ai.py
@@ -1,0 +1,27 @@
+"""Caso de uso para aplicação da moderação por IA."""
+
+from __future__ import annotations
+
+import logging
+from typing import Literal
+
+from feed.infrastructure.moderation_ai import analisar_conteudo
+from feed.models import ModeracaoPost, Post
+
+Decision = Literal["aceito", "suspeito", "rejeitado"]
+
+logger = logging.getLogger(__name__)
+
+
+def pre_analise(texto: str, images: list[bytes] | None = None) -> Decision:
+    """Executa a análise de conteúdo sem efeitos colaterais."""
+
+    return analisar_conteudo(texto, images)
+
+
+def aplicar_decisao(post: Post, decision: Decision) -> None:
+    """Atualiza o status de moderação do ``post`` e registra em log."""
+
+    status_map = {"aceito": "aprovado", "suspeito": "pendente", "rejeitado": "rejeitado"}
+    ModeracaoPost.objects.update_or_create(post=post, defaults={"status": status_map[decision]})
+    logger.info("moderacao_ai", extra={"post_id": str(post.id), "decision": decision})

--- a/feed/infrastructure/moderation_ai.py
+++ b/feed/infrastructure/moderation_ai.py
@@ -1,0 +1,38 @@
+"""Ferramentas simples de moderação automática.
+
+Este módulo simula uma análise de conteúdo baseada em IA utilizando
+palavras proibidas e thresholds configuráveis. Para um ambiente real,
+um modelo de linguagem deveria ser integrado aqui.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from django.conf import settings
+
+Decision = Literal["aceito", "suspeito", "rejeitado"]
+
+
+def analisar_conteudo(texto: str, images: list[bytes] | None = None) -> Decision:
+    """Analisa o ``texto`` e retorna a decisão da IA.
+
+    A implementação atual é heurística: calcula uma pontuação proporcional
+    à quantidade de palavras proibidas presentes no texto. As decisões são
+    determinadas pelos limiares definidos em ``settings.FEED_AI_THRESHOLDS``.
+    """
+
+    thresholds = getattr(
+        settings, "FEED_AI_THRESHOLDS", {"suspeito": 0.5, "rejeitado": 0.8}
+    )
+    bad_words = [w.lower() for w in getattr(settings, "FEED_BAD_WORDS", [])]
+    texto_lower = (texto or "").lower()
+    words = texto_lower.split()
+    total = len(words) or 1
+    matches = sum(texto_lower.count(w) for w in bad_words)
+    score = matches / total
+    if score >= thresholds.get("rejeitado", 0.8):
+        return "rejeitado"
+    if score >= thresholds.get("suspeito", 0.5):
+        return "suspeito"
+    return "aceito"

--- a/feed/tests/test_ai_moderation.py
+++ b/feed/tests/test_ai_moderation.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from django.test import TestCase, override_settings
+from rest_framework.test import APIClient
+
+from accounts.factories import UserFactory
+from feed.forms import PostForm
+from feed.models import ModeracaoPost
+from organizacoes.factories import OrganizacaoFactory
+
+
+@override_settings(FEED_BAD_WORDS=["ruim"], FEED_AI_THRESHOLDS={"suspeito": 0.1, "rejeitado": 0.2})
+class AIModerationAPITest(TestCase):
+    def setUp(self) -> None:
+        org = OrganizacaoFactory()
+        self.user = UserFactory(organizacao=org)
+        self.user.set_password("pass123")
+        self.user.save()
+        self.client = APIClient()
+        self.client.force_authenticate(self.user)
+
+    def test_rejects_inappropriate_content(self):
+        res = self.client.post(
+            "/api/feed/posts/", {"conteudo": "ruim ruim", "tipo_feed": "global"}
+        )
+        self.assertEqual(res.status_code, 400)
+
+    def test_flags_suspect_content(self):
+        res = self.client.post(
+            "/api/feed/posts/", {"conteudo": "ruim", "tipo_feed": "global"}
+        )
+        self.assertEqual(res.status_code, 201)
+        post_id = res.data["id"]
+        moderacao = ModeracaoPost.objects.get(post_id=post_id)
+        self.assertEqual(moderacao.status, "pendente")
+
+
+@override_settings(FEED_BAD_WORDS=["ruim"], FEED_AI_THRESHOLDS={"suspeito": 0.1, "rejeitado": 0.2})
+class AIModerationFormTest(TestCase):
+    def setUp(self) -> None:
+        org = OrganizacaoFactory()
+        self.user = UserFactory(organizacao=org)
+
+    def test_form_rejects_content(self):
+        form = PostForm(
+            data={"tipo_feed": "global", "conteudo": "ruim ruim"}, user=self.user
+        )
+        self.assertFalse(form.is_valid())
+
+    def test_form_flags_suspect(self):
+        form = PostForm(
+            data={"tipo_feed": "global", "conteudo": "ruim"}, user=self.user
+        )
+        self.assertTrue(form.is_valid())
+        post = form.save()
+        moderacao = post.moderacao
+        self.assertEqual(moderacao.status, "pendente")


### PR DESCRIPTION
## Summary
- add heuristic AI moderation module
- integrate AI moderation into post creation and forms
- add API and form tests for moderation decisions

## Testing
- `ruff check feed/infrastructure/moderation_ai.py feed/application/moderar_ai.py feed/api.py feed/forms.py feed/tests/test_ai_moderation.py`
- `mypy feed/infrastructure/moderation_ai.py feed/application/moderar_ai.py --ignore-missing-imports --strict` (failed: Class cannot subclass "Model")
- `pytest feed/tests/test_ai_moderation.py feed/tests/test_post_api.py feed/tests/test_post_form.py` (failed: ModuleNotFoundError: No module named 'bleach')

------
https://chatgpt.com/codex/tasks/task_e_68952aff71988325b00d070cdd76c371