### PR TITLE
feat: extend convites and member suspension

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,13 @@ npm run build
 - **Feed**: Suporte a tipos de feed (`global`, `usuario`, `nucleo`, `evento`).
 - **Discussões**: Categorias e tópicos com respostas e interações.
 
+### Núcleos: Convites, Suspensão e Feed
+- **Convites de Núcleo**: admins geram convites com `POST /api/nucleos/<id>/convites/` e revogam com `DELETE /api/nucleos/<id>/convites/<convite_id>/`, respeitando a quota diária.
+- **Suspensão de Membros**: coordenadores podem suspender ou reativar participantes (`POST /api/nucleos/<id>/membros/<user_id>/suspender` / `.../reativar`).
+- **Membro Status**: consulta de papel e suspensão em `GET /api/nucleos/<id>/membro-status/`.
+- **Feed do Núcleo**: membros ativos podem publicar via `POST /api/nucleos/<id>/posts/`.
+
+
 ### Dashboard
 - **Dashboard**: Estatísticas de eventos, inscrições e interações.
 

--- a/chat/services.py
+++ b/chat/services.py
@@ -70,8 +70,8 @@ def _usuario_no_contexto(user: User, contexto_tipo: str, contexto_id: Optional[s
     if contexto_tipo == "organizacao":
         return str(user.organizacao_id) == str(contexto_id)
     if contexto_tipo == "nucleo":
-        participa, info = user_belongs_to_nucleo(user, contexto_id)
-        return participa and info.endswith("ativo")
+        participa, info, suspenso = user_belongs_to_nucleo(user, contexto_id)
+        return participa and info.endswith("ativo") and not suspenso
     if contexto_tipo == "evento":
         return InscricaoEvento.objects.filter(
             user=user, evento_id=contexto_id, status="confirmada"

--- a/discussao/consumers.py
+++ b/discussao/consumers.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
+from channels.db import database_sync_to_async
 from channels.generic.websocket import AsyncJsonWebsocketConsumer
 from django.contrib.auth.models import AnonymousUser
+
+from services.nucleos import user_belongs_to_nucleo
+
+from .models import TopicoDiscussao
 
 
 class DiscussionConsumer(AsyncJsonWebsocketConsumer):
@@ -13,12 +18,27 @@ class DiscussionConsumer(AsyncJsonWebsocketConsumer):
         if not user or isinstance(user, AnonymousUser):
             await self.close()
             return
+        try:
+            topico = await database_sync_to_async(TopicoDiscussao.objects.select_related("nucleo").get)(
+                pk=self.topico_id
+            )
+        except TopicoDiscussao.DoesNotExist:
+            await self.close()
+            return
+        if topico.nucleo_id:
+            participa, info, suspenso = await database_sync_to_async(user_belongs_to_nucleo)(
+                user, topico.nucleo_id
+            )
+            if not participa or not info.endswith("ativo") or suspenso:
+                await self.close()
+                return
         self.group_name = f"discussao_{self.topico_id}"
         await self.channel_layer.group_add(self.group_name, self.channel_name)
         await self.accept()
 
     async def disconnect(self, close_code):  # pragma: no cover - channels handles
-        await self.channel_layer.group_discard(self.group_name, self.channel_name)
+        if hasattr(self, "group_name"):
+            await self.channel_layer.group_discard(self.group_name, self.channel_name)
 
     async def receive_json(self, content, **kwargs):  # pragma: no cover - somente broadcast
         pass

--- a/docs/nucleos_api.md
+++ b/docs/nucleos_api.md
@@ -1,0 +1,15 @@
+# API de Núcleos
+
+Endpoints introduzidos na Sprint 2 para convites, suspensão de membros e posts no feed.
+
+## Convites
+- `POST /api/nucleos/{id}/convites/` — gera um convite para o núcleo, respeitando o limite diário por usuário.
+- `DELETE /api/nucleos/{id}/convites/{convite_id}/` — revoga o convite informado, marcando-o como expirado.
+
+## Suspensão de Membros
+- `POST /api/nucleos/{id}/membros/{user_id}/suspender/` — suspende o participante ativo.
+- `POST /api/nucleos/{id}/membros/{user_id}/reativar/` — reativa o participante suspenso.
+- `GET /api/nucleos/{id}/membro-status/` — retorna `{papel, ativo, suspenso}` para o usuário autenticado.
+
+## Feed do Núcleo
+- `POST /api/nucleos/{id}/posts/` — cria um post no feed do núcleo para membros ativos não suspensos.

--- a/feed/api.py
+++ b/feed/api.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from datetime import datetime
 import re
+from datetime import datetime
 from math import ceil
 
 import boto3
@@ -125,6 +125,22 @@ class PostSerializer(serializers.ModelSerializer):
         key = getattr(obj.video, "name", obj.video)
         return self._generate_presigned(key)
 
+
+class NucleoPostSerializer(PostSerializer):
+    """Serializer específico para posts de núcleo."""
+
+    class Meta(PostSerializer.Meta):
+        fields = [
+            f
+            for f in PostSerializer.Meta.fields
+            if f not in {"tipo_feed", "nucleo", "evento"}
+        ]
+        read_only_fields = PostSerializer.Meta.read_only_fields
+
+    def validate(self, attrs):
+        attrs["tipo_feed"] = "nucleo"
+        attrs["nucleo"] = self.context["nucleo"]
+        return super().validate(attrs)
 
 def _rate_with_multiplier(base: str, multiplier: float) -> str:
     match = re.match(r"(\d+)/(\w+)", base)

--- a/nucleos/api_urls.py
+++ b/nucleos/api_urls.py
@@ -3,7 +3,6 @@ from rest_framework.routers import DefaultRouter
 
 from .api import (
     AceitarConviteAPIView,
-    ConviteNucleoCreateAPIView,
     NucleoViewSet,
 )
 
@@ -11,7 +10,6 @@ router = DefaultRouter()
 router.register(r"nucleos", NucleoViewSet, basename="nucleo")
 
 urlpatterns = router.urls + [
-    path("convites/", ConviteNucleoCreateAPIView.as_view(), name="nucleo-convite"),
     path(
         "aceitar-convite/",
         AceitarConviteAPIView.as_view(),

--- a/nucleos/metrics.py
+++ b/nucleos/metrics.py
@@ -1,0 +1,17 @@
+from prometheus_client import Counter  # type: ignore
+
+convites_gerados_total = Counter(
+    "convites_gerados_total",
+    "Total de convites de núcleo gerados",
+)
+
+convites_usados_total = Counter(
+    "convites_usados_total",
+    "Total de convites de núcleo utilizados",
+)
+
+membros_suspensos_total = Counter(
+    "membros_suspensos_total",
+    "Total de suspensões de membros em núcleos",
+)
+

--- a/nucleos/migrations/0003_convite_tokens_suspensao.py
+++ b/nucleos/migrations/0003_convite_tokens_suspensao.py
@@ -1,0 +1,48 @@
+from datetime import timedelta
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+def set_convite_expiration(apps, schema_editor):
+    Convite = apps.get_model('nucleos', 'ConviteNucleo')
+    for convite in Convite.objects.all():
+        if not convite.data_expiracao:
+            convite.data_expiracao = convite.criado_em + timedelta(days=7)
+            convite.save(update_fields=['data_expiracao'])
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('nucleos', '0002_refatoracao'),
+        ('tokens', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='convitenucleo',
+            name='token_obj',
+            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, related_name='convites_nucleo', db_column='token_id', to='tokens.tokenacesso'),
+        ),
+        migrations.AddField(
+            model_name='convitenucleo',
+            name='data_expiracao',
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='convitenucleo',
+            name='limite_uso_diario',
+            field=models.PositiveSmallIntegerField(default=1),
+        ),
+        migrations.AddField(
+            model_name='participacaonucleo',
+            name='status_suspensao',
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AddField(
+            model_name='participacaonucleo',
+            name='data_suspensao',
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+        migrations.RunPython(set_convite_expiration, migrations.RunPython.noop),
+    ]

--- a/nucleos/serializers.py
+++ b/nucleos/serializers.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from rest_framework import serializers
 
-from .models import CoordenadorSuplente, Nucleo, ParticipacaoNucleo, ConviteNucleo
+from .models import ConviteNucleo, CoordenadorSuplente, Nucleo, ParticipacaoNucleo
 
 
 class CoordenadorSuplenteSerializer(serializers.ModelSerializer):
@@ -36,6 +36,8 @@ class ParticipacaoNucleoSerializer(serializers.ModelSerializer):
             "nucleo",
             "papel",
             "status",
+            "status_suspensao",
+            "data_suspensao",
             "data_solicitacao",
             "data_decisao",
             "decidido_por",
@@ -43,10 +45,12 @@ class ParticipacaoNucleoSerializer(serializers.ModelSerializer):
         ]
         read_only_fields = [
             "status",
+            "status_suspensao",
             "data_solicitacao",
             "data_decisao",
             "decidido_por",
             "justificativa",
+            "data_suspensao",
         ]
 
 
@@ -75,5 +79,15 @@ class NucleoSerializer(serializers.ModelSerializer):
 class ConviteNucleoSerializer(serializers.ModelSerializer):
     class Meta:
         model = ConviteNucleo
-        fields = ["id", "token", "email", "papel", "nucleo", "usado_em", "criado_em"]
-        read_only_fields = ["id", "token", "usado_em", "criado_em"]
+        fields = [
+            "id",
+            "token",
+            "email",
+            "papel",
+            "nucleo",
+            "limite_uso_diario",
+            "data_expiracao",
+            "usado_em",
+            "criado_em",
+        ]
+        read_only_fields = ["id", "token", "data_expiracao", "usado_em", "criado_em"]

--- a/nucleos/services.py
+++ b/nucleos/services.py
@@ -1,12 +1,21 @@
 from __future__ import annotations
 
+import logging
+from datetime import timedelta
 from typing import Iterable
 
+from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.core.cache import cache
+from django.utils import timezone
 
-from .models import Nucleo, ParticipacaoNucleo
+from tokens.models import TokenAcesso
+
+from .metrics import convites_gerados_total
+from .models import ConviteNucleo, Nucleo, ParticipacaoNucleo
 
 User = get_user_model()
+logger = logging.getLogger(__name__)
 
 
 def criar_participacoes_membros(nucleo: Nucleo, membros: Iterable[User]) -> list[ParticipacaoNucleo]:
@@ -18,4 +27,45 @@ def criar_participacoes_membros(nucleo: Nucleo, membros: Iterable[User]) -> list
         part.save(update_fields=["status"])
         participacoes.append(part)
     return participacoes
+
+
+def gerar_convite_nucleo(user: User, nucleo: Nucleo, email: str, papel: str) -> ConviteNucleo:
+    """Gera um convite para o núcleo respeitando a cota diária do emissor."""
+
+    limite = getattr(settings, "CONVITE_NUCLEO_DIARIO_LIMITE", 5)
+    cache_key = f"convites_nucleo:{user.id}:{timezone.now().date()}"
+    count = cache.get(cache_key, 0)
+    if count >= limite:
+        raise ValueError("limite diário de convites atingido")
+    cache.set(cache_key, count + 1, 24 * 60 * 60)
+
+    token = TokenAcesso.objects.create(
+        gerado_por=user,
+        tipo_destino=(
+            TokenAcesso.TipoUsuario.COORDENADOR if papel == "coordenador" else TokenAcesso.TipoUsuario.NUCLEADO
+        ),
+        organizacao=nucleo.organizacao,
+        data_expiracao=timezone.now() + timedelta(days=7),
+    )
+    token.nucleos.add(nucleo)
+    convite = ConviteNucleo.objects.create(
+        token=token.codigo,
+        token_obj=token,
+        email=email,
+        papel=papel,
+        nucleo=nucleo,
+        data_expiracao=token.data_expiracao,
+    )
+    convites_gerados_total.inc()
+    logger.info(
+        "convite_gerado",
+        extra={
+            "convite_id": str(convite.pk),
+            "nucleo_id": str(nucleo.pk),
+            "emissor_id": str(user.pk),
+            "email": email,
+            "papel": papel,
+        },
+    )
+    return convite
 

--- a/nucleos/templates/nucleos/convites_modal.html
+++ b/nucleos/templates/nucleos/convites_modal.html
@@ -1,0 +1,27 @@
+{% load i18n %}
+<div class="p-4 bg-white rounded shadow max-w-md" id="convites-modal">
+  <h2 class="text-lg font-semibold mb-2">{% trans 'Convites do núcleo' %}</h2>
+  <p class="text-sm text-gray-600">{% trans 'Convites restantes hoje:' %} {{ convites_restantes }}</p>
+  <form class="mt-2 flex flex-col gap-2" hx-post="{% url 'nucleos_api:nucleo-convites' nucleo.pk %}" hx-target="#convites-list" hx-swap="afterbegin">
+    {% csrf_token %}
+    <input type="email" name="email" class="border rounded px-2 py-1" placeholder="email@example.com" required />
+    <select name="papel" class="border rounded px-2 py-1">
+      <option value="membro">{% trans 'Membro' %}</option>
+      <option value="coordenador">{% trans 'Coordenador' %}</option>
+    </select>
+    <div class="flex justify-end gap-2">
+      <button type="button" class="px-3 py-1 border rounded" hx-on="click: document.getElementById('convites-modal').remove()">{% trans 'Fechar' %}</button>
+      <button type="submit" class="px-3 py-1 bg-blue-600 text-white rounded">{% trans 'Enviar convite' %}</button>
+    </div>
+  </form>
+  <ul id="convites-list" class="mt-4 space-y-2">
+    {% for c in convites %}
+    <li id="convite-{{ c.id }}" class="flex justify-between items-center">
+      <span>{{ c.email }} - {{ c.papel }}</span>
+      <button class="text-red-600" hx-delete="{% url 'nucleos_api:nucleo-revogar-convite' nucleo.pk c.id %}" hx-target="#convite-{{ c.id }}" hx-swap="outerHTML">{% trans 'Revogar' %}</button>
+    </li>
+    {% empty %}
+    <li class="text-sm text-gray-500">{% trans 'Nenhum convite pendente.' %}</li>
+    {% endfor %}
+  </ul>
+</div>

--- a/nucleos/templates/nucleos/detail.html
+++ b/nucleos/templates/nucleos/detail.html
@@ -19,7 +19,9 @@
   <h2 class="mt-6 font-semibold">{% trans 'Membros' %}</h2>
   <ul>
     {% for part in membros_ativos %}
-    <li>{{ part.user.get_full_name|default:part.user.username }}{% if part.papel == 'coordenador' %} - {% trans 'Coordenador' %}{% endif %}
+    <li>
+      {{ part.user.get_full_name|default:part.user.username }}{% if part.papel == 'coordenador' %} - {% trans 'Coordenador' %}{% endif %}
+      {% if part.status_suspensao %}<span class="text-red-600">({% trans 'Suspenso' %})</span>{% endif %}
       {% if request.user.user_type == 'admin' or request.user.user_type == 'coordenador' %}
       <form method="post" action="{% url 'nucleos:membro_role' object.pk part.pk %}" class="inline">{% csrf_token %}
         <input type="hidden" name="papel" value="{% if part.papel == 'coordenador' %}membro{% else %}coordenador{% endif %}">
@@ -28,6 +30,15 @@
       <form method="post" action="{% url 'nucleos:membro_remover' object.pk part.pk %}" class="inline">{% csrf_token %}
         <button class="text-sm text-red-600">{% trans 'Remover' %}</button>
       </form>
+      {% if part.status_suspensao %}
+      <form hx-post="{% url 'nucleos_api:nucleo-reativar-membro' object.pk part.user.pk %}" hx-on="htmx:afterRequest: location.reload()" class="inline">{% csrf_token %}
+        <button class="text-sm text-green-600">{% trans 'Reativar' %}</button>
+      </form>
+      {% else %}
+      <form hx-post="{% url 'nucleos_api:nucleo-suspender-membro' object.pk part.user.pk %}" hx-on="htmx:afterRequest: location.reload()" class="inline">{% csrf_token %}
+        <button class="text-sm text-yellow-600">{% trans 'Suspender' %}</button>
+      </form>
+      {% endif %}
       {% endif %}
     </li>
     {% empty %}
@@ -80,6 +91,15 @@
   </div>
   {% endif %}
 
+  {% if request.user.user_type in ('admin','coordenador') %}
+  <div class="mt-4">
+    <button type="button" class="px-4 py-2 bg-purple-600 text-white rounded" hx-get="{% url 'nucleos:convites_modal' object.pk %}" hx-target="#modal">
+      {% trans 'Gerenciar convites' %} ({{ convites_pendentes }})
+    </button>
+    <p class="text-sm text-gray-500 mt-1">{% trans 'Convites restantes hoje:' %} {{ convites_restantes }}</p>
+  </div>
+  {% endif %}
+
   <div class="mt-6 space-x-2">
     <div class="inline-block relative">
       <button class="text-blue-600" hx-get="{% url 'nucleos:exportar_membros' object.pk %}?formato=csv" hx-trigger="click" hx-swap="none">{% trans 'Exportar CSV' %}</button>
@@ -95,6 +115,11 @@
     {% if mostrar_solicitar and request.user.user_type not in ('admin','coordenador') %}
     <div class="mt-4">
       <button id="solicitar-btn" type="button" class="px-4 py-2 bg-blue-600 text-white rounded" hx-get="{% url 'nucleos:solicitar_modal' object.pk %}" hx-target="#modal">{% trans 'Solicitar participação' %}</button>
+    </div>
+    {% endif %}
+    {% if pode_postar %}
+    <div class="mt-4">
+      <button type="button" class="px-4 py-2 bg-green-600 text-white rounded" hx-get="{% url 'nucleos:postar_modal' object.pk %}" hx-target="#modal">{% trans 'Postar no feed' %}</button>
     </div>
     {% endif %}
     <div id="modal"></div>

--- a/nucleos/templates/nucleos/postar_modal.html
+++ b/nucleos/templates/nucleos/postar_modal.html
@@ -1,0 +1,18 @@
+{% load i18n %}
+<div class="p-4 bg-white rounded shadow max-w-md">
+  <h2 class="text-lg font-semibold mb-4">{% trans 'Postar no feed do núcleo' %}</h2>
+  <form hx-post="{% url 'nucleos_api:nucleo-posts' nucleo.pk %}"
+        hx-encoding="multipart/form-data"
+        hx-swap="none"
+        hx-on="htmx:afterRequest: document.getElementById('modal').innerHTML='';">
+    {% csrf_token %}
+    <textarea name="conteudo" class="w-full border rounded mb-2" placeholder="{% trans 'Escreva algo...' %}"></textarea>
+    <input type="file" name="image" class="mb-2" />
+    <input type="file" name="pdf" class="mb-2" />
+    <input type="file" name="video" class="mb-4" />
+      <div class="flex justify-end gap-2">
+        <button type="button" class="px-3 py-1 border rounded" hx-on="click: document.getElementById('modal').innerHTML=''">{% trans 'Cancelar' %}</button>
+        <button type="submit" class="px-3 py-1 bg-blue-600 text-white rounded">{% trans 'Postar' %}</button>
+      </div>
+    </form>
+  </div>

--- a/nucleos/urls.py
+++ b/nucleos/urls.py
@@ -22,6 +22,16 @@ urlpatterns = [
         name="participacao_decidir",
     ),
     path(
+        "<int:pk>/postar/novo/",
+        views.PostarFeedModalView.as_view(),
+        name="postar_modal",
+    ),
+    path(
+        "<int:pk>/convites/",
+        views.ConvitesModalView.as_view(),
+        name="convites_modal",
+    ),
+    path(
         "<int:pk>/membro/<int:participacao_id>/remover/",
         views.MembroRemoveView.as_view(),
         name="membro_remover",

--- a/services/nucleos.py
+++ b/services/nucleos.py
@@ -1,13 +1,14 @@
 from django.contrib.auth import get_user_model
+
 from nucleos.models import ParticipacaoNucleo
 
 User = get_user_model()
 
 
-def user_belongs_to_nucleo(user: User, nucleo_id: str) -> tuple[bool, str]:
-    """Return (participa, "papel:status") for given user and núcleo."""
+def user_belongs_to_nucleo(user: User, nucleo_id: str) -> tuple[bool, str, bool]:
+    """Return (participa, "papel:status", suspenso) for given user and núcleo."""
     try:
         part = ParticipacaoNucleo.objects.get(user=user, nucleo_id=nucleo_id)
     except ParticipacaoNucleo.DoesNotExist:
-        return False, ""
-    return True, f"{part.papel}:{part.status}"
+        return False, "", False
+    return True, f"{part.papel}:{part.status}", part.status_suspensao

--- a/tests/discussao/test_consumers.py
+++ b/tests/discussao/test_consumers.py
@@ -1,0 +1,42 @@
+import asyncio
+
+import pytest
+from channels.db import database_sync_to_async
+from channels.testing import WebsocketCommunicator
+from django.utils import timezone
+
+from discussao.models import TopicoDiscussao
+from Hubx.asgi import application
+from nucleos.models import ParticipacaoNucleo
+
+pytestmark = pytest.mark.django_db(transaction=True)
+
+
+@pytest.fixture(autouse=True)
+def in_memory_channel_layer(settings):
+    settings.CHANNEL_LAYERS = {"default": {"BACKEND": "channels.layers.InMemoryChannelLayer"}}
+
+
+def test_discussion_consumer_blocks_suspended_member(categoria, nucleo, coordenador_user):
+    async def inner():
+        part = await database_sync_to_async(ParticipacaoNucleo.objects.create)(
+            user=coordenador_user, nucleo=nucleo, status="ativo"
+        )
+        topico = await database_sync_to_async(TopicoDiscussao.objects.create)(
+            categoria=categoria,
+            titulo="Topico",
+            conteudo="x",
+            autor=coordenador_user,
+            publico_alvo=0,
+            nucleo=nucleo,
+        )
+        part.status_suspensao = True
+        part.data_suspensao = timezone.now()
+        await database_sync_to_async(part.save)()
+        communicator = WebsocketCommunicator(application, f"/ws/discussao/{topico.id}/")
+        communicator.scope["user"] = coordenador_user
+        connected, _ = await communicator.connect()
+        assert connected is False
+        await communicator.disconnect()
+
+    asyncio.run(inner())

--- a/tests/nucleos/test_convites.py
+++ b/tests/nucleos/test_convites.py
@@ -4,7 +4,9 @@ from django.utils import timezone
 from rest_framework.test import APIClient
 
 from accounts.models import UserType
+from nucleos.metrics import convites_gerados_total, convites_usados_total
 from nucleos.models import ConviteNucleo, Nucleo, ParticipacaoNucleo
+from services.nucleos import user_belongs_to_nucleo
 
 pytestmark = pytest.mark.django_db
 
@@ -49,13 +51,15 @@ def _auth(client, user):
 
 def test_convite_flow(api_client, admin_user, membro_user, organizacao):
     nucleo = Nucleo.objects.create(nome="N", slug="n", organizacao=organizacao)
+    before_generated = convites_gerados_total._value.get()
+    before_used = convites_usados_total._value.get()
+
     _auth(api_client, admin_user)
-    url = reverse("nucleos_api:nucleo-convite")
-    resp = api_client.post(
-        url, {"email": membro_user.email, "papel": "membro", "nucleo": nucleo.pk}
-    )
+    url = reverse("nucleos_api:nucleo-convites", kwargs={"pk": nucleo.pk})
+    resp = api_client.post(url, {"email": membro_user.email, "papel": "membro"})
     assert resp.status_code == 201
     token = resp.data["token"]
+    assert convites_gerados_total._value.get() == before_generated + 1
 
     _auth(api_client, membro_user)
     accept_url = reverse("nucleos_api:nucleo-aceitar-convite") + f"?token={token}"
@@ -64,15 +68,14 @@ def test_convite_flow(api_client, admin_user, membro_user, organizacao):
     assert ParticipacaoNucleo.objects.filter(
         user=membro_user, nucleo=nucleo, status="ativo"
     ).exists()
+    assert convites_usados_total._value.get() == before_used + 1
 
 
 def test_convite_apenas_admin(api_client, membro_user, organizacao):
     nucleo = Nucleo.objects.create(nome="N2", slug="n2", organizacao=organizacao)
     _auth(api_client, membro_user)
-    url = reverse("nucleos_api:nucleo-convite")
-    resp = api_client.post(
-        url, {"email": "alguem@example.com", "papel": "membro", "nucleo": nucleo.pk}
-    )
+    url = reverse("nucleos_api:nucleo-convites", kwargs={"pk": nucleo.pk})
+    resp = api_client.post(url, {"email": "alguem@example.com", "papel": "membro"})
     assert resp.status_code == 403
 
 
@@ -88,4 +91,49 @@ def test_convite_expirado(api_client, admin_user, membro_user, organizacao):
     url = reverse("nucleos_api:nucleo-aceitar-convite") + f"?token={convite.token}"
     resp = api_client.get(url)
     assert resp.status_code == 400
+
+
+def test_user_belongs_to_nucleo_suspenso(membro_user, organizacao):
+    nucleo = Nucleo.objects.create(nome="N4", slug="n4", organizacao=organizacao)
+    ParticipacaoNucleo.objects.create(
+        user=membro_user,
+        nucleo=nucleo,
+        status="ativo",
+        status_suspensao=True,
+    )
+    participa, info, suspenso = user_belongs_to_nucleo(membro_user, nucleo.id)
+    assert participa is True
+    assert info == "membro:ativo"
+    assert suspenso is True
+
+
+def test_revogar_convite(api_client, admin_user, membro_user, organizacao):
+    nucleo = Nucleo.objects.create(nome="N5", slug="n5", organizacao=organizacao)
+    _auth(api_client, admin_user)
+    create_url = reverse("nucleos_api:nucleo-convites", kwargs={"pk": nucleo.pk})
+    resp = api_client.post(create_url, {"email": membro_user.email, "papel": "membro"})
+    convite_id = resp.data["id"]
+    delete_url = reverse(
+        "nucleos_api:nucleo-revogar-convite",
+        kwargs={"pk": nucleo.pk, "convite_id": convite_id},
+    )
+    resp = api_client.delete(delete_url)
+    assert resp.status_code == 204
+    convite = ConviteNucleo.objects.get(pk=convite_id)
+    assert convite.usado_em is not None
+
+
+def test_convite_quota_diaria(api_client, admin_user, organizacao):
+    from django.core.cache import cache
+    from django.test import override_settings
+
+    nucleo = Nucleo.objects.create(nome="N6", slug="n6", organizacao=organizacao)
+    _auth(api_client, admin_user)
+    url = reverse("nucleos_api:nucleo-convites", kwargs={"pk": nucleo.pk})
+    cache.clear()
+    with override_settings(CONVITE_NUCLEO_DIARIO_LIMITE=1):
+        resp1 = api_client.post(url, {"email": "a@example.com", "papel": "membro"})
+        assert resp1.status_code == 201
+        resp2 = api_client.post(url, {"email": "b@example.com", "papel": "membro"})
+        assert resp2.status_code == 429
 

--- a/tests/nucleos/test_posts.py
+++ b/tests/nucleos/test_posts.py
@@ -1,0 +1,66 @@
+import pytest
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from accounts.models import UserType
+from feed.models import Post
+from nucleos.models import Nucleo, ParticipacaoNucleo
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+
+@pytest.fixture
+def organizacao():
+    from organizacoes.models import Organizacao
+
+    return Organizacao.objects.create(nome='Org', cnpj='00.000.000/0001-00', slug='org')
+
+
+@pytest.fixture
+def membro_user(organizacao, django_user_model):
+    return django_user_model.objects.create_user(
+        username='user',
+        email='user@example.com',
+        password='pass',
+        user_type=UserType.NUCLEADO,
+        organizacao=organizacao,
+    )
+
+
+@pytest.fixture
+def outro_user(organizacao, django_user_model):
+    return django_user_model.objects.create_user(
+        username='other',
+        email='other@example.com',
+        password='pass',
+        user_type=UserType.NUCLEADO,
+        organizacao=organizacao,
+    )
+
+
+def _auth(client, user):
+    client.force_authenticate(user=user)
+
+
+def test_postar_no_feed(api_client, membro_user, organizacao):
+    nucleo = Nucleo.objects.create(nome='N', slug='n', organizacao=organizacao)
+    ParticipacaoNucleo.objects.create(user=membro_user, nucleo=nucleo, status='ativo')
+    _auth(api_client, membro_user)
+    url = reverse('nucleos_api:nucleo-posts', kwargs={'pk': nucleo.pk})
+    resp = api_client.post(url, {'conteudo': 'olá'})
+    assert resp.status_code == 201
+    assert Post.objects.filter(nucleo=nucleo, autor=membro_user).exists()
+
+
+def test_postar_requer_membro(api_client, outro_user, organizacao):
+    nucleo = Nucleo.objects.create(nome='N2', slug='n2', organizacao=organizacao)
+    _auth(api_client, outro_user)
+    url = reverse('nucleos_api:nucleo-posts', kwargs={'pk': nucleo.pk})
+    resp = api_client.post(url, {'conteudo': 'oi'})
+    assert resp.status_code == 403
+    assert Post.objects.count() == 0

--- a/tests/nucleos/test_suspensao.py
+++ b/tests/nucleos/test_suspensao.py
@@ -1,0 +1,85 @@
+import pytest
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from accounts.models import UserType
+from nucleos.metrics import membros_suspensos_total
+from nucleos.models import Nucleo, ParticipacaoNucleo
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+
+@pytest.fixture
+def organizacao():
+    from organizacoes.models import Organizacao
+
+    return Organizacao.objects.create(nome="Org", cnpj="00.000.000/0001-00", slug="org")
+
+
+@pytest.fixture
+def admin_user(organizacao, django_user_model):
+    return django_user_model.objects.create_user(
+        username="admin",
+        email="admin@example.com",
+        password="pass",
+        user_type=UserType.ADMIN,
+        organizacao=organizacao,
+    )
+
+
+@pytest.fixture
+def membro_user(organizacao, django_user_model):
+    return django_user_model.objects.create_user(
+        username="user",
+        email="user@example.com",
+        password="pass",
+        user_type=UserType.NUCLEADO,
+        organizacao=organizacao,
+    )
+
+
+def _auth(client, user):
+    client.force_authenticate(user=user)
+
+
+def test_suspender_e_reativar(api_client, admin_user, membro_user, organizacao, monkeypatch):
+    nucleo = Nucleo.objects.create(nome="N", slug="n", organizacao=organizacao)
+    ParticipacaoNucleo.objects.create(user=membro_user, nucleo=nucleo, status="ativo")
+    _auth(api_client, admin_user)
+    calls = []
+    monkeypatch.setattr("nucleos.api.atualizar_cobranca", lambda *a: calls.append(a))
+
+    before = membros_suspensos_total._value.get()
+    url = reverse("nucleos_api:nucleo-suspender-membro", args=[nucleo.pk, membro_user.pk])
+    resp = api_client.post(url)
+    assert resp.status_code == 200
+    part = ParticipacaoNucleo.objects.get(user=membro_user, nucleo=nucleo)
+    assert part.status_suspensao is True and part.data_suspensao is not None
+    assert calls[-1] == (nucleo.id, membro_user.id, "inativo")
+    assert membros_suspensos_total._value.get() == before + 1
+
+    url = reverse("nucleos_api:nucleo-reativar-membro", args=[nucleo.pk, membro_user.pk])
+    resp = api_client.post(url)
+    assert resp.status_code == 200
+    part.refresh_from_db()
+    assert part.status_suspensao is False and part.data_suspensao is None
+    assert calls[-1] == (nucleo.id, membro_user.id, "ativo")
+
+
+def test_membro_status_endpoint(api_client, membro_user, organizacao):
+    nucleo = Nucleo.objects.create(nome="N", slug="n", organizacao=organizacao)
+    ParticipacaoNucleo.objects.create(user=membro_user, nucleo=nucleo, status="ativo")
+    _auth(api_client, membro_user)
+    url = reverse("nucleos_api:nucleo-membro-status", args=[nucleo.pk])
+    resp = api_client.get(url)
+    assert resp.status_code == 200
+    assert resp.data == {"papel": "membro", "ativo": True, "suspenso": False}
+
+    ParticipacaoNucleo.objects.filter(user=membro_user, nucleo=nucleo).update(status_suspensao=True)
+    resp = api_client.get(url)
+    assert resp.data == {"papel": "membro", "ativo": True, "suspenso": True}


### PR DESCRIPTION
## Summary
- instrument Prometheus counters for nucleus invites and member suspensions with structured logs for invite lifecycle and suspension actions
- expose endpoints and frontend for generating and revoking invites, suspending/reativating members, núcleo feed posts, and chat/discussion protections
- document nucleus API endpoints and invite/suspension flow

## Testing
- `ruff check nucleos/services.py nucleos/api.py nucleos/tasks.py nucleos/metrics.py tests/nucleos/test_convites.py tests/nucleos/test_suspensao.py`
- `mypy nucleos/services.py nucleos/api.py nucleos/tasks.py nucleos/metrics.py` *(fails: many missing type annotations and stubs)*
- `pytest tests/nucleos/test_convites.py tests/nucleos/test_posts.py tests/nucleos/test_suspensao.py tests/chat/test_consumers.py tests/discussao/test_consumers.py -q`
- `pytest tests/nucleos/test_convites.py tests/nucleos/test_posts.py tests/nucleos/test_suspensao.py tests/chat/test_consumers.py tests/discussao/test_consumers.py --cov=nucleos --cov=chat --cov=discussao --cov=feed --cov-report=term-missing -q` *(coverage ~50%)*

------
https://chatgpt.com/codex/tasks/task_e_68964cad85e48325a447d57b2cfc7068