### PR TITLE
feat: add chat message metric to dashboard

### DIFF
--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -38,6 +38,7 @@ METRICAS_INFO = {
     "num_posts_feed_recent": {"label": _("Posts (24h)"), "icon": "fa-clock"},
     "num_topicos": {"label": _("Tópicos"), "icon": "fa-comments"},
     "num_respostas": {"label": _("Respostas"), "icon": "fa-reply"},
+    "num_mensagens_chat": {"label": _("Mensagens de chat"), "icon": "fa-message"},
 }
 
 

--- a/tests/dashboard/test_services.py
+++ b/tests/dashboard/test_services.py
@@ -75,6 +75,17 @@ def test_calcular_mensagens_chat(conversa, admin_user):
     assert DashboardService.calcular_mensagens_chat() >= 1
 
 
+def test_get_metrics_mensagens_chat(conversa, admin_user, organizacao):
+    ChatMessage.objects.create(channel=conversa, remetente=admin_user, conteudo="hi")
+    metrics = DashboardMetricsService.get_metrics(
+        admin_user,
+        metricas=["num_mensagens_chat"],
+        escopo="organizacao",
+        organizacao_id=organizacao.id,
+    )
+    assert metrics["num_mensagens_chat"]["total"] == 1
+
+
 def test_calcular_valores_eventos(evento, cliente_user):
     InscricaoEvento.objects.create(evento=evento, user=cliente_user, valor_pago=10)
     values = DashboardService.calcular_valores_eventos()


### PR DESCRIPTION
## Summary
- add metric for chat messages with filtering support
- expose chat message totals in dashboard views
- test chat message metric integration

## Testing
- `ruff check dashboard/services.py dashboard/views.py tests/dashboard/test_services.py`
- `pytest tests/dashboard/test_services.py::test_get_metrics_mensagens_chat tests/dashboard/test_templates.py::test_metricas_info_used_in_context -q`


------
https://chatgpt.com/codex/tasks/task_e_689633902a1883258d87a345a97fe535