### PR TITLE
feat: add exports and gamification

### DIFF
--- a/agenda/serializers.py
+++ b/agenda/serializers.py
@@ -14,6 +14,7 @@ from .models import (
     ParceriaEvento,
 )
 from .tasks import upload_material_divulgacao
+from dashboard.services import check_achievements
 
 
 class EventoSerializer(serializers.ModelSerializer):
@@ -100,6 +101,7 @@ class InscricaoEventoSerializer(serializers.ModelSerializer):
         validated_data["user"] = request.user
         instance = super().create(validated_data)
         instance.confirmar_inscricao()
+        check_achievements(request.user)
         return instance
 
 

--- a/agenda/views.py
+++ b/agenda/views.py
@@ -58,6 +58,7 @@ from .models import (
     ParceriaEvento,
 )
 from .tasks import notificar_briefing_status
+from dashboard.services import check_achievements
 
 User = get_user_model()
 
@@ -438,7 +439,9 @@ class InscricaoEventoCreateView(LoginRequiredMixin, CreateView):
 
     def form_valid(self, form):
         form.instance.user = self.request.user
-        return super().form_valid(form)
+        response = super().form_valid(form)
+        check_achievements(self.request.user)
+        return response
 
 
 class MaterialDivulgacaoEventoListView(LoginRequiredMixin, ListView):

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -43,6 +43,8 @@ Usuários root, admin e coordenador podem exportar as métricas atuais:
 ```
 /dashboard/export/?formato=csv
 /dashboard/export/?formato=pdf&periodo=mensal&escopo=global
+/dashboard/export/?formato=xlsx
+/dashboard/export/?formato=png
 ```
 
 O arquivo gerado inclui `total` e a variação percentual calculada como `(valor_atual - valor_anterior) / max(valor_anterior, 1) * 100`.
