### PR TITLE
feat(financeiro): add integration config and ERP connector

### DIFF
--- a/financeiro/admin.py
+++ b/financeiro/admin.py
@@ -5,6 +5,8 @@ from .models import (
     ContaAssociado,
     FinanceiroLog,
     ImportacaoPagamentos,
+    IntegracaoConfig,
+    IntegracaoLog,
     LancamentoFinanceiro,
 )
 
@@ -37,3 +39,16 @@ class ImportacaoPagamentosAdmin(admin.ModelAdmin):
 class FinanceiroLogAdmin(admin.ModelAdmin):
     list_display = ["acao", "usuario", "created_at"]
     list_filter = ["acao"]
+
+
+@admin.register(IntegracaoConfig)
+class IntegracaoConfigAdmin(admin.ModelAdmin):
+    list_display = ["nome", "tipo", "ativo"]
+    list_filter = ["tipo", "ativo"]
+    search_fields = ["nome"]
+
+
+@admin.register(IntegracaoLog)
+class IntegracaoLogAdmin(admin.ModelAdmin):
+    list_display = ["provedor", "acao", "status", "created_at"]
+    list_filter = ["provedor", "status"]

--- a/financeiro/migrations/0002_integracoes.py
+++ b/financeiro/migrations/0002_integracoes.py
@@ -1,0 +1,93 @@
+from django.db import migrations, models
+import uuid
+import django.db.models.deletion
+
+import core.fields
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("financeiro", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="IntegracaoConfig",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(
+                        primary_key=True, default=uuid.uuid4, serialize=False, editable=False
+                    ),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                ("nome", models.CharField(max_length=255)),
+                (
+                    "tipo",
+                    models.CharField(
+                        choices=[
+                            ("erp", "ERP"),
+                            ("contabilidade", "Contabilidade"),
+                            ("gateway", "Gateway de Pagamento"),
+                        ],
+                        max_length=20,
+                    ),
+                ),
+                ("base_url", core.fields.URLField(max_length=255)),
+                (
+                    "credenciais_encrypted",
+                    core.fields.EncryptedCharField(blank=True, max_length=512),
+                ),
+                ("ativo", models.BooleanField(default=True)),
+            ],
+            options={
+                "verbose_name": "Configuração de Integração",
+                "verbose_name_plural": "Configurações de Integração",
+                "ordering": ["nome"],
+            },
+        ),
+        migrations.CreateModel(
+            name="IntegracaoIdempotency",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID"),
+                ),
+                ("idempotency_key", models.CharField(max_length=255, unique=True)),
+                ("provedor", models.CharField(max_length=100)),
+                ("recurso", models.CharField(max_length=100)),
+                ("status", models.CharField(max_length=50)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+            ],
+            options={
+                "verbose_name": "Idempotência de Integração",
+                "verbose_name_plural": "Idempotências de Integração",
+                "ordering": ["-created_at"],
+            },
+        ),
+        migrations.CreateModel(
+            name="IntegracaoLog",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(
+                        primary_key=True, default=uuid.uuid4, serialize=False, editable=False
+                    ),
+                ),
+                ("provedor", models.CharField(max_length=100)),
+                ("acao", models.CharField(max_length=100)),
+                ("payload_in", models.JSONField(blank=True, default=dict)),
+                ("payload_out", models.JSONField(blank=True, default=dict)),
+                ("status", models.CharField(max_length=50)),
+                ("duracao_ms", models.PositiveIntegerField(default=0)),
+                ("erro", models.TextField(blank=True)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+            ],
+            options={
+                "verbose_name": "Log de Integração",
+                "verbose_name_plural": "Logs de Integração",
+                "ordering": ["-created_at"],
+            },
+        ),
+    ]

