### PR TITLE
Add PWA offline support for dashboard

### DIFF
--- a/Hubx/urls.py
+++ b/Hubx/urls.py
@@ -3,6 +3,7 @@
 from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
+from django.contrib.staticfiles.views import serve as static_serve
 from django.urls import include, path
 from django.views.generic import RedirectView
 
@@ -94,3 +95,7 @@ urlpatterns = [
 if settings.DEBUG:
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
     urlpatterns += [path("silk/", include("silk.urls", namespace="silk"))]
+    urlpatterns += [
+        path("service-worker.js", static_serve, kwargs={"path": "service-worker.js"}),
+        path("manifest.json", static_serve, kwargs={"path": "manifest.json"}),
+    ]

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -2,6 +2,17 @@
 
 Este app fornece visualizações de métricas com parâmetros flexíveis e suporte a exportação.
 
+## PWA e suporte offline
+
+O dashboard pode ser instalado como um aplicativo no navegador. Ao acessar `/dashboard/`,
+o navegador oferece a opção de adicionar o Hubx Dashboard à tela inicial. O aplicativo
+funciona offline graças ao *service worker*, que armazena em cache os assets estáticos e
+as requisições HTMX mais recentes.
+
+1. Visite `/dashboard/` em um navegador compatível.
+2. Aceite o prompt de instalação ou utilize a opção "Adicionar à tela inicial".
+3. O aplicativo continua acessível mesmo sem conexão de rede.
+
 ## Parâmetros
 
 A view base aceita os seguintes parâmetros via query string:

--- a/static/icons/README.md
+++ b/static/icons/README.md
@@ -1,0 +1,1 @@
+Coloque aqui os ícones PNG gerados a partir do logotipo nas dimensões 192x192 e 512x512.

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -1,0 +1,6 @@
+// Registers the service worker responsible for offline support.
+if ("serviceWorker" in navigator) {
+  window.addEventListener("load", () => {
+    navigator.serviceWorker.register("/service-worker.js");
+  });
+}

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "Hubx Dashboard",
+  "short_name": "Dashboard",
+  "start_url": "/dashboard/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#0f172a",
+  "icons": [
+    {
+      "src": "/static/icons/icon-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/static/icons/icon-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/static/service-worker.js
+++ b/static/service-worker.js
@@ -1,0 +1,47 @@
+// Service worker for Hubx Dashboard PWA
+// Cache version. Update the suffix (e.g., -v2) to force cache refresh on deploys.
+const CACHE_NAME = "dashboard-static-v1";
+
+// List of core resources to pre-cache for offline usage.
+const CORE_ASSETS = ["/dashboard/"];
+
+self.addEventListener("install", event => {
+  // Pre-cache core assets so the dashboard shell is available offline.
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(CORE_ASSETS))
+  );
+});
+
+self.addEventListener("activate", event => {
+  // Clean up old caches when a new version is activated.
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key)))
+    )
+  );
+  // Take control of clients immediately so no reload is required.
+  self.clients.claim();
+});
+
+// Helper implementing stale-while-revalidate strategy.
+async function staleWhileRevalidate(request) {
+  const cache = await caches.open(CACHE_NAME);
+  const cached = await cache.match(request);
+  const fetchPromise = fetch(request)
+    .then(response => {
+      cache.put(request, response.clone());
+      return response;
+    })
+    .catch(() => cached);
+  return cached || fetchPromise;
+}
+
+self.addEventListener("fetch", event => {
+  if (event.request.method !== "GET") return;
+  const url = new URL(event.request.url);
+  const isStatic = /\.css$|\.js$|\.png$|\.svg$/.test(url.pathname);
+  const isDashboardPartial =
+    url.pathname.startsWith("/dashboard/") && url.pathname.endsWith("-partial/");
+  if (!(isStatic || isDashboardPartial)) return;
+  event.respondWith(staleWhileRevalidate(event.request));
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,6 +5,8 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="manifest" href="{% static 'manifest.json' %}">
+  <meta name="theme-color" content="#0f172a">
   <script>
     (function () {
       let theme = localStorage.getItem('tema');
@@ -150,6 +152,7 @@
   <script src="{% static 'chat/js/notifications_socket.js' %}"></script>
   <script src="{% static 'notificacoes/js/push_socket.js' %}"></script>
   <script src="https://unpkg.com/htmx.org@{{ HTMX_VERSION }}"></script>
+  <script src="{% static 'js/dashboard.js' %}"></script>
   <script>
     (function () {
       const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');

--- a/tests/dashboard/test_manifest.py
+++ b/tests/dashboard/test_manifest.py
@@ -1,0 +1,14 @@
+import json
+from pathlib import Path
+
+
+def test_manifest_fields():
+    data = json.loads(Path("static/manifest.json").read_text())
+    assert data["name"] == "Hubx Dashboard"
+    assert data["short_name"] == "Dashboard"
+    assert data["start_url"] == "/dashboard/"
+    assert data["display"] == "standalone"
+    assert data["background_color"] == "#ffffff"
+    assert data["theme_color"] == "#0f172a"
+    sizes = {icon["sizes"] for icon in data["icons"]}
+    assert {"192x192", "512x512"} <= sizes

--- a/tests/e2e/test_pwa_offline.py
+++ b/tests/e2e/test_pwa_offline.py
@@ -1,0 +1,34 @@
+import pytest
+from django.urls import reverse
+from playwright.sync_api import sync_playwright
+from rest_framework.test import APIClient
+
+from accounts.factories import UserFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def test_dashboard_pwa_offline(live_server):
+    user = UserFactory(password="pw")
+    client = APIClient()
+    client.force_login(user)
+    sessionid = client.cookies.get("sessionid").value
+
+    with sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        context = browser.new_context(base_url=live_server.url)
+        context.add_cookies([{"name": "sessionid", "value": sessionid, "url": live_server.url}])
+        page = context.new_page()
+        page.goto(reverse("dashboard:dashboard"))
+
+        # Ensure service worker is controlling the page
+        page.wait_for_function("navigator.serviceWorker.controller !== null")
+        manifest = page.get_attribute("link[rel='manifest']", "href")
+        assert manifest and manifest.endswith("manifest.json")
+
+        metrics = page.evaluate("fetch('/dashboard/metrics-partial/').then(r => r.text())")
+        context.set_offline(True)
+        offline_metrics = page.evaluate("fetch('/dashboard/metrics-partial/').then(r => r.text())")
+        assert offline_metrics == metrics
+
+        browser.close()


### PR DESCRIPTION
## Summary
- add PWA manifest and service worker for offline caching
- register service worker and include manifest in base template
- document installation and add tests for manifest and offline behavior

## Testing
- `make vet` (fails: deprecated config and many lint errors)
- `make test` (fails: 44 errors during collection)
- `pip-audit` (fails: 3 known vulnerabilities)


------
https://chatgpt.com/codex/tasks/task_e_68960b08854c8325b844f7bb7e2d9799