@@ -67,6 +69,10 @@ Exemplo de JSON armazenado:
 ```
 
 O cache das métricas expira em 5 minutos e utiliza a chave `dashboard-<escopo>-<json dos filtros>`, permitindo reutilização entre usuários com o mesmo escopo e filtros. Para invalidar manualmente, utilize o comando `python manage.py clear_cache` ou limpe o backend configurado.
+
+## Conquistas
+
+O dashboard possui um sistema de conquistas que registra marcos como 100 inscrições em eventos ou a criação de 5 dashboards personalizados. As conquistas disponíveis e o progresso do usuário podem ser visualizados em `/dashboard/achievements/`.
 
 ## Modelos e persistência
 

--- a/dashboard/migrations/0002_achievement.py
+++ b/dashboard/migrations/0002_achievement.py
@@ -1,0 +1,64 @@
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+def create_initial_achievements(apps, schema_editor):
+    Achievement = apps.get_model('dashboard', 'Achievement')
+    Achievement.objects.create(
+        code='100_inscricoes',
+        titulo='Participante Assíduo',
+        descricao='Realizou 100 inscrições em eventos.',
+        criterio='Atingir 100 inscrições em eventos',
+        icon='trophy',
+    )
+    Achievement.objects.create(
+        code='5_dashboards',
+        titulo='Explorador de Dashboards',
+        descricao='Criou 5 dashboards personalizados.',
+        criterio='Criar 5 dashboards personalizados',
+        icon='chart-bar',
+    )
+
+
+def remove_initial_achievements(apps, schema_editor):
+    Achievement = apps.get_model('dashboard', 'Achievement')
+    Achievement.objects.filter(code__in=['100_inscricoes', '5_dashboards']).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('dashboard', '0001_initial'),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Achievement',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('created', models.DateTimeField(auto_now_add=True, null=True)),
+                ('modified', models.DateTimeField(auto_now=True, null=True)),
+                ('code', models.CharField(max_length=50, unique=True)),
+                ('titulo', models.CharField(max_length=100)),
+                ('descricao', models.TextField()),
+                ('criterio', models.CharField(max_length=200)),
+                ('icon', models.CharField(blank=True, max_length=200)),
+            ],
+            options={'abstract': False},
+        ),
+        migrations.CreateModel(
+            name='UserAchievement',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('created', models.DateTimeField(auto_now_add=True, null=True)),
+                ('modified', models.DateTimeField(auto_now=True, null=True)),
+                ('completado_em', models.DateTimeField(auto_now_add=True)),
+                ('achievement', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='dashboard.achievement')),
+                ('user', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL)),
+            ],
+            options={'unique_together': {('user', 'achievement')}},
+        ),
+        migrations.RunPython(create_initial_achievements, remove_initial_achievements),
+    ]

--- a/dashboard/models.py
+++ b/dashboard/models.py
@@ -47,3 +47,30 @@ class DashboardConfig(SoftDeleteModel, TimeStampedModel):
 
     def __str__(self) -> str:  # pragma: no cover - simples
         return self.nome
+
+
+class Achievement(TimeStampedModel):
+    """Representa uma conquista disponível para os usuários."""
+
+    code = models.CharField(max_length=50, unique=True)
+    titulo = models.CharField(max_length=100)
+    descricao = models.TextField()
+    criterio = models.CharField(max_length=200)
+    icon = models.CharField(max_length=200, blank=True)
+
+    def __str__(self) -> str:  # pragma: no cover - simples representação
+        return self.titulo
+
+
+class UserAchievement(TimeStampedModel):
+    """Conquistas obtidas por um usuário."""
+
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
+    achievement = models.ForeignKey(Achievement, on_delete=models.CASCADE)
+    completado_em = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        unique_together = ("user", "achievement")
+
+    def __str__(self) -> str:  # pragma: no cover - simples representação
+        return f"{self.user} - {self.achievement}"

--- a/dashboard/templates/dashboard/achievement_list.html
+++ b/dashboard/templates/dashboard/achievement_list.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Conquistas" %} | Hubx{% endblock %}
+
+{% block content %}
+<main class="max-w-4xl mx-auto p-4" aria-label="{% trans 'Conquistas' %}">
+  <h1 class="text-2xl font-semibold mb-4">{% trans 'Conquistas' %}</h1>
+  <ul class="grid grid-cols-1 gap-4">
+    {% for ach in object_list %}
+      <li class="p-4 bg-white rounded shadow flex items-center justify-between">
+        <span class="flex items-center gap-2">
+          <i class="fa-solid fa-{{ ach.icon }}" aria-hidden="true"></i>
+          <span>{{ ach.titulo }}</span>
+        </span>
+        {% if ach.id in user_achievements %}
+          <span class="text-green-600">{% trans 'Concluída' %}</span>
+        {% else %}
+          <span class="text-neutral-500">{% trans 'Pendente' %}</span>
+        {% endif %}
+      </li>
+    {% empty %}
+      <li>{% trans 'Nenhuma conquista cadastrada.' %}</li>
+    {% endfor %}
+  </ul>
+</main>
+{% endblock %}

--- a/dashboard/templates/dashboard/admin.html
+++ b/dashboard/templates/dashboard/admin.html
@@ -9,6 +9,7 @@
   <h1 class="text-3xl font-semibold text-neutral-900 text-center mb-10">{% trans "Dashboard Administrativo" %}</h1>
 
   {% include 'dashboard/partials/messages.html' %}
+  {% include 'dashboard/partials/achievements_badges.html' %}
 
   {% include 'dashboard/partials/filters_form.html' %}
 

--- a/dashboard/templates/dashboard/cliente.html
+++ b/dashboard/templates/dashboard/cliente.html
@@ -9,6 +9,7 @@
   <h1 class="text-3xl font-semibold text-neutral-900 text-center mb-10">{% trans "Dashboard Cliente" %}</h1>
 
   {% include 'dashboard/partials/messages.html' %}
+  {% include 'dashboard/partials/achievements_badges.html' %}
 
   {% include 'dashboard/partials/filters_form.html' %}
 

--- a/dashboard/templates/dashboard/gerente.html
+++ b/dashboard/templates/dashboard/gerente.html
@@ -9,6 +9,7 @@
   <h1 class="text-3xl font-semibold text-neutral-900 text-center mb-10">{% trans "Dashboard Gerente" %}</h1>
 
   {% include 'dashboard/partials/messages.html' %}
+  {% include 'dashboard/partials/achievements_badges.html' %}
 
   {% include 'dashboard/partials/filters_form.html' %}
 

--- a/dashboard/templates/dashboard/partials/achievements_badges.html
+++ b/dashboard/templates/dashboard/partials/achievements_badges.html
@@ -1,0 +1,11 @@
+{% load i18n %}
+<div class="flex flex-wrap gap-2 mb-4" aria-label="{% trans 'Conquistas alcançadas' %}">
+{% for ua in request.user.userachievement_set.select_related('achievement').all %}
+  <span class="bg-indigo-100 text-indigo-800 px-2 py-1 rounded flex items-center gap-1" aria-label="{{ ua.achievement.titulo }}">
+    <i class="fa-solid fa-{{ ua.achievement.icon }}" aria-hidden="true"></i>
+    {{ ua.achievement.titulo }}
+  </span>
+{% empty %}
+  <p class="text-sm text-neutral-600">{% trans 'Nenhuma conquista ainda.' %}</p>
+{% endfor %}
+</div>

--- a/dashboard/templates/dashboard/partials/filters_form.html
+++ b/dashboard/templates/dashboard/partials/filters_form.html
@@ -52,7 +52,13 @@
   </fieldset>
   <div class="flex gap-2 mt-4">
     <button type="submit" class="px-4 py-2 bg-primary-600 text-white rounded focus:outline-none focus:ring" aria-label="{% trans 'Aplicar filtros' %}">{% trans 'Filtrar' %}</button>
-    <a href="{% url 'dashboard:export' %}?{{ request.GET.urlencode }}" class="px-4 py-2 bg-neutral-200 text-neutral-800 rounded focus:outline-none focus:ring" aria-label="{% trans 'Exportar métricas' %}">{% trans 'Exportar' %}</a>
+    <select name="formato" class="border-gray-300 rounded" aria-label="{% trans 'Formato de exportação' %}">
+      <option value="csv">CSV</option>
+      <option value="pdf">PDF</option>
+      <option value="xlsx">Excel</option>
+      <option value="png">PNG</option>
+    </select>
+    <button type="submit" formaction="{% url 'dashboard:export' %}" class="px-4 py-2 bg-neutral-200 text-neutral-800 rounded focus:outline-none focus:ring" aria-label="{% trans 'Exportar métricas' %}">{% trans 'Exportar' %}</button>
     <a href="{% url 'dashboard:filter-create' %}?{{ request.GET.urlencode }}" class="px-4 py-2 bg-neutral-200 text-neutral-800 rounded focus:outline-none focus:ring" aria-label="{% trans 'Salvar filtro rápido' %}">{% trans 'Salvar filtro' %}</a>
     <a href="{% url 'dashboard:filters' %}" class="px-4 py-2 bg-neutral-200 text-neutral-800 rounded focus:outline-none focus:ring" aria-label="{% trans 'Ver filtros salvos' %}">{% trans 'Meus filtros' %}</a>
     <a href="{% url 'dashboard:config-create' %}?{{ request.GET.urlencode }}" class="px-4 py-2 bg-neutral-200 text-neutral-800 rounded focus:outline-none focus:ring" aria-label="{% trans 'Salvar configuração' %}">{% trans 'Salvar configuração' %}</a>

--- a/dashboard/templates/dashboard/root.html
+++ b/dashboard/templates/dashboard/root.html
@@ -9,6 +9,7 @@
   <h1 class="text-3xl font-semibold text-neutral-900 text-center mb-10">{% trans "Dashboard Root" %}</h1>
 
   {% include 'dashboard/partials/messages.html' %}
+  {% include 'dashboard/partials/achievements_badges.html' %}
 
   {% include 'dashboard/partials/filters_form.html' %}
 

--- a/dashboard/urls.py
+++ b/dashboard/urls.py
@@ -16,6 +16,7 @@ urlpatterns = [
     path("tarefas-partial/", views.tarefas_partial, name="tarefas-partial"),
     path("eventos-partial/", views.eventos_partial, name="eventos-partial"),
     path("export/", views.DashboardExportView.as_view(), name="export"),
+    path("export/images/<str:filename>", views.DashboardExportedImageView.as_view(), name="export-image"),
     path("configs/", views.DashboardConfigListView.as_view(), name="configs"),
     path("configs/create/", views.DashboardConfigCreateView.as_view(), name="config-create"),
     path("configs/<uuid:pk>/apply/", views.DashboardConfigApplyView.as_view(), name="config-apply"),
@@ -23,4 +24,5 @@ urlpatterns = [
     path("filters/create/", views.DashboardFilterCreateView.as_view(), name="filter-create"),
     path("filters/<int:pk>/apply/", views.DashboardFilterApplyView.as_view(), name="filter-apply"),
     path("filters/<int:pk>/delete/", views.DashboardFilterDeleteView.as_view(), name="filter-delete"),
+    path("achievements/", views.AchievementListView.as_view(), name="achievements"),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -72,6 +72,7 @@ pypdfium2==4.30.0
 openpyxl==3.1.5
 tablib==3.5.0
 reportlab==4.2.0
+matplotlib==3.8.2
 
 # Outros utilitários
 Pygments==2.19.2

--- a/tests/dashboard/test_achievements.py
+++ b/tests/dashboard/test_achievements.py
@@ -1,0 +1,25 @@
+import pytest
+
+from agenda.models import InscricaoEvento
+from agenda.factories import EventoFactory
+from dashboard.models import Achievement, DashboardConfig, UserAchievement
+from dashboard.services import check_achievements
+
+
+@pytest.mark.django_db
+def test_award_dashboard_achievement(admin_user):
+    ach = Achievement.objects.get(code="5_dashboards")
+    for i in range(5):
+        DashboardConfig.objects.create(user=admin_user, nome=f"cfg{i}", config={})
+    check_achievements(admin_user)
+    assert UserAchievement.objects.filter(user=admin_user, achievement=ach).exists()
+
+
+@pytest.mark.django_db
+def test_award_inscricao_achievement(admin_user):
+    ach = Achievement.objects.get(code="100_inscricoes")
+    for _ in range(100):
+        ev = EventoFactory(organizacao=admin_user.organizacao, coordenador=admin_user)
+        InscricaoEvento.objects.create(user=admin_user, evento=ev)
+    check_achievements(admin_user)
+    assert UserAchievement.objects.filter(user=admin_user, achievement=ach).exists()


### PR DESCRIPTION
## Summary
- add Excel and PNG export options for dashboard metrics
- introduce achievement models and badge display on dashboard
- cover new exports and achievements with tests

## Testing
- `pytest tests/dashboard/test_views.py::test_export_view_xlsx tests/dashboard/test_views.py::test_export_view_png tests/dashboard/test_api.py::test_export_xlsx tests/dashboard/test_achievements.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68963c90ff588325bf3a518adad3bc02