--- a/financeiro/services/integracoes/erp_conector.py
+++ b/financeiro/services/integracoes/erp_conector.py
@@ -1,0 +1,99 @@
+"""Serviço de comunicação com ERPs externos."""
+from __future__ import annotations
+
+import time
+import uuid
+from typing import Any, Dict, Optional
+
+import requests
+
+from financeiro.models import IntegracaoConfig, IntegracaoIdempotency, IntegracaoLog
+
+
+class ERPConector:
+    """Cliente simples para integração com ERPs.
+
+    Este serviço encapsula detalhes de autenticação, uso de ``Idempotency-Key``
+    e registro de logs das requisições. A implementação foca em oferecer uma
+    base para extensões futuras e é propositalmente minimalista.
+    """
+
+    def __init__(self, config: IntegracaoConfig):
+        self.config = config
+        self.base_url = config.base_url.rstrip("/")
+        self.session = requests.Session()
+        if config.credenciais_encrypted:
+            self.session.headers["Authorization"] = f"Bearer {config.credenciais_encrypted}"
+
+    # ------------------------------------------------------------------
+    # Métodos públicos
+    # ------------------------------------------------------------------
+    def listar_lancamentos_externos(self) -> Any:
+        """Retorna lançamentos financeiros disponíveis no ERP."""
+        response = self._request("GET", "/lancamentos/")
+        return response.json()
+
+    def enviar_lancamento(self, lancamento: Dict[str, Any]) -> Any:
+        """Envia um lançamento financeiro para o ERP."""
+        idem = self._registrar_idempotencia("lancamento")
+        response = self._request(
+            "POST", "/lancamentos/", json=lancamento, idempotency_key=idem
+        )
+        return response.json()
+
+    def conciliar_pagamento(
+        self, lancamento: Dict[str, Any], dados_externos: Dict[str, Any]
+    ) -> Any:
+        """Solicita conciliação de um pagamento."""
+        idem = self._registrar_idempotencia("conciliacao")
+        payload = {"lancamento": lancamento, "dados": dados_externos}
+        response = self._request(
+            "POST", "/conciliacao/", json=payload, idempotency_key=idem
+        )
+        return response.json()
+
+    # ------------------------------------------------------------------
+    # Métodos auxiliares
+    # ------------------------------------------------------------------
+    def _registrar_idempotencia(self, recurso: str) -> str:
+        """Cria registro de idempotência e retorna chave gerada."""
+        key = str(uuid.uuid4())
+        IntegracaoIdempotency.objects.create(
+            idempotency_key=key, provedor=self.config.nome, recurso=recurso, status="pending"
+        )
+        return key
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        idempotency_key: Optional[str] = None,
+        **kwargs: Any,
+    ) -> requests.Response:
+        """Executa a requisição HTTP registrando logs e erros."""
+        url = f"{self.base_url}/{path.lstrip('/')}"
+        headers = kwargs.pop("headers", {})
+        if idempotency_key:
+            headers["Idempotency-Key"] = idempotency_key
+        start = time.monotonic()
+        response = self.session.request(method, url, headers=headers, **kwargs)
+        duration = int((time.monotonic() - start) * 1000)
+        IntegracaoLog.objects.create(
+            provedor=self.config.nome,
+            acao=f"{method} {path}",
+            payload_in=kwargs.get("json"),
+            payload_out=self._safe_json(response),
+            status=str(response.status_code),
+            duracao_ms=duration,
+            erro="" if response.ok else response.text,
+        )
+        response.raise_for_status()
+        return response
+
+    @staticmethod
+    def _safe_json(response: requests.Response) -> Any:
+        try:
+            return response.json()
+        except ValueError:
+            return response.text


### PR DESCRIPTION
## Summary
- add models for integration config, idempotency and logs
- register integration models in admin interface
- scaffold ERP connector service for external integrations

## Testing
- `ruff check financeiro/models/__init__.py financeiro/admin.py financeiro/services/integracoes/erp_conector.py`
- `pytest` *(fails: 43 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68952d61cff48325a367b93c276f2e0f