### PR TITLE
feat: add i18n to base, auth, profile, agenda and communication templates

### DIFF
--- a/accounts/locale/en/LC_MESSAGES/django.po
+++ b/accounts/locale/en/LC_MESSAGES/django.po
@@ -1,0 +1,846 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-14 16:23+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: templates/accounts/delete_account_confirm.html:3
+#: templates/accounts/delete_account_confirm.html:6
+msgid "Excluir Conta"
+msgstr ""
+
+#: templates/accounts/delete_account_confirm.html:8
+msgid "A exclusão da conta é permanente e você perderá acesso aos seus dados."
+msgstr ""
+
+#: templates/accounts/delete_account_confirm.html:13
+msgid "Digite EXCLUIR para confirmar"
+msgstr ""
+
+#: templates/accounts/delete_account_confirm.html:27
+msgid "Confirmar exclusão"
+msgstr ""
+
+#: templates/accounts/email_confirm.html:3
+msgid "Confirmação de Email"
+msgstr ""
+
+#: templates/accounts/email_confirm.html:8
+msgid "Seu e-mail foi confirmado com sucesso."
+msgstr ""
+
+#: templates/accounts/email_confirm.html:12
+msgid "Link inválido ou expirado."
+msgstr ""
+
+#: templates/accounts/gerar_token.html:4 templates/accounts/gerar_token.html:8
+msgid "Gerar Token de Acesso"
+msgstr ""
+
+#: templates/accounts/gerar_token.html:22
+msgid "Gerar Token"
+msgstr ""
+
+#: templates/accounts/gerar_token.html:28
+msgid "Código gerado:"
+msgstr ""
+
+#: templates/accounts/password_reset.html:3
+#: templates/accounts/password_reset.html:7
+msgid "Recuperar Senha"
+msgstr ""
+
+#: templates/accounts/password_reset.html:8
+msgid "Informe o e-mail cadastrado para receber instruções."
+msgstr ""
+
+#: templates/accounts/password_reset.html:12
+msgid "E-mail"
+msgstr ""
+
+#: templates/accounts/password_reset.html:15
+#: templates/accounts/resend_confirmation.html:11
+#: templates/perfil/midias.html:30
+msgid "Enviar"
+msgstr ""
+
+#: templates/accounts/password_reset_confirm.html:3
+#: templates/accounts/password_reset_confirm.html:7
+msgid "Definir Nova Senha"
+msgstr ""
+
+#: templates/accounts/password_reset_confirm.html:32
+#: templates/perfil/seguranca.html:45
+msgid "Alterar Senha"
+msgstr ""
+
+#: templates/accounts/resend_confirmation.html:3
+#: templates/accounts/resend_confirmation.html:7
+#: templates/register/registro_pendente.html:9
+msgid "Reenviar confirmação"
+msgstr ""
+
+#: templates/accounts/resend_confirmation.html:10
+msgid "Seu e-mail"
+msgstr ""
+
+#: templates/login/login.html:4 templates/login/login.html:60
+#: templates/register/token.html:48
+msgid "Entrar"
+msgstr ""
+
+#: templates/login/login.html:9
+msgid "Bem-vindo de volta"
+msgstr ""
+
+#: templates/login/login.html:11
+msgid "Entre para acessar sua conta e conectar-se à sua rede"
+msgstr ""
+
+#: templates/login/login.html:21 templates/perfil/detail.html:16
+#: templates/perfil/informacoes_pessoais.html:30
+#: templates/register/email.html:27
+msgid "Email"
+msgstr ""
+
+#: templates/login/login.html:24
+msgid "Digite seu e-mail"
+msgstr ""
+
+#: templates/login/login.html:35 templates/register/senha.html:27
+msgid "Senha"
+msgstr ""
+
+#: templates/login/login.html:37 templates/register/senha.html:28
+msgid "Digite sua senha"
+msgstr ""
+
+#: templates/login/login.html:47
+msgid "TOTP"
+msgstr ""
+
+#: templates/login/login.html:50
+msgid "Código 2FA"
+msgstr ""
+
+#: templates/login/login.html:66
+msgid "Esqueceu sua senha?"
+msgstr ""
+
+#: templates/login/login.html:70
+msgid "Reenviar confirmação de e-mail"
+msgstr ""
+
+#: templates/login/login.html:76
+msgid "Não tem uma conta?"
+msgstr ""
+
+#: templates/login/login.html:78
+msgid "Cadastre-se gratuitamente"
+msgstr ""
+
+#: templates/perfil/conexoes.html:4 templates/perfil/conexoes.html:9
+#: templates/perfil/conexoes.html:15
+msgid "Minhas Conexões"
+msgstr ""
+
+#: templates/perfil/conexoes.html:10
+msgid "Gerencie sua rede de contatos"
+msgstr ""
+
+#: templates/perfil/conexoes.html:16
+msgid "Solicitações"
+msgstr ""
+
+#: templates/perfil/conexoes.html:25
+msgid "Buscar conexões..."
+msgstr ""
+
+#: templates/perfil/conexoes.html:26
+msgid "Buscar"
+msgstr ""
+
+#: templates/perfil/conexoes.html:46
+msgid "Chat"
+msgstr ""
+
+#: templates/perfil/conexoes.html:47
+msgid "Tem certeza que deseja remover esta conexão?"
+msgstr ""
+
+#: templates/perfil/conexoes.html:49
+msgid "Remover conexão"
+msgstr ""
+
+#: templates/perfil/conexoes.html:55
+msgid "Você ainda não tem conexões."
+msgstr ""
+
+#: templates/perfil/conexoes.html:56
+msgid "Encontrar Pessoas"
+msgstr ""
+
+#: templates/perfil/conexoes.html:84
+msgid "Aceitar"
+msgstr ""
+
+#: templates/perfil/conexoes.html:88
+msgid "Recusar"
+msgstr ""
+
+#: templates/perfil/conexoes.html:94
+msgid "Você não tem solicitações de conexão pendentes."
+msgstr ""
+
+#: templates/perfil/conexoes.html:116
+#: templates/perfil/informacoes_pessoais.html:133
+#: templates/perfil/midias.html:73 templates/perfil/redes_sociais.html:29
+#: templates/perfil/seguranca.html:100 templates/register/cpf.html:33
+#: templates/register/email.html:33 templates/register/foto.html:34
+#: templates/register/nome.html:33 templates/register/senha.html:39
+#: templates/register/termos.html:50 templates/register/token.html:40
+#: templates/register/usuario.html:34
+msgid "Voltar"
+msgstr ""
+
+#: templates/perfil/detail.html:3
+msgid "Meu Perfil"
+msgstr ""
+
+#: templates/perfil/detail.html:15
+msgid "Contato"
+msgstr ""
+
+#: templates/perfil/detail.html:17
+#: templates/perfil/informacoes_pessoais.html:78
+msgid "Telefone"
+msgstr ""
+
+#: templates/perfil/detail.html:18
+#: templates/perfil/informacoes_pessoais.html:84
+msgid "WhatsApp"
+msgstr ""
+
+#: templates/perfil/detail.html:21
+msgid "Localização"
+msgstr ""
+
+#: templates/perfil/detail.html:27 templates/perfil/redes_sociais.html:4
+#: templates/perfil/redes_sociais.html:8
+msgid "Redes Sociais"
+msgstr ""
+
+#: templates/perfil/detail.html:38
+msgid "Editar perfil"
+msgstr ""
+
+#: templates/perfil/disable_2fa.html:3 templates/perfil/disable_2fa.html:5
+#: templates/perfil/seguranca.html:58
+msgid "Desativar 2FA"
+msgstr ""
+
+#: templates/perfil/disable_2fa.html:6
+msgid ""
+"Digite o código do seu aplicativo autenticador para desativar a verificação "
+"em duas etapas."
+msgstr ""
+
+#: templates/perfil/disable_2fa.html:10 templates/perfil/enable_2fa.html:11
+msgid "Código"
+msgstr ""
+
+#: templates/perfil/disable_2fa.html:13
+msgid "Desativar"
+msgstr ""
+
+#: templates/perfil/enable_2fa.html:3 templates/perfil/enable_2fa.html:5
+#: templates/perfil/seguranca.html:62
+msgid "Ativar 2FA"
+msgstr ""
+
+#: templates/perfil/enable_2fa.html:6
+msgid ""
+"Escaneie o QR-code abaixo com seu aplicativo autenticador e informe o código "
+"gerado."
+msgstr ""
+
+#: templates/perfil/enable_2fa.html:7
+msgid "QR Code"
+msgstr ""
+
+#: templates/perfil/enable_2fa.html:14
+msgid "Ativar"
+msgstr ""
+
+#: templates/perfil/informacoes_pessoais.html:4
+#: templates/perfil/informacoes_pessoais.html:8 templates/perfil/perfil.html:31
+msgid "Informações Pessoais"
+msgstr ""
+
+#: templates/perfil/informacoes_pessoais.html:9
+msgid "Atualize seus dados básicos e de contato"
+msgstr ""
+
+#: templates/perfil/informacoes_pessoais.html:15
+msgid "Nome completo"
+msgstr ""
+
+#: templates/perfil/informacoes_pessoais.html:23
+msgid "Usuário"
+msgstr ""
+
+#: templates/perfil/informacoes_pessoais.html:38
+msgid "Bio"
+msgstr ""
+
+#: templates/perfil/informacoes_pessoais.html:45
+msgid "Data de Nascimento"
+msgstr ""
+
+#: templates/perfil/informacoes_pessoais.html:52
+msgid "Gênero"
+msgstr ""
+
+#: templates/perfil/informacoes_pessoais.html:55
+#: templates/perfil/informacoes_pessoais.html:109
+msgid "Selecione..."
+msgstr ""
+
+#: templates/perfil/informacoes_pessoais.html:56
+msgid "Masculino"
+msgstr ""
+
+#: templates/perfil/informacoes_pessoais.html:57
+msgid "Feminino"
+msgstr ""
+
+#: templates/perfil/informacoes_pessoais.html:58
+msgid "Outro"
+msgstr ""
+
+#: templates/perfil/informacoes_pessoais.html:64
+msgid "Foto de Perfil"
+msgstr ""
+
+#: templates/perfil/informacoes_pessoais.html:67
+msgid "Capa"
+msgstr ""
+
+#: templates/perfil/informacoes_pessoais.html:74
+msgid "Informações de Contato"
+msgstr ""
+
+#: templates/perfil/informacoes_pessoais.html:92
+msgid "Endereço"
+msgstr ""
+
+#: templates/perfil/informacoes_pessoais.html:95
+msgid "Rua, número, complemento"
+msgstr ""
+
+#: templates/perfil/informacoes_pessoais.html:100
+msgid "Cidade"
+msgstr ""
+
+#: templates/perfil/informacoes_pessoais.html:106
+msgid "Estado"
+msgstr ""
+
+#: templates/perfil/informacoes_pessoais.html:116
+msgid "CEP"
+msgstr ""
+
+#: templates/perfil/informacoes_pessoais.html:126
+#: templates/perfil/redes_sociais.html:22
+msgid "Salvar Alterações"
+msgstr ""
+
+#: templates/perfil/midia_confirm_delete.html:3
+#: templates/perfil/midia_confirm_delete.html:7
+msgid "Remover Mídia"
+msgstr ""
+
+#: templates/perfil/midia_confirm_delete.html:8
+msgid "Tem certeza que deseja remover esta mídia?"
+msgstr ""
+
+#: templates/perfil/midia_confirm_delete.html:11
+#: templates/perfil/midia_form.html:16
+msgid "Cancelar"
+msgstr ""
+
+#: templates/perfil/midia_confirm_delete.html:12
+msgid "Remover"
+msgstr ""
+
+#: templates/perfil/midia_detail.html:4
+msgid "Mídia"
+msgstr ""
+
+#: templates/perfil/midia_detail.html:11
+msgid "Voltar para mídias"
+msgstr ""
+
+#: templates/perfil/midia_form.html:4 templates/perfil/midia_form.html:9
+msgid "Editar Mídia"
+msgstr ""
+
+#: templates/perfil/midia_form.html:4
+msgid "Nova Mídia"
+msgstr ""
+
+#: templates/perfil/midia_form.html:9
+msgid "Cadastrar Mídia"
+msgstr ""
+
+#: templates/perfil/midia_form.html:17
+msgid "Salvar"
+msgstr ""
+
+#: templates/perfil/midias.html:4 templates/perfil/midias.html:9
+msgid "Mídias"
+msgstr ""
+
+#: templates/perfil/midias.html:10
+msgid "Gerencie suas imagens, vídeos e documentos"
+msgstr ""
+
+#: templates/perfil/midias.html:17
+msgid "Enviar arquivo"
+msgstr ""
+
+#: templates/perfil/midias.html:21
+msgid "Descrição"
+msgstr ""
+
+#: templates/perfil/midias.html:25
+msgid "Tags"
+msgstr ""
+
+#: templates/perfil/midias.html:26
+msgid "paisagem, viagem"
+msgstr ""
+
+#: templates/perfil/midias.html:37
+msgid "Adicionar Mídias"
+msgstr ""
+
+#: templates/perfil/midias.html:42
+msgid "Buscar por descrição ou tags..."
+msgstr ""
+
+#: templates/perfil/midias.html:50
+msgid "Editar"
+msgstr ""
+
+#: templates/perfil/midias.html:51
+msgid "Excluir"
+msgstr ""
+
+#: templates/perfil/midias.html:67
+msgid "Nenhum arquivo enviado."
+msgstr ""
+
+#: templates/perfil/perfil.html:4
+msgid "Perfil"
+msgstr ""
+
+#: templates/perfil/perfil.html:23
+msgid "Alterar foto"
+msgstr ""
+
+#: templates/perfil/perfil.html:35 templates/perfil/seguranca.html:8
+msgid "Segurança"
+msgstr ""
+
+#: templates/perfil/perfil.html:39
+msgid "Notificações"
+msgstr ""
+
+#: templates/perfil/redes_sociais.html:9
+msgid "Conecte suas redes sociais com seu perfil"
+msgstr ""
+
+#: templates/perfil/seguranca.html:4
+msgid "Segurança da Conta"
+msgstr ""
+
+#: templates/perfil/seguranca.html:9
+msgid "Gerencie sua senha e a proteção da conta"
+msgstr ""
+
+#: templates/perfil/seguranca.html:15
+msgid "Senha Atual"
+msgstr ""
+
+#: templates/perfil/seguranca.html:22
+msgid "Nova Senha"
+msgstr ""
+
+#: templates/perfil/seguranca.html:27
+msgid "Confirmar Nova Senha"
+msgstr ""
+
+#: templates/perfil/seguranca.html:35
+msgid "Força da senha:"
+msgstr ""
+
+#: templates/perfil/seguranca.html:39
+msgid "Digite uma senha"
+msgstr ""
+
+#: templates/perfil/seguranca.html:51
+msgid "Verificação em Duas Etapas"
+msgstr ""
+
+#: templates/perfil/seguranca.html:53
+msgid ""
+"A verificação em duas etapas adiciona uma camada extra de segurança à sua "
+"conta, exigindo um código além da sua senha ao fazer login."
+msgstr ""
+
+#: templates/perfil/seguranca.html:56
+msgid "2FA está ativado."
+msgstr ""
+
+#: templates/perfil/seguranca.html:60
+msgid "2FA não está ativado."
+msgstr ""
+
+#: templates/register/cpf.html:4
+msgid "Registro - CPF"
+msgstr ""
+
+#: templates/register/cpf.html:11 templates/register/email.html:11
+#: templates/register/nome.html:11 templates/register/senha.html:11
+#: templates/register/token.html:11 templates/register/usuario.html:11
+#, python-format
+msgid "Passo %(step)s de %(total)s"
+msgstr ""
+
+#: templates/register/cpf.html:20
+msgid "Qual seu CPF?"
+msgstr ""
+
+#: templates/register/cpf.html:21
+msgid "Precisamos para validar sua identidade e segurança"
+msgstr ""
+
+#: templates/register/cpf.html:27
+msgid "CPF"
+msgstr ""
+
+#: templates/register/cpf.html:34 templates/register/email.html:34
+#: templates/register/foto.html:35 templates/register/nome.html:34
+#: templates/register/senha.html:40 templates/register/token.html:41
+#: templates/register/usuario.html:35
+msgid "Continuar"
+msgstr ""
+
+#: templates/register/email.html:4
+msgid "Registro - Email"
+msgstr ""
+
+#: templates/register/email.html:20
+msgid "Qual seu email?"
+msgstr ""
+
+#: templates/register/email.html:21
+msgid "Usaremos para comunicação e recuperação de conta"
+msgstr ""
+
+#: templates/register/email.html:28
+msgid "Digite seu email"
+msgstr ""
+
+#: templates/register/foto.html:4
+msgid "Registro - Foto"
+msgstr ""
+
+#: templates/register/foto.html:11
+msgid "Passo 6 de 7"
+msgstr ""
+
+#: templates/register/foto.html:20
+msgid "Adicione uma foto de perfil"
+msgstr ""
+
+#: templates/register/foto.html:21
+msgid "Personalize sua presença na comunidade"
+msgstr ""
+
+#: templates/register/foto.html:27
+msgid "Escolher Foto"
+msgstr ""
+
+#: templates/register/foto.html:30
+msgid "Formatos aceitos: JPG, PNG. Tamanho máximo: 5MB"
+msgstr ""
+
+#: templates/register/nome.html:4
+msgid "Registro - Nome"
+msgstr ""
+
+#: templates/register/nome.html:20
+msgid "Como podemos te chamar?"
+msgstr ""
+
+#: templates/register/nome.html:21 templates/register/nome.html:28
+msgid "Digite seu nome completo"
+msgstr ""
+
+#: templates/register/nome.html:27
+msgid "Nome Completo"
+msgstr ""
+
+#: templates/register/onboarding.html:4
+msgid "Cadastre-se"
+msgstr ""
+
+#: templates/register/onboarding.html:19
+msgid "Junte-se ao HubX"
+msgstr ""
+
+#: templates/register/onboarding.html:22
+msgid ""
+"Conecte-se com comunidades, empresas e organizações em uma única plataforma"
+msgstr ""
+
+#: templates/register/onboarding.html:35
+msgid "Compartilhe"
+msgstr ""
+
+#: templates/register/onboarding.html:37
+msgid "Publique conteúdo e mantenha sua comunidade informada"
+msgstr ""
+
+#: templates/register/onboarding.html:49
+msgid "Conecte"
+msgstr ""
+
+#: templates/register/onboarding.html:51
+msgid "Encontre e conecte-se com pessoas e organizações"
+msgstr ""
+
+#: templates/register/onboarding.html:63
+msgid "Organize"
+msgstr ""
+
+#: templates/register/onboarding.html:65
+msgid "Crie e participe de eventos da sua comunidade"
+msgstr ""
+
+#: templates/register/onboarding.html:78
+msgid "Começar Cadastro"
+msgstr ""
+
+#: templates/register/onboarding.html:81
+msgid "Já tenho conta"
+msgstr ""
+
+#: templates/register/onboarding.html:87
+msgid ""
+"Ao se cadastrar, você concorda com nossos <a href=\"#\" class=\"text-"
+"primary-600 hover:text-primary-700\">Termos de Uso</a> e <a href=\"#\" "
+"class=\"text-primary-600 hover:text-primary-700\">Política de Privacidade</a>"
+msgstr ""
+
+#: templates/register/registro_pendente.html:3
+msgid "Confirme seu e-mail"
+msgstr ""
+
+#: templates/register/registro_pendente.html:7
+#: templates/register/termos.html:20
+msgid "Quase lá!"
+msgstr ""
+
+#: templates/register/registro_pendente.html:8
+msgid "Conta criada. Confirme seu e-mail em até 24 horas para ativá-la."
+msgstr ""
+
+#: templates/register/registro_sucesso.html:4
+msgid "Registro Concluído"
+msgstr ""
+
+#: templates/register/registro_sucesso.html:9
+msgid "Bem-vindo ao HubX!"
+msgstr ""
+
+#: templates/register/registro_sucesso.html:10
+#: templates/register/sucesso.html:10
+msgid "Seu cadastro foi concluído com sucesso."
+msgstr ""
+
+#: templates/register/registro_sucesso.html:11
+msgid "Ir para meu Perfil →"
+msgstr ""
+
+#: templates/register/senha.html:4
+msgid "Registro - Senha"
+msgstr ""
+
+#: templates/register/senha.html:20
+msgid "Crie uma senha segura"
+msgstr ""
+
+#: templates/register/senha.html:21
+msgid "Proteja sua conta com uma senha forte"
+msgstr ""
+
+#: templates/register/senha.html:33
+msgid "Confirmar Senha"
+msgstr ""
+
+#: templates/register/senha.html:34
+msgid "Confirme sua senha"
+msgstr ""
+
+#: templates/register/sucesso.html:4
+msgid "Cadastro Concluído"
+msgstr ""
+
+#: templates/register/sucesso.html:9
+msgid "Parabéns!"
+msgstr ""
+
+#: templates/register/sucesso.html:11
+msgid "Fazer login"
+msgstr ""
+
+#: templates/register/termos.html:4
+msgid "Registro - Termos"
+msgstr ""
+
+#: templates/register/termos.html:11
+msgid "Passo 7 de 7"
+msgstr ""
+
+#: templates/register/termos.html:21
+msgid "Revise e aceite os termos para finalizar"
+msgstr ""
+
+#: templates/register/termos.html:27
+msgid "Termos de Uso e Política de Privacidade"
+msgstr ""
+
+#: templates/register/termos.html:28
+msgid ""
+"Ao utilizar o HubX, você concorda com nossos termos de uso e política de "
+"privacidade. Abaixo estão os principais pontos:"
+msgstr ""
+
+#: templates/register/termos.html:29
+msgid "1. Uso da Plataforma"
+msgstr ""
+
+#: templates/register/termos.html:30
+msgid ""
+"O HubX é uma plataforma para comunidades, entidades e associações. Você "
+"concorda em utilizar a plataforma de acordo com as leis aplicáveis e não "
+"violar os direitos de outros usuários."
+msgstr ""
+
+#: templates/register/termos.html:31
+msgid "2. Privacidade"
+msgstr ""
+
+#: templates/register/termos.html:32
+msgid ""
+"Respeitamos sua privacidade. Seus dados serão utilizados apenas para os fins "
+"especificados em nossa política de privacidade."
+msgstr ""
+
+#: templates/register/termos.html:33
+msgid "3. Conteúdo"
+msgstr ""
+
+#: templates/register/termos.html:34
+msgid ""
+"Você é responsável pelo conteúdo que compartilha na plataforma. Não "
+"toleramos conteúdo ofensivo, ilegal ou que viole direitos de terceiros."
+msgstr ""
+
+#: templates/register/termos.html:35
+msgid "4. Segurança"
+msgstr ""
+
+#: templates/register/termos.html:36
+msgid ""
+"Você é responsável por manter a segurança de sua conta e senha. Notifique-"
+"nos imediatamente sobre qualquer uso não autorizado."
+msgstr ""
+
+#: templates/register/termos.html:41
+msgid ""
+"Eu li e concordo com os <a href=\"/termos/\" class=\"text-primary-600 hover:"
+"text-primary-700\" target=\"_blank\">Termos de Uso</a> e <a href=\"/"
+"privacidade/\" class=\"text-primary-600 hover:text-primary-700\" "
+"target=\"_blank\">Política de Privacidade</a>"
+msgstr ""
+
+#: templates/register/termos.html:46
+msgid "Quero receber atualizações e novidades do HubX"
+msgstr ""
+
+#: templates/register/termos.html:51
+msgid "Finalizar Cadastro"
+msgstr ""
+
+#: templates/register/token.html:4 templates/register/token.html:27
+#: templates/register/token.html:34
+msgid "Token de Convite"
+msgstr ""
+
+#: templates/register/token.html:28
+msgid "Digite seu token de convite para começar o cadastro"
+msgstr ""
+
+#: templates/register/token.html:35
+msgid "Digite seu token de convite"
+msgstr ""
+
+#: templates/register/token.html:36
+msgid "O token é necessário para continuar o cadastro na plataforma"
+msgstr ""
+
+#: templates/register/token.html:47
+msgid "Já tem uma conta?"
+msgstr ""
+
+#: templates/register/usuario.html:4
+msgid "Registro - Usuário"
+msgstr ""
+
+#: templates/register/usuario.html:20
+msgid "Escolha seu nome de usuário"
+msgstr ""
+
+#: templates/register/usuario.html:21
+msgid "Como você será identificado na plataforma"
+msgstr ""
+
+#: templates/register/usuario.html:27
+msgid "Nome de Usuário"
+msgstr ""
+
+#: templates/register/usuario.html:28
+msgid "Digite seu nome de usuário"
+msgstr ""
+
+#: templates/register/usuario.html:30
+msgid "Use apenas letras, números e underscore (_)"
+msgstr ""

--- a/accounts/locale/pt_BR/LC_MESSAGES/django.po
+++ b/accounts/locale/pt_BR/LC_MESSAGES/django.po
@@ -1,0 +1,846 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-14 16:23+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: templates/accounts/delete_account_confirm.html:3
+#: templates/accounts/delete_account_confirm.html:6
+msgid "Excluir Conta"
+msgstr ""
+
+#: templates/accounts/delete_account_confirm.html:8
+msgid "A exclusão da conta é permanente e você perderá acesso aos seus dados."
+msgstr ""
+
+#: templates/accounts/delete_account_confirm.html:13
+msgid "Digite EXCLUIR para confirmar"
+msgstr ""
+
+#: templates/accounts/delete_account_confirm.html:27
+msgid "Confirmar exclusão"
+msgstr ""
+
+#: templates/accounts/email_confirm.html:3
+msgid "Confirmação de Email"
+msgstr ""
+
+#: templates/accounts/email_confirm.html:8
+msgid "Seu e-mail foi confirmado com sucesso."
+msgstr ""
+
+#: templates/accounts/email_confirm.html:12
+msgid "Link inválido ou expirado."
+msgstr ""
+
+#: templates/accounts/gerar_token.html:4 templates/accounts/gerar_token.html:8
+msgid "Gerar Token de Acesso"
+msgstr ""
+
+#: templates/accounts/gerar_token.html:22
+msgid "Gerar Token"
+msgstr ""
+
+#: templates/accounts/gerar_token.html:28
+msgid "Código gerado:"
+msgstr ""
+
+#: templates/accounts/password_reset.html:3
+#: templates/accounts/password_reset.html:7
+msgid "Recuperar Senha"
+msgstr ""
+
+#: templates/accounts/password_reset.html:8
+msgid "Informe o e-mail cadastrado para receber instruções."
+msgstr ""
+
+#: templates/accounts/password_reset.html:12
+msgid "E-mail"
+msgstr ""
+
+#: templates/accounts/password_reset.html:15
+#: templates/accounts/resend_confirmation.html:11
+#: templates/perfil/midias.html:30
+msgid "Enviar"
+msgstr ""
+
+#: templates/accounts/password_reset_confirm.html:3
+#: templates/accounts/password_reset_confirm.html:7
+msgid "Definir Nova Senha"
+msgstr ""
+
+#: templates/accounts/password_reset_confirm.html:32
+#: templates/perfil/seguranca.html:45
+msgid "Alterar Senha"
+msgstr ""
+
+#: templates/accounts/resend_confirmation.html:3
+#: templates/accounts/resend_confirmation.html:7
+#: templates/register/registro_pendente.html:9
+msgid "Reenviar confirmação"
+msgstr ""
+
+#: templates/accounts/resend_confirmation.html:10
+msgid "Seu e-mail"
+msgstr ""
+
+#: templates/login/login.html:4 templates/login/login.html:60
+#: templates/register/token.html:48
+msgid "Entrar"
+msgstr ""
+
+#: templates/login/login.html:9
+msgid "Bem-vindo de volta"
+msgstr ""
+
+#: templates/login/login.html:11
+msgid "Entre para acessar sua conta e conectar-se à sua rede"
+msgstr ""
+
+#: templates/login/login.html:21 templates/perfil/detail.html:16
+#: templates/perfil/informacoes_pessoais.html:30
+#: templates/register/email.html:27
+msgid "Email"
+msgstr ""
+
+#: templates/login/login.html:24
+msgid "Digite seu e-mail"
+msgstr ""
+
+#: templates/login/login.html:35 templates/register/senha.html:27
+msgid "Senha"
+msgstr ""
+
+#: templates/login/login.html:37 templates/register/senha.html:28
+msgid "Digite sua senha"
+msgstr ""
+
+#: templates/login/login.html:47
+msgid "TOTP"
+msgstr ""
+
+#: templates/login/login.html:50
+msgid "Código 2FA"
+msgstr ""
+
+#: templates/login/login.html:66
+msgid "Esqueceu sua senha?"
+msgstr ""
+
+#: templates/login/login.html:70
+msgid "Reenviar confirmação de e-mail"
+msgstr ""
+
+#: templates/login/login.html:76
+msgid "Não tem uma conta?"
+msgstr ""
+
+#: templates/login/login.html:78
+msgid "Cadastre-se gratuitamente"
+msgstr ""
+
+#: templates/perfil/conexoes.html:4 templates/perfil/conexoes.html:9
+#: templates/perfil/conexoes.html:15
+msgid "Minhas Conexões"
+msgstr ""
+
+#: templates/perfil/conexoes.html:10
+msgid "Gerencie sua rede de contatos"
+msgstr ""
+
+#: templates/perfil/conexoes.html:16
+msgid "Solicitações"
+msgstr ""
+
+#: templates/perfil/conexoes.html:25
+msgid "Buscar conexões..."
+msgstr ""
+
+#: templates/perfil/conexoes.html:26
+msgid "Buscar"
+msgstr ""
+
+#: templates/perfil/conexoes.html:46
+msgid "Chat"
+msgstr ""
+
+#: templates/perfil/conexoes.html:47
+msgid "Tem certeza que deseja remover esta conexão?"
+msgstr ""
+
+#: templates/perfil/conexoes.html:49
+msgid "Remover conexão"
+msgstr ""
+
+#: templates/perfil/conexoes.html:55
+msgid "Você ainda não tem conexões."
+msgstr ""
+
+#: templates/perfil/conexoes.html:56
+msgid "Encontrar Pessoas"
+msgstr ""
+
+#: templates/perfil/conexoes.html:84
+msgid "Aceitar"
+msgstr ""
+
+#: templates/perfil/conexoes.html:88
+msgid "Recusar"
+msgstr ""
+
+#: templates/perfil/conexoes.html:94
+msgid "Você não tem solicitações de conexão pendentes."
+msgstr ""
+
+#: templates/perfil/conexoes.html:116
+#: templates/perfil/informacoes_pessoais.html:133
+#: templates/perfil/midias.html:73 templates/perfil/redes_sociais.html:29
+#: templates/perfil/seguranca.html:100 templates/register/cpf.html:33
+#: templates/register/email.html:33 templates/register/foto.html:34
+#: templates/register/nome.html:33 templates/register/senha.html:39
+#: templates/register/termos.html:50 templates/register/token.html:40
+#: templates/register/usuario.html:34
+msgid "Voltar"
+msgstr ""
+
+#: templates/perfil/detail.html:3
+msgid "Meu Perfil"
+msgstr ""
+
+#: templates/perfil/detail.html:15
+msgid "Contato"
+msgstr ""
+
+#: templates/perfil/detail.html:17
+#: templates/perfil/informacoes_pessoais.html:78
+msgid "Telefone"
+msgstr ""
+
+#: templates/perfil/detail.html:18
+#: templates/perfil/informacoes_pessoais.html:84
+msgid "WhatsApp"
+msgstr ""
+
+#: templates/perfil/detail.html:21
+msgid "Localização"
+msgstr ""
+
+#: templates/perfil/detail.html:27 templates/perfil/redes_sociais.html:4
+#: templates/perfil/redes_sociais.html:8
+msgid "Redes Sociais"
+msgstr ""
+
+#: templates/perfil/detail.html:38
+msgid "Editar perfil"
+msgstr ""
+
+#: templates/perfil/disable_2fa.html:3 templates/perfil/disable_2fa.html:5
+#: templates/perfil/seguranca.html:58
+msgid "Desativar 2FA"
+msgstr ""
+
+#: templates/perfil/disable_2fa.html:6
+msgid ""
+"Digite o código do seu aplicativo autenticador para desativar a verificação "
+"em duas etapas."
+msgstr ""
+
+#: templates/perfil/disable_2fa.html:10 templates/perfil/enable_2fa.html:11
+msgid "Código"
+msgstr ""
+
+#: templates/perfil/disable_2fa.html:13
+msgid "Desativar"
+msgstr ""
+
+#: templates/perfil/enable_2fa.html:3 templates/perfil/enable_2fa.html:5
+#: templates/perfil/seguranca.html:62
+msgid "Ativar 2FA"
+msgstr ""
+
+#: templates/perfil/enable_2fa.html:6
+msgid ""
+"Escaneie o QR-code abaixo com seu aplicativo autenticador e informe o código "
+"gerado."
+msgstr ""
+
+#: templates/perfil/enable_2fa.html:7
+msgid "QR Code"
+msgstr ""
+
+#: templates/perfil/enable_2fa.html:14
+msgid "Ativar"
+msgstr ""
+
+#: templates/perfil/informacoes_pessoais.html:4
+#: templates/perfil/informacoes_pessoais.html:8 templates/perfil/perfil.html:31
+msgid "Informações Pessoais"
+msgstr ""
+
+#: templates/perfil/informacoes_pessoais.html:9
+msgid "Atualize seus dados básicos e de contato"
+msgstr ""
+
+#: templates/perfil/informacoes_pessoais.html:15
+msgid "Nome completo"
+msgstr ""
+
+#: templates/perfil/informacoes_pessoais.html:23
+msgid "Usuário"
+msgstr ""
+
+#: templates/perfil/informacoes_pessoais.html:38
+msgid "Bio"
+msgstr ""
+
+#: templates/perfil/informacoes_pessoais.html:45
+msgid "Data de Nascimento"
+msgstr ""
+
+#: templates/perfil/informacoes_pessoais.html:52
+msgid "Gênero"
+msgstr ""
+
+#: templates/perfil/informacoes_pessoais.html:55
+#: templates/perfil/informacoes_pessoais.html:109
+msgid "Selecione..."
+msgstr ""
+
+#: templates/perfil/informacoes_pessoais.html:56
+msgid "Masculino"
+msgstr ""
+
+#: templates/perfil/informacoes_pessoais.html:57
+msgid "Feminino"
+msgstr ""
+
+#: templates/perfil/informacoes_pessoais.html:58
+msgid "Outro"
+msgstr ""
+
+#: templates/perfil/informacoes_pessoais.html:64
+msgid "Foto de Perfil"
+msgstr ""
+
+#: templates/perfil/informacoes_pessoais.html:67
+msgid "Capa"
+msgstr ""
+
+#: templates/perfil/informacoes_pessoais.html:74
+msgid "Informações de Contato"
+msgstr ""
+
+#: templates/perfil/informacoes_pessoais.html:92
+msgid "Endereço"
+msgstr ""
+
+#: templates/perfil/informacoes_pessoais.html:95
+msgid "Rua, número, complemento"
+msgstr ""
+
+#: templates/perfil/informacoes_pessoais.html:100
+msgid "Cidade"
+msgstr ""
+
+#: templates/perfil/informacoes_pessoais.html:106
+msgid "Estado"
+msgstr ""
+
+#: templates/perfil/informacoes_pessoais.html:116
+msgid "CEP"
+msgstr ""
+
+#: templates/perfil/informacoes_pessoais.html:126
+#: templates/perfil/redes_sociais.html:22
+msgid "Salvar Alterações"
+msgstr ""
+
+#: templates/perfil/midia_confirm_delete.html:3
+#: templates/perfil/midia_confirm_delete.html:7
+msgid "Remover Mídia"
+msgstr ""
+
+#: templates/perfil/midia_confirm_delete.html:8
+msgid "Tem certeza que deseja remover esta mídia?"
+msgstr ""
+
+#: templates/perfil/midia_confirm_delete.html:11
+#: templates/perfil/midia_form.html:16
+msgid "Cancelar"
+msgstr ""
+
+#: templates/perfil/midia_confirm_delete.html:12
+msgid "Remover"
+msgstr ""
+
+#: templates/perfil/midia_detail.html:4
+msgid "Mídia"
+msgstr ""
+
+#: templates/perfil/midia_detail.html:11
+msgid "Voltar para mídias"
+msgstr ""
+
+#: templates/perfil/midia_form.html:4 templates/perfil/midia_form.html:9
+msgid "Editar Mídia"
+msgstr ""
+
+#: templates/perfil/midia_form.html:4
+msgid "Nova Mídia"
+msgstr ""
+
+#: templates/perfil/midia_form.html:9
+msgid "Cadastrar Mídia"
+msgstr ""
+
+#: templates/perfil/midia_form.html:17
+msgid "Salvar"
+msgstr ""
+
+#: templates/perfil/midias.html:4 templates/perfil/midias.html:9
+msgid "Mídias"
+msgstr ""
+
+#: templates/perfil/midias.html:10
+msgid "Gerencie suas imagens, vídeos e documentos"
+msgstr ""
+
+#: templates/perfil/midias.html:17
+msgid "Enviar arquivo"
+msgstr ""
+
+#: templates/perfil/midias.html:21
+msgid "Descrição"
+msgstr ""
+
+#: templates/perfil/midias.html:25
+msgid "Tags"
+msgstr ""
+
+#: templates/perfil/midias.html:26
+msgid "paisagem, viagem"
+msgstr ""
+
+#: templates/perfil/midias.html:37
+msgid "Adicionar Mídias"
+msgstr ""
+
+#: templates/perfil/midias.html:42
+msgid "Buscar por descrição ou tags..."
+msgstr ""
+
+#: templates/perfil/midias.html:50
+msgid "Editar"
+msgstr ""
+
+#: templates/perfil/midias.html:51
+msgid "Excluir"
+msgstr ""
+
+#: templates/perfil/midias.html:67
+msgid "Nenhum arquivo enviado."
+msgstr ""
+
+#: templates/perfil/perfil.html:4
+msgid "Perfil"
+msgstr ""
+
+#: templates/perfil/perfil.html:23
+msgid "Alterar foto"
+msgstr ""
+
+#: templates/perfil/perfil.html:35 templates/perfil/seguranca.html:8
+msgid "Segurança"
+msgstr ""
+
+#: templates/perfil/perfil.html:39
+msgid "Notificações"
+msgstr ""
+
+#: templates/perfil/redes_sociais.html:9
+msgid "Conecte suas redes sociais com seu perfil"
+msgstr ""
+
+#: templates/perfil/seguranca.html:4
+msgid "Segurança da Conta"
+msgstr ""
+
+#: templates/perfil/seguranca.html:9
+msgid "Gerencie sua senha e a proteção da conta"
+msgstr ""
+
+#: templates/perfil/seguranca.html:15
+msgid "Senha Atual"
+msgstr ""
+
+#: templates/perfil/seguranca.html:22
+msgid "Nova Senha"
+msgstr ""
+
+#: templates/perfil/seguranca.html:27
+msgid "Confirmar Nova Senha"
+msgstr ""
+
+#: templates/perfil/seguranca.html:35
+msgid "Força da senha:"
+msgstr ""
+
+#: templates/perfil/seguranca.html:39
+msgid "Digite uma senha"
+msgstr ""
+
+#: templates/perfil/seguranca.html:51
+msgid "Verificação em Duas Etapas"
+msgstr ""
+
+#: templates/perfil/seguranca.html:53
+msgid ""
+"A verificação em duas etapas adiciona uma camada extra de segurança à sua "
+"conta, exigindo um código além da sua senha ao fazer login."
+msgstr ""
+
+#: templates/perfil/seguranca.html:56
+msgid "2FA está ativado."
+msgstr ""
+
+#: templates/perfil/seguranca.html:60
+msgid "2FA não está ativado."
+msgstr ""
+
+#: templates/register/cpf.html:4
+msgid "Registro - CPF"
+msgstr ""
+
+#: templates/register/cpf.html:11 templates/register/email.html:11
+#: templates/register/nome.html:11 templates/register/senha.html:11
+#: templates/register/token.html:11 templates/register/usuario.html:11
+#, python-format
+msgid "Passo %(step)s de %(total)s"
+msgstr ""
+
+#: templates/register/cpf.html:20
+msgid "Qual seu CPF?"
+msgstr ""
+
+#: templates/register/cpf.html:21
+msgid "Precisamos para validar sua identidade e segurança"
+msgstr ""
+
+#: templates/register/cpf.html:27
+msgid "CPF"
+msgstr ""
+
+#: templates/register/cpf.html:34 templates/register/email.html:34
+#: templates/register/foto.html:35 templates/register/nome.html:34
+#: templates/register/senha.html:40 templates/register/token.html:41
+#: templates/register/usuario.html:35
+msgid "Continuar"
+msgstr ""
+
+#: templates/register/email.html:4
+msgid "Registro - Email"
+msgstr ""
+
+#: templates/register/email.html:20
+msgid "Qual seu email?"
+msgstr ""
+
+#: templates/register/email.html:21
+msgid "Usaremos para comunicação e recuperação de conta"
+msgstr ""
+
+#: templates/register/email.html:28
+msgid "Digite seu email"
+msgstr ""
+
+#: templates/register/foto.html:4
+msgid "Registro - Foto"
+msgstr ""
+
+#: templates/register/foto.html:11
+msgid "Passo 6 de 7"
+msgstr ""
+
+#: templates/register/foto.html:20
+msgid "Adicione uma foto de perfil"
+msgstr ""
+
+#: templates/register/foto.html:21
+msgid "Personalize sua presença na comunidade"
+msgstr ""
+
+#: templates/register/foto.html:27
+msgid "Escolher Foto"
+msgstr ""
+
+#: templates/register/foto.html:30
+msgid "Formatos aceitos: JPG, PNG. Tamanho máximo: 5MB"
+msgstr ""
+
+#: templates/register/nome.html:4
+msgid "Registro - Nome"
+msgstr ""
+
+#: templates/register/nome.html:20
+msgid "Como podemos te chamar?"
+msgstr ""
+
+#: templates/register/nome.html:21 templates/register/nome.html:28
+msgid "Digite seu nome completo"
+msgstr ""
+
+#: templates/register/nome.html:27
+msgid "Nome Completo"
+msgstr ""
+
+#: templates/register/onboarding.html:4
+msgid "Cadastre-se"
+msgstr ""
+
+#: templates/register/onboarding.html:19
+msgid "Junte-se ao HubX"
+msgstr ""
+
+#: templates/register/onboarding.html:22
+msgid ""
+"Conecte-se com comunidades, empresas e organizações em uma única plataforma"
+msgstr ""
+
+#: templates/register/onboarding.html:35
+msgid "Compartilhe"
+msgstr ""
+
+#: templates/register/onboarding.html:37
+msgid "Publique conteúdo e mantenha sua comunidade informada"
+msgstr ""
+
+#: templates/register/onboarding.html:49
+msgid "Conecte"
+msgstr ""
+
+#: templates/register/onboarding.html:51
+msgid "Encontre e conecte-se com pessoas e organizações"
+msgstr ""
+
+#: templates/register/onboarding.html:63
+msgid "Organize"
+msgstr ""
+
+#: templates/register/onboarding.html:65
+msgid "Crie e participe de eventos da sua comunidade"
+msgstr ""
+
+#: templates/register/onboarding.html:78
+msgid "Começar Cadastro"
+msgstr ""
+
+#: templates/register/onboarding.html:81
+msgid "Já tenho conta"
+msgstr ""
+
+#: templates/register/onboarding.html:87
+msgid ""
+"Ao se cadastrar, você concorda com nossos <a href=\"#\" class=\"text-"
+"primary-600 hover:text-primary-700\">Termos de Uso</a> e <a href=\"#\" "
+"class=\"text-primary-600 hover:text-primary-700\">Política de Privacidade</a>"
+msgstr ""
+
+#: templates/register/registro_pendente.html:3
+msgid "Confirme seu e-mail"
+msgstr ""
+
+#: templates/register/registro_pendente.html:7
+#: templates/register/termos.html:20
+msgid "Quase lá!"
+msgstr ""
+
+#: templates/register/registro_pendente.html:8
+msgid "Conta criada. Confirme seu e-mail em até 24 horas para ativá-la."
+msgstr ""
+
+#: templates/register/registro_sucesso.html:4
+msgid "Registro Concluído"
+msgstr ""
+
+#: templates/register/registro_sucesso.html:9
+msgid "Bem-vindo ao HubX!"
+msgstr ""
+
+#: templates/register/registro_sucesso.html:10
+#: templates/register/sucesso.html:10
+msgid "Seu cadastro foi concluído com sucesso."
+msgstr ""
+
+#: templates/register/registro_sucesso.html:11
+msgid "Ir para meu Perfil →"
+msgstr ""
+
+#: templates/register/senha.html:4
+msgid "Registro - Senha"
+msgstr ""
+
+#: templates/register/senha.html:20
+msgid "Crie uma senha segura"
+msgstr ""
+
+#: templates/register/senha.html:21
+msgid "Proteja sua conta com uma senha forte"
+msgstr ""
+
+#: templates/register/senha.html:33
+msgid "Confirmar Senha"
+msgstr ""
+
+#: templates/register/senha.html:34
+msgid "Confirme sua senha"
+msgstr ""
+
+#: templates/register/sucesso.html:4
+msgid "Cadastro Concluído"
+msgstr ""
+
+#: templates/register/sucesso.html:9
+msgid "Parabéns!"
+msgstr ""
+
+#: templates/register/sucesso.html:11
+msgid "Fazer login"
+msgstr ""
+
+#: templates/register/termos.html:4
+msgid "Registro - Termos"
+msgstr ""
+
+#: templates/register/termos.html:11
+msgid "Passo 7 de 7"
+msgstr ""
+
+#: templates/register/termos.html:21
+msgid "Revise e aceite os termos para finalizar"
+msgstr ""
+
+#: templates/register/termos.html:27
+msgid "Termos de Uso e Política de Privacidade"
+msgstr ""
+
+#: templates/register/termos.html:28
+msgid ""
+"Ao utilizar o HubX, você concorda com nossos termos de uso e política de "
+"privacidade. Abaixo estão os principais pontos:"
+msgstr ""
+
+#: templates/register/termos.html:29
+msgid "1. Uso da Plataforma"
+msgstr ""
+
+#: templates/register/termos.html:30
+msgid ""
+"O HubX é uma plataforma para comunidades, entidades e associações. Você "
+"concorda em utilizar a plataforma de acordo com as leis aplicáveis e não "
+"violar os direitos de outros usuários."
+msgstr ""
+
+#: templates/register/termos.html:31
+msgid "2. Privacidade"
+msgstr ""
+
+#: templates/register/termos.html:32
+msgid ""
+"Respeitamos sua privacidade. Seus dados serão utilizados apenas para os fins "
+"especificados em nossa política de privacidade."
+msgstr ""
+
+#: templates/register/termos.html:33
+msgid "3. Conteúdo"
+msgstr ""
+
+#: templates/register/termos.html:34
+msgid ""
+"Você é responsável pelo conteúdo que compartilha na plataforma. Não "
+"toleramos conteúdo ofensivo, ilegal ou que viole direitos de terceiros."
+msgstr ""
+
+#: templates/register/termos.html:35
+msgid "4. Segurança"
+msgstr ""
+
+#: templates/register/termos.html:36
+msgid ""
+"Você é responsável por manter a segurança de sua conta e senha. Notifique-"
+"nos imediatamente sobre qualquer uso não autorizado."
+msgstr ""
+
+#: templates/register/termos.html:41
+msgid ""
+"Eu li e concordo com os <a href=\"/termos/\" class=\"text-primary-600 hover:"
+"text-primary-700\" target=\"_blank\">Termos de Uso</a> e <a href=\"/"
+"privacidade/\" class=\"text-primary-600 hover:text-primary-700\" "
+"target=\"_blank\">Política de Privacidade</a>"
+msgstr ""
+
+#: templates/register/termos.html:46
+msgid "Quero receber atualizações e novidades do HubX"
+msgstr ""
+
+#: templates/register/termos.html:51
+msgid "Finalizar Cadastro"
+msgstr ""
+
+#: templates/register/token.html:4 templates/register/token.html:27
+#: templates/register/token.html:34
+msgid "Token de Convite"
+msgstr ""
+
+#: templates/register/token.html:28
+msgid "Digite seu token de convite para começar o cadastro"
+msgstr ""
+
+#: templates/register/token.html:35
+msgid "Digite seu token de convite"
+msgstr ""
+
+#: templates/register/token.html:36
+msgid "O token é necessário para continuar o cadastro na plataforma"
+msgstr ""
+
+#: templates/register/token.html:47
+msgid "Já tem uma conta?"
+msgstr ""
+
+#: templates/register/usuario.html:4
+msgid "Registro - Usuário"
+msgstr ""
+
+#: templates/register/usuario.html:20
+msgid "Escolha seu nome de usuário"
+msgstr ""
+
+#: templates/register/usuario.html:21
+msgid "Como você será identificado na plataforma"
+msgstr ""
+
+#: templates/register/usuario.html:27
+msgid "Nome de Usuário"
+msgstr ""
+
+#: templates/register/usuario.html:28
+msgid "Digite seu nome de usuário"
+msgstr ""
+
+#: templates/register/usuario.html:30
+msgid "Use apenas letras, números e underscore (_)"
+msgstr ""

--- a/accounts/templates/accounts/gerar_token.html
+++ b/accounts/templates/accounts/gerar_token.html
@@ -1,11 +1,11 @@
 {% extends "base.html" %}
-{% load widget_tweaks %}
+{% load widget_tweaks i18n %}
 
-{% block title %}Gerar Token de Acesso | HubX{% endblock %}
+{% block title %}{% trans "Gerar Token de Acesso" %} | HubX{% endblock %}
 
 {% block content %}
 <section class="max-w-md mx-auto px-4 py-12">
-  <h1 class="text-2xl font-bold text-center mb-6">Gerar Token de Acesso</h1>
+  <h1 class="text-2xl font-bold text-center mb-6">{% trans "Gerar Token de Acesso" %}</h1>
 
   <form method="post" action="" class="bg-white rounded-2xl shadow p-6 space-y-4">
     {% csrf_token %}
@@ -19,13 +19,13 @@
       </div>
     {% endfor %}
     <div class="text-right">
-      <button type="submit" class="rounded-xl bg-primary px-4 py-2 text-white hover:bg-primary/90">Gerar Token</button>
+      <button type="submit" class="rounded-xl bg-primary px-4 py-2 text-white hover:bg-primary/90">{% trans "Gerar Token" %}</button>
     </div>
   </form>
 
   {% if token %}
     <div class="mt-6 text-center rounded-xl bg-green-100 px-4 py-3 text-sm text-green-700">
-      Código gerado: <strong>{{ token.codigo }}</strong>
+      {% trans "Código gerado:" %} <strong>{{ token.codigo }}</strong>
     </div>
   {% endif %}
 </section>

--- a/accounts/templates/accounts/password_reset.html
+++ b/accounts/templates/accounts/password_reset.html
@@ -1,17 +1,18 @@
 {% extends "base.html" %}
-{% block title %}Recuperar Senha - HubX{% endblock %}
+{% load i18n %}
+{% block title %}{% trans "Recuperar Senha" %} - HubX{% endblock %}
 {% block content %}
 <div class="flex items-center justify-center min-h-screen">
     <div class="max-w-md mx-auto p-6 rounded-2xl shadow bg-white w-full">
-        <h1 class="text-2xl font-bold mb-6 text-center">Recuperar Senha</h1>
-        <p class="text-center text-neutral-600 mb-4">Informe o e-mail cadastrado para receber instruções.</p>
+        <h1 class="text-2xl font-bold mb-6 text-center">{% trans "Recuperar Senha" %}</h1>
+        <p class="text-center text-neutral-600 mb-4">{% trans "Informe o e-mail cadastrado para receber instruções." %}</p>
         <form method="post" class="space-y-4">
             {% csrf_token %}
             <div>
-                <label for="id_email" class="block mb-1 font-medium">E-mail</label>
+                <label for="id_email" class="block mb-1 font-medium">{% trans "E-mail" %}</label>
                 <input type="email" name="email" id="id_email" required class="w-full p-3 border rounded-md focus:ring-2 focus:ring-primary">
             </div>
-            <button type="submit" class="bg-primary text-white font-semibold py-2 px-4 rounded-xl w-full">Enviar</button>
+            <button type="submit" class="bg-primary text-white font-semibold py-2 px-4 rounded-xl w-full">{% trans "Enviar" %}</button>
         </form>
     </div>
 </div>

--- a/accounts/templates/accounts/password_reset_confirm.html
+++ b/accounts/templates/accounts/password_reset_confirm.html
@@ -1,9 +1,10 @@
 {% extends "base.html" %}
-{% block title %}Definir Nova Senha - HubX{% endblock %}
+{% load i18n %}
+{% block title %}{% trans "Definir Nova Senha" %} - HubX{% endblock %}
 {% block content %}
 <div class="flex items-center justify-center min-h-screen">
     <div class="max-w-md mx-auto p-6 rounded-2xl shadow bg-white w-full">
-        <h1 class="text-2xl font-bold mb-6 text-center">Definir Nova Senha</h1>
+        <h1 class="text-2xl font-bold mb-6 text-center">{% trans "Definir Nova Senha" %}</h1>
         <form method="post" class="space-y-4">
             {% csrf_token %}
             <div>
@@ -28,7 +29,7 @@
                     <div class="text-red-600 text-sm">{{ form.new_password2.errors }}</div>
                 {% endif %}
             </div>
-            <button type="submit" class="bg-primary text-white font-semibold py-2 px-4 rounded-xl w-full">Alterar Senha</button>
+            <button type="submit" class="bg-primary text-white font-semibold py-2 px-4 rounded-xl w-full">{% trans "Alterar Senha" %}</button>
         </form>
     </div>
 </div>

--- a/accounts/templates/login/login.html
+++ b/accounts/templates/login/login.html
@@ -1,14 +1,14 @@
 {% extends "base.html" %}
-{% load static %}
+{% load static i18n %}
 
-{% block title %}Entrar - HubX{% endblock %}
+{% block title %}{% trans "Entrar" %} - HubX{% endblock %}
 
 {% block content %}
 <main class="bg-muted min-h-screen flex items-center justify-center px-4">
   <div class="bg-white p-8 rounded-2xl shadow max-w-md w-full mx-auto" role="dialog" aria-labelledby="login-title">
-    <h1 id="login-title" class="text-2xl font-bold text-center text-gray-900 mb-1">Bem-vindo de volta</h1>
+    <h1 id="login-title" class="text-2xl font-bold text-center text-gray-900 mb-1">{% trans "Bem-vindo de volta" %}</h1>
     <p class="text-center text-sm text-gray-600 mb-6">
-      Entre para acessar sua conta e conectar-se à sua rede
+      {% trans "Entre para acessar sua conta e conectar-se à sua rede" %}
     </p>
 
     {% if form.non_field_errors %}
@@ -18,10 +18,10 @@
     <form method="post" action="{% url 'accounts:login' %}" class="space-y-5">
       {% csrf_token %}
       <div>
-        <label for="id_email" class="block mb-1 text-sm font-medium text-gray-700">Email</label>
+        <label for="id_email" class="block mb-1 text-sm font-medium text-gray-700">{% trans "Email" %}</label>
         <input type="email" id="id_email" name="email"
                value="{{ form.email.value|default_if_none:'' }}"
-               placeholder="Digite seu e-mail"
+               placeholder="{% trans 'Digite seu e-mail' %}"
                data-check-url="{% url 'accounts:check_2fa' %}"
                class="w-full p-3 border border-gray-300 rounded-lg text-sm placeholder-gray-400 shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
                required
@@ -32,9 +32,9 @@
         {% endif %}
       </div>
       <div>
-        <label for="id_password" class="block mb-1 text-sm font-medium text-gray-700">Senha</label>
+        <label for="id_password" class="block mb-1 text-sm font-medium text-gray-700">{% trans "Senha" %}</label>
         <input type="password" id="id_password" name="password"
-               placeholder="Digite sua senha"
+               placeholder="{% trans 'Digite sua senha' %}"
                class="w-full p-3 border border-gray-300 rounded-lg text-sm placeholder-gray-400 shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
                required
                aria-describedby="password-error"
@@ -44,10 +44,10 @@
         {% endif %}
       </div>
       <div id="totp-field" style="display:none">
-        <label for="id_totp" class="block mb-1 text-sm font-medium text-gray-700">TOTP</label>
+        <label for="id_totp" class="block mb-1 text-sm font-medium text-gray-700">{% trans "TOTP" %}</label>
         <input type="text" id="id_totp" name="totp"
                value="{{ form.totp.value|default_if_none:'' }}"
-               placeholder="Código 2FA"
+               placeholder="{% trans 'Código 2FA' %}"
                class="w-full p-3 border border-gray-300 rounded-lg text-sm placeholder-gray-400 shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
                aria-describedby="totp-error"
                {% if form.totp.errors %}aria-invalid="true"{% endif %}>
@@ -57,25 +57,25 @@
       </div>
       <button type="submit"
               class="w-full bg-primary text-white py-3 px-4 rounded-xl font-semibold text-sm shadow hover:bg-primary/90 transition">
-        Entrar
+        {% trans "Entrar" %}
       </button>
     </form>
 
     <div class="text-center mt-6 space-y-2">
       <a href="{% url 'accounts:password_reset' %}" class="text-sm text-primary hover:underline">
-        Esqueceu sua senha?
+        {% trans "Esqueceu sua senha?" %}
       </a>
       <div>
         <a href="{% url 'accounts:resend_confirmation' %}" class="text-sm text-primary hover:underline">
-          Reenviar confirmação de e-mail
+          {% trans "Reenviar confirmação de e-mail" %}
         </a>
       </div>
     </div>
 
     <div class="text-center mt-4 text-sm text-gray-600">
-      Não tem uma conta?
+      {% trans "Não tem uma conta?" %}
       <a href="{% url 'accounts:onboarding' %}" class="text-primary hover:underline">
-        Cadastre-se gratuitamente
+        {% trans "Cadastre-se gratuitamente" %}
       </a>
     </div>
   </div>

--- a/accounts/templates/perfil/conexoes.html
+++ b/accounts/templates/perfil/conexoes.html
@@ -1,23 +1,19 @@
 {% extends 'perfil/perfil.html' %}
-{% load static %}
+{% load static i18n %}
 
-{% block title %}Minhas Conexões | HubX
-<div class="mt-6 text-center">
-  <a href="{% url 'accounts:perfil' %}" class="text-sm text-primary hover:underline">← Voltar</a>
-</div>
-{% endblock %}
+{% block title %}{% trans "Minhas Conexões" %} | HubX{% endblock %}
 
 {% block perfil_content %}
 <section id="conexoes" class="space-y-6">
   <div>
-    <h2 class="text-xl font-semibold">Minhas Conexões</h2>
-    <p class="text-sm text-gray-500">Gerencie sua rede de contatos</p>
+    <h2 class="text-xl font-semibold">{% trans "Minhas Conexões" %}</h2>
+    <p class="text-sm text-gray-500">{% trans "Gerencie sua rede de contatos" %}</p>
   </div>
 
   <!-- Abas -->
   <div class="flex gap-4 border-b">
-    <button class="tab-btn py-2 px-4 text-sm border-b-2 border-primary text-primary font-medium" data-tab="minhas-conexoes">Minhas Conexões</button>
-    <button class="tab-btn py-2 px-4 text-sm text-gray-600 hover:text-primary" data-tab="solicitacoes">Solicitações</button>
+    <button class="tab-btn py-2 px-4 text-sm border-b-2 border-primary text-primary font-medium" data-tab="minhas-conexoes">{% trans "Minhas Conexões" %}</button>
+    <button class="tab-btn py-2 px-4 text-sm text-gray-600 hover:text-primary" data-tab="solicitacoes">{% trans "Solicitações" %}</button>
   </div>
 
   <!-- Conteúdo das abas -->
@@ -26,8 +22,8 @@
     <!-- MINHAS CONEXÕES -->
     <div class="tab-pane" id="minhas-conexoes">
       <div class="flex gap-2 mb-4">
-        <input type="text" placeholder="Buscar conexões..." class="flex-grow border rounded-lg p-2 text-sm" />
-        <button class="text-gray-600 text-sm">🔍</button>
+        <input type="text" placeholder="{% trans 'Buscar conexões...' %}" class="flex-grow border rounded-lg p-2 text-sm" />
+        <button class="text-gray-600 text-sm" aria-label="{% trans 'Buscar' %}">🔍</button>
       </div>
 
       <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
@@ -47,17 +43,17 @@
             </div>
           </div>
           <div class="flex gap-2">
-            <a href="#" onclick="abrirChat({{ connection.id }})" title="Chat" class="text-green-500 hover:text-green-600">💬</a>
-            <form method="post" action="{% url 'accounts:remover_conexao' connection.id %}" onsubmit="return confirm('Tem certeza que deseja remover esta conexão?');">
+            <a href="#" onclick="abrirChat({{ connection.id }})" title="{% trans 'Chat' %}" class="text-green-500 hover:text-green-600">💬</a>
+            <form method="post" action="{% url 'accounts:remover_conexao' connection.id %}" onsubmit="return confirm('{% trans 'Tem certeza que deseja remover esta conexão?' %}');">
               {% csrf_token %}
-              <button title="Remover conexão" class="text-red-500 hover:text-red-600">❌</button>
+              <button title="{% trans 'Remover conexão' %}" class="text-red-500 hover:text-red-600">❌</button>
             </form>
           </div>
         </div>
         {% empty %}
         <div class="text-center text-sm text-gray-500 col-span-full">
-          <p>Você ainda não tem conexões.</p>
-          <a href="#" class="mt-2 inline-block bg-gray-100 px-4 py-2 rounded hover:bg-gray-200 text-sm">Encontrar Pessoas</a>
+          <p>{% trans "Você ainda não tem conexões." %}</p>
+          <a href="#" class="mt-2 inline-block bg-gray-100 px-4 py-2 rounded hover:bg-gray-200 text-sm">{% trans "Encontrar Pessoas" %}</a>
         </div>
         {% endfor %}
       </div>
@@ -85,17 +81,17 @@
           <div class="flex flex-col gap-1">
             <form method="post" action="{% url 'accounts:aceitar_conexao' request.id %}">
               {% csrf_token %}
-              <button class="text-sm bg-green-100 text-green-700 px-3 py-1 rounded">Aceitar</button>
+              <button class="text-sm bg-green-100 text-green-700 px-3 py-1 rounded">{% trans "Aceitar" %}</button>
             </form>
             <form method="post" action="{% url 'accounts:recusar_conexao' request.id %}">
               {% csrf_token %}
-              <button class="text-sm bg-red-100 text-red-600 px-3 py-1 rounded">Recusar</button>
+              <button class="text-sm bg-red-100 text-red-600 px-3 py-1 rounded">{% trans "Recusar" %}</button>
             </form>
           </div>
         </div>
         {% empty %}
         <div class="text-center text-sm text-gray-500">
-          <p>Você não tem solicitações de conexão pendentes.</p>
+          <p>{% trans "Você não tem solicitações de conexão pendentes." %}</p>
         </div>
         {% endfor %}
       </div>
@@ -117,6 +113,6 @@
 </script>
 
 <div class="mt-6 text-center">
-  <a href="{% url 'accounts:perfil' %}" class="text-sm text-primary hover:underline">← Voltar</a>
+  <a href="{% url 'accounts:perfil' %}" class="text-sm text-primary hover:underline">← {% trans "Voltar" %}</a>
 </div>
 {% endblock %}

--- a/accounts/templates/perfil/detail.html
+++ b/accounts/templates/perfil/detail.html
@@ -1,5 +1,6 @@
 {% extends 'perfil/perfil.html' %}
-{% block title %}Meu Perfil | Hubx{% endblock %}
+{% load i18n %}
+{% block title %}{% trans "Meu Perfil" %} | Hubx{% endblock %}
 {% block perfil_content %}
 <section class="max-w-4xl mx-auto px-4 py-6 bg-white rounded-xl shadow">
 
@@ -11,19 +12,19 @@
 
   <div class="grid sm:grid-cols-2 gap-6 text-sm text-gray-700">
     <div>
-      <h4 class="font-medium mb-1">Contato</h4>
-      <p>Email: {{ user.email }}</p>
-      <p>Telefone: {{ user.fone }}</p>
-      <p>WhatsApp: {{ user.whatsapp }}</p>
+      <h4 class="font-medium mb-1">{% trans "Contato" %}</h4>
+      <p>{% trans "Email" %}: {{ user.email }}</p>
+      <p>{% trans "Telefone" %}: {{ user.fone }}</p>
+      <p>{% trans "WhatsApp" %}: {{ user.whatsapp }}</p>
     </div>
     <div>
-      <h4 class="font-medium mb-1">Localização</h4>
+      <h4 class="font-medium mb-1">{% trans "Localização" %}</h4>
       <p>{{ user.endereco }}</p>
       <p>{{ user.cidade }} - {{ user.estado }}</p>
       <p>{{ user.cep }}</p>
     </div>
     <div>
-    <h4 class="font-medium mb-1">Redes Sociais</h4>
+    <h4 class="font-medium mb-1">{% trans "Redes Sociais" %}</h4>
     {% if user.redes_sociais %}
       {% for nome, link in user.redes_sociais.items %}
         <p><a href="{{ link }}" class="text-primary hover:underline" target="_blank">{{ nome|title }}</a></p>
@@ -34,7 +35,7 @@
   </div>
 
   <div class="mt-6 text-right">
-    <a href="{% url 'accounts:informacoes_pessoais' %}" class="text-primary font-medium hover:underline">Editar perfil</a>
+    <a href="{% url 'accounts:informacoes_pessoais' %}" class="text-primary font-medium hover:underline">{% trans "Editar perfil" %}</a>
   </div>
 
 </section>

--- a/accounts/templates/perfil/disable_2fa.html
+++ b/accounts/templates/perfil/disable_2fa.html
@@ -1,13 +1,15 @@
 {% extends 'perfil/perfil.html' %}
+{% load i18n %}
+{% block title %}{% trans "Desativar 2FA" %} | HubX{% endblock %}
 {% block perfil_content %}
-<h3 class="text-xl font-semibold mb-4">Desativar 2FA</h3>
-<p class="text-sm text-gray-600 mb-4">Digite o código do seu aplicativo autenticador para desativar a verificação em duas etapas.</p>
+<h3 class="text-xl font-semibold mb-4">{% trans "Desativar 2FA" %}</h3>
+<p class="text-sm text-gray-600 mb-4">{% trans "Digite o código do seu aplicativo autenticador para desativar a verificação em duas etapas." %}</p>
 <form method="post" class="space-y-4">
   {% csrf_token %}
   <div>
-    <label for="code" class="block text-sm font-medium text-gray-700">Código</label>
+    <label for="code" class="block text-sm font-medium text-gray-700">{% trans "Código" %}</label>
     <input type="text" name="code" id="code" class="mt-1 block w-full border rounded-lg p-2 text-sm" required />
   </div>
-  <button type="submit" class="bg-primary text-white px-4 py-2 rounded-lg text-sm">Desativar</button>
+  <button type="submit" class="bg-primary text-white px-4 py-2 rounded-lg text-sm">{% trans "Desativar" %}</button>
 </form>
 {% endblock %}

--- a/accounts/templates/perfil/enable_2fa.html
+++ b/accounts/templates/perfil/enable_2fa.html
@@ -1,14 +1,16 @@
 {% extends 'perfil/perfil.html' %}
+{% load i18n %}
+{% block title %}{% trans "Ativar 2FA" %} | HubX{% endblock %}
 {% block perfil_content %}
-<h3 class="text-xl font-semibold mb-4">Ativar 2FA</h3>
-<p class="text-sm text-gray-600 mb-4">Escaneie o QR-code abaixo com seu aplicativo autenticador e informe o código gerado.</p>
-<img src="data:image/png;base64,{{ qr_base64 }}" alt="QR Code" class="mb-4 mx-auto"/>
+<h3 class="text-xl font-semibold mb-4">{% trans "Ativar 2FA" %}</h3>
+<p class="text-sm text-gray-600 mb-4">{% trans "Escaneie o QR-code abaixo com seu aplicativo autenticador e informe o código gerado." %}</p>
+<img src="data:image/png;base64,{{ qr_base64 }}" alt="{% trans 'QR Code' %}" class="mb-4 mx-auto"/>
 <form method="post" class="space-y-4">
   {% csrf_token %}
   <div>
-    <label for="code" class="block text-sm font-medium text-gray-700">Código</label>
+    <label for="code" class="block text-sm font-medium text-gray-700">{% trans "Código" %}</label>
     <input type="text" name="code" id="code" class="mt-1 block w-full border rounded-lg p-2 text-sm" required />
   </div>
-  <button type="submit" class="bg-primary text-white px-4 py-2 rounded-lg text-sm">Ativar</button>
+  <button type="submit" class="bg-primary text-white px-4 py-2 rounded-lg text-sm">{% trans "Ativar" %}</button>
 </form>
 {% endblock %}

--- a/accounts/templates/perfil/informacoes_pessoais.html
+++ b/accounts/templates/perfil/informacoes_pessoais.html
@@ -1,18 +1,18 @@
 {% extends 'perfil/perfil.html' %}
-{% load static %}
+{% load static i18n %}
 
-{% block title %}Informações Pessoais | HubX{% endblock %}
+{% block title %}{% trans "Informações Pessoais" %} | HubX{% endblock %}
 
 {% block perfil_content %}
 <div class="max-w-3xl mx-auto">
-  <h3 class="text-xl font-semibold mb-1">Informações Pessoais</h3>
-  <p class="text-sm text-gray-500 mb-6">Atualize seus dados básicos e de contato</p>
+  <h3 class="text-xl font-semibold mb-1">{% trans "Informações Pessoais" %}</h3>
+  <p class="text-sm text-gray-500 mb-6">{% trans "Atualize seus dados básicos e de contato" %}</p>
 
   <form method="post" enctype="multipart/form-data" class="space-y-6">
     {% csrf_token %}
 
     <div>
-      <label for="nome_completo" class="block text-sm font-medium text-gray-700">Nome completo</label>
+      <label for="nome_completo" class="block text-sm font-medium text-gray-700">{% trans "Nome completo" %}</label>
       <input type="text" id="nome_completo" name="nome_completo"
              class="mt-1 block w-full border rounded-lg p-2 text-sm"
              value="{{ user.nome_completo }}" required>
@@ -20,14 +20,14 @@
 
     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
       <div>
-        <label for="username" class="block text-sm font-medium text-gray-700">Usuário</label>
+        <label for="username" class="block text-sm font-medium text-gray-700">{% trans "Usuário" %}</label>
         <input type="text" id="username" name="username"
                class="mt-1 block w-full border rounded-lg p-2 text-sm"
                value="{{ user.username }}" required>
       </div>
 
       <div>
-        <label for="email" class="block text-sm font-medium text-gray-700">Email</label>
+        <label for="email" class="block text-sm font-medium text-gray-700">{% trans "Email" %}</label>
         <input type="email" id="email" name="email"
                class="mt-1 block w-full border rounded-lg p-2 text-sm"
                value="{{ user.email }}" required>
@@ -35,53 +35,53 @@
     </div>
 
     <div>
-      <label for="biografia" class="block text-sm font-medium text-gray-700">Bio</label>
+      <label for="biografia" class="block text-sm font-medium text-gray-700">{% trans "Bio" %}</label>
       <textarea id="biografia" name="biografia" rows="4"
                 class="mt-1 block w-full border rounded-lg p-2 text-sm">{{ user.biografia }}</textarea>
     </div>
 
     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
       <div>
-        <label for="data_nascimento" class="block text-sm font-medium text-gray-700">Data de Nascimento</label>
+        <label for="data_nascimento" class="block text-sm font-medium text-gray-700">{% trans "Data de Nascimento" %}</label>
         <input type="date" id="data_nascimento" name="data_nascimento"
                class="mt-1 block w-full border rounded-lg p-2 text-sm"
                value="{{ user.data_nascimento|date:'Y-m-d' }}">
       </div>
 
       <div>
-        <label for="genero" class="block text-sm font-medium text-gray-700">Gênero</label>
+        <label for="genero" class="block text-sm font-medium text-gray-700">{% trans "Gênero" %}</label>
         <select id="genero" name="genero"
                 class="mt-1 block w-full border rounded-lg p-2 text-sm">
-          <option value="">Selecione...</option>
-          <option value="M" {% if user.genero == 'M' %}selected{% endif %}>Masculino</option>
-          <option value="F" {% if user.genero == 'F' %}selected{% endif %}>Feminino</option>
-          <option value="O" {% if user.genero == 'O' %}selected{% endif %}>Outro</option>
+          <option value="">{% trans "Selecione..." %}</option>
+          <option value="M" {% if user.genero == 'M' %}selected{% endif %}>{% trans "Masculino" %}</option>
+          <option value="F" {% if user.genero == 'F' %}selected{% endif %}>{% trans "Feminino" %}</option>
+          <option value="O" {% if user.genero == 'O' %}selected{% endif %}>{% trans "Outro" %}</option>
         </select>
       </div>
     </div>
 
     <div>
-      <label for="avatar" class="block text-sm font-medium text-gray-700">Foto de Perfil</label>
+      <label for="avatar" class="block text-sm font-medium text-gray-700">{% trans "Foto de Perfil" %}</label>
       <input type="file" id="avatar" name="avatar"
              class="mt-1 block w-full border rounded-lg p-2 text-sm">
-      <label for="cover" class="block text-sm font-medium text-gray-700 mt-2">Capa</label>
+      <label for="cover" class="block text-sm font-medium text-gray-700 mt-2">{% trans "Capa" %}</label>
       <input type="file" id="cover" name="cover"
              class="mt-1 block w-full border rounded-lg p-2 text-sm">
     </div>
 
     <hr class="my-6">
 
-    <h4 class="text-lg font-semibold">Informações de Contato</h4>
+    <h4 class="text-lg font-semibold">{% trans "Informações de Contato" %}</h4>
 
     <div class="grid md:grid-cols-2 gap-4">
       <div>
-        <label for="fone" class="block text-sm font-medium text-gray-700">Telefone</label>
+        <label for="fone" class="block text-sm font-medium text-gray-700">{% trans "Telefone" %}</label>
         <input type="tel" id="fone" name="fone"
                class="mt-1 block w-full border rounded-lg p-2 text-sm"
                value="{{ user.fone }}" placeholder="(00) 00000-0000">
       </div>
       <div>
-        <label for="whatsapp" class="block text-sm font-medium text-gray-700">WhatsApp</label>
+        <label for="whatsapp" class="block text-sm font-medium text-gray-700">{% trans "WhatsApp" %}</label>
         <input type="tel" id="whatsapp" name="whatsapp"
                class="mt-1 block w-full border rounded-lg p-2 text-sm"
                value="{{ user.whatsapp }}" placeholder="(00) 00000-0000">
@@ -89,31 +89,31 @@
     </div>
 
     <div>
-      <label for="endereco" class="block text-sm font-medium text-gray-700">Endereço</label>
+      <label for="endereco" class="block text-sm font-medium text-gray-700">{% trans "Endereço" %}</label>
       <input type="text" id="endereco" name="endereco"
              class="mt-1 block w-full border rounded-lg p-2 text-sm"
-             value="{{ user.endereco }}" placeholder="Rua, número, complemento">
+             value="{{ user.endereco }}" placeholder="{% trans 'Rua, número, complemento' %}">
     </div>
 
     <div class="grid md:grid-cols-3 gap-4">
       <div>
-        <label for="cidade" class="block text-sm font-medium text-gray-700">Cidade</label>
+        <label for="cidade" class="block text-sm font-medium text-gray-700">{% trans "Cidade" %}</label>
         <input type="text" id="cidade" name="cidade"
                class="mt-1 block w-full border rounded-lg p-2 text-sm"
                value="{{ user.cidade }}">
       </div>
       <div>
-        <label for="estado" class="block text-sm font-medium text-gray-700">Estado</label>
+        <label for="estado" class="block text-sm font-medium text-gray-700">{% trans "Estado" %}</label>
         <select id="estado" name="estado"
                 class="mt-1 block w-full border rounded-lg p-2 text-sm">
-          <option value="">Selecione...</option>
+          <option value="">{% trans "Selecione..." %}</option>
           {% for uf, sigla in estados %}
             <option value="{{ sigla }}" {% if user.estado == sigla %}selected{% endif %}>{{ uf }}</option>
           {% endfor %}
         </select>
       </div>
       <div>
-        <label for="cep" class="block text-sm font-medium text-gray-700">CEP</label>
+        <label for="cep" class="block text-sm font-medium text-gray-700">{% trans "CEP" %}</label>
         <input type="text" id="cep" name="cep"
                class="mt-1 block w-full border rounded-lg p-2 text-sm"
                value="{{ user.cep }}" placeholder="00000-000">
@@ -123,13 +123,13 @@
     <div class="pt-4">
       <button type="submit"
               class="bg-primary text-white px-5 py-2 rounded-xl font-semibold text-sm hover:bg-primary/90 transition">
-        Salvar Alterações
+        {% trans "Salvar Alterações" %}
       </button>
     </div>
   </form>
 </div>
 
 <div class="mt-6 text-center">
-  <a href="{% url 'accounts:perfil' %}" class="text-sm text-primary hover:underline">← Voltar</a>
+  <a href="{% url 'accounts:perfil' %}" class="text-sm text-primary hover:underline">← {% trans "Voltar" %}</a>
 </div>
 {% endblock %}

--- a/accounts/templates/perfil/midia_confirm_delete.html
+++ b/accounts/templates/perfil/midia_confirm_delete.html
@@ -1,14 +1,15 @@
 {% extends 'perfil/perfil.html' %}
-{% block title %}Remover Mídia | Hubx{% endblock %}
+{% load i18n %}
+{% block title %}{% trans "Remover Mídia" %} | Hubx{% endblock %}
 
 {% block perfil_content %}
 <section class="space-y-4">
-  <h2 class="text-xl font-semibold text-red-600">Remover Mídia</h2>
-  <p class="text-gray-600">Tem certeza que deseja remover esta mídia?</p>
+  <h2 class="text-xl font-semibold text-red-600">{% trans "Remover Mídia" %}</h2>
+  <p class="text-gray-600">{% trans "Tem certeza que deseja remover esta mídia?" %}</p>
   <form method="post" class="flex justify-end gap-2">
     {% csrf_token %}
-    <a href="{% url 'accounts:midias' %}" class="px-4 py-2 border rounded text-sm hover:bg-gray-100">Cancelar</a>
-    <button type="submit" class="bg-red-500 text-white px-4 py-2 rounded hover:bg-red-600">Remover</button>
+    <a href="{% url 'accounts:midias' %}" class="px-4 py-2 border rounded text-sm hover:bg-gray-100">{% trans "Cancelar" %}</a>
+    <button type="submit" class="bg-red-500 text-white px-4 py-2 rounded hover:bg-red-600">{% trans "Remover" %}</button>
   </form>
 </section>
 {% endblock %}

--- a/accounts/templates/perfil/midia_detail.html
+++ b/accounts/templates/perfil/midia_detail.html
@@ -1,13 +1,14 @@
 {% extends 'perfil/perfil.html' %}
+{% load i18n %}
 
-{% block title %}Mídia | Hubx{% endblock %}
+{% block title %}{% trans "Mídia" %} | Hubx{% endblock %}
 
 {% block perfil_content %}
 <section class="space-y-4">
   <img src="{{ media.file.url }}" alt="{{ media.descricao }}" class="rounded shadow max-w-full mx-auto" />
   <p class="text-center text-gray-700">{{ media.descricao }}</p>
   <div class="text-center">
-    <a href="{% url 'accounts:midias' %}" class="text-sm text-primary hover:underline">← Voltar para mídias</a>
+    <a href="{% url 'accounts:midias' %}" class="text-sm text-primary hover:underline">← {% trans "Voltar para mídias" %}</a>
   </div>
 </section>
 {% endblock %}

--- a/accounts/templates/perfil/midia_form.html
+++ b/accounts/templates/perfil/midia_form.html
@@ -1,19 +1,20 @@
 {% extends 'perfil/perfil.html' %}
+{% load i18n %}
 
-{% block title %}{% if form.instance.pk %}Editar Mídia{% else %}Nova Mídia{% endif %} | Hubx{% endblock %}
+{% block title %}{% if form.instance.pk %}{% trans "Editar Mídia" %}{% else %}{% trans "Nova Mídia" %}{% endif %} | Hubx{% endblock %}
 
 {% block perfil_content %}
 <section class="space-y-6">
   <h2 class="text-xl font-semibold">
-    {% if form.instance.pk %}Editar Mídia{% else %}Cadastrar Mídia{% endif %}
+    {% if form.instance.pk %}{% trans "Editar Mídia" %}{% else %}{% trans "Cadastrar Mídia" %}{% endif %}
   </h2>
 
   <form method="post" enctype="multipart/form-data" class="space-y-4">
     {% csrf_token %}
     {{ form.as_p }}
     <div class="flex justify-end gap-2">
-      <a href="{% url 'accounts:midias' %}" class="text-sm px-4 py-2 border rounded hover:bg-gray-100">Cancelar</a>
-      <button type="submit" class="bg-primary text-white px-4 py-2 rounded hover:bg-emerald-600">Salvar</button>
+      <a href="{% url 'accounts:midias' %}" class="text-sm px-4 py-2 border rounded hover:bg-gray-100">{% trans "Cancelar" %}</a>
+      <button type="submit" class="bg-primary text-white px-4 py-2 rounded hover:bg-emerald-600">{% trans "Salvar" %}</button>
     </div>
   </form>
 </section>

--- a/accounts/templates/perfil/midias.html
+++ b/accounts/templates/perfil/midias.html
@@ -1,45 +1,45 @@
 {% extends 'perfil/perfil.html' %}
-{% load static %}
+{% load static i18n %}
 
-{% block title %}Mídias | Hubx{% endblock %}
+{% block title %}{% trans "Mídias" %} | Hubx{% endblock %}
 
 {% block perfil_content %}
 <section id="midias" class="perfil-section active">
   <div class="section-header mb-6">
-    <h2 class="text-xl font-semibold">Mídias</h2>
-    <p class="text-sm text-gray-500">Gerencie suas imagens, vídeos e documentos</p>
+    <h2 class="text-xl font-semibold">{% trans "Mídias" %}</h2>
+    <p class="text-sm text-gray-500">{% trans "Gerencie suas imagens, vídeos e documentos" %}</p>
   </div>
 
   {% if show_form %}
   <form id="formMidias" class="space-y-6" method="post" action="{% url 'accounts:midias' %}" enctype="multipart/form-data">
     {% csrf_token %}
     <div>
-      <label for="id_file" class="block text-sm font-medium text-gray-700">Enviar arquivo</label>
+      <label for="id_file" class="block text-sm font-medium text-gray-700">{% trans "Enviar arquivo" %}</label>
       <input type="file" id="id_file" name="file" class="mt-1 block w-full border rounded-lg p-2 text-sm" required>
     </div>
     <div>
-      <label for="id_descricao" class="block text-sm font-medium text-gray-700">Descrição</label>
+      <label for="id_descricao" class="block text-sm font-medium text-gray-700">{% trans "Descrição" %}</label>
       <input type="text" id="id_descricao" name="descricao" class="mt-1 block w-full border rounded-lg p-2 text-sm">
     </div>
     <div>
-      <label for="id_tags_field" class="block text-sm font-medium text-gray-700">Tags</label>
-      <input type="text" id="id_tags_field" name="tags_field" class="mt-1 block w-full border rounded-lg p-2 text-sm" placeholder="paisagem, viagem">
+      <label for="id_tags_field" class="block text-sm font-medium text-gray-700">{% trans "Tags" %}</label>
+      <input type="text" id="id_tags_field" name="tags_field" class="mt-1 block w-full border rounded-lg p-2 text-sm" placeholder="{% trans 'paisagem, viagem' %}">
     </div>
     <div>
       <button type="submit" class="bg-primary text-white px-5 py-2 rounded-xl font-semibold text-sm hover:bg-primary/90 transition">
-        Enviar
+        {% trans "Enviar" %}
       </button>
     </div>
   </form>
   {% else %}
     <a href="{% url 'accounts:midias' %}?adicionar=1"
        class="inline-block bg-primary text-white px-4 py-2 rounded-xl text-sm font-medium hover:bg-primary/90 transition">
-      Adicionar Mídias
+      {% trans "Adicionar Mídias" %}
     </a>
   {% endif %}
 
   <form method="get" class="mt-6">
-    <input type="text" name="q" value="{{ q }}" placeholder="Buscar por descrição ou tags..."
+    <input type="text" name="q" value="{{ q }}" placeholder="{% trans 'Buscar por descrição ou tags...' %}"
            class="w-full border border-gray-300 rounded-lg px-4 py-2 text-sm">
   </form>
 
@@ -47,15 +47,15 @@
     {% for media in medias %}
     <div class="bg-white border rounded-lg shadow p-3 relative">
       <div class="absolute top-2 right-2 flex gap-2">
-        <a href="{% url 'accounts:midia_edit' media.pk %}" class="text-sm text-blue-600 hover:underline">✏️</a>
-        <a href="{% url 'accounts:midia_delete' media.pk %}" class="text-sm text-red-600 hover:underline">🗑️</a>
+        <a href="{% url 'accounts:midia_edit' media.pk %}" class="text-sm text-blue-600 hover:underline" aria-label="{% trans 'Editar' %}">✏️</a>
+        <a href="{% url 'accounts:midia_delete' media.pk %}" class="text-sm text-red-600 hover:underline" aria-label="{% trans 'Excluir' %}">🗑️</a>
       </div>
       <a href="{% url 'accounts:midia_detail' media.pk %}">
         <img src="{{ media.file.url }}" alt="{{ media.descricao }}" class="w-full h-40 object-cover rounded">
       </a>
       <div class="mt-2">
         <p class="text-sm font-medium text-gray-700">{{ media.descricao }}</p>
-        <p class="text-xs text-gray-400">{{ media.uploaded_at|date:"d/m/Y H:i" }}</p>
+        <p class="text-xs text-gray-400">{{ media.uploaded_at|date:SHORT_DATETIME_FORMAT }}</p>
         <div class="flex flex-wrap gap-1 mt-1">
           {% for tag in media.tags.all %}
             <span class="bg-gray-100 text-gray-700 text-xs px-2 py-0.5 rounded">{{ tag.nome }}</span>
@@ -64,12 +64,12 @@
       </div>
     </div>
     {% empty %}
-      <p class="text-sm text-gray-500">Nenhum arquivo enviado.</p>
+      <p class="text-sm text-gray-500">{% trans "Nenhum arquivo enviado." %}</p>
     {% endfor %}
   </div>
 </section>
 
 <div class="mt-8 text-center">
-  <a href="{% url 'accounts:perfil' %}" class="text-sm text-primary hover:underline">← Voltar</a>
+  <a href="{% url 'accounts:perfil' %}" class="text-sm text-primary hover:underline">← {% trans "Voltar" %}</a>
 </div>
 {% endblock %}

--- a/accounts/templates/perfil/perfil.html
+++ b/accounts/templates/perfil/perfil.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
-{% load static %}
+{% load static i18n %}
 
-{% block title %}Perfil | HubX{% endblock %}
+{% block title %}{% trans "Perfil" %} | HubX{% endblock %}
 
 {% block content %}
 <div class="max-w-5xl mx-auto mt-8 px-4">
@@ -20,7 +20,7 @@
 
       <h2 class="text-lg font-bold">{{ user.get_full_name }}</h2>
       <p class="text-sm text-gray-500 mb-2">@{{ user.username }}</p>
-      <button class="text-sm text-primary hover:underline">Alterar foto</button>
+      <button class="text-sm text-primary hover:underline">{% trans "Alterar foto" %}</button>
     </div>
 
     <!-- Abas de navegação -->
@@ -28,15 +28,15 @@
       <a href="{% url 'accounts:informacoes_pessoais' %}"
          class="px-3 py-2 -mb-px border-b-2 {% if request.resolver_match.url_name == 'informacoes_pessoais' %}border-primary text-primary{% else %}border-transparent hover:text-primary{% endif %}"
          role="tab"
-         aria-selected="{% if request.resolver_match.url_name == 'informacoes_pessoais' %}true{% else %}false{% endif %}">Informações Pessoais</a>
+         aria-selected="{% if request.resolver_match.url_name == 'informacoes_pessoais' %}true{% else %}false{% endif %}">{% trans "Informações Pessoais" %}</a>
       <a href="{% url 'accounts:seguranca' %}"
          class="px-3 py-2 -mb-px border-b-2 {% if request.resolver_match.url_name == 'seguranca' %}border-primary text-primary{% else %}border-transparent hover:text-primary{% endif %}"
          role="tab"
-         aria-selected="{% if request.resolver_match.url_name == 'seguranca' %}true{% else %}false{% endif %}">Segurança</a>
+         aria-selected="{% if request.resolver_match.url_name == 'seguranca' %}true{% else %}false{% endif %}">{% trans "Segurança" %}</a>
       <a href="{% url 'configuracoes' %}?tab=preferencias"
          class="px-3 py-2 -mb-px border-b-2 border-transparent hover:text-primary"
          role="tab"
-         aria-selected="false">Notificações</a>
+         aria-selected="false">{% trans "Notificações" %}</a>
     </nav>
 
     <!-- Bloco dinâmico para subpáginas -->

--- a/accounts/templates/perfil/redes_sociais.html
+++ b/accounts/templates/perfil/redes_sociais.html
@@ -1,12 +1,12 @@
 {% extends 'perfil/perfil.html' %}
-{% load static %}
+{% load static i18n %}
 
-{% block title %}Redes Sociais | HubX{% endblock %}
+{% block title %}{% trans "Redes Sociais" %} | HubX{% endblock %}
 
 {% block perfil_content %}
 <div class="max-w-3xl mx-auto">
-  <h3 class="text-xl font-semibold mb-1">Redes Sociais</h3>
-  <p class="text-sm text-gray-500 mb-6">Conecte suas redes sociais com seu perfil</p>
+  <h3 class="text-xl font-semibold mb-1">{% trans "Redes Sociais" %}</h3>
+  <p class="text-sm text-gray-500 mb-6">{% trans "Conecte suas redes sociais com seu perfil" %}</p>
 
   <form method="post" action="{% url 'accounts:redes_sociais' %}" class="space-y-6">
     {% csrf_token %}
@@ -19,13 +19,13 @@
     <div class="pt-4">
       <button type="submit"
               class="bg-primary text-white px-5 py-2 rounded-xl font-semibold text-sm hover:bg-primary/90 transition">
-        Salvar Alterações
+        {% trans "Salvar Alterações" %}
       </button>
     </div>
   </form>
 </div>
 
 <div class="mt-6 text-center">
-  <a href="{% url 'accounts:perfil' %}" class="text-sm text-primary hover:underline">← Voltar</a>
+  <a href="{% url 'accounts:perfil' %}" class="text-sm text-primary hover:underline">← {% trans "Voltar" %}</a>
 </div>
 {% endblock %}

--- a/accounts/templates/perfil/seguranca.html
+++ b/accounts/templates/perfil/seguranca.html
@@ -1,30 +1,30 @@
 {% extends 'perfil/perfil.html' %}
-{% load static %}
+{% load static i18n %}
 
-{% block title %}Segurança da Conta | HubX{% endblock %}
+{% block title %}{% trans "Segurança da Conta" %} | HubX{% endblock %}
 
 {% block perfil_content %}
 <div class="max-w-3xl mx-auto">
-  <h3 class="text-xl font-semibold mb-1">Segurança</h3>
-  <p class="text-sm text-gray-500 mb-6">Gerencie sua senha e a proteção da conta</p>
+  <h3 class="text-xl font-semibold mb-1">{% trans "Segurança" %}</h3>
+  <p class="text-sm text-gray-500 mb-6">{% trans "Gerencie sua senha e a proteção da conta" %}</p>
 
   <form method="post" action="{% url 'accounts:seguranca' %}" class="space-y-6">
     {% csrf_token %}
 
     <div>
-      <label for="senha_atual" class="block text-sm font-medium text-gray-700">Senha Atual</label>
+      <label for="senha_atual" class="block text-sm font-medium text-gray-700">{% trans "Senha Atual" %}</label>
       <input type="password" id="senha_atual" name="senha_atual"
              class="mt-1 block w-full border rounded-lg p-2 text-sm" required>
     </div>
 
     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
       <div>
-        <label for="nova_senha" class="block text-sm font-medium text-gray-700">Nova Senha</label>
+        <label for="nova_senha" class="block text-sm font-medium text-gray-700">{% trans "Nova Senha" %}</label>
         <input type="password" id="nova_senha" name="nova_senha"
                class="mt-1 block w-full border rounded-lg p-2 text-sm" required>
       </div>
       <div>
-        <label for="confirmar_senha" class="block text-sm font-medium text-gray-700">Confirmar Nova Senha</label>
+        <label for="confirmar_senha" class="block text-sm font-medium text-gray-700">{% trans "Confirmar Nova Senha" %}</label>
         <input type="password" id="confirmar_senha" name="confirmar_senha"
                class="mt-1 block w-full border rounded-lg p-2 text-sm" required>
       </div>
@@ -32,34 +32,34 @@
 
     <!-- Indicador de força de senha -->
     <div>
-      <label class="block text-sm font-medium text-gray-700">Força da senha:</label>
+      <label class="block text-sm font-medium text-gray-700">{% trans "Força da senha:" %}</label>
       <div class="w-full h-2 bg-gray-200 rounded mt-1">
         <div id="strengthFill" class="h-2 bg-green-500 rounded w-1/4 transition-all duration-300"></div>
       </div>
-      <div id="strengthText" class="text-sm text-gray-500 mt-1">Digite uma senha</div>
+      <div id="strengthText" class="text-sm text-gray-500 mt-1">{% trans "Digite uma senha" %}</div>
     </div>
 
     <div>
       <button type="submit"
               class="bg-primary text-white px-5 py-2 rounded-xl font-semibold text-sm hover:bg-primary/90 transition">
-        Alterar Senha
+        {% trans "Alterar Senha" %}
       </button>
     </div>
   </form>
 
   <div class="mt-12 border-t pt-8">
-    <h4 class="text-lg font-semibold mb-2">Verificação em Duas Etapas</h4>
+    <h4 class="text-lg font-semibold mb-2">{% trans "Verificação em Duas Etapas" %}</h4>
     <p class="text-sm text-gray-600 mb-4">
-      A verificação em duas etapas adiciona uma camada extra de segurança à sua conta, exigindo um código além da sua senha ao fazer login.
+      {% trans "A verificação em duas etapas adiciona uma camada extra de segurança à sua conta, exigindo um código além da sua senha ao fazer login." %}
     </p>
     {% if request.user.two_factor_enabled %}
-      <p class="text-sm text-green-600 mb-4">2FA está ativado.</p>
+      <p class="text-sm text-green-600 mb-4">{% trans "2FA está ativado." %}</p>
       <a href="{% url 'accounts:disable_2fa' %}"
-         class="border border-gray-300 px-4 py-2 rounded-lg text-sm hover:bg-gray-100 transition">Desativar 2FA</a>
+         class="border border-gray-300 px-4 py-2 rounded-lg text-sm hover:bg-gray-100 transition">{% trans "Desativar 2FA" %}</a>
     {% else %}
-      <p class="text-sm text-red-600 mb-4">2FA não está ativado.</p>
+      <p class="text-sm text-red-600 mb-4">{% trans "2FA não está ativado." %}</p>
       <a href="{% url 'accounts:enable_2fa' %}"
-         class="border border-gray-300 px-4 py-2 rounded-lg text-sm hover:bg-gray-100 transition">Ativar 2FA</a>
+         class="border border-gray-300 px-4 py-2 rounded-lg text-sm hover:bg-gray-100 transition">{% trans "Ativar 2FA" %}</a>
     {% endif %}
   </div>
 </div>
@@ -76,27 +76,27 @@
     if (!val) {
       strengthFill.style.width = '0%';
       strengthFill.className = 'h-2 bg-gray-300 rounded';
-      strengthText.textContent = 'Digite uma senha';
+      strengthText.textContent = gettext('Digite uma senha');
       return;
     }
 
     if (length < 6) {
       strengthFill.style.width = '25%';
       strengthFill.className = 'h-2 bg-red-500 rounded';
-      strengthText.textContent = 'Fraca';
+      strengthText.textContent = gettext('Fraca');
     } else if (length < 10) {
       strengthFill.style.width = '50%';
       strengthFill.className = 'h-2 bg-yellow-500 rounded';
-      strengthText.textContent = 'Média';
+      strengthText.textContent = gettext('Média');
     } else {
       strengthFill.style.width = '100%';
       strengthFill.className = 'h-2 bg-green-500 rounded';
-      strengthText.textContent = 'Forte';
+      strengthText.textContent = gettext('Forte');
     }
   });
 </script>
 
 <div class="mt-6 text-center">
-  <a href="{% url 'accounts:perfil' %}" class="text-sm text-primary hover:underline">← Voltar</a>
+  <a href="{% url 'accounts:perfil' %}" class="text-sm text-primary hover:underline">← {% trans "Voltar" %}</a>
 </div>
 {% endblock %}

--- a/accounts/templates/register/cpf.html
+++ b/accounts/templates/register/cpf.html
@@ -1,13 +1,14 @@
 {% extends "base.html" %}
+{% load i18n %}
 
-{% block title %}Registro - CPF | Hubx{% endblock %}
+{% block title %}{% trans "Registro - CPF" %} | Hubx{% endblock %}
 
 {% block content %}
 <section class="max-w-md mx-auto px-4 py-12">
   <div class="rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
     <div class="mb-8">
       <div class="mb-2 flex items-center justify-between">
-        <span class="text-sm font-medium text-primary-600">Passo 5 de 7</span>
+        <span class="text-sm font-medium text-primary-600">{% blocktrans with step=5 total=7 %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
         <span class="text-sm text-neutral-500">70%</span>
       </div>
       <div class="h-2 w-full rounded-xl bg-neutral-200">
@@ -16,21 +17,21 @@
     </div>
 
     <div class="mb-8 text-center">
-      <h1 class="mb-2 text-3xl font-bold text-neutral-900">Qual seu CPF?</h1>
-      <p class="text-neutral-600">Precisamos para validar sua identidade e segurança</p>
+      <h1 class="mb-2 text-3xl font-bold text-neutral-900">{% trans "Qual seu CPF?" %}</h1>
+      <p class="text-neutral-600">{% trans "Precisamos para validar sua identidade e segurança" %}</p>
     </div>
 
     <form id="cpfForm" method="post" action="{% url 'accounts:cpf' %}" class="space-y-6">
       {% csrf_token %}
       <div>
-        <label for="cpf" class="mb-1 block text-sm font-medium text-neutral-700">CPF</label>
+        <label for="cpf" class="mb-1 block text-sm font-medium text-neutral-700">{% trans "CPF" %}</label>
         <input type="text" id="cpf" name="cpf" maxlength="14" class="w-full rounded-lg border border-neutral-300 px-4 py-2 placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder="000.000.000-00" required autofocus>
         <div class="text-sm text-red-600" id="cpf_validation"></div>
       </div>
 
       <div class="flex gap-4">
-        <a href="{% url 'accounts:nome' %}" class="flex-1 rounded-xl border border-neutral-300 px-4 py-2 text-center text-neutral-700 hover:bg-neutral-100">Voltar</a>
-        <button type="submit" id="submitButton" class="flex-1 rounded-xl bg-primary-600 px-4 py-2 text-white hover:bg-primary-700">Continuar</button>
+        <a href="{% url 'accounts:nome' %}" class="flex-1 rounded-xl border border-neutral-300 px-4 py-2 text-center text-neutral-700 hover:bg-neutral-100">{% trans "Voltar" %}</a>
+        <button type="submit" id="submitButton" class="flex-1 rounded-xl bg-primary-600 px-4 py-2 text-white hover:bg-primary-700">{% trans "Continuar" %}</button>
       </div>
     </form>
   </div>

--- a/accounts/templates/register/email.html
+++ b/accounts/templates/register/email.html
@@ -1,13 +1,14 @@
 {% extends "base.html" %}
+{% load i18n %}
 
-{% block title %}Registro - Email | Hubx{% endblock %}
+{% block title %}{% trans "Registro - Email" %} | Hubx{% endblock %}
 
 {% block content %}
 <section class="max-w-md mx-auto px-4 py-12">
   <div class="rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
     <div class="mb-8">
       <div class="mb-2 flex items-center justify-between">
-        <span class="text-sm font-medium text-primary-600">Passo 4 de 7</span>
+        <span class="text-sm font-medium text-primary-600">{% blocktrans with step=4 total=7 %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
         <span class="text-sm text-neutral-500">56%</span>
       </div>
       <div class="h-2 w-full rounded-xl bg-neutral-200">
@@ -16,21 +17,21 @@
     </div>
 
     <div class="mb-8 text-center">
-      <h1 class="mb-2 text-3xl font-bold text-neutral-900">Qual seu email?</h1>
-      <p class="text-neutral-600">Usaremos para comunicação e recuperação de conta</p>
+      <h1 class="mb-2 text-3xl font-bold text-neutral-900">{% trans "Qual seu email?" %}</h1>
+      <p class="text-neutral-600">{% trans "Usaremos para comunicação e recuperação de conta" %}</p>
     </div>
 
     <form id="emailForm" method="post" action="{% url 'accounts:email' %}" class="space-y-6">
       {% csrf_token %}
       <div>
-        <label for="email" class="mb-1 block text-sm font-medium text-neutral-700">Email</label>
-        <input type="email" id="email" name="email" class="w-full rounded-lg border border-neutral-300 px-4 py-2 placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder="Digite seu email" required autofocus>
+        <label for="email" class="mb-1 block text-sm font-medium text-neutral-700">{% trans "Email" %}</label>
+        <input type="email" id="email" name="email" class="w-full rounded-lg border border-neutral-300 px-4 py-2 placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder="{% trans 'Digite seu email' %}" required autofocus>
         <div class="text-sm text-red-600" id="email_validation"></div>
       </div>
 
       <div class="flex gap-4">
-        <a href="{% url 'accounts:nome' %}" class="flex-1 rounded-xl border border-neutral-300 px-4 py-2 text-center text-neutral-700 hover:bg-neutral-100">Voltar</a>
-        <button type="submit" id="submitButton" class="flex-1 rounded-xl bg-primary-600 px-4 py-2 text-white hover:bg-primary-700">Continuar</button>
+        <a href="{% url 'accounts:nome' %}" class="flex-1 rounded-xl border border-neutral-300 px-4 py-2 text-center text-neutral-700 hover:bg-neutral-100">{% trans "Voltar" %}</a>
+        <button type="submit" id="submitButton" class="flex-1 rounded-xl bg-primary-600 px-4 py-2 text-white hover:bg-primary-700">{% trans "Continuar" %}</button>
       </div>
     </form>
   </div>

--- a/accounts/templates/register/foto.html
+++ b/accounts/templates/register/foto.html
@@ -1,13 +1,14 @@
 {% extends "base.html" %}
+{% load i18n %}
 
-{% block title %}Registro - Foto | Hubx{% endblock %}
+{% block title %}{% trans "Registro - Foto" %} | Hubx{% endblock %}
 
 {% block content %}
 <section class="max-w-md mx-auto px-4 py-12">
   <div class="rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
     <div class="mb-8">
       <div class="mb-2 flex items-center justify-between">
-        <span class="text-sm font-medium text-primary-600">Passo 6 de 7</span>
+        <span class="text-sm font-medium text-primary-600">{% trans "Passo 6 de 7" %}</span>
         <span class="text-sm text-neutral-500">84%</span>
       </div>
       <div class="h-2 w-full rounded-xl bg-neutral-200">
@@ -16,22 +17,22 @@
     </div>
 
     <div class="mb-8 text-center">
-      <h1 class="mb-2 text-3xl font-bold text-neutral-900">Adicione uma foto de perfil</h1>
-      <p class="text-neutral-600">Personalize sua presença na comunidade</p>
+      <h1 class="mb-2 text-3xl font-bold text-neutral-900">{% trans "Adicione uma foto de perfil" %}</h1>
+      <p class="text-neutral-600">{% trans "Personalize sua presença na comunidade" %}</p>
     </div>
 
     <form id="fotoForm" method="post" action="{% url 'accounts:foto' %}" enctype="multipart/form-data" class="space-y-6">
       {% csrf_token %}
       <div>
-        <label for="foto" class="mb-1 block text-sm font-medium text-neutral-700">Escolher Foto</label>
+        <label for="foto" class="mb-1 block text-sm font-medium text-neutral-700">{% trans "Escolher Foto" %}</label>
         <input type="file" id="foto" name="foto" accept="image/*" class="w-full rounded-lg border border-neutral-300 px-4 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500">
         <div class="text-sm text-red-600" id="foto_validation"></div>
-        <small class="text-sm text-neutral-500">Formatos aceitos: JPG, PNG. Tamanho máximo: 5MB</small>
+        <small class="text-sm text-neutral-500">{% trans "Formatos aceitos: JPG, PNG. Tamanho máximo: 5MB" %}</small>
       </div>
 
       <div class="flex gap-4">
-        <a href="{% url 'accounts:senha' %}" class="flex-1 rounded-xl border border-neutral-300 px-4 py-2 text-center text-neutral-700 hover:bg-neutral-100">Voltar</a>
-        <button type="submit" id="submitButton" class="flex-1 rounded-xl bg-primary-600 px-4 py-2 text-white hover:bg-primary-700">Continuar</button>
+        <a href="{% url 'accounts:senha' %}" class="flex-1 rounded-xl border border-neutral-300 px-4 py-2 text-center text-neutral-700 hover:bg-neutral-100">{% trans "Voltar" %}</a>
+        <button type="submit" id="submitButton" class="flex-1 rounded-xl bg-primary-600 px-4 py-2 text-white hover:bg-primary-700">{% trans "Continuar" %}</button>
       </div>
     </form>
   </div>

--- a/accounts/templates/register/nome.html
+++ b/accounts/templates/register/nome.html
@@ -1,13 +1,14 @@
 {% extends "base.html" %}
+{% load i18n %}
 
-{% block title %}Registro - Nome | Hubx{% endblock %}
+{% block title %}{% trans "Registro - Nome" %} | Hubx{% endblock %}
 
 {% block content %}
 <section class="max-w-md mx-auto px-4 py-12">
   <div class="rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
     <div class="mb-8">
       <div class="mb-2 flex items-center justify-between">
-        <span class="text-sm font-medium text-primary-600">Passo 3 de 7</span>
+        <span class="text-sm font-medium text-primary-600">{% blocktrans with step=3 total=7 %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
         <span class="text-sm text-neutral-500">42%</span>
       </div>
       <div class="h-2 w-full rounded-xl bg-neutral-200">
@@ -16,21 +17,21 @@
     </div>
 
     <div class="mb-8 text-center">
-      <h1 class="mb-2 text-3xl font-bold text-neutral-900">Como podemos te chamar?</h1>
-      <p class="text-neutral-600">Digite seu nome completo</p>
+      <h1 class="mb-2 text-3xl font-bold text-neutral-900">{% trans "Como podemos te chamar?" %}</h1>
+      <p class="text-neutral-600">{% trans "Digite seu nome completo" %}</p>
     </div>
 
     <form id="nomeForm" method="post" action="{% url 'accounts:nome' %}" class="space-y-6">
       {% csrf_token %}
       <div>
-        <label for="nome" class="mb-1 block text-sm font-medium text-neutral-700">Nome Completo</label>
-        <input type="text" id="nome" name="nome" class="w-full rounded-lg border border-neutral-300 px-4 py-2 placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder="Digite seu nome completo" required autofocus>
+        <label for="nome" class="mb-1 block text-sm font-medium text-neutral-700">{% trans "Nome Completo" %}</label>
+        <input type="text" id="nome" name="nome" class="w-full rounded-lg border border-neutral-300 px-4 py-2 placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder="{% trans 'Digite seu nome completo' %}" required autofocus>
         <div class="text-sm text-red-600" id="nome_validation"></div>
       </div>
 
       <div class="flex gap-4">
-        <a href="{% url 'tokens:token' %}" class="flex-1 rounded-xl border border-neutral-300 px-4 py-2 text-center text-neutral-700 hover:bg-neutral-100">Voltar</a>
-        <button type="submit" id="submitButton" class="flex-1 rounded-xl bg-primary-600 px-4 py-2 text-white hover:bg-primary-700">Continuar</button>
+        <a href="{% url 'tokens:token' %}" class="flex-1 rounded-xl border border-neutral-300 px-4 py-2 text-center text-neutral-700 hover:bg-neutral-100">{% trans "Voltar" %}</a>
+        <button type="submit" id="submitButton" class="flex-1 rounded-xl bg-primary-600 px-4 py-2 text-white hover:bg-primary-700">{% trans "Continuar" %}</button>
       </div>
     </form>
   </div>

--- a/accounts/templates/register/onboarding.html
+++ b/accounts/templates/register/onboarding.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
+{% load i18n %}
 
-{% block title %}Cadastre-se - HubX{% endblock %}
+{% block title %}{% trans "Cadastre-se" %} - HubX{% endblock %}
 
 {% block content %}
 <div class="flex items-center justify-center min-h-screen">
@@ -15,10 +16,10 @@
                 </svg>
             </div>
             <h1 class="text-2xl font-bold mb-6 text-center">
-                Junte-se ao HubX
+                {% trans "Junte-se ao HubX" %}
             </h1>
             <p class="text-neutral-600 mb-6">
-                Conecte-se com comunidades, empresas e organizações em uma única plataforma
+                {% trans "Conecte-se com comunidades, empresas e organizações em uma única plataforma" %}
             </p>
         </div>
 
@@ -31,9 +32,9 @@
                         <line x1="12" y1="14" x2="12" y2="3"/>
                     </svg>
                 </div>
-                <h3 class="font-semibold text-neutral-900 mb-2">Compartilhe</h3>
+                <h3 class="font-semibold text-neutral-900 mb-2">{% trans "Compartilhe" %}</h3>
                 <p class="text-sm text-neutral-600">
-                    Publique conteúdo e mantenha sua comunidade informada
+                    {% trans "Publique conteúdo e mantenha sua comunidade informada" %}
                 </p>
             </div>
             <div class="text-center">
@@ -45,9 +46,9 @@
                         <path d="M16 3.13a4 4 0 0 1 0 7.75"/>
                     </svg>
                 </div>
-                <h3 class="font-semibold text-neutral-900 mb-2">Conecte</h3>
+                <h3 class="font-semibold text-neutral-900 mb-2">{% trans "Conecte" %}</h3>
                 <p class="text-sm text-neutral-600">
-                    Encontre e conecte-se com pessoas e organizações
+                    {% trans "Encontre e conecte-se com pessoas e organizações" %}
                 </p>
             </div>
             <div class="text-center">
@@ -59,9 +60,9 @@
                         <line x1="3" y1="10" x2="21" y2="10"/>
                     </svg>
                 </div>
-                <h3 class="font-semibold text-neutral-900 mb-2">Organize</h3>
+                <h3 class="font-semibold text-neutral-900 mb-2">{% trans "Organize" %}</h3>
                 <p class="text-sm text-neutral-600">
-                    Crie e participe de eventos da sua comunidade
+                    {% trans "Crie e participe de eventos da sua comunidade" %}
                 </p>
             </div>
         </div>
@@ -74,20 +75,17 @@
                     <line x1="19" y1="8" x2="19" y2="14"/>
                     <line x1="22" y1="11" x2="16" y2="11"/>
                 </svg>
-                Começar Cadastro
+                {% trans "Começar Cadastro" %}
             </a>
             <a href="{% url 'accounts:login' %}" class="bg-gray-100 text-neutral-700 font-semibold py-2 px-4 rounded-xl">
-                Já tenho conta
+                {% trans "Já tenho conta" %}
             </a>
         </div>
 
         <div class="mt-8 pt-6 border-t border-neutral-200">
             <p class="text-xs text-neutral-500">
-                    Ao se cadastrar, você concorda com nossos
-                    <a href="#" class="text-primary-600 hover:text-primary-700">Termos de Uso</a>
-                    e
-                    <a href="#" class="text-primary-600 hover:text-primary-700">Política de Privacidade</a>
-                </p>
+                {% blocktrans trimmed %}Ao se cadastrar, você concorda com nossos <a href="#" class="text-primary-600 hover:text-primary-700">Termos de Uso</a> e <a href="#" class="text-primary-600 hover:text-primary-700">Política de Privacidade</a>{% endblocktrans %}
+            </p>
             </div>
         </div>
     </div>

--- a/accounts/templates/register/registro_sucesso.html
+++ b/accounts/templates/register/registro_sucesso.html
@@ -1,13 +1,14 @@
 {% extends "base.html" %}
+{% load i18n %}
 
-{% block title %}Registro Concluído | Hubx{% endblock %}
+{% block title %}{% trans "Registro Concluído" %} | Hubx{% endblock %}
 
 {% block content %}
 <section class="max-w-md mx-auto px-4 py-12 text-center">
   <div class="rounded-2xl border border-neutral-200 bg-white p-8 shadow-sm">
-    <h1 class="mb-4 text-3xl font-bold text-neutral-900">Bem-vindo ao HubX!</h1>
-    <p class="mb-6 text-neutral-600">Seu cadastro foi concluído com sucesso.</p>
-    <a href="{% url 'accounts:perfil' %}" class="rounded-xl bg-primary-600 px-4 py-2 text-white hover:bg-primary-700">Ir para meu Perfil →</a>
+    <h1 class="mb-4 text-3xl font-bold text-neutral-900">{% trans "Bem-vindo ao HubX!" %}</h1>
+    <p class="mb-6 text-neutral-600">{% trans "Seu cadastro foi concluído com sucesso." %}</p>
+    <a href="{% url 'accounts:perfil' %}" class="rounded-xl bg-primary-600 px-4 py-2 text-white hover:bg-primary-700">{% trans "Ir para meu Perfil →" %}</a>
   </div>
 </section>
 {% endblock %}

--- a/accounts/templates/register/senha.html
+++ b/accounts/templates/register/senha.html
@@ -1,13 +1,14 @@
 {% extends "base.html" %}
+{% load i18n %}
 
-{% block title %}Registro - Senha | Hubx{% endblock %}
+{% block title %}{% trans "Registro - Senha" %} | Hubx{% endblock %}
 
 {% block content %}
 <section class="max-w-md mx-auto px-4 py-12">
   <div class="rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
     <div class="mb-8">
       <div class="mb-2 flex items-center justify-between">
-        <span class="text-sm font-medium text-primary-600">Passo 5 de 7</span>
+        <span class="text-sm font-medium text-primary-600">{% blocktrans with step=5 total=7 %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
         <span class="text-sm text-neutral-500">70%</span>
       </div>
       <div class="h-2 w-full rounded-xl bg-neutral-200">
@@ -16,27 +17,27 @@
     </div>
 
     <div class="mb-8 text-center">
-      <h1 class="mb-2 text-3xl font-bold text-neutral-900">Crie uma senha segura</h1>
-      <p class="text-neutral-600">Proteja sua conta com uma senha forte</p>
+      <h1 class="mb-2 text-3xl font-bold text-neutral-900">{% trans "Crie uma senha segura" %}</h1>
+      <p class="text-neutral-600">{% trans "Proteja sua conta com uma senha forte" %}</p>
     </div>
 
     <form id="senhaForm" method="post" action="{% url 'accounts:senha' %}" class="space-y-6">
       {% csrf_token %}
       <div>
-        <label for="senha" class="mb-1 block text-sm font-medium text-neutral-700">Senha</label>
-        <input type="password" id="senha" name="senha" class="w-full rounded-lg border border-neutral-300 px-4 py-2 placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder="Digite sua senha" required autofocus>
+        <label for="senha" class="mb-1 block text-sm font-medium text-neutral-700">{% trans "Senha" %}</label>
+        <input type="password" id="senha" name="senha" class="w-full rounded-lg border border-neutral-300 px-4 py-2 placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder="{% trans 'Digite sua senha' %}" required autofocus>
         <div class="text-sm text-red-600" id="senha_validation"></div>
       </div>
 
       <div>
-        <label for="confirmar_senha" class="mb-1 block text-sm font-medium text-neutral-700">Confirmar Senha</label>
-        <input type="password" id="confirmar_senha" name="confirmar_senha" class="w-full rounded-lg border border-neutral-300 px-4 py-2 placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder="Confirme sua senha" required>
+        <label for="confirmar_senha" class="mb-1 block text-sm font-medium text-neutral-700">{% trans "Confirmar Senha" %}</label>
+        <input type="password" id="confirmar_senha" name="confirmar_senha" class="w-full rounded-lg border border-neutral-300 px-4 py-2 placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder="{% trans 'Confirme sua senha' %}" required>
         <div class="text-sm text-red-600" id="confirmar_senha_validation"></div>
       </div>
 
       <div class="flex gap-4">
-        <a href="{% url 'accounts:email' %}" class="flex-1 rounded-xl border border-neutral-300 px-4 py-2 text-center text-neutral-700 hover:bg-neutral-100">Voltar</a>
-        <button type="submit" id="submitButton" class="flex-1 rounded-xl bg-primary-600 px-4 py-2 text-white hover:bg-primary-700">Continuar</button>
+        <a href="{% url 'accounts:email' %}" class="flex-1 rounded-xl border border-neutral-300 px-4 py-2 text-center text-neutral-700 hover:bg-neutral-100">{% trans "Voltar" %}</a>
+        <button type="submit" id="submitButton" class="flex-1 rounded-xl bg-primary-600 px-4 py-2 text-white hover:bg-primary-700">{% trans "Continuar" %}</button>
       </div>
     </form>
   </div>

--- a/accounts/templates/register/sucesso.html
+++ b/accounts/templates/register/sucesso.html
@@ -1,13 +1,14 @@
 {% extends "base.html" %}
+{% load i18n %}
 
-{% block title %}Cadastro Concluído | HubX{% endblock %}
+{% block title %}{% trans "Cadastro Concluído" %} | HubX{% endblock %}
 
 {% block content %}
 <section class="max-w-md mx-auto px-4 py-12 text-center">
   <div class="rounded-2xl border border-neutral-200 bg-white p-8 shadow-sm">
-    <h1 class="mb-4 text-3xl font-bold text-neutral-900">Parabéns!</h1>
-    <p class="mb-6 text-neutral-600">Seu cadastro foi concluído com sucesso.</p>
-    <a href="{% url 'accounts:login' %}" class="rounded-xl bg-primary-600 px-4 py-2 text-white hover:bg-primary-700">Fazer login</a>
+    <h1 class="mb-4 text-3xl font-bold text-neutral-900">{% trans "Parabéns!" %}</h1>
+    <p class="mb-6 text-neutral-600">{% trans "Seu cadastro foi concluído com sucesso." %}</p>
+    <a href="{% url 'accounts:login' %}" class="rounded-xl bg-primary-600 px-4 py-2 text-white hover:bg-primary-700">{% trans "Fazer login" %}</a>
   </div>
 </section>
 {% endblock %}

--- a/accounts/templates/register/termos.html
+++ b/accounts/templates/register/termos.html
@@ -1,13 +1,14 @@
 {% extends "base.html" %}
+{% load i18n %}
 
-{% block title %}Registro - Termos | Hubx{% endblock %}
+{% block title %}{% trans "Registro - Termos" %} | Hubx{% endblock %}
 
 {% block content %}
 <section class="max-w-md mx-auto px-4 py-12">
   <div class="rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
     <div class="mb-8">
       <div class="mb-2 flex items-center justify-between">
-        <span class="text-sm font-medium text-primary-600">Passo 7 de 7</span>
+        <span class="text-sm font-medium text-primary-600">{% trans "Passo 7 de 7" %}</span>
         <span class="text-sm text-neutral-500">100%</span>
       </div>
       <div class="h-2 w-full rounded-xl bg-neutral-200">
@@ -16,38 +17,38 @@
     </div>
 
     <div class="mb-8 text-center">
-      <h1 class="mb-2 text-3xl font-bold text-neutral-900">Quase lá!</h1>
-      <p class="text-neutral-600">Revise e aceite os termos para finalizar</p>
+      <h1 class="mb-2 text-3xl font-bold text-neutral-900">{% trans "Quase lá!" %}</h1>
+      <p class="text-neutral-600">{% trans "Revise e aceite os termos para finalizar" %}</p>
     </div>
 
     <form id="termosForm" method="post" action="{% url 'accounts:termos' %}" class="space-y-6">
       {% csrf_token %}
       <div class="space-y-4 max-h-64 overflow-y-auto p-4 border border-neutral-200 rounded-lg">
-        <h3 class="font-semibold">Termos de Uso e Política de Privacidade</h3>
-        <p>Ao utilizar o HubX, você concorda com nossos termos de uso e política de privacidade. Abaixo estão os principais pontos:</p>
-        <h4 class="font-medium">1. Uso da Plataforma</h4>
-        <p>O HubX é uma plataforma para comunidades, entidades e associações. Você concorda em utilizar a plataforma de acordo com as leis aplicáveis e não violar os direitos de outros usuários.</p>
-        <h4 class="font-medium">2. Privacidade</h4>
-        <p>Respeitamos sua privacidade. Seus dados serão utilizados apenas para os fins especificados em nossa política de privacidade.</p>
-        <h4 class="font-medium">3. Conteúdo</h4>
-        <p>Você é responsável pelo conteúdo que compartilha na plataforma. Não toleramos conteúdo ofensivo, ilegal ou que viole direitos de terceiros.</p>
-        <h4 class="font-medium">4. Segurança</h4>
-        <p>Você é responsável por manter a segurança de sua conta e senha. Notifique-nos imediatamente sobre qualquer uso não autorizado.</p>
+        <h3 class="font-semibold">{% trans "Termos de Uso e Política de Privacidade" %}</h3>
+        <p>{% trans "Ao utilizar o HubX, você concorda com nossos termos de uso e política de privacidade. Abaixo estão os principais pontos:" %}</p>
+        <h4 class="font-medium">{% trans "1. Uso da Plataforma" %}</h4>
+        <p>{% trans "O HubX é uma plataforma para comunidades, entidades e associações. Você concorda em utilizar a plataforma de acordo com as leis aplicáveis e não violar os direitos de outros usuários." %}</p>
+        <h4 class="font-medium">{% trans "2. Privacidade" %}</h4>
+        <p>{% trans "Respeitamos sua privacidade. Seus dados serão utilizados apenas para os fins especificados em nossa política de privacidade." %}</p>
+        <h4 class="font-medium">{% trans "3. Conteúdo" %}</h4>
+        <p>{% trans "Você é responsável pelo conteúdo que compartilha na plataforma. Não toleramos conteúdo ofensivo, ilegal ou que viole direitos de terceiros." %}</p>
+        <h4 class="font-medium">{% trans "4. Segurança" %}</h4>
+        <p>{% trans "Você é responsável por manter a segurança de sua conta e senha. Notifique-nos imediatamente sobre qualquer uso não autorizado." %}</p>
       </div>
 
       <div class="flex items-start gap-2">
         <input type="checkbox" id="aceitar_termos" name="aceitar_termos" class="mt-1 rounded border-neutral-300 text-primary-600 focus:ring-primary-500" required>
-        <label for="aceitar_termos" class="text-sm text-neutral-700">Eu li e concordo com os <a href="/termos/" class="text-primary-600 hover:text-primary-700" target="_blank">Termos de Uso</a> e <a href="/privacidade/" class="text-primary-600 hover:text-primary-700" target="_blank">Política de Privacidade</a></label>
+        <label for="aceitar_termos" class="text-sm text-neutral-700">{% blocktrans trimmed %}Eu li e concordo com os <a href="/termos/" class="text-primary-600 hover:text-primary-700" target="_blank">Termos de Uso</a> e <a href="/privacidade/" class="text-primary-600 hover:text-primary-700" target="_blank">Política de Privacidade</a>{% endblocktrans %}</label>
       </div>
 
       <div class="flex items-start gap-2">
         <input type="checkbox" id="newsletter" name="newsletter" class="mt-1 rounded border-neutral-300 text-primary-600 focus:ring-primary-500">
-        <label for="newsletter" class="text-sm text-neutral-700">Quero receber atualizações e novidades do HubX</label>
+        <label for="newsletter" class="text-sm text-neutral-700">{% trans "Quero receber atualizações e novidades do HubX" %}</label>
       </div>
 
       <div class="flex gap-4">
-        <a href="{% url 'accounts:foto' %}" class="flex-1 rounded-xl border border-neutral-300 px-4 py-2 text-center text-neutral-700 hover:bg-neutral-100">Voltar</a>
-        <button type="submit" id="submitButton" class="flex-1 rounded-xl bg-primary-600 px-4 py-2 text-white hover:bg-primary-700">Finalizar Cadastro</button>
+        <a href="{% url 'accounts:foto' %}" class="flex-1 rounded-xl border border-neutral-300 px-4 py-2 text-center text-neutral-700 hover:bg-neutral-100">{% trans "Voltar" %}</a>
+        <button type="submit" id="submitButton" class="flex-1 rounded-xl bg-primary-600 px-4 py-2 text-white hover:bg-primary-700">{% trans "Finalizar Cadastro" %}</button>
       </div>
     </form>
   </div>

--- a/accounts/templates/register/token.html
+++ b/accounts/templates/register/token.html
@@ -1,13 +1,14 @@
 {% extends "base.html" %}
+{% load i18n %}
 
-{% block title %}Token de Convite - HubX{% endblock %}
+{% block title %}{% trans "Token de Convite" %} - HubX{% endblock %}
 
 {% block content %}
 <section class="max-w-md mx-auto px-4 py-12">
   <div class="rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
     <div class="mb-8">
       <div class="mb-2 flex items-center justify-between">
-        <span class="text-sm font-medium text-primary-600">Passo 1 de 7</span>
+        <span class="text-sm font-medium text-primary-600">{% blocktrans with step=1 total=7 %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
         <span class="text-sm text-neutral-500">14%</span>
       </div>
       <div class="h-2 w-full rounded-xl bg-neutral-200">
@@ -23,28 +24,28 @@
           <path d="M7 11V7a5 5 0 0 1 10 0v4"/>
         </svg>
       </div>
-      <h1 class="mb-2 text-3xl font-bold text-neutral-900">Token de Convite</h1>
-      <p class="text-neutral-600">Digite seu token de convite para começar o cadastro</p>
+      <h1 class="mb-2 text-3xl font-bold text-neutral-900">{% trans "Token de Convite" %}</h1>
+      <p class="text-neutral-600">{% trans "Digite seu token de convite para começar o cadastro" %}</p>
     </div>
 
     <form method="post" action="{% url 'tokens:token' %}" class="space-y-6">
       {% csrf_token %}
       <div>
-        <label for="token" class="mb-1 block text-sm font-medium text-neutral-700">Token de Convite</label>
-        <input type="text" id="token" name="token" class="w-full rounded-lg border border-neutral-300 px-4 py-2 text-center font-mono tracking-widest placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder="Digite seu token de convite" required autofocus>
-        <p class="mt-1 text-sm text-neutral-500">O token é necessário para continuar o cadastro na plataforma</p>
+        <label for="token" class="mb-1 block text-sm font-medium text-neutral-700">{% trans "Token de Convite" %}</label>
+        <input type="text" id="token" name="token" class="w-full rounded-lg border border-neutral-300 px-4 py-2 text-center font-mono tracking-widest placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder="{% trans 'Digite seu token de convite' %}" required autofocus>
+        <p class="mt-1 text-sm text-neutral-500">{% trans "O token é necessário para continuar o cadastro na plataforma" %}</p>
       </div>
 
       <div class="flex gap-4">
-        <a href="{% url 'accounts:login' %}" class="flex-1 rounded-xl border border-neutral-300 px-4 py-2 text-center text-neutral-700 hover:bg-neutral-100">Voltar</a>
-        <button type="submit" class="flex-1 rounded-xl bg-primary-600 px-4 py-2 text-white hover:bg-primary-700">Continuar</button>
+        <a href="{% url 'accounts:login' %}" class="flex-1 rounded-xl border border-neutral-300 px-4 py-2 text-center text-neutral-700 hover:bg-neutral-100">{% trans "Voltar" %}</a>
+        <button type="submit" class="flex-1 rounded-xl bg-primary-600 px-4 py-2 text-white hover:bg-primary-700">{% trans "Continuar" %}</button>
       </div>
     </form>
 
     <div class="mt-8 text-center">
       <p class="text-sm text-neutral-600">
-        Já tem uma conta?
-        <a href="{% url 'accounts:login' %}" class="font-medium text-primary-600 hover:text-primary-700">Entrar</a>
+        {% trans "Já tem uma conta?" %}
+        <a href="{% url 'accounts:login' %}" class="font-medium text-primary-600 hover:text-primary-700">{% trans "Entrar" %}</a>
       </p>
     </div>
   </div>

--- a/accounts/templates/register/usuario.html
+++ b/accounts/templates/register/usuario.html
@@ -1,13 +1,14 @@
 {% extends "base.html" %}
+{% load i18n %}
 
-{% block title %}Registro - Usuário | Hubx{% endblock %}
+{% block title %}{% trans "Registro - Usuário" %} | Hubx{% endblock %}
 
 {% block content %}
 <section class="max-w-md mx-auto px-4 py-12">
   <div class="rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
     <div class="mb-8">
       <div class="mb-2 flex items-center justify-between">
-        <span class="text-sm font-medium text-primary-600">Passo 2 de 7</span>
+        <span class="text-sm font-medium text-primary-600">{% blocktrans with step=2 total=7 %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
         <span class="text-sm text-neutral-500">28%</span>
       </div>
       <div class="h-2 w-full rounded-xl bg-neutral-200">
@@ -16,22 +17,22 @@
     </div>
 
     <div class="mb-8 text-center">
-      <h1 class="mb-2 text-3xl font-bold text-neutral-900">Escolha seu nome de usuário</h1>
-      <p class="text-neutral-600">Como você será identificado na plataforma</p>
+      <h1 class="mb-2 text-3xl font-bold text-neutral-900">{% trans "Escolha seu nome de usuário" %}</h1>
+      <p class="text-neutral-600">{% trans "Como você será identificado na plataforma" %}</p>
     </div>
 
     <form id="usuarioForm" method="post" action="{% url 'accounts:usuario' %}" class="space-y-6">
       {% csrf_token %}
       <div>
-        <label for="usuario" class="mb-1 block text-sm font-medium text-neutral-700">Nome de Usuário</label>
-        <input type="text" id="usuario" name="usuario" class="w-full rounded-lg border border-neutral-300 px-4 py-2 placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder="Digite seu nome de usuário" required autofocus>
+        <label for="usuario" class="mb-1 block text-sm font-medium text-neutral-700">{% trans "Nome de Usuário" %}</label>
+        <input type="text" id="usuario" name="usuario" class="w-full rounded-lg border border-neutral-300 px-4 py-2 placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder="{% trans 'Digite seu nome de usuário' %}" required autofocus>
         <div class="text-sm text-red-600" id="usuario_validation"></div>
-        <small class="text-sm text-neutral-500">Use apenas letras, números e underscore (_)</small>
+        <small class="text-sm text-neutral-500">{% trans "Use apenas letras, números e underscore (_)" %}</small>
       </div>
 
       <div class="flex gap-4">
-        <a href="{% url 'accounts:email' %}" class="flex-1 rounded-xl border border-neutral-300 px-4 py-2 text-center text-neutral-700 hover:bg-neutral-100">Voltar</a>
-        <button type="submit" id="submitButton" class="flex-1 rounded-xl bg-primary-600 px-4 py-2 text-white hover:bg-primary-700">Continuar</button>
+        <a href="{% url 'accounts:email' %}" class="flex-1 rounded-xl border border-neutral-300 px-4 py-2 text-center text-neutral-700 hover:bg-neutral-100">{% trans "Voltar" %}</a>
+        <button type="submit" id="submitButton" class="flex-1 rounded-xl bg-primary-600 px-4 py-2 text-white hover:bg-primary-700">{% trans "Continuar" %}</button>
       </div>
     </form>
   </div>

--- a/agenda/locale/en/LC_MESSAGES/django.po
+++ b/agenda/locale/en/LC_MESSAGES/django.po
@@ -1,0 +1,293 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-14 11:28-0300\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+#: templates/agenda/_lista_eventos_dia.html:3
+#, python-format
+msgid "Eventos de %(date)s"
+msgstr ""
+
+#: templates/agenda/_lista_eventos_dia.html:18
+msgid "Sem eventos."
+msgstr ""
+
+#: templates/agenda/briefing_form.html:3 templates/agenda/briefing_form.html:8
+msgid "Editar Briefing"
+msgstr ""
+
+#: templates/agenda/briefing_form.html:3 templates/agenda/briefing_form.html:8
+#: templates/agenda/briefing_list.html:13
+msgid "Novo Briefing"
+msgstr ""
+
+#: templates/agenda/briefing_form.html:14 templates/agenda/create.html:15
+#: templates/agenda/delete.html:13
+#: templates/agenda/parceria_confirm_delete.html:13
+#: templates/agenda/parceria_form.html:13 templates/agenda/update.html:26
+msgid "Cancelar"
+msgstr ""
+
+#: templates/agenda/briefing_form.html:15 templates/agenda/create.html:16
+#: templates/agenda/parceria_form.html:14 templates/agenda/update.html:27
+msgid "Salvar"
+msgstr ""
+
+#: templates/agenda/briefing_list.html:4
+msgid "Briefings"
+msgstr ""
+
+#: templates/agenda/briefing_list.html:9
+msgid "Briefings de Eventos"
+msgstr ""
+
+#: templates/agenda/briefing_list.html:34
+msgid "Buscar por evento"
+msgstr ""
+
+#: templates/agenda/briefing_list.html:41
+#: templates/agenda/inscricao_list.html:37
+#: templates/agenda/material_list.html:37
+msgid "Filtrar"
+msgstr ""
+
+#: templates/agenda/briefing_list.html:50
+#: templates/agenda/inscricao_list.html:47
+#: templates/agenda/parceria_list.html:18
+msgid "Evento"
+msgstr ""
+
+#: templates/agenda/briefing_list.html:51
+msgid "Objetivos"
+msgstr ""
+
+#: templates/agenda/briefing_list.html:52
+msgid "Público Alvo"
+msgstr ""
+
+#: templates/agenda/briefing_list.html:53
+msgid "Requisitos Técnicos"
+msgstr ""
+
+#: templates/agenda/briefing_list.html:54
+msgid "Cronograma Resumido"
+msgstr ""
+
+#: templates/agenda/briefing_list.html:55
+msgid "Conteúdo Programático"
+msgstr ""
+
+#: templates/agenda/briefing_list.html:56
+msgid "Observações"
+msgstr ""
+
+#: templates/agenda/briefing_list.html:57
+#: templates/agenda/inscricao_list.html:53
+#: templates/agenda/material_list.html:49
+#: templates/agenda/parceria_list.html:20
+msgid "Ações"
+msgstr ""
+
+#: templates/agenda/briefing_list.html:74
+#: templates/agenda/parceria_list.html:30
+msgid "Editar"
+msgstr ""
+
+#: templates/agenda/briefing_list.html:82
+msgid "Orçar"
+msgstr ""
+
+#: templates/agenda/briefing_list.html:92
+msgid "Aprovar"
+msgstr ""
+
+#: templates/agenda/briefing_list.html:102
+msgid "Recusar"
+msgstr ""
+
+#: templates/agenda/briefing_list.html:109
+msgid "Nenhum briefing encontrado."
+msgstr ""
+
+#: templates/agenda/briefing_list.html:118
+#: templates/agenda/inscricao_list.html:86
+#: templates/agenda/material_list.html:78
+msgid "Voltar à agenda"
+msgstr ""
+
+#: templates/agenda/calendario.html:15 templates/agenda/calendario.html:19
+#: templates/agenda/create.html:3
+msgid "Novo Evento"
+msgstr ""
+
+#: templates/agenda/create.html:7
+msgid "Cadastrar Evento"
+msgstr ""
+
+#: templates/agenda/delete.html:3 templates/agenda/delete.html:8
+msgid "Remover Evento"
+msgstr ""
+
+#: templates/agenda/delete.html:9
+#, python-format
+msgid "Tem certeza que deseja remover <strong>%(title)s</strong>?"
+msgstr ""
+
+#: templates/agenda/delete.html:14
+#: templates/agenda/parceria_confirm_delete.html:14
+#: templates/agenda/update.html:45
+msgid "Remover"
+msgstr ""
+
+#: templates/agenda/detail.html:21
+msgid "Início"
+msgstr ""
+
+#: templates/agenda/detail.html:22
+msgid "Fim"
+msgstr ""
+
+#: templates/agenda/detail.html:30
+msgid "Cancelar inscrição"
+msgstr ""
+
+#: templates/agenda/detail.html:32
+msgid "Inscrever-se"
+msgstr ""
+
+#: templates/agenda/detail.html:38 templates/agenda/update.html:32
+msgid "Inscritos"
+msgstr ""
+
+#: templates/agenda/detail.html:61 templates/agenda/update.html:53
+msgid "Nenhum inscrito."
+msgstr ""
+
+#: templates/agenda/detail.html:66
+msgid "Voltar"
+msgstr ""
+
+#: templates/agenda/inscricao_list.html:4
+msgid "Inscrições"
+msgstr ""
+
+#: templates/agenda/inscricao_list.html:9
+msgid "Lista de Inscrições"
+msgstr ""
+
+#: templates/agenda/inscricao_list.html:30
+msgid "Buscar por usuário ou evento"
+msgstr ""
+
+#: templates/agenda/inscricao_list.html:46
+msgid "Usuário"
+msgstr ""
+
+#: templates/agenda/inscricao_list.html:48
+msgid "Status"
+msgstr ""
+
+#: templates/agenda/inscricao_list.html:49
+msgid "Presente"
+msgstr ""
+
+#: templates/agenda/inscricao_list.html:50
+msgid "Valor Pago"
+msgstr ""
+
+#: templates/agenda/inscricao_list.html:51
+msgid "Método de Pagamento"
+msgstr ""
+
+#: templates/agenda/inscricao_list.html:52
+msgid "Observação"
+msgstr ""
+
+#: templates/agenda/inscricao_list.html:71
+msgid "Ver"
+msgstr ""
+
+#: templates/agenda/inscricao_list.html:77
+msgid "Nenhuma inscrição encontrada."
+msgstr ""
+
+#: templates/agenda/material_list.html:4 templates/agenda/material_list.html:9
+msgid "Materiais de Divulgação"
+msgstr ""
+
+#: templates/agenda/material_list.html:30
+msgid "Buscar por título"
+msgstr ""
+
+#: templates/agenda/material_list.html:46
+msgid "Título"
+msgstr ""
+
+#: templates/agenda/material_list.html:47
+msgid "Descrição"
+msgstr ""
+
+#: templates/agenda/material_list.html:48
+msgid "Arquivo"
+msgstr ""
+
+#: templates/agenda/material_list.html:63
+msgid "Download"
+msgstr ""
+
+#: templates/agenda/material_list.html:69
+msgid "Nenhum material disponível."
+msgstr ""
+
+#: templates/agenda/parceria_confirm_delete.html:4
+#: templates/agenda/parceria_confirm_delete.html:9
+msgid "Remover Parceria"
+msgstr ""
+
+#: templates/agenda/parceria_confirm_delete.html:10
+#, python-format
+msgid ""
+"Tem certeza que deseja remover <strong>%(object.empresa.nome)s</strong>?"
+msgstr ""
+
+#: templates/agenda/parceria_form.html:4 templates/agenda/parceria_form.html:8
+msgid "Parceria"
+msgstr ""
+
+#: templates/agenda/parceria_list.html:4 templates/agenda/parceria_list.html:9
+msgid "Parcerias"
+msgstr ""
+
+#: templates/agenda/parceria_list.html:17
+msgid "Empresa"
+msgstr ""
+
+#: templates/agenda/parceria_list.html:19
+msgid "Tipo"
+msgstr ""
+
+#: templates/agenda/parceria_list.html:31
+msgid "Excluir"
+msgstr ""
+
+#: templates/agenda/parceria_list.html:36
+msgid "Nenhuma parceria encontrada."
+msgstr ""
+
+#: templates/agenda/update.html:3 templates/agenda/update.html:7
+msgid "Editar Evento"
+msgstr ""

--- a/agenda/locale/pt_BR/LC_MESSAGES/django.po
+++ b/agenda/locale/pt_BR/LC_MESSAGES/django.po
@@ -1,0 +1,293 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-14 11:28-0300\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+#: templates/agenda/_lista_eventos_dia.html:3
+#, python-format
+msgid "Eventos de %(date)s"
+msgstr ""
+
+#: templates/agenda/_lista_eventos_dia.html:18
+msgid "Sem eventos."
+msgstr ""
+
+#: templates/agenda/briefing_form.html:3 templates/agenda/briefing_form.html:8
+msgid "Editar Briefing"
+msgstr ""
+
+#: templates/agenda/briefing_form.html:3 templates/agenda/briefing_form.html:8
+#: templates/agenda/briefing_list.html:13
+msgid "Novo Briefing"
+msgstr ""
+
+#: templates/agenda/briefing_form.html:14 templates/agenda/create.html:15
+#: templates/agenda/delete.html:13
+#: templates/agenda/parceria_confirm_delete.html:13
+#: templates/agenda/parceria_form.html:13 templates/agenda/update.html:26
+msgid "Cancelar"
+msgstr ""
+
+#: templates/agenda/briefing_form.html:15 templates/agenda/create.html:16
+#: templates/agenda/parceria_form.html:14 templates/agenda/update.html:27
+msgid "Salvar"
+msgstr ""
+
+#: templates/agenda/briefing_list.html:4
+msgid "Briefings"
+msgstr ""
+
+#: templates/agenda/briefing_list.html:9
+msgid "Briefings de Eventos"
+msgstr ""
+
+#: templates/agenda/briefing_list.html:34
+msgid "Buscar por evento"
+msgstr ""
+
+#: templates/agenda/briefing_list.html:41
+#: templates/agenda/inscricao_list.html:37
+#: templates/agenda/material_list.html:37
+msgid "Filtrar"
+msgstr ""
+
+#: templates/agenda/briefing_list.html:50
+#: templates/agenda/inscricao_list.html:47
+#: templates/agenda/parceria_list.html:18
+msgid "Evento"
+msgstr ""
+
+#: templates/agenda/briefing_list.html:51
+msgid "Objetivos"
+msgstr ""
+
+#: templates/agenda/briefing_list.html:52
+msgid "Público Alvo"
+msgstr ""
+
+#: templates/agenda/briefing_list.html:53
+msgid "Requisitos Técnicos"
+msgstr ""
+
+#: templates/agenda/briefing_list.html:54
+msgid "Cronograma Resumido"
+msgstr ""
+
+#: templates/agenda/briefing_list.html:55
+msgid "Conteúdo Programático"
+msgstr ""
+
+#: templates/agenda/briefing_list.html:56
+msgid "Observações"
+msgstr ""
+
+#: templates/agenda/briefing_list.html:57
+#: templates/agenda/inscricao_list.html:53
+#: templates/agenda/material_list.html:49
+#: templates/agenda/parceria_list.html:20
+msgid "Ações"
+msgstr ""
+
+#: templates/agenda/briefing_list.html:74
+#: templates/agenda/parceria_list.html:30
+msgid "Editar"
+msgstr ""
+
+#: templates/agenda/briefing_list.html:82
+msgid "Orçar"
+msgstr ""
+
+#: templates/agenda/briefing_list.html:92
+msgid "Aprovar"
+msgstr ""
+
+#: templates/agenda/briefing_list.html:102
+msgid "Recusar"
+msgstr ""
+
+#: templates/agenda/briefing_list.html:109
+msgid "Nenhum briefing encontrado."
+msgstr ""
+
+#: templates/agenda/briefing_list.html:118
+#: templates/agenda/inscricao_list.html:86
+#: templates/agenda/material_list.html:78
+msgid "Voltar à agenda"
+msgstr ""
+
+#: templates/agenda/calendario.html:15 templates/agenda/calendario.html:19
+#: templates/agenda/create.html:3
+msgid "Novo Evento"
+msgstr ""
+
+#: templates/agenda/create.html:7
+msgid "Cadastrar Evento"
+msgstr ""
+
+#: templates/agenda/delete.html:3 templates/agenda/delete.html:8
+msgid "Remover Evento"
+msgstr ""
+
+#: templates/agenda/delete.html:9
+#, python-format
+msgid "Tem certeza que deseja remover <strong>%(title)s</strong>?"
+msgstr ""
+
+#: templates/agenda/delete.html:14
+#: templates/agenda/parceria_confirm_delete.html:14
+#: templates/agenda/update.html:45
+msgid "Remover"
+msgstr ""
+
+#: templates/agenda/detail.html:21
+msgid "Início"
+msgstr ""
+
+#: templates/agenda/detail.html:22
+msgid "Fim"
+msgstr ""
+
+#: templates/agenda/detail.html:30
+msgid "Cancelar inscrição"
+msgstr ""
+
+#: templates/agenda/detail.html:32
+msgid "Inscrever-se"
+msgstr ""
+
+#: templates/agenda/detail.html:38 templates/agenda/update.html:32
+msgid "Inscritos"
+msgstr ""
+
+#: templates/agenda/detail.html:61 templates/agenda/update.html:53
+msgid "Nenhum inscrito."
+msgstr ""
+
+#: templates/agenda/detail.html:66
+msgid "Voltar"
+msgstr ""
+
+#: templates/agenda/inscricao_list.html:4
+msgid "Inscrições"
+msgstr ""
+
+#: templates/agenda/inscricao_list.html:9
+msgid "Lista de Inscrições"
+msgstr ""
+
+#: templates/agenda/inscricao_list.html:30
+msgid "Buscar por usuário ou evento"
+msgstr ""
+
+#: templates/agenda/inscricao_list.html:46
+msgid "Usuário"
+msgstr ""
+
+#: templates/agenda/inscricao_list.html:48
+msgid "Status"
+msgstr ""
+
+#: templates/agenda/inscricao_list.html:49
+msgid "Presente"
+msgstr ""
+
+#: templates/agenda/inscricao_list.html:50
+msgid "Valor Pago"
+msgstr ""
+
+#: templates/agenda/inscricao_list.html:51
+msgid "Método de Pagamento"
+msgstr ""
+
+#: templates/agenda/inscricao_list.html:52
+msgid "Observação"
+msgstr ""
+
+#: templates/agenda/inscricao_list.html:71
+msgid "Ver"
+msgstr ""
+
+#: templates/agenda/inscricao_list.html:77
+msgid "Nenhuma inscrição encontrada."
+msgstr ""
+
+#: templates/agenda/material_list.html:4 templates/agenda/material_list.html:9
+msgid "Materiais de Divulgação"
+msgstr ""
+
+#: templates/agenda/material_list.html:30
+msgid "Buscar por título"
+msgstr ""
+
+#: templates/agenda/material_list.html:46
+msgid "Título"
+msgstr ""
+
+#: templates/agenda/material_list.html:47
+msgid "Descrição"
+msgstr ""
+
+#: templates/agenda/material_list.html:48
+msgid "Arquivo"
+msgstr ""
+
+#: templates/agenda/material_list.html:63
+msgid "Download"
+msgstr ""
+
+#: templates/agenda/material_list.html:69
+msgid "Nenhum material disponível."
+msgstr ""
+
+#: templates/agenda/parceria_confirm_delete.html:4
+#: templates/agenda/parceria_confirm_delete.html:9
+msgid "Remover Parceria"
+msgstr ""
+
+#: templates/agenda/parceria_confirm_delete.html:10
+#, python-format
+msgid ""
+"Tem certeza que deseja remover <strong>%(object.empresa.nome)s</strong>?"
+msgstr ""
+
+#: templates/agenda/parceria_form.html:4 templates/agenda/parceria_form.html:8
+msgid "Parceria"
+msgstr ""
+
+#: templates/agenda/parceria_list.html:4 templates/agenda/parceria_list.html:9
+msgid "Parcerias"
+msgstr ""
+
+#: templates/agenda/parceria_list.html:17
+msgid "Empresa"
+msgstr ""
+
+#: templates/agenda/parceria_list.html:19
+msgid "Tipo"
+msgstr ""
+
+#: templates/agenda/parceria_list.html:31
+msgid "Excluir"
+msgstr ""
+
+#: templates/agenda/parceria_list.html:36
+msgid "Nenhuma parceria encontrada."
+msgstr ""
+
+#: templates/agenda/update.html:3 templates/agenda/update.html:7
+msgid "Editar Evento"
+msgstr ""

--- a/agenda/templates/agenda/_lista_eventos_dia.html
+++ b/agenda/templates/agenda/_lista_eventos_dia.html
@@ -1,5 +1,6 @@
+{% load i18n %}
 <h2 class="text-xl font-semibold mb-4">
-  Eventos de {{ dia_iso|date:"d/m/Y" }}
+  {% blocktrans trimmed with date=dia_iso|date:DATE_FORMAT %}Eventos de {{ date }}{% endblocktrans %}
 </h2>
 
 <ul class="space-y-2">
@@ -9,11 +10,11 @@
          class="block bg-white rounded shadow p-4 hover:bg-gray-50">
         <p class="font-medium">{{ ev.titulo }}</p>
         <p class="text-xs text-gray-500">
-          {{ ev.data_inicio|date:"H:i" }} – {{ ev.fim|date:"H:i" }}
+          {{ ev.data_inicio|date:TIME_FORMAT }} – {{ ev.fim|date:TIME_FORMAT }}
         </p>
       </a>
     </li>
   {% empty %}
-    <li class="text-sm text-gray-400">Sem eventos.</li>
+    <li class="text-sm text-gray-400">{% trans "Sem eventos." %}</li>
   {% endfor %}
 </ul>

--- a/agenda/templates/agenda/calendario.html
+++ b/agenda/templates/agenda/calendario.html
@@ -1,21 +1,22 @@
 {% extends "base.html" %}
+{% load i18n %}
 {% block content %}
 
 <section class="max-w-screen-xl mx-auto pt-8 px-6 lg:px-8">
   <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
     <h2 class="font-semibold text-2xl mb-4 flex items-center justify-between">
       <a href="{% url 'agenda:calendario_mes' prev_ano prev_mes %}" class="px-2 py-1 rounded hover:bg-gray-100">&laquo;</a>
-      <span>{{ data_atual|date:"F Y" }}</span>
+      <span>{{ data_atual|date:'YEAR_MONTH_FORMAT' }}</span>
       <a href="{% url 'agenda:calendario_mes' next_ano next_mes %}" class="px-2 py-1 rounded hover:bg-gray-100">&raquo;</a>
     </h2>
     {% if request.user.username != 'root' and perms.agenda.add_evento %}
     <a href="{% url 'agenda:evento_novo' %}"
        class="btn-primary inline-flex items-center gap-2 px-4 py-2 bg-primary-600 text-white rounded-md hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-600 sm:ml-auto sm:order-last mt-4 sm:mt-0"
-       aria-label="Novo Evento">
+       aria-label="{% trans 'Novo Evento' %}">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
         </svg>
-        Novo Evento
+        {% trans "Novo Evento" %}
     </a>
     {% endif %}
   </div>

--- a/agenda/templates/agenda/create.html
+++ b/agenda/templates/agenda/create.html
@@ -1,9 +1,10 @@
 {% extends 'base.html' %}
-{% block title %}Novo Evento | Hubx{% endblock %}
+{% load i18n %}
+{% block title %}{% trans "Novo Evento" %} | Hubx{% endblock %}
 
 {% block content %}
 <section class="max-w-screen-xl mx-auto pt-8 px-6 lg:px-8">
-  <h1 class="text-2xl font-bold text-neutral-900 mb-6">Cadastrar Evento</h1>
+  <h1 class="text-2xl font-bold text-neutral-900 mb-6">{% trans "Cadastrar Evento" %}</h1>
 
   <form method="post" enctype="multipart/form-data" class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 space-y-6">
     {% csrf_token %}
@@ -11,8 +12,8 @@
     {{ form.as_p }}
 
     <div class="flex justify-end gap-3 pt-4 border-t border-neutral-100">
-      <a href="{% url 'agenda:calendario' %}" class="btn-secondary" aria-label="Cancelar">Cancelar</a>
-      <button type="submit" class="btn-primary" aria-label="Salvar">Salvar</button>
+      <a href="{% url 'agenda:calendario' %}" class="btn-secondary" aria-label="{% trans 'Cancelar' %}">{% trans "Cancelar" %}</a>
+      <button type="submit" class="btn-primary" aria-label="{% trans 'Salvar' %}">{% trans "Salvar" %}</button>
     </div>
   </form>
 </section>

--- a/agenda/templates/agenda/delete.html
+++ b/agenda/templates/agenda/delete.html
@@ -1,16 +1,17 @@
 {% extends 'base.html' %}
-{% block title %}Remover Evento | Hubx{% endblock %}
+{% load i18n %}
+{% block title %}{% trans "Remover Evento" %} | Hubx{% endblock %}
 
 {% block content %}
 <section class="max-w-screen-xl mx-auto pt-8 px-6 lg:px-8">
   <div class="bg-white border border-red-200 rounded-2xl shadow-sm p-6 text-center">
-    <h2 class="text-xl font-semibold text-red-700 mb-4">Remover Evento</h2>
-    <p class="text-sm text-neutral-700">Tem certeza que deseja remover <strong>{{ object.titulo }}</strong>?</p>
+    <h2 class="text-xl font-semibold text-red-700 mb-4">{% trans "Remover Evento" %}</h2>
+    <p class="text-sm text-neutral-700">{% blocktrans with title=object.titulo %}Tem certeza que deseja remover <strong>{{ title }}</strong>?{% endblocktrans %}</p>
 
     <form method="post" class="mt-6 flex justify-center gap-3">
       {% csrf_token %}
-      <a href="{% url 'agenda:calendario' %}" class="btn-secondary" aria-label="Cancelar">Cancelar</a>
-      <button type="submit" class="btn-danger" aria-label="Remover">Remover</button>
+      <a href="{% url 'agenda:calendario' %}" class="btn-secondary" aria-label="{% trans 'Cancelar' %}">{% trans "Cancelar" %}</a>
+      <button type="submit" class="btn-danger" aria-label="{% trans 'Remover' %}">{% trans "Remover" %}</button>
     </form>
   </div>
 </section>

--- a/agenda/templates/agenda/detail.html
+++ b/agenda/templates/agenda/detail.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% load i18n %}
 {% block title %}{{ object.titulo }} | Hubx{% endblock %}
 
 {% block content %}
@@ -17,8 +18,8 @@
 
   <!-- Informações -->
   <div class="space-y-2 text-sm text-neutral-800 mb-6">
-    <p><strong>Início:</strong> {{ object.data_inicio|date:"d/m/Y H:i" }}</p>
-    <p><strong>Fim:</strong> {{ object.data_fim|date:"d/m/Y H:i" }}</p>
+    <p><strong>{% trans "Início" %}:</strong> {{ object.data_inicio|date:SHORT_DATETIME_FORMAT }}</p>
+    <p><strong>{% trans "Fim" %}:</strong> {{ object.data_fim|date:SHORT_DATETIME_FORMAT }}</p>
   </div>
 
   <!-- Inscrição -->
@@ -26,15 +27,15 @@
     <form method="post" action="{% url 'agenda:evento_subscribe' object.pk %}" class="mb-10">
       {% csrf_token %}
       {% if object.inscricoes.filter(user=user, status='confirmada').exists %}
-        <button type="submit" class="btn-secondary" aria-label="Cancelar inscrição">Cancelar inscrição</button>
+        <button type="submit" class="btn-secondary" aria-label="{% trans 'Cancelar inscrição' %}">{% trans "Cancelar inscrição" %}</button>
       {% else %}
-        <button type="submit" class="btn-primary" aria-label="Inscrever-se">Inscrever-se</button>
+        <button type="submit" class="btn-primary" aria-label="{% trans 'Inscrever-se' %}">{% trans "Inscrever-se" %}</button>
       {% endif %}
     </form>
   {% endif %}
 
   <!-- Lista de Inscritos -->
-  <h2 class="text-lg font-semibold text-neutral-900 mb-4">Inscritos</h2>
+  <h2 class="text-lg font-semibold text-neutral-900 mb-4">{% trans "Inscritos" %}</h2>
 
   {% if object.inscricoes.all %}
     <div class="grid gap-4 sm:grid-cols-2">
@@ -57,12 +58,12 @@
       {% endfor %}
     </div>
   {% else %}
-    <p class="text-sm text-neutral-500 mb-6">Nenhum inscrito.</p>
+    <p class="text-sm text-neutral-500 mb-6">{% trans "Nenhum inscrito." %}</p>
   {% endif %}
 
   <!-- Voltar -->
   <div class="flex justify-end mt-10">
-    <a href="{% url 'agenda:calendario' %}" class="btn-secondary" aria-label="Voltar">Voltar</a>
+    <a href="{% url 'agenda:calendario' %}" class="btn-secondary" aria-label="{% trans 'Voltar' %}">{% trans "Voltar" %}</a>
   </div>
 </section>
 {% endblock %}

--- a/agenda/templates/agenda/tarefa_detail.html
+++ b/agenda/templates/agenda/tarefa_detail.html
@@ -1,4 +1,6 @@
 {% extends "base.html" %}
+{% load i18n %}
+{% block title %}{{ object.titulo }} | Hubx{% endblock %}
 {% block content %}
 <h1>{{ object.titulo }}</h1>
 <p>{{ object.descricao }}</p>

--- a/agenda/templates/agenda/update.html
+++ b/agenda/templates/agenda/update.html
@@ -1,9 +1,10 @@
 {% extends 'base.html' %}
-{% block title %}Editar Evento | Hubx{% endblock %}
+{% load i18n %}
+{% block title %}{% trans "Editar Evento" %} | Hubx{% endblock %}
 
 {% block content %}
 <section class="max-w-screen-xl mx-auto pt-8 px-6 lg:px-8">
-  <h1 class="text-2xl font-bold text-neutral-900 mb-6">Editar Evento</h1>
+  <h1 class="text-2xl font-bold text-neutral-900 mb-6">{% trans "Editar Evento" %}</h1>
 
   <form method="post" enctype="multipart/form-data" class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 space-y-6">
     {% csrf_token %}
@@ -22,13 +23,13 @@
     {% endfor %}
 
     <div class="flex justify-end gap-3 pt-4 border-t border-neutral-100">
-      <a href="{% url 'agenda:calendario' %}" class="btn-secondary" aria-label="Cancelar">Cancelar</a>
-      <button type="submit" class="btn-primary" aria-label="Salvar">Salvar</button>
+      <a href="{% url 'agenda:calendario' %}" class="btn-secondary" aria-label="{% trans 'Cancelar' %}">{% trans "Cancelar" %}</a>
+      <button type="submit" class="btn-primary" aria-label="{% trans 'Salvar' %}">{% trans "Salvar" %}</button>
     </div>
   </form>
 
   <!-- Inscritos -->
-  <h2 class="text-lg font-semibold text-neutral-900 mt-10 mb-4">Inscritos</h2>
+  <h2 class="text-lg font-semibold text-neutral-900 mt-10 mb-4">{% trans "Inscritos" %}</h2>
   {% if object.inscricoes.all %}
     <div class="grid gap-4 sm:grid-cols-2">
       {% for ins in object.inscricoes.all %}
@@ -41,7 +42,7 @@
           {% if user.user_type in ("admin","gerente","root") %}
           <form method="post" action="{% url 'agenda:evento_remover_inscrito' object.pk inscrito.pk %}">
             {% csrf_token %}
-            <button type="submit" class="text-sm text-red-600 hover:underline" aria-label="Remover">Remover</button>
+            <button type="submit" class="text-sm text-red-600 hover:underline" aria-label="{% trans 'Remover' %}">{% trans "Remover" %}</button>
           </form>
           {% endif %}
         </div>
@@ -49,7 +50,7 @@
       {% endfor %}
     </div>
   {% else %}
-    <p class="text-sm text-neutral-500">Nenhum inscrito.</p>
+    <p class="text-sm text-neutral-500">{% trans "Nenhum inscrito." %}</p>
   {% endif %}
 </section>
 {% endblock %}

--- a/chat/locale/en/LC_MESSAGES/django.po
+++ b/chat/locale/en/LC_MESSAGES/django.po
@@ -1,0 +1,366 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-14 11:48-0300\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+#: templates/chat/conversation_detail.html:8
+#: templates/chat/conversation_detail.html:113
+msgid "Nenhum resultado encontrado."
+msgstr ""
+
+#: templates/chat/conversation_detail.html:8
+#: templates/chat/conversation_detail.html:132
+msgid "Carregar mais"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:8
+#: templates/chat/conversation_detail.html:55
+msgid "Limpar"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:8
+#: templates/chat/partials/message.html:35
+msgid "Adicionar reação"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:8
+msgid "Reagir com"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:8
+msgid "Fixar"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:8
+msgid "Desafixar"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:8
+#: templates/chat/partials/message.html:68
+msgid "Fixar mensagem"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:8
+msgid "Desafixar mensagem"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:8
+msgid "Editar"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:8
+msgid "Erro no upload"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:8
+#: templates/chat/partials/message.html:23
+msgid "Player de vídeo"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:32
+msgid "participantes"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:34
+msgid "Sair do canal"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:34
+msgid "Sair"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:37
+msgid "Exportar histórico"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:42
+#: templates/chat/conversation_detail.html:43
+msgid "Buscar mensagens"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:44
+#: templates/chat/conversation_detail.html:54
+msgid "Buscar"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:48
+msgid "Todos"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:49
+#: templates/chat/partials/export_modal.html:18
+msgid "Texto"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:50
+#: templates/chat/partials/export_modal.html:19
+msgid "Imagem"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:51
+#: templates/chat/partials/export_modal.html:20
+msgid "Vídeo"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:52
+#: templates/chat/partials/export_modal.html:21
+msgid "Arquivo"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:61
+#: templates/chat/conversation_detail.html:62
+msgid "Mensagens fixadas"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:73 templates/chat/modal_room.html:27
+msgid "Nenhuma mensagem."
+msgstr ""
+
+#: templates/chat/conversation_detail.html:77
+#: templates/chat/conversation_detail.html:82
+msgid "Enviar mensagem"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:79
+msgid "Mensagem"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:81
+msgid "Enviar arquivo"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:82
+msgid "Enviar"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:88
+msgid "Editar mensagem"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:91
+msgid "Cancelar edição"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:91
+msgid "Cancelar"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:92
+msgid "Salvar mensagem editada"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:92
+msgid "Salvar"
+msgstr ""
+
+#: templates/chat/conversation_form.html:4
+#: templates/chat/conversation_form.html:8
+#: templates/chat/conversation_list.html:13
+#: templates/chat/conversation_list.html:15
+msgid "Nova conversa"
+msgstr ""
+
+#: templates/chat/conversation_form.html:55
+msgid "Criar"
+msgstr ""
+
+#: templates/chat/conversation_list.html:4
+msgid "Conversas"
+msgstr ""
+
+#: templates/chat/conversation_list.html:9
+msgid "Minhas conversas"
+msgstr ""
+
+#: templates/chat/conversation_list.html:18
+msgid "Canais de chat"
+msgstr ""
+
+#: templates/chat/conversation_list.html:22
+msgid "Privado"
+msgstr ""
+
+#: templates/chat/conversation_list.html:22
+msgid "Núcleo"
+msgstr ""
+
+#: templates/chat/conversation_list.html:22
+msgid "Evento"
+msgstr ""
+
+#: templates/chat/conversation_list.html:22
+msgid "Organização"
+msgstr ""
+
+#: templates/chat/conversation_list.html:24
+msgid "Lista de conversas"
+msgstr ""
+
+#: templates/chat/conversation_list.html:51
+msgid "Nenhuma conversa."
+msgstr ""
+
+#: templates/chat/historico_edicoes.html:5
+#: templates/chat/partials/message.html:77
+msgid "Histórico de edições"
+msgstr ""
+
+#: templates/chat/historico_edicoes.html:9
+#: templates/chat/partials/export_modal.html:10
+msgid "Início"
+msgstr ""
+
+#: templates/chat/historico_edicoes.html:13
+#: templates/chat/partials/export_modal.html:13
+msgid "Fim"
+msgstr ""
+
+#: templates/chat/historico_edicoes.html:16
+msgid "Filtrar"
+msgstr ""
+
+#: templates/chat/historico_edicoes.html:17
+msgid "Exportar CSV"
+msgstr ""
+
+#: templates/chat/historico_edicoes.html:23
+msgid "Data"
+msgstr ""
+
+#: templates/chat/historico_edicoes.html:24
+msgid "Moderador"
+msgstr ""
+
+#: templates/chat/historico_edicoes.html:25
+msgid "Conteúdo anterior"
+msgstr ""
+
+#: templates/chat/historico_edicoes.html:26
+msgid "Ações"
+msgstr ""
+
+#: templates/chat/historico_edicoes.html:39
+msgid "Restaurar"
+msgstr ""
+
+#: templates/chat/historico_edicoes.html:45
+msgid "Nenhum registro"
+msgstr ""
+
+#: templates/chat/historico_edicoes.html:54
+msgid "Anterior"
+msgstr ""
+
+#: templates/chat/historico_edicoes.html:60
+msgid "Próxima"
+msgstr ""
+
+#: templates/chat/modal_room.html:15 templates/chat/modal_user_list.html:15
+msgid "Fechar"
+msgstr ""
+
+#: templates/chat/modal_user_list.html:17
+msgid "Escolha um usuário para conversar"
+msgstr ""
+
+#: templates/chat/modal_user_list.html:40
+msgid "Nenhum outro membro encontrado."
+msgstr ""
+
+#: templates/chat/moderacao.html:5
+msgid "Moderação"
+msgstr ""
+
+#: templates/chat/moderacao.html:10
+msgid "Flags"
+msgstr ""
+
+#: templates/chat/moderacao.html:11
+msgid "Aprovar"
+msgstr ""
+
+#: templates/chat/moderacao.html:12
+msgid "Remover"
+msgstr ""
+
+#: templates/chat/moderacao.html:15
+msgid "Nenhuma mensagem sinalizada."
+msgstr ""
+
+#: templates/chat/partials/export_modal.html:4
+msgid "Formato"
+msgstr ""
+
+#: templates/chat/partials/export_modal.html:6
+msgid "JSON"
+msgstr ""
+
+#: templates/chat/partials/export_modal.html:7
+msgid "CSV"
+msgstr ""
+
+#: templates/chat/partials/export_modal.html:17
+msgid "Tipos"
+msgstr ""
+
+#: templates/chat/partials/export_modal.html:23
+msgid "Exportar"
+msgstr ""
+
+#: templates/chat/partials/export_modal.html:24
+msgid "Gerando..."
+msgstr ""
+
+#: templates/chat/partials/message.html:14
+msgid "Mensagem fixada"
+msgstr ""
+
+#: templates/chat/partials/message.html:15
+msgid "Oculta"
+msgstr ""
+
+#: templates/chat/partials/message.html:42
+msgid "Reagir com 🙂"
+msgstr ""
+
+#: templates/chat/partials/message.html:45
+msgid "Reagir com ❤️"
+msgstr ""
+
+#: templates/chat/partials/message.html:48
+msgid "Reagir com 👍"
+msgstr ""
+
+#: templates/chat/partials/message.html:51
+msgid "Reagir com 😂"
+msgstr ""
+
+#: templates/chat/partials/message.html:54
+msgid "Reagir com 🎉"
+msgstr ""
+
+#: templates/chat/partials/message.html:57
+msgid "Reagir com 😢"
+msgstr ""
+
+#: templates/chat/partials/message.html:60
+msgid "Reagir com 😡"
+msgstr ""
+
+#: templates/chat/partials/message.html:80
+msgid "Histórico"
+msgstr ""

--- a/chat/locale/pt_BR/LC_MESSAGES/django.po
+++ b/chat/locale/pt_BR/LC_MESSAGES/django.po
@@ -1,0 +1,366 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-14 11:48-0300\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+#: templates/chat/conversation_detail.html:8
+#: templates/chat/conversation_detail.html:113
+msgid "Nenhum resultado encontrado."
+msgstr ""
+
+#: templates/chat/conversation_detail.html:8
+#: templates/chat/conversation_detail.html:132
+msgid "Carregar mais"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:8
+#: templates/chat/conversation_detail.html:55
+msgid "Limpar"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:8
+#: templates/chat/partials/message.html:35
+msgid "Adicionar reação"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:8
+msgid "Reagir com"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:8
+msgid "Fixar"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:8
+msgid "Desafixar"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:8
+#: templates/chat/partials/message.html:68
+msgid "Fixar mensagem"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:8
+msgid "Desafixar mensagem"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:8
+msgid "Editar"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:8
+msgid "Erro no upload"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:8
+#: templates/chat/partials/message.html:23
+msgid "Player de vídeo"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:32
+msgid "participantes"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:34
+msgid "Sair do canal"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:34
+msgid "Sair"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:37
+msgid "Exportar histórico"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:42
+#: templates/chat/conversation_detail.html:43
+msgid "Buscar mensagens"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:44
+#: templates/chat/conversation_detail.html:54
+msgid "Buscar"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:48
+msgid "Todos"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:49
+#: templates/chat/partials/export_modal.html:18
+msgid "Texto"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:50
+#: templates/chat/partials/export_modal.html:19
+msgid "Imagem"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:51
+#: templates/chat/partials/export_modal.html:20
+msgid "Vídeo"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:52
+#: templates/chat/partials/export_modal.html:21
+msgid "Arquivo"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:61
+#: templates/chat/conversation_detail.html:62
+msgid "Mensagens fixadas"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:73 templates/chat/modal_room.html:27
+msgid "Nenhuma mensagem."
+msgstr ""
+
+#: templates/chat/conversation_detail.html:77
+#: templates/chat/conversation_detail.html:82
+msgid "Enviar mensagem"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:79
+msgid "Mensagem"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:81
+msgid "Enviar arquivo"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:82
+msgid "Enviar"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:88
+msgid "Editar mensagem"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:91
+msgid "Cancelar edição"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:91
+msgid "Cancelar"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:92
+msgid "Salvar mensagem editada"
+msgstr ""
+
+#: templates/chat/conversation_detail.html:92
+msgid "Salvar"
+msgstr ""
+
+#: templates/chat/conversation_form.html:4
+#: templates/chat/conversation_form.html:8
+#: templates/chat/conversation_list.html:13
+#: templates/chat/conversation_list.html:15
+msgid "Nova conversa"
+msgstr ""
+
+#: templates/chat/conversation_form.html:55
+msgid "Criar"
+msgstr ""
+
+#: templates/chat/conversation_list.html:4
+msgid "Conversas"
+msgstr ""
+
+#: templates/chat/conversation_list.html:9
+msgid "Minhas conversas"
+msgstr ""
+
+#: templates/chat/conversation_list.html:18
+msgid "Canais de chat"
+msgstr ""
+
+#: templates/chat/conversation_list.html:22
+msgid "Privado"
+msgstr ""
+
+#: templates/chat/conversation_list.html:22
+msgid "Núcleo"
+msgstr ""
+
+#: templates/chat/conversation_list.html:22
+msgid "Evento"
+msgstr ""
+
+#: templates/chat/conversation_list.html:22
+msgid "Organização"
+msgstr ""
+
+#: templates/chat/conversation_list.html:24
+msgid "Lista de conversas"
+msgstr ""
+
+#: templates/chat/conversation_list.html:51
+msgid "Nenhuma conversa."
+msgstr ""
+
+#: templates/chat/historico_edicoes.html:5
+#: templates/chat/partials/message.html:77
+msgid "Histórico de edições"
+msgstr ""
+
+#: templates/chat/historico_edicoes.html:9
+#: templates/chat/partials/export_modal.html:10
+msgid "Início"
+msgstr ""
+
+#: templates/chat/historico_edicoes.html:13
+#: templates/chat/partials/export_modal.html:13
+msgid "Fim"
+msgstr ""
+
+#: templates/chat/historico_edicoes.html:16
+msgid "Filtrar"
+msgstr ""
+
+#: templates/chat/historico_edicoes.html:17
+msgid "Exportar CSV"
+msgstr ""
+
+#: templates/chat/historico_edicoes.html:23
+msgid "Data"
+msgstr ""
+
+#: templates/chat/historico_edicoes.html:24
+msgid "Moderador"
+msgstr ""
+
+#: templates/chat/historico_edicoes.html:25
+msgid "Conteúdo anterior"
+msgstr ""
+
+#: templates/chat/historico_edicoes.html:26
+msgid "Ações"
+msgstr ""
+
+#: templates/chat/historico_edicoes.html:39
+msgid "Restaurar"
+msgstr ""
+
+#: templates/chat/historico_edicoes.html:45
+msgid "Nenhum registro"
+msgstr ""
+
+#: templates/chat/historico_edicoes.html:54
+msgid "Anterior"
+msgstr ""
+
+#: templates/chat/historico_edicoes.html:60
+msgid "Próxima"
+msgstr ""
+
+#: templates/chat/modal_room.html:15 templates/chat/modal_user_list.html:15
+msgid "Fechar"
+msgstr ""
+
+#: templates/chat/modal_user_list.html:17
+msgid "Escolha um usuário para conversar"
+msgstr ""
+
+#: templates/chat/modal_user_list.html:40
+msgid "Nenhum outro membro encontrado."
+msgstr ""
+
+#: templates/chat/moderacao.html:5
+msgid "Moderação"
+msgstr ""
+
+#: templates/chat/moderacao.html:10
+msgid "Flags"
+msgstr ""
+
+#: templates/chat/moderacao.html:11
+msgid "Aprovar"
+msgstr ""
+
+#: templates/chat/moderacao.html:12
+msgid "Remover"
+msgstr ""
+
+#: templates/chat/moderacao.html:15
+msgid "Nenhuma mensagem sinalizada."
+msgstr ""
+
+#: templates/chat/partials/export_modal.html:4
+msgid "Formato"
+msgstr ""
+
+#: templates/chat/partials/export_modal.html:6
+msgid "JSON"
+msgstr ""
+
+#: templates/chat/partials/export_modal.html:7
+msgid "CSV"
+msgstr ""
+
+#: templates/chat/partials/export_modal.html:17
+msgid "Tipos"
+msgstr ""
+
+#: templates/chat/partials/export_modal.html:23
+msgid "Exportar"
+msgstr ""
+
+#: templates/chat/partials/export_modal.html:24
+msgid "Gerando..."
+msgstr ""
+
+#: templates/chat/partials/message.html:14
+msgid "Mensagem fixada"
+msgstr ""
+
+#: templates/chat/partials/message.html:15
+msgid "Oculta"
+msgstr ""
+
+#: templates/chat/partials/message.html:42
+msgid "Reagir com 🙂"
+msgstr ""
+
+#: templates/chat/partials/message.html:45
+msgid "Reagir com ❤️"
+msgstr ""
+
+#: templates/chat/partials/message.html:48
+msgid "Reagir com 👍"
+msgstr ""
+
+#: templates/chat/partials/message.html:51
+msgid "Reagir com 😂"
+msgstr ""
+
+#: templates/chat/partials/message.html:54
+msgid "Reagir com 🎉"
+msgstr ""
+
+#: templates/chat/partials/message.html:57
+msgid "Reagir com 😢"
+msgstr ""
+
+#: templates/chat/partials/message.html:60
+msgid "Reagir com 😡"
+msgstr ""
+
+#: templates/chat/partials/message.html:80
+msgid "Histórico"
+msgstr ""

--- a/chat/templates/chat/partials/export_modal.html
+++ b/chat/templates/chat/partials/export_modal.html
@@ -1,25 +1,26 @@
+{% load i18n %}
 <div class="bg-white p-4 border rounded">
   <form hx-get="/api/chat/channels/{{ channel.id }}/export/" hx-target="#export-status" hx-swap="innerHTML" hx-indicator="#export-progress">
-    <label class="block mb-2">Formato
+    <label class="block mb-2">{% trans "Formato" %}
       <select name="formato" class="border rounded p-1">
-        <option value="json">JSON</option>
-        <option value="csv">CSV</option>
+        <option value="json">{% trans "JSON" %}</option>
+        <option value="csv">{% trans "CSV" %}</option>
       </select>
     </label>
-    <label class="block mb-2">Início
+    <label class="block mb-2">{% trans "Início" %}
       <input type="date" name="inicio" class="border rounded p-1" />
     </label>
-    <label class="block mb-2">Fim
+    <label class="block mb-2">{% trans "Fim" %}
       <input type="date" name="fim" class="border rounded p-1" />
     </label>
     <fieldset class="mb-2">
-      <legend class="mb-1">Tipos</legend>
-      <label class="mr-2"><input type="checkbox" name="tipos" value="text" /> Texto</label>
-      <label class="mr-2"><input type="checkbox" name="tipos" value="image" /> Imagem</label>
-      <label class="mr-2"><input type="checkbox" name="tipos" value="video" /> Vídeo</label>
-      <label class="mr-2"><input type="checkbox" name="tipos" value="file" /> Arquivo</label>
+      <legend class="mb-1">{% trans "Tipos" %}</legend>
+      <label class="mr-2"><input type="checkbox" name="tipos" value="text" /> {% trans "Texto" %}</label>
+      <label class="mr-2"><input type="checkbox" name="tipos" value="image" /> {% trans "Imagem" %}</label>
+      <label class="mr-2"><input type="checkbox" name="tipos" value="video" /> {% trans "Vídeo" %}</label>
+      <label class="mr-2"><input type="checkbox" name="tipos" value="file" /> {% trans "Arquivo" %}</label>
     </fieldset>
-    <button type="submit" class="bg-primary text-white px-4 py-2 rounded">Exportar</button>
+    <button type="submit" class="bg-primary text-white px-4 py-2 rounded">{% trans "Exportar" %}</button>
     <span id="export-progress" class="htmx-indicator ml-2">{% trans "Gerando..." %}</span>
   </form>
   <div id="export-status" class="mt-2"></div>

--- a/chat/templates/chat/partials/message.html
+++ b/chat/templates/chat/partials/message.html
@@ -10,7 +10,7 @@
   <div class="flex-1">
     <header class="flex items-center gap-2 text-xs text-gray-500">
       <span class="font-semibold text-gray-700">{{ m.remetente.username }}</span>
-      <time datetime="{{ m.created|date:'c' }}">{{ m.created|date:"d/m/Y H:i" }}</time>
+      <time datetime="{{ m.created|date:'c' }}">{{ m.created|date:SHORT_DATETIME_FORMAT }}</time>
       {% if m.pinned_at %}<span class="text-primary" aria-label="{% trans 'Mensagem fixada' %}">📌</span>{% endif %}
       {% if m.hidden_at %}<span class="text-red-500">{% trans "Oculta" %}</span>{% endif %}
     </header>

--- a/core/locale/en/LC_MESSAGES/django.po
+++ b/core/locale/en/LC_MESSAGES/django.po
@@ -1,0 +1,155 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-14 13:04-0300\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+#: templates/core/about.html:4
+msgid "Sobre"
+msgstr ""
+
+#: templates/core/about.html:8
+msgid "Sobre o HubX"
+msgstr ""
+
+#: templates/core/about.html:9
+msgid ""
+"HubX é uma plataforma colaborativa que integra comunidades de organizações, "
+"empresas e voluntários."
+msgstr ""
+
+#: templates/core/about.html:10
+msgid ""
+"Nosso objetivo é facilitar a comunicação, gestão de eventos e colaboração "
+"entre membros."
+msgstr ""
+
+#: templates/core/home.html:4
+msgid "Bem-vindo ao HubX"
+msgstr ""
+
+#: templates/core/home.html:9
+msgid "Junte-se à comunidade Hubx.space"
+msgstr ""
+
+#: templates/core/home.html:10
+msgid "Plataforma colaborativa que conecta organizações, empresas e pessoas."
+msgstr ""
+
+#: templates/core/home.html:13
+msgid "Ir para Dashboard"
+msgstr ""
+
+#: templates/core/home.html:14
+msgid "Ver Feed"
+msgstr ""
+
+#: templates/core/home.html:18
+msgid "Criar conta"
+msgstr ""
+
+#: templates/core/home.html:19
+msgid "Entrar"
+msgstr ""
+
+#: templates/core/home.html:28
+msgid "Principais Funcionalidades"
+msgstr ""
+
+#: templates/core/home.html:32
+msgid "Feed/Mural"
+msgstr ""
+
+#: templates/core/home.html:33
+msgid "Compartilhe novidades e acompanhe atualizações."
+msgstr ""
+
+#: templates/core/home.html:34 templates/core/home.html:40
+#: templates/core/home.html:46 templates/core/home.html:52
+#: templates/core/home.html:58
+msgid "Acessar"
+msgstr ""
+
+#: templates/core/home.html:38
+msgid "Agenda"
+msgstr ""
+
+#: templates/core/home.html:39
+msgid "Organize eventos e gerencie inscrições."
+msgstr ""
+
+#: templates/core/home.html:44
+msgid "Núcleos"
+msgstr ""
+
+#: templates/core/home.html:45
+msgid "Encontre grupos de interesse e colabore."
+msgstr ""
+
+#: templates/core/home.html:50
+msgid "Dashboard/Financeiro"
+msgstr ""
+
+#: templates/core/home.html:51
+msgid "Acompanhe métricas e controle financeiro."
+msgstr ""
+
+#: templates/core/home.html:56
+msgid "Notificações"
+msgstr ""
+
+#: templates/core/home.html:57
+msgid "Centralize alertas e preferências de contato."
+msgstr ""
+
+#: templates/core/home.html:67
+msgid "Próximos Eventos"
+msgstr ""
+
+#: templates/core/home.html:69
+msgid "Carregando eventos..."
+msgstr ""
+
+#: templates/core/home.html:78
+msgid "Posts em destaque"
+msgstr ""
+
+#: templates/core/home.html:80
+msgid "Carregando posts..."
+msgstr ""
+
+#: templates/core/home.html:88
+msgid "Hubx"
+msgstr ""
+
+#: templates/core/privacy.html:4 templates/core/privacy.html:8
+msgid "Política de Privacidade"
+msgstr ""
+
+#: templates/core/privacy.html:9
+msgid ""
+"Seus dados pessoais são tratados com segurança e apenas para fins da "
+"plataforma."
+msgstr ""
+
+#: templates/core/terms.html:4 templates/core/terms.html:8
+msgid "Termos de Uso"
+msgstr ""
+
+#: templates/core/terms.html:9
+msgid ""
+"Ao utilizar o HubX, você concorda com nossas políticas de uso e privacidade."
+msgstr ""

--- a/core/locale/pt_BR/LC_MESSAGES/django.po
+++ b/core/locale/pt_BR/LC_MESSAGES/django.po
@@ -1,0 +1,155 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-14 13:04-0300\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+#: templates/core/about.html:4
+msgid "Sobre"
+msgstr ""
+
+#: templates/core/about.html:8
+msgid "Sobre o HubX"
+msgstr ""
+
+#: templates/core/about.html:9
+msgid ""
+"HubX é uma plataforma colaborativa que integra comunidades de organizações, "
+"empresas e voluntários."
+msgstr ""
+
+#: templates/core/about.html:10
+msgid ""
+"Nosso objetivo é facilitar a comunicação, gestão de eventos e colaboração "
+"entre membros."
+msgstr ""
+
+#: templates/core/home.html:4
+msgid "Bem-vindo ao HubX"
+msgstr ""
+
+#: templates/core/home.html:9
+msgid "Junte-se à comunidade Hubx.space"
+msgstr ""
+
+#: templates/core/home.html:10
+msgid "Plataforma colaborativa que conecta organizações, empresas e pessoas."
+msgstr ""
+
+#: templates/core/home.html:13
+msgid "Ir para Dashboard"
+msgstr ""
+
+#: templates/core/home.html:14
+msgid "Ver Feed"
+msgstr ""
+
+#: templates/core/home.html:18
+msgid "Criar conta"
+msgstr ""
+
+#: templates/core/home.html:19
+msgid "Entrar"
+msgstr ""
+
+#: templates/core/home.html:28
+msgid "Principais Funcionalidades"
+msgstr ""
+
+#: templates/core/home.html:32
+msgid "Feed/Mural"
+msgstr ""
+
+#: templates/core/home.html:33
+msgid "Compartilhe novidades e acompanhe atualizações."
+msgstr ""
+
+#: templates/core/home.html:34 templates/core/home.html:40
+#: templates/core/home.html:46 templates/core/home.html:52
+#: templates/core/home.html:58
+msgid "Acessar"
+msgstr ""
+
+#: templates/core/home.html:38
+msgid "Agenda"
+msgstr ""
+
+#: templates/core/home.html:39
+msgid "Organize eventos e gerencie inscrições."
+msgstr ""
+
+#: templates/core/home.html:44
+msgid "Núcleos"
+msgstr ""
+
+#: templates/core/home.html:45
+msgid "Encontre grupos de interesse e colabore."
+msgstr ""
+
+#: templates/core/home.html:50
+msgid "Dashboard/Financeiro"
+msgstr ""
+
+#: templates/core/home.html:51
+msgid "Acompanhe métricas e controle financeiro."
+msgstr ""
+
+#: templates/core/home.html:56
+msgid "Notificações"
+msgstr ""
+
+#: templates/core/home.html:57
+msgid "Centralize alertas e preferências de contato."
+msgstr ""
+
+#: templates/core/home.html:67
+msgid "Próximos Eventos"
+msgstr ""
+
+#: templates/core/home.html:69
+msgid "Carregando eventos..."
+msgstr ""
+
+#: templates/core/home.html:78
+msgid "Posts em destaque"
+msgstr ""
+
+#: templates/core/home.html:80
+msgid "Carregando posts..."
+msgstr ""
+
+#: templates/core/home.html:88
+msgid "Hubx"
+msgstr ""
+
+#: templates/core/privacy.html:4 templates/core/privacy.html:8
+msgid "Política de Privacidade"
+msgstr ""
+
+#: templates/core/privacy.html:9
+msgid ""
+"Seus dados pessoais são tratados com segurança e apenas para fins da "
+"plataforma."
+msgstr ""
+
+#: templates/core/terms.html:4 templates/core/terms.html:8
+msgid "Termos de Uso"
+msgstr ""
+
+#: templates/core/terms.html:9
+msgid ""
+"Ao utilizar o HubX, você concorda com nossas políticas de uso e privacidade."
+msgstr ""

--- a/core/templates/core/home.html
+++ b/core/templates/core/home.html
@@ -85,6 +85,6 @@
 </main>
 
 <footer class="py-6 text-center text-sm text-neutral-500">
-  &copy; {{ now|date:"Y" }} Hubx
+  &copy; {{ now|date:"Y" }} {% trans "Hubx" %}
 </footer>
 {% endblock %}

--- a/dashboard/locale/en/LC_MESSAGES/django.po
+++ b/dashboard/locale/en/LC_MESSAGES/django.po
@@ -1,20 +1,479 @@
 msgid ""
 msgstr ""
-"Content-Type: text/plain; charset=UTF-8\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-14 16:57+0000\n"
 "Language: en\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 
-#: templates/dashboard/export_pdf.html:5 templates/dashboard/export_pdf.html:13
+#: templates/dashboard/achievement_list.html:4
+#: templates/dashboard/achievement_list.html:7
+#: templates/dashboard/achievement_list.html:8
+msgid "Conquistas"
+msgstr ""
+
+#: templates/dashboard/achievement_list.html:17
+msgid "Concluída"
+msgstr ""
+
+#: templates/dashboard/achievement_list.html:19
+msgid "Pendente"
+msgstr ""
+
+#: templates/dashboard/achievement_list.html:23
+msgid "Nenhuma conquista cadastrada."
+msgstr ""
+
+#: templates/dashboard/admin.html:5
+msgid "Dashboard Admin"
+msgstr ""
+
+#: templates/dashboard/admin.html:8 templates/dashboard/root.html:8
+msgid "Dashboard"
+msgstr ""
+
+#: templates/dashboard/admin.html:9
+msgid "Dashboard Administrativo"
+msgstr ""
+
+#: templates/dashboard/admin.html:21
+msgid "Comparar com média global"
+msgstr ""
+
+#: templates/dashboard/admin.html:22
+msgid "Ativar comparativo de métricas"
+msgstr ""
+
+#: templates/dashboard/admin.html:23
+msgid "Gráfico comparativo"
+msgstr ""
+
+#: templates/dashboard/admin.html:41
+msgid "Atual"
+msgstr ""
+
+#: templates/dashboard/admin.html:41
+msgid "Média"
+msgstr ""
+
+#: templates/dashboard/admin.html:42
+msgid "Usuários"
+msgstr ""
+
+#: templates/dashboard/admin.html:55 templates/dashboard/root.html:21
+msgid "Distribuição de Métricas"
+msgstr ""
+
+#: templates/dashboard/admin.html:63
+#, fuzzy
+#| msgid "Métricas do Dashboard"
+msgid "Métricas do Feed"
+msgstr "Dashboard Metrics"
+
+#: templates/dashboard/admin.html:65
+msgid "Posts por tipo"
+msgstr ""
+
+#: templates/dashboard/admin.html:66
+msgid "Top tags"
+msgstr ""
+
+#: templates/dashboard/admin.html:67
+msgid "Top autores"
+msgstr ""
+
+#: templates/dashboard/admin.html:95 templates/dashboard/gerente.html:25
+#: templates/dashboard/root.html:55
+msgid "Ações Rápidas"
+msgstr ""
+
+#: templates/dashboard/admin.html:99
+msgid "Administrar Usuários"
+msgstr ""
+
+#: templates/dashboard/admin.html:103
+msgid "Aprovar Eventos"
+msgstr ""
+
+#: templates/dashboard/admin.html:107
+msgid "Relatórios Financeiros"
+msgstr ""
+
+#: templates/dashboard/admin.html:111
+msgid "Logs de Notificações"
+msgstr ""
+
+#: templates/dashboard/cliente.html:5 templates/dashboard/cliente.html:9
+msgid "Dashboard Cliente"
+msgstr ""
+
+#: templates/dashboard/cliente.html:27
+msgid "Atalhos"
+msgstr ""
+
+#: templates/dashboard/cliente.html:31
+msgid "Inscrever-se em Eventos"
+msgstr ""
+
+#: templates/dashboard/cliente.html:35
+msgid "Ver Feed"
+msgstr ""
+
+#: templates/dashboard/config_form.html:3
+#: templates/dashboard/config_form.html:6
+msgid "Salvar filtros"
+msgstr ""
+
+#: templates/dashboard/config_form.html:7
+msgid "Formulário de configuração do dashboard"
+msgstr ""
+
+#: templates/dashboard/config_form.html:10
+#: templates/dashboard/filter_form.html:10
+#: templates/dashboard/layout_form.html:10
+msgid "Nome"
+msgstr ""
+
+#: templates/dashboard/config_form.html:15
+#: templates/dashboard/filter_form.html:15
+msgid "Público"
+msgstr ""
+
+#: templates/dashboard/config_form.html:17
+#: templates/dashboard/partials/filters_form.html:64
+msgid "Salvar configuração"
+msgstr ""
+
+#: templates/dashboard/config_form.html:17
+#: templates/dashboard/filter_form.html:17
+#: templates/dashboard/layout_form.html:18
+msgid "Salvar"
+msgstr ""
+
+#: templates/dashboard/config_list.html:3
+#: templates/dashboard/config_list.html:6
+msgid "Configurações salvas"
+msgstr ""
+
+#: templates/dashboard/config_list.html:12
+msgid "Aplicar configuração"
+msgstr ""
+
+#: templates/dashboard/config_list.html:12
+#: templates/dashboard/filter_list.html:13
+msgid "Aplicar"
+msgstr ""
+
+#: templates/dashboard/config_list.html:15
+msgid "Nenhuma configuração salva."
+msgstr ""
+
+#: templates/dashboard/export_pdf.html:7 templates/dashboard/export_pdf.html:15
 msgid "Métricas do Dashboard"
 msgstr "Dashboard Metrics"
 
-#: templates/dashboard/export_pdf.html:16
+#: templates/dashboard/export_pdf.html:18
 msgid "Métrica"
 msgstr "Metric"
 
-#: templates/dashboard/export_pdf.html:16
+#: templates/dashboard/export_pdf.html:18
 msgid "Total"
 msgstr "Total"
 
-#: templates/dashboard/export_pdf.html:16
-msgid "Variação (%)"
+#: templates/dashboard/export_pdf.html:18
+#, fuzzy, python-format
+#| msgid "Variação (%)"
+msgid "Variação (%%)"
 msgstr "Change (%)"
+
+#: templates/dashboard/filter_form.html:3
+#: templates/dashboard/filter_form.html:6
+#: templates/dashboard/filter_form.html:17
+#: templates/dashboard/partials/filters_form.html:62
+msgid "Salvar filtro"
+msgstr ""
+
+#: templates/dashboard/filter_form.html:7
+msgid "Formulário de filtro rápido"
+msgstr ""
+
+#: templates/dashboard/filter_list.html:3
+#: templates/dashboard/filter_list.html:6
+msgid "Filtros salvos"
+msgstr ""
+
+#: templates/dashboard/filter_list.html:13
+msgid "Aplicar filtro"
+msgstr ""
+
+#: templates/dashboard/filter_list.html:16
+msgid "Excluir filtro"
+msgstr ""
+
+#: templates/dashboard/filter_list.html:16
+#: templates/dashboard/layout_confirm_delete.html:10
+msgid "Excluir"
+msgstr ""
+
+#: templates/dashboard/filter_list.html:21
+msgid "Nenhum filtro salvo."
+msgstr ""
+
+#: templates/dashboard/gerente.html:5 templates/dashboard/gerente.html:9
+msgid "Dashboard Gerente"
+msgstr ""
+
+#: templates/dashboard/gerente.html:29
+msgid "Aprovar Tarefas"
+msgstr ""
+
+#: templates/dashboard/gerente.html:33
+msgid "Gerenciar Eventos"
+msgstr ""
+
+#: templates/dashboard/layout_confirm_delete.html:3
+#: templates/dashboard/layout_confirm_delete.html:6
+msgid "Excluir Layout"
+msgstr ""
+
+#: templates/dashboard/layout_confirm_delete.html:7
+msgid "Tem certeza que deseja excluir este layout?"
+msgstr ""
+
+#: templates/dashboard/layout_form.html:3
+#: templates/dashboard/layout_form.html:6
+msgid "Layout"
+msgstr ""
+
+#: templates/dashboard/layout_form.html:5
+msgid "Layout form"
+msgstr ""
+
+#: templates/dashboard/layout_list.html:3
+#: templates/dashboard/layout_list.html:5
+msgid "Layouts"
+msgstr ""
+
+#: templates/dashboard/layout_list.html:6
+msgid "Meus Layouts"
+msgstr ""
+
+#: templates/dashboard/layout_list.html:11
+msgid "Nenhum layout"
+msgstr ""
+
+#: templates/dashboard/layout_list.html:14
+msgid "Novo Layout"
+msgstr ""
+
+#: templates/dashboard/partials/achievements_badges.html:2
+msgid "Conquistas alcançadas"
+msgstr ""
+
+#: templates/dashboard/partials/achievements_badges.html:9
+msgid "Nenhuma conquista ainda."
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:2
+#, fuzzy
+#| msgid "Métricas do Dashboard"
+msgid "Filtros do dashboard"
+msgstr "Dashboard Metrics"
+
+#: templates/dashboard/partials/filters_form.html:4
+msgid "Período"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:5
+msgid "Selecionar período"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:6
+msgid "Mensal"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:7
+msgid "Trimestral"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:8
+msgid "Semestral"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:9
+msgid "Anual"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:13
+msgid "Escopo"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:14
+msgid "Selecionar escopo"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:15
+msgid "Automático"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:16
+msgid "Global"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:17
+#: templates/dashboard/partials/filters_form.html:23
+msgid "Organização"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:18
+#: templates/dashboard/partials/filters_form.html:27
+msgid "Núcleo"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:19
+#: templates/dashboard/partials/filters_form.html:31
+msgid "Evento"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:24
+msgid "Selecionar organização"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:28
+msgid "Selecionar núcleo"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:32
+msgid "Selecionar evento"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:35
+msgid "Data início"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:39
+msgid "Data fim"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:43
+#, fuzzy
+#| msgid "Métrica"
+msgid "Métricas"
+msgstr "Metric"
+
+#: templates/dashboard/partials/filters_form.html:54
+msgid "Aplicar filtros"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:54
+msgid "Filtrar"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:55
+msgid "Formato de exportação"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:56
+msgid "CSV"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:57
+msgid "PDF"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:58
+msgid "Excel"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:59
+msgid "PNG"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:61
+msgid "Exportar métricas"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:61
+msgid "Exportar"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:62
+msgid "Salvar filtro rápido"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:63
+msgid "Ver filtros salvos"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:63
+msgid "Meus filtros"
+msgstr ""
+
+#: templates/dashboard/partials/latest_transactions.html:3
+msgid "Últimos Lançamentos"
+msgstr ""
+
+#: templates/dashboard/partials/latest_transactions.html:11
+msgid "Nenhum lançamento encontrado."
+msgstr ""
+
+#: templates/dashboard/partials/notifications_list.html:3
+msgid "Notificações Recentes"
+msgstr ""
+
+#: templates/dashboard/partials/notifications_list.html:24
+msgid "Marcar como lida"
+msgstr ""
+
+#: templates/dashboard/partials/notifications_list.html:29
+msgid "Nenhuma notificação."
+msgstr ""
+
+#: templates/dashboard/partials/pending_tasks.html:3
+msgid "Tarefas Pendentes"
+msgstr ""
+
+#: templates/dashboard/partials/pending_tasks.html:11
+msgid "Nenhuma tarefa pendente."
+msgstr ""
+
+#: templates/dashboard/partials/upcoming_events.html:3
+msgid "Próximos Eventos"
+msgstr ""
+
+#: templates/dashboard/partials/upcoming_events.html:11
+msgid "Nenhum evento futuro."
+msgstr ""
+
+#: templates/dashboard/root.html:5 templates/dashboard/root.html:9
+msgid "Dashboard Root"
+msgstr ""
+
+#: templates/dashboard/root.html:25
+msgid "Status dos Serviços"
+msgstr ""
+
+#: templates/dashboard/root.html:28
+msgid "Celery"
+msgstr ""
+
+#: templates/dashboard/root.html:32
+msgid "Fila de Mensagens"
+msgstr ""
+
+#: templates/dashboard/root.html:36
+msgid "Uso de Disco"
+msgstr ""
+
+#: templates/dashboard/root.html:43
+#, fuzzy
+#| msgid "Métricas do Dashboard"
+msgid "Métricas de Segurança"
+msgstr "Dashboard Metrics"
+
+#: templates/dashboard/root.html:46
+msgid "Tentativas de Login Bloqueadas"
+msgstr ""
+
+#: templates/dashboard/root.html:59
+msgid "Django Admin"
+msgstr ""

--- a/dashboard/locale/pt_BR/LC_MESSAGES/django.po
+++ b/dashboard/locale/pt_BR/LC_MESSAGES/django.po
@@ -1,20 +1,479 @@
 msgid ""
 msgstr ""
-"Content-Type: text/plain; charset=UTF-8\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-14 16:57+0000\n"
 "Language: pt_BR\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 
-#: templates/dashboard/export_pdf.html:5 templates/dashboard/export_pdf.html:13
+#: templates/dashboard/achievement_list.html:4
+#: templates/dashboard/achievement_list.html:7
+#: templates/dashboard/achievement_list.html:8
+msgid "Conquistas"
+msgstr ""
+
+#: templates/dashboard/achievement_list.html:17
+msgid "Concluída"
+msgstr ""
+
+#: templates/dashboard/achievement_list.html:19
+msgid "Pendente"
+msgstr ""
+
+#: templates/dashboard/achievement_list.html:23
+msgid "Nenhuma conquista cadastrada."
+msgstr ""
+
+#: templates/dashboard/admin.html:5
+msgid "Dashboard Admin"
+msgstr ""
+
+#: templates/dashboard/admin.html:8 templates/dashboard/root.html:8
+msgid "Dashboard"
+msgstr ""
+
+#: templates/dashboard/admin.html:9
+msgid "Dashboard Administrativo"
+msgstr ""
+
+#: templates/dashboard/admin.html:21
+msgid "Comparar com média global"
+msgstr ""
+
+#: templates/dashboard/admin.html:22
+msgid "Ativar comparativo de métricas"
+msgstr ""
+
+#: templates/dashboard/admin.html:23
+msgid "Gráfico comparativo"
+msgstr ""
+
+#: templates/dashboard/admin.html:41
+msgid "Atual"
+msgstr ""
+
+#: templates/dashboard/admin.html:41
+msgid "Média"
+msgstr ""
+
+#: templates/dashboard/admin.html:42
+msgid "Usuários"
+msgstr ""
+
+#: templates/dashboard/admin.html:55 templates/dashboard/root.html:21
+msgid "Distribuição de Métricas"
+msgstr ""
+
+#: templates/dashboard/admin.html:63
+#, fuzzy
+#| msgid "Métricas do Dashboard"
+msgid "Métricas do Feed"
+msgstr "Métricas do Dashboard"
+
+#: templates/dashboard/admin.html:65
+msgid "Posts por tipo"
+msgstr ""
+
+#: templates/dashboard/admin.html:66
+msgid "Top tags"
+msgstr ""
+
+#: templates/dashboard/admin.html:67
+msgid "Top autores"
+msgstr ""
+
+#: templates/dashboard/admin.html:95 templates/dashboard/gerente.html:25
+#: templates/dashboard/root.html:55
+msgid "Ações Rápidas"
+msgstr ""
+
+#: templates/dashboard/admin.html:99
+msgid "Administrar Usuários"
+msgstr ""
+
+#: templates/dashboard/admin.html:103
+msgid "Aprovar Eventos"
+msgstr ""
+
+#: templates/dashboard/admin.html:107
+msgid "Relatórios Financeiros"
+msgstr ""
+
+#: templates/dashboard/admin.html:111
+msgid "Logs de Notificações"
+msgstr ""
+
+#: templates/dashboard/cliente.html:5 templates/dashboard/cliente.html:9
+msgid "Dashboard Cliente"
+msgstr ""
+
+#: templates/dashboard/cliente.html:27
+msgid "Atalhos"
+msgstr ""
+
+#: templates/dashboard/cliente.html:31
+msgid "Inscrever-se em Eventos"
+msgstr ""
+
+#: templates/dashboard/cliente.html:35
+msgid "Ver Feed"
+msgstr ""
+
+#: templates/dashboard/config_form.html:3
+#: templates/dashboard/config_form.html:6
+msgid "Salvar filtros"
+msgstr ""
+
+#: templates/dashboard/config_form.html:7
+msgid "Formulário de configuração do dashboard"
+msgstr ""
+
+#: templates/dashboard/config_form.html:10
+#: templates/dashboard/filter_form.html:10
+#: templates/dashboard/layout_form.html:10
+msgid "Nome"
+msgstr ""
+
+#: templates/dashboard/config_form.html:15
+#: templates/dashboard/filter_form.html:15
+msgid "Público"
+msgstr ""
+
+#: templates/dashboard/config_form.html:17
+#: templates/dashboard/partials/filters_form.html:64
+msgid "Salvar configuração"
+msgstr ""
+
+#: templates/dashboard/config_form.html:17
+#: templates/dashboard/filter_form.html:17
+#: templates/dashboard/layout_form.html:18
+msgid "Salvar"
+msgstr ""
+
+#: templates/dashboard/config_list.html:3
+#: templates/dashboard/config_list.html:6
+msgid "Configurações salvas"
+msgstr ""
+
+#: templates/dashboard/config_list.html:12
+msgid "Aplicar configuração"
+msgstr ""
+
+#: templates/dashboard/config_list.html:12
+#: templates/dashboard/filter_list.html:13
+msgid "Aplicar"
+msgstr ""
+
+#: templates/dashboard/config_list.html:15
+msgid "Nenhuma configuração salva."
+msgstr ""
+
+#: templates/dashboard/export_pdf.html:7 templates/dashboard/export_pdf.html:15
 msgid "Métricas do Dashboard"
 msgstr "Métricas do Dashboard"
 
-#: templates/dashboard/export_pdf.html:16
+#: templates/dashboard/export_pdf.html:18
 msgid "Métrica"
 msgstr "Métrica"
 
-#: templates/dashboard/export_pdf.html:16
+#: templates/dashboard/export_pdf.html:18
 msgid "Total"
 msgstr "Total"
 
-#: templates/dashboard/export_pdf.html:16
-msgid "Variação (%)"
+#: templates/dashboard/export_pdf.html:18
+#, fuzzy, python-format
+#| msgid "Variação (%)"
+msgid "Variação (%%)"
 msgstr "Variação (%)"
+
+#: templates/dashboard/filter_form.html:3
+#: templates/dashboard/filter_form.html:6
+#: templates/dashboard/filter_form.html:17
+#: templates/dashboard/partials/filters_form.html:62
+msgid "Salvar filtro"
+msgstr ""
+
+#: templates/dashboard/filter_form.html:7
+msgid "Formulário de filtro rápido"
+msgstr ""
+
+#: templates/dashboard/filter_list.html:3
+#: templates/dashboard/filter_list.html:6
+msgid "Filtros salvos"
+msgstr ""
+
+#: templates/dashboard/filter_list.html:13
+msgid "Aplicar filtro"
+msgstr ""
+
+#: templates/dashboard/filter_list.html:16
+msgid "Excluir filtro"
+msgstr ""
+
+#: templates/dashboard/filter_list.html:16
+#: templates/dashboard/layout_confirm_delete.html:10
+msgid "Excluir"
+msgstr ""
+
+#: templates/dashboard/filter_list.html:21
+msgid "Nenhum filtro salvo."
+msgstr ""
+
+#: templates/dashboard/gerente.html:5 templates/dashboard/gerente.html:9
+msgid "Dashboard Gerente"
+msgstr ""
+
+#: templates/dashboard/gerente.html:29
+msgid "Aprovar Tarefas"
+msgstr ""
+
+#: templates/dashboard/gerente.html:33
+msgid "Gerenciar Eventos"
+msgstr ""
+
+#: templates/dashboard/layout_confirm_delete.html:3
+#: templates/dashboard/layout_confirm_delete.html:6
+msgid "Excluir Layout"
+msgstr ""
+
+#: templates/dashboard/layout_confirm_delete.html:7
+msgid "Tem certeza que deseja excluir este layout?"
+msgstr ""
+
+#: templates/dashboard/layout_form.html:3
+#: templates/dashboard/layout_form.html:6
+msgid "Layout"
+msgstr ""
+
+#: templates/dashboard/layout_form.html:5
+msgid "Layout form"
+msgstr ""
+
+#: templates/dashboard/layout_list.html:3
+#: templates/dashboard/layout_list.html:5
+msgid "Layouts"
+msgstr ""
+
+#: templates/dashboard/layout_list.html:6
+msgid "Meus Layouts"
+msgstr ""
+
+#: templates/dashboard/layout_list.html:11
+msgid "Nenhum layout"
+msgstr ""
+
+#: templates/dashboard/layout_list.html:14
+msgid "Novo Layout"
+msgstr ""
+
+#: templates/dashboard/partials/achievements_badges.html:2
+msgid "Conquistas alcançadas"
+msgstr ""
+
+#: templates/dashboard/partials/achievements_badges.html:9
+msgid "Nenhuma conquista ainda."
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:2
+#, fuzzy
+#| msgid "Métricas do Dashboard"
+msgid "Filtros do dashboard"
+msgstr "Métricas do Dashboard"
+
+#: templates/dashboard/partials/filters_form.html:4
+msgid "Período"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:5
+msgid "Selecionar período"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:6
+msgid "Mensal"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:7
+msgid "Trimestral"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:8
+msgid "Semestral"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:9
+msgid "Anual"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:13
+msgid "Escopo"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:14
+msgid "Selecionar escopo"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:15
+msgid "Automático"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:16
+msgid "Global"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:17
+#: templates/dashboard/partials/filters_form.html:23
+msgid "Organização"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:18
+#: templates/dashboard/partials/filters_form.html:27
+msgid "Núcleo"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:19
+#: templates/dashboard/partials/filters_form.html:31
+msgid "Evento"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:24
+msgid "Selecionar organização"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:28
+msgid "Selecionar núcleo"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:32
+msgid "Selecionar evento"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:35
+msgid "Data início"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:39
+msgid "Data fim"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:43
+#, fuzzy
+#| msgid "Métrica"
+msgid "Métricas"
+msgstr "Métrica"
+
+#: templates/dashboard/partials/filters_form.html:54
+msgid "Aplicar filtros"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:54
+msgid "Filtrar"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:55
+msgid "Formato de exportação"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:56
+msgid "CSV"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:57
+msgid "PDF"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:58
+msgid "Excel"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:59
+msgid "PNG"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:61
+msgid "Exportar métricas"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:61
+msgid "Exportar"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:62
+msgid "Salvar filtro rápido"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:63
+msgid "Ver filtros salvos"
+msgstr ""
+
+#: templates/dashboard/partials/filters_form.html:63
+msgid "Meus filtros"
+msgstr ""
+
+#: templates/dashboard/partials/latest_transactions.html:3
+msgid "Últimos Lançamentos"
+msgstr ""
+
+#: templates/dashboard/partials/latest_transactions.html:11
+msgid "Nenhum lançamento encontrado."
+msgstr ""
+
+#: templates/dashboard/partials/notifications_list.html:3
+msgid "Notificações Recentes"
+msgstr ""
+
+#: templates/dashboard/partials/notifications_list.html:24
+msgid "Marcar como lida"
+msgstr ""
+
+#: templates/dashboard/partials/notifications_list.html:29
+msgid "Nenhuma notificação."
+msgstr ""
+
+#: templates/dashboard/partials/pending_tasks.html:3
+msgid "Tarefas Pendentes"
+msgstr ""
+
+#: templates/dashboard/partials/pending_tasks.html:11
+msgid "Nenhuma tarefa pendente."
+msgstr ""
+
+#: templates/dashboard/partials/upcoming_events.html:3
+msgid "Próximos Eventos"
+msgstr ""
+
+#: templates/dashboard/partials/upcoming_events.html:11
+msgid "Nenhum evento futuro."
+msgstr ""
+
+#: templates/dashboard/root.html:5 templates/dashboard/root.html:9
+msgid "Dashboard Root"
+msgstr ""
+
+#: templates/dashboard/root.html:25
+msgid "Status dos Serviços"
+msgstr ""
+
+#: templates/dashboard/root.html:28
+msgid "Celery"
+msgstr ""
+
+#: templates/dashboard/root.html:32
+msgid "Fila de Mensagens"
+msgstr ""
+
+#: templates/dashboard/root.html:36
+msgid "Uso de Disco"
+msgstr ""
+
+#: templates/dashboard/root.html:43
+#, fuzzy
+#| msgid "Métricas do Dashboard"
+msgid "Métricas de Segurança"
+msgstr "Métricas do Dashboard"
+
+#: templates/dashboard/root.html:46
+msgid "Tentativas de Login Bloqueadas"
+msgstr ""
+
+#: templates/dashboard/root.html:59
+msgid "Django Admin"
+msgstr ""

--- a/dashboard/templates/dashboard/admin.html
+++ b/dashboard/templates/dashboard/admin.html
@@ -5,7 +5,7 @@
 {% block title %}{% trans "Dashboard Admin" %} | Hubx{% endblock %}
 
 {% block content %}
-<main class="max-w-7xl mx-auto px-4 py-10" role="main" aria-label="Dashboard">
+<main class="max-w-7xl mx-auto px-4 py-10" role="main" aria-label="{% trans 'Dashboard' %}">
   <h1 class="text-3xl font-semibold text-neutral-900 text-center mb-10">{% trans "Dashboard Administrativo" %}</h1>
 
   {% include 'dashboard/partials/messages.html' %}

--- a/dashboard/templates/dashboard/export_pdf.html
+++ b/dashboard/templates/dashboard/export_pdf.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
-{% load i18n %}
-<html lang="pt-br">
+{% load i18n l10n %}
+{% get_current_language as LANGUAGE_CODE %}
+<html lang="{{ LANGUAGE_CODE }}" dir="{% if LANGUAGE_BIDI %}rtl{% else %}ltr{% endif %}">
 <head>
   <meta charset="utf-8" />
   <title>{% trans "Métricas do Dashboard" %}</title>
@@ -19,7 +20,7 @@
     <tbody>
     {% for key, data in metrics.items %}
       <tr>
-        <td>{{ key }}</td><td>{{ data.total }}</td><td>{{ data.crescimento|floatformat:2 }}</td>
+        <td>{{ key }}</td><td>{{ data.total|localize }}</td><td>{{ data.crescimento|floatformat:2|localize }}</td>
       </tr>
     {% endfor %}
     </tbody>

--- a/dashboard/templates/dashboard/partials/filters_form.html
+++ b/dashboard/templates/dashboard/partials/filters_form.html
@@ -53,10 +53,10 @@
   <div class="flex gap-2 mt-4">
     <button type="submit" class="px-4 py-2 bg-primary-600 text-white rounded focus:outline-none focus:ring" aria-label="{% trans 'Aplicar filtros' %}">{% trans 'Filtrar' %}</button>
     <select name="formato" class="border-gray-300 rounded" aria-label="{% trans 'Formato de exportação' %}">
-      <option value="csv">CSV</option>
-      <option value="pdf">PDF</option>
-      <option value="xlsx">Excel</option>
-      <option value="png">PNG</option>
+      <option value="csv">{% trans 'CSV' %}</option>
+      <option value="pdf">{% trans 'PDF' %}</option>
+      <option value="xlsx">{% trans 'Excel' %}</option>
+      <option value="png">{% trans 'PNG' %}</option>
     </select>
     <button type="submit" formaction="{% url 'dashboard:export' %}" class="px-4 py-2 bg-neutral-200 text-neutral-800 rounded focus:outline-none focus:ring" aria-label="{% trans 'Exportar métricas' %}">{% trans 'Exportar' %}</button>
     <a href="{% url 'dashboard:filter-create' %}?{{ request.GET.urlencode }}" class="px-4 py-2 bg-neutral-200 text-neutral-800 rounded focus:outline-none focus:ring" aria-label="{% trans 'Salvar filtro rápido' %}">{% trans 'Salvar filtro' %}</a>

--- a/dashboard/templates/dashboard/root.html
+++ b/dashboard/templates/dashboard/root.html
@@ -5,7 +5,7 @@
 {% block title %}{% trans "Dashboard Root" %} | Hubx{% endblock %}
 
 {% block content %}
-<main class="max-w-7xl mx-auto px-4 py-10" role="main" aria-label="Dashboard">
+<main class="max-w-7xl mx-auto px-4 py-10" role="main" aria-label="{% trans 'Dashboard' %}">
   <h1 class="text-3xl font-semibold text-neutral-900 text-center mb-10">{% trans "Dashboard Root" %}</h1>
 
   {% include 'dashboard/partials/messages.html' %}

--- a/discussao/locale/en/LC_MESSAGES/django.po
+++ b/discussao/locale/en/LC_MESSAGES/django.po
@@ -1,0 +1,182 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-14 11:48-0300\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+#: templates/discussao/categoria_confirm_delete.html:3
+#: templates/discussao/categoria_confirm_delete.html:6
+msgid "Remover Categoria"
+msgstr ""
+
+#: templates/discussao/categoria_confirm_delete.html:7
+msgid "Tem certeza que deseja remover esta categoria?"
+msgstr ""
+
+#: templates/discussao/categoria_confirm_delete.html:10
+msgid "Confirmar"
+msgstr ""
+
+#: templates/discussao/categoria_form.html:3
+#: templates/discussao/categoria_form.html:7
+msgid "Editar Categoria"
+msgstr ""
+
+#: templates/discussao/categoria_form.html:3
+#: templates/discussao/categoria_form.html:7
+msgid "Nova Categoria"
+msgstr ""
+
+#: templates/discussao/categoria_form.html:13
+#: templates/discussao/tag_form.html:13
+msgid "Salvar"
+msgstr ""
+
+#: templates/discussao/categorias.html:3 templates/discussao/categorias.html:7
+msgid "Categorias"
+msgstr ""
+
+#: templates/discussao/categorias.html:9
+msgid "Novo"
+msgstr ""
+
+#: templates/discussao/categorias.html:19
+msgid "Nenhuma categoria cadastrada."
+msgstr ""
+
+#: templates/discussao/comentario_item.html:11
+msgid "Remover"
+msgstr ""
+
+#: templates/discussao/comentario_item.html:18
+#: templates/discussao/topico_detail.html:25
+msgid "Marcar como resolvido"
+msgstr ""
+
+#: templates/discussao/comentario_item.html:25
+msgid "Melhor resposta"
+msgstr ""
+
+#: templates/discussao/tag_form.html:3 templates/discussao/tag_form.html:7
+msgid "Editar Tag"
+msgstr ""
+
+#: templates/discussao/tag_form.html:3 templates/discussao/tag_form.html:7
+msgid "Nova Tag"
+msgstr ""
+
+#: templates/discussao/tags.html:3 templates/discussao/tags.html:7
+msgid "Tags"
+msgstr ""
+
+#: templates/discussao/tags.html:8
+msgid "Nova"
+msgstr ""
+
+#: templates/discussao/tags.html:14
+msgid "Editar"
+msgstr ""
+
+#: templates/discussao/tags.html:17
+msgid "Nenhuma tag cadastrada."
+msgstr ""
+
+#: templates/discussao/topico_detail.html:15
+msgid "Resolvido"
+msgstr ""
+
+#: templates/discussao/topico_detail.html:18
+msgid "Por"
+msgstr ""
+
+#: templates/discussao/topico_detail.html:23
+msgid "Desmarcar resolução"
+msgstr ""
+
+#: templates/discussao/topico_detail.html:37
+#: templates/discussao/topicos_list.html:47
+msgid "Coment\\u00e1rios"
+msgstr ""
+
+#: templates/discussao/topico_detail.html:47
+msgid "Anterior"
+msgstr ""
+
+#: templates/discussao/topico_detail.html:49
+msgid "P\\u00e1gina"
+msgstr ""
+
+#: templates/discussao/topico_detail.html:51
+msgid "Pr\\u00f3xima"
+msgstr ""
+
+#: templates/discussao/topico_detail.html:58
+#: templates/discussao/topico_detail.html:60
+msgid "Comentar"
+msgstr ""
+
+#: templates/discussao/topico_detail.html:65
+msgid "Fechar tópico"
+msgstr ""
+
+#: templates/discussao/topico_detail.html:71
+msgid "Reabrir tópico"
+msgstr ""
+
+#: templates/discussao/topico_novo.html:4
+#: templates/discussao/topicos_list.html:37
+msgid "Novo T\\u00f3pico"
+msgstr ""
+
+#: templates/discussao/topico_novo.html:8
+msgid "Criar T\\u00f3pico"
+msgstr ""
+
+#: templates/discussao/topico_novo.html:39
+msgid "Cancelar"
+msgstr ""
+
+#: templates/discussao/topico_novo.html:40
+msgid "Publicar"
+msgstr ""
+
+#: templates/discussao/topicos_list.html:34
+msgid "Mais recentes"
+msgstr ""
+
+#: templates/discussao/topicos_list.html:35
+msgid "Mais comentados"
+msgstr ""
+
+#: templates/discussao/topicos_list.html:43
+msgid "T\\u00edtulo"
+msgstr ""
+
+#: templates/discussao/topicos_list.html:44
+msgid "Autor"
+msgstr ""
+
+#: templates/discussao/topicos_list.html:45
+msgid "Criado em"
+msgstr ""
+
+#: templates/discussao/topicos_list.html:46
+msgid "Votos"
+msgstr ""
+
+#: templates/discussao/topicos_list.html:48
+msgid "\\u00daltima atividade"
+msgstr ""

--- a/discussao/locale/pt_BR/LC_MESSAGES/django.po
+++ b/discussao/locale/pt_BR/LC_MESSAGES/django.po
@@ -1,0 +1,182 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-14 11:48-0300\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+#: templates/discussao/categoria_confirm_delete.html:3
+#: templates/discussao/categoria_confirm_delete.html:6
+msgid "Remover Categoria"
+msgstr ""
+
+#: templates/discussao/categoria_confirm_delete.html:7
+msgid "Tem certeza que deseja remover esta categoria?"
+msgstr ""
+
+#: templates/discussao/categoria_confirm_delete.html:10
+msgid "Confirmar"
+msgstr ""
+
+#: templates/discussao/categoria_form.html:3
+#: templates/discussao/categoria_form.html:7
+msgid "Editar Categoria"
+msgstr ""
+
+#: templates/discussao/categoria_form.html:3
+#: templates/discussao/categoria_form.html:7
+msgid "Nova Categoria"
+msgstr ""
+
+#: templates/discussao/categoria_form.html:13
+#: templates/discussao/tag_form.html:13
+msgid "Salvar"
+msgstr ""
+
+#: templates/discussao/categorias.html:3 templates/discussao/categorias.html:7
+msgid "Categorias"
+msgstr ""
+
+#: templates/discussao/categorias.html:9
+msgid "Novo"
+msgstr ""
+
+#: templates/discussao/categorias.html:19
+msgid "Nenhuma categoria cadastrada."
+msgstr ""
+
+#: templates/discussao/comentario_item.html:11
+msgid "Remover"
+msgstr ""
+
+#: templates/discussao/comentario_item.html:18
+#: templates/discussao/topico_detail.html:25
+msgid "Marcar como resolvido"
+msgstr ""
+
+#: templates/discussao/comentario_item.html:25
+msgid "Melhor resposta"
+msgstr ""
+
+#: templates/discussao/tag_form.html:3 templates/discussao/tag_form.html:7
+msgid "Editar Tag"
+msgstr ""
+
+#: templates/discussao/tag_form.html:3 templates/discussao/tag_form.html:7
+msgid "Nova Tag"
+msgstr ""
+
+#: templates/discussao/tags.html:3 templates/discussao/tags.html:7
+msgid "Tags"
+msgstr ""
+
+#: templates/discussao/tags.html:8
+msgid "Nova"
+msgstr ""
+
+#: templates/discussao/tags.html:14
+msgid "Editar"
+msgstr ""
+
+#: templates/discussao/tags.html:17
+msgid "Nenhuma tag cadastrada."
+msgstr ""
+
+#: templates/discussao/topico_detail.html:15
+msgid "Resolvido"
+msgstr ""
+
+#: templates/discussao/topico_detail.html:18
+msgid "Por"
+msgstr ""
+
+#: templates/discussao/topico_detail.html:23
+msgid "Desmarcar resolução"
+msgstr ""
+
+#: templates/discussao/topico_detail.html:37
+#: templates/discussao/topicos_list.html:47
+msgid "Coment\\u00e1rios"
+msgstr ""
+
+#: templates/discussao/topico_detail.html:47
+msgid "Anterior"
+msgstr ""
+
+#: templates/discussao/topico_detail.html:49
+msgid "P\\u00e1gina"
+msgstr ""
+
+#: templates/discussao/topico_detail.html:51
+msgid "Pr\\u00f3xima"
+msgstr ""
+
+#: templates/discussao/topico_detail.html:58
+#: templates/discussao/topico_detail.html:60
+msgid "Comentar"
+msgstr ""
+
+#: templates/discussao/topico_detail.html:65
+msgid "Fechar tópico"
+msgstr ""
+
+#: templates/discussao/topico_detail.html:71
+msgid "Reabrir tópico"
+msgstr ""
+
+#: templates/discussao/topico_novo.html:4
+#: templates/discussao/topicos_list.html:37
+msgid "Novo T\\u00f3pico"
+msgstr ""
+
+#: templates/discussao/topico_novo.html:8
+msgid "Criar T\\u00f3pico"
+msgstr ""
+
+#: templates/discussao/topico_novo.html:39
+msgid "Cancelar"
+msgstr ""
+
+#: templates/discussao/topico_novo.html:40
+msgid "Publicar"
+msgstr ""
+
+#: templates/discussao/topicos_list.html:34
+msgid "Mais recentes"
+msgstr ""
+
+#: templates/discussao/topicos_list.html:35
+msgid "Mais comentados"
+msgstr ""
+
+#: templates/discussao/topicos_list.html:43
+msgid "T\\u00edtulo"
+msgstr ""
+
+#: templates/discussao/topicos_list.html:44
+msgid "Autor"
+msgstr ""
+
+#: templates/discussao/topicos_list.html:45
+msgid "Criado em"
+msgstr ""
+
+#: templates/discussao/topicos_list.html:46
+msgid "Votos"
+msgstr ""
+
+#: templates/discussao/topicos_list.html:48
+msgid "\\u00daltima atividade"
+msgstr ""

--- a/discussao/templates/discussao/comentario_item.html
+++ b/discussao/templates/discussao/comentario_item.html
@@ -1,7 +1,8 @@
+{% load i18n %}
 <article class="p-4 border-b border-neutral-200 {% if melhor %}bg-green-50{% endif %}" id="coment-{{ comentario.id }}">
   <header class="mb-2 flex items-center justify-between">
     <div class="text-sm text-neutral-700">
-      {{ comentario.autor.get_full_name|default:comentario.autor.username }} - {{ comentario.created|date:"d/m/Y H:i" }}
+      {{ comentario.autor.get_full_name|default:comentario.autor.username }} - {{ comentario.created|date:"SHORT_DATETIME_FORMAT" }}
     </div>
     <div class="flex items-center gap-2">
     {% if user == comentario.autor or user.get_tipo_usuario in ['admin','coordenador','root'] %}

--- a/discussao/templates/discussao/topico_detail.html
+++ b/discussao/templates/discussao/topico_detail.html
@@ -15,7 +15,7 @@
       <span class="ml-2 px-2 py-1 text-xs font-semibold bg-green-100 text-green-800 rounded">{% trans "Resolvido" %}</span>
       {% endif %}
     </h1>
-    <p class="text-sm text-neutral-600">{% trans "Por" %} {{ topico.autor.get_full_name|default:topico.autor.username }} · {{ topico.created|date:"d/m/Y H:i" }}</p>
+    <p class="text-sm text-neutral-600">{% trans "Por" %} {{ topico.autor.get_full_name|default:topico.autor.username }} · {{ topico.created|date:SHORT_DATETIME_FORMAT }}</p>
     {% if user == topico.autor or user.get_tipo_usuario in ['admin','root'] %}
     <form method="post" hx-post="{% url 'discussao:topico_resolver' topico.categoria.slug topico.slug %}" hx-target="#topico-container" hx-swap="outerHTML" class="mt-2">
       {% csrf_token %}

--- a/discussao/templates/discussao/topicos_list.html
+++ b/discussao/templates/discussao/topicos_list.html
@@ -10,7 +10,7 @@
       </div>
     </td>
     <td class="px-4 py-2">{{ topico.autor.get_full_name|default:topico.autor.username }}</td>
-    <td class="px-4 py-2">{{ topico.created|date:"d/m/Y" }}</td>
+    <td class="px-4 py-2">{{ topico.created|date:SHORT_DATE_FORMAT }}</td>
     <td class="px-4 py-2 text-center">
       <div class="flex items-center justify-center space-x-1">
         <button hx-post="{% url 'discussao:interacao' content_type_id topico.id 'up' %}" hx-swap="none" hx-on:afterRequest="document.getElementById('score-{{topico.id}}').innerText = event.detail.xhr.responseJSON.score">&#9650;</button>
@@ -19,7 +19,7 @@
       </div>
     </td>
     <td class="px-4 py-2 text-center">{{ topico.num_comentarios }}</td>
-    <td class="px-4 py-2">{{ topico.last_activity|date:"d/m/Y H:i" }}</td>
+    <td class="px-4 py-2">{{ topico.last_activity|date:SHORT_DATETIME_FORMAT }}</td>
   </tr>
   {% endfor %}
 {% else %}

--- a/empresas/locale/en/LC_MESSAGES/django.po
+++ b/empresas/locale/en/LC_MESSAGES/django.po
@@ -1,0 +1,307 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-14 12:47-0300\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+#: templates/empresas/avaliacao_form.html:4
+msgid "Avaliar empresa"
+msgstr ""
+
+#: templates/empresas/avaliacao_form.html:8
+msgid "Avaliação"
+msgstr ""
+
+#: templates/empresas/avaliacao_form.html:12
+#: templates/empresas/contato_form.html:32 templates/empresas/nova.html:86
+#: templates/empresas/tag_form.html:24
+msgid "Salvar"
+msgstr ""
+
+#: templates/empresas/busca.html:4 templates/empresas/busca.html:9
+msgid "Buscar Empresas"
+msgstr ""
+
+#: templates/empresas/busca.html:10
+msgid "Encontre empresas na plataforma HubX"
+msgstr ""
+
+#: templates/empresas/busca.html:14
+msgid "Buscar por nome, CNPJ ou localização..."
+msgstr ""
+
+#: templates/empresas/busca.html:23
+msgid "Voltar para Minhas Empresas"
+msgstr ""
+
+#: templates/empresas/contato_confirm_delete.html:3
+msgid "Remover Contato"
+msgstr ""
+
+#: templates/empresas/contato_confirm_delete.html:7
+#, python-format
+msgid "Confirma remover contato %(contato.nome)s?"
+msgstr ""
+
+#: templates/empresas/contato_confirm_delete.html:10
+#: templates/empresas/nova.html:83
+#: templates/empresas/tag_confirm_delete.html:11
+#: templates/empresas/tag_form.html:23
+msgid "Cancelar"
+msgstr ""
+
+#: templates/empresas/contato_confirm_delete.html:11
+#: templates/empresas/favoritos.html:20
+#: templates/empresas/includes/empresas_table.html:33
+#: templates/empresas/tag_confirm_delete.html:12
+#: templates/empresas/tags_list.html:45
+msgid "Remover"
+msgstr ""
+
+#: templates/empresas/contato_form.html:3
+msgid "Contato"
+msgstr ""
+
+#: templates/empresas/contato_form.html:9
+#: templates/empresas/includes/empresas_table.html:6
+#: templates/empresas/lista.html:25 templates/empresas/tags_list.html:33
+msgid "Nome"
+msgstr ""
+
+#: templates/empresas/contato_form.html:14
+msgid "E-mail"
+msgstr ""
+
+#: templates/empresas/contato_form.html:19
+msgid "Telefone"
+msgstr ""
+
+#: templates/empresas/contato_form.html:24
+msgid "Cargo"
+msgstr ""
+
+#: templates/empresas/contato_form.html:30
+#: templates/empresas/includes/empresas_table.html:7
+msgid "Contato principal"
+msgstr ""
+
+#: templates/empresas/favoritos.html:4 templates/empresas/favoritos.html:9
+msgid "Empresas Favoritas"
+msgstr ""
+
+#: templates/empresas/favoritos.html:23
+msgid "Nenhuma empresa favorita."
+msgstr ""
+
+#: templates/empresas/historico.html:3 templates/empresas/historico.html:6
+msgid "Histórico de alterações"
+msgstr ""
+
+#: templates/empresas/historico.html:10
+msgid "Campo"
+msgstr ""
+
+#: templates/empresas/historico.html:11 templates/empresas/historico.html:32
+#: templates/empresas/includes/empresas_table.html:43
+#: templates/empresas/includes/empresas_table.html:45
+msgid "Anterior"
+msgstr ""
+
+#: templates/empresas/historico.html:12
+msgid "Novo"
+msgstr ""
+
+#: templates/empresas/historico.html:13
+msgid "Data"
+msgstr ""
+
+#: templates/empresas/historico.html:25
+msgid "Nenhuma alteração registrada."
+msgstr ""
+
+#: templates/empresas/historico.html:30
+#: templates/empresas/includes/empresas_table.html:41
+msgid "Paginação"
+msgstr ""
+
+#: templates/empresas/historico.html:35
+#: templates/empresas/includes/empresas_table.html:49
+#: templates/empresas/includes/empresas_table.html:51
+msgid "Próxima"
+msgstr ""
+
+#: templates/empresas/includes/avaliacoes.html:3
+msgid "Avaliações"
+msgstr ""
+
+#: templates/empresas/includes/avaliacoes.html:5
+msgid "Média"
+msgstr ""
+
+#: templates/empresas/includes/avaliacoes.html:5
+msgid "avaliações"
+msgstr ""
+
+#: templates/empresas/includes/avaliacoes.html:11
+msgid "Avaliar com"
+msgstr ""
+
+#: templates/empresas/includes/avaliacoes.html:11
+msgid "estrelas"
+msgstr ""
+
+#: templates/empresas/includes/avaliacoes.html:29
+msgid "Nenhuma avaliação registrada."
+msgstr ""
+
+#: templates/empresas/includes/empresas_table.html:8
+msgid "Setor"
+msgstr ""
+
+#: templates/empresas/includes/empresas_table.html:9
+#: templates/empresas/lista.html:29
+msgid "Município"
+msgstr ""
+
+#: templates/empresas/includes/empresas_table.html:10
+#: templates/empresas/lista.html:37
+msgid "Tags"
+msgstr ""
+
+#: templates/empresas/includes/empresas_table.html:11
+#: templates/empresas/tags_list.html:35
+msgid "Ações"
+msgstr ""
+
+#: templates/empresas/includes/empresas_table.html:17
+msgid "excluída"
+msgstr ""
+
+#: templates/empresas/includes/empresas_table.html:31
+#: templates/empresas/tag_form.html:7 templates/empresas/tags_list.html:44
+msgid "Editar"
+msgstr ""
+
+#: templates/empresas/includes/empresas_table.html:56
+msgid "Nenhuma empresa encontrada."
+msgstr ""
+
+#: templates/empresas/lista.html:4 templates/empresas/lista.html:19
+msgid "Empresas"
+msgstr ""
+
+#: templates/empresas/lista.html:20 templates/empresas/nova.html:4
+#: templates/empresas/nova.html:11
+msgid "Nova Empresa"
+msgstr ""
+
+#: templates/empresas/lista.html:33
+msgid "Estado"
+msgstr ""
+
+#: templates/empresas/lista.html:45
+msgid "Palavras-chave"
+msgstr ""
+
+#: templates/empresas/lista.html:49
+msgid "Busca"
+msgstr ""
+
+#: templates/empresas/lista.html:53 templates/empresas/tags_list.html:25
+msgid "Filtrar"
+msgstr ""
+
+#: templates/empresas/nova.html:4 templates/empresas/nova.html:11
+msgid "Editar Empresa"
+msgstr ""
+
+#: templates/empresas/nova.html:9
+msgid "Voltar"
+msgstr ""
+
+#: templates/empresas/nova.html:12
+msgid "Cadastre sua empresa na plataforma"
+msgstr ""
+
+#: templates/empresas/nova.html:56
+msgid "Descreva brevemente o que sua empresa faz e seus principais objetivos."
+msgstr ""
+
+#: templates/empresas/nova.html:74
+msgid "Separe por vírgulas."
+msgstr ""
+
+#: templates/empresas/nova.html:86
+msgid "Cadastrar Empresa"
+msgstr ""
+
+#: templates/empresas/tag_confirm_delete.html:3
+#: templates/empresas/tag_confirm_delete.html:7
+msgid "Remover Item"
+msgstr ""
+
+#: templates/empresas/tag_confirm_delete.html:8
+#, python-format
+msgid "Tem certeza que deseja remover <strong>%(object.nome)s</strong>?"
+msgstr ""
+
+#: templates/empresas/tag_form.html:3
+msgid "Editar Item"
+msgstr ""
+
+#: templates/empresas/tag_form.html:3 templates/empresas/tags_list.html:8
+msgid "Novo Item"
+msgstr ""
+
+#: templates/empresas/tag_form.html:7
+msgid "Cadastrar"
+msgstr ""
+
+#: templates/empresas/tag_form.html:7
+msgid "Item"
+msgstr ""
+
+#: templates/empresas/tag_form.html:8
+msgid "Preencha o nome e a categoria do item"
+msgstr ""
+
+#: templates/empresas/tags_list.html:3 templates/empresas/tags_list.html:7
+msgid "Produtos e Serviços"
+msgstr ""
+
+#: templates/empresas/tags_list.html:13 templates/empresas/tags_list.html:34
+msgid "Categoria"
+msgstr ""
+
+#: templates/empresas/tags_list.html:15
+msgid "Todas"
+msgstr ""
+
+#: templates/empresas/tags_list.html:16
+msgid "Produtos"
+msgstr ""
+
+#: templates/empresas/tags_list.html:17
+msgid "Serviços"
+msgstr ""
+
+#: templates/empresas/tags_list.html:21
+msgid "Palavra-chave"
+msgstr ""
+
+#: templates/empresas/tags_list.html:52
+msgid "Nenhum item cadastrado."
+msgstr ""

--- a/empresas/locale/pt_BR/LC_MESSAGES/django.po
+++ b/empresas/locale/pt_BR/LC_MESSAGES/django.po
@@ -1,0 +1,307 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-14 12:47-0300\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+#: templates/empresas/avaliacao_form.html:4
+msgid "Avaliar empresa"
+msgstr ""
+
+#: templates/empresas/avaliacao_form.html:8
+msgid "Avaliação"
+msgstr ""
+
+#: templates/empresas/avaliacao_form.html:12
+#: templates/empresas/contato_form.html:32 templates/empresas/nova.html:86
+#: templates/empresas/tag_form.html:24
+msgid "Salvar"
+msgstr ""
+
+#: templates/empresas/busca.html:4 templates/empresas/busca.html:9
+msgid "Buscar Empresas"
+msgstr ""
+
+#: templates/empresas/busca.html:10
+msgid "Encontre empresas na plataforma HubX"
+msgstr ""
+
+#: templates/empresas/busca.html:14
+msgid "Buscar por nome, CNPJ ou localização..."
+msgstr ""
+
+#: templates/empresas/busca.html:23
+msgid "Voltar para Minhas Empresas"
+msgstr ""
+
+#: templates/empresas/contato_confirm_delete.html:3
+msgid "Remover Contato"
+msgstr ""
+
+#: templates/empresas/contato_confirm_delete.html:7
+#, python-format
+msgid "Confirma remover contato %(contato.nome)s?"
+msgstr ""
+
+#: templates/empresas/contato_confirm_delete.html:10
+#: templates/empresas/nova.html:83
+#: templates/empresas/tag_confirm_delete.html:11
+#: templates/empresas/tag_form.html:23
+msgid "Cancelar"
+msgstr ""
+
+#: templates/empresas/contato_confirm_delete.html:11
+#: templates/empresas/favoritos.html:20
+#: templates/empresas/includes/empresas_table.html:33
+#: templates/empresas/tag_confirm_delete.html:12
+#: templates/empresas/tags_list.html:45
+msgid "Remover"
+msgstr ""
+
+#: templates/empresas/contato_form.html:3
+msgid "Contato"
+msgstr ""
+
+#: templates/empresas/contato_form.html:9
+#: templates/empresas/includes/empresas_table.html:6
+#: templates/empresas/lista.html:25 templates/empresas/tags_list.html:33
+msgid "Nome"
+msgstr ""
+
+#: templates/empresas/contato_form.html:14
+msgid "E-mail"
+msgstr ""
+
+#: templates/empresas/contato_form.html:19
+msgid "Telefone"
+msgstr ""
+
+#: templates/empresas/contato_form.html:24
+msgid "Cargo"
+msgstr ""
+
+#: templates/empresas/contato_form.html:30
+#: templates/empresas/includes/empresas_table.html:7
+msgid "Contato principal"
+msgstr ""
+
+#: templates/empresas/favoritos.html:4 templates/empresas/favoritos.html:9
+msgid "Empresas Favoritas"
+msgstr ""
+
+#: templates/empresas/favoritos.html:23
+msgid "Nenhuma empresa favorita."
+msgstr ""
+
+#: templates/empresas/historico.html:3 templates/empresas/historico.html:6
+msgid "Histórico de alterações"
+msgstr ""
+
+#: templates/empresas/historico.html:10
+msgid "Campo"
+msgstr ""
+
+#: templates/empresas/historico.html:11 templates/empresas/historico.html:32
+#: templates/empresas/includes/empresas_table.html:43
+#: templates/empresas/includes/empresas_table.html:45
+msgid "Anterior"
+msgstr ""
+
+#: templates/empresas/historico.html:12
+msgid "Novo"
+msgstr ""
+
+#: templates/empresas/historico.html:13
+msgid "Data"
+msgstr ""
+
+#: templates/empresas/historico.html:25
+msgid "Nenhuma alteração registrada."
+msgstr ""
+
+#: templates/empresas/historico.html:30
+#: templates/empresas/includes/empresas_table.html:41
+msgid "Paginação"
+msgstr ""
+
+#: templates/empresas/historico.html:35
+#: templates/empresas/includes/empresas_table.html:49
+#: templates/empresas/includes/empresas_table.html:51
+msgid "Próxima"
+msgstr ""
+
+#: templates/empresas/includes/avaliacoes.html:3
+msgid "Avaliações"
+msgstr ""
+
+#: templates/empresas/includes/avaliacoes.html:5
+msgid "Média"
+msgstr ""
+
+#: templates/empresas/includes/avaliacoes.html:5
+msgid "avaliações"
+msgstr ""
+
+#: templates/empresas/includes/avaliacoes.html:11
+msgid "Avaliar com"
+msgstr ""
+
+#: templates/empresas/includes/avaliacoes.html:11
+msgid "estrelas"
+msgstr ""
+
+#: templates/empresas/includes/avaliacoes.html:29
+msgid "Nenhuma avaliação registrada."
+msgstr ""
+
+#: templates/empresas/includes/empresas_table.html:8
+msgid "Setor"
+msgstr ""
+
+#: templates/empresas/includes/empresas_table.html:9
+#: templates/empresas/lista.html:29
+msgid "Município"
+msgstr ""
+
+#: templates/empresas/includes/empresas_table.html:10
+#: templates/empresas/lista.html:37
+msgid "Tags"
+msgstr ""
+
+#: templates/empresas/includes/empresas_table.html:11
+#: templates/empresas/tags_list.html:35
+msgid "Ações"
+msgstr ""
+
+#: templates/empresas/includes/empresas_table.html:17
+msgid "excluída"
+msgstr ""
+
+#: templates/empresas/includes/empresas_table.html:31
+#: templates/empresas/tag_form.html:7 templates/empresas/tags_list.html:44
+msgid "Editar"
+msgstr ""
+
+#: templates/empresas/includes/empresas_table.html:56
+msgid "Nenhuma empresa encontrada."
+msgstr ""
+
+#: templates/empresas/lista.html:4 templates/empresas/lista.html:19
+msgid "Empresas"
+msgstr ""
+
+#: templates/empresas/lista.html:20 templates/empresas/nova.html:4
+#: templates/empresas/nova.html:11
+msgid "Nova Empresa"
+msgstr ""
+
+#: templates/empresas/lista.html:33
+msgid "Estado"
+msgstr ""
+
+#: templates/empresas/lista.html:45
+msgid "Palavras-chave"
+msgstr ""
+
+#: templates/empresas/lista.html:49
+msgid "Busca"
+msgstr ""
+
+#: templates/empresas/lista.html:53 templates/empresas/tags_list.html:25
+msgid "Filtrar"
+msgstr ""
+
+#: templates/empresas/nova.html:4 templates/empresas/nova.html:11
+msgid "Editar Empresa"
+msgstr ""
+
+#: templates/empresas/nova.html:9
+msgid "Voltar"
+msgstr ""
+
+#: templates/empresas/nova.html:12
+msgid "Cadastre sua empresa na plataforma"
+msgstr ""
+
+#: templates/empresas/nova.html:56
+msgid "Descreva brevemente o que sua empresa faz e seus principais objetivos."
+msgstr ""
+
+#: templates/empresas/nova.html:74
+msgid "Separe por vírgulas."
+msgstr ""
+
+#: templates/empresas/nova.html:86
+msgid "Cadastrar Empresa"
+msgstr ""
+
+#: templates/empresas/tag_confirm_delete.html:3
+#: templates/empresas/tag_confirm_delete.html:7
+msgid "Remover Item"
+msgstr ""
+
+#: templates/empresas/tag_confirm_delete.html:8
+#, python-format
+msgid "Tem certeza que deseja remover <strong>%(object.nome)s</strong>?"
+msgstr ""
+
+#: templates/empresas/tag_form.html:3
+msgid "Editar Item"
+msgstr ""
+
+#: templates/empresas/tag_form.html:3 templates/empresas/tags_list.html:8
+msgid "Novo Item"
+msgstr ""
+
+#: templates/empresas/tag_form.html:7
+msgid "Cadastrar"
+msgstr ""
+
+#: templates/empresas/tag_form.html:7
+msgid "Item"
+msgstr ""
+
+#: templates/empresas/tag_form.html:8
+msgid "Preencha o nome e a categoria do item"
+msgstr ""
+
+#: templates/empresas/tags_list.html:3 templates/empresas/tags_list.html:7
+msgid "Produtos e Serviços"
+msgstr ""
+
+#: templates/empresas/tags_list.html:13 templates/empresas/tags_list.html:34
+msgid "Categoria"
+msgstr ""
+
+#: templates/empresas/tags_list.html:15
+msgid "Todas"
+msgstr ""
+
+#: templates/empresas/tags_list.html:16
+msgid "Produtos"
+msgstr ""
+
+#: templates/empresas/tags_list.html:17
+msgid "Serviços"
+msgstr ""
+
+#: templates/empresas/tags_list.html:21
+msgid "Palavra-chave"
+msgstr ""
+
+#: templates/empresas/tags_list.html:52
+msgid "Nenhum item cadastrado."
+msgstr ""

--- a/empresas/templates/empresas/historico.html
+++ b/empresas/templates/empresas/historico.html
@@ -1,15 +1,16 @@
 {% extends 'base.html' %}
-{% block title %}Histórico de alterações - {{ empresa.nome }}{% endblock %}
+{% load i18n %}
+{% block title %}{% trans "Histórico de alterações" %} - {{ empresa.nome }}{% endblock %}
 {% block content %}
 <section class="max-w-4xl mx-auto px-4 py-10 space-y-6">
-  <h1 class="text-2xl font-bold">Histórico de alterações - {{ empresa.nome }}</h1>
+  <h1 class="text-2xl font-bold">{% trans "Histórico de alterações" %} - {{ empresa.nome }}</h1>
   <table class="min-w-full divide-y divide-neutral-200 bg-white border">
     <thead>
       <tr>
-        <th class="px-4 py-2 text-left text-sm font-medium">Campo</th>
-        <th class="px-4 py-2 text-left text-sm font-medium">Anterior</th>
-        <th class="px-4 py-2 text-left text-sm font-medium">Novo</th>
-        <th class="px-4 py-2 text-left text-sm font-medium">Data</th>
+        <th class="px-4 py-2 text-left text-sm font-medium">{% trans "Campo" %}</th>
+        <th class="px-4 py-2 text-left text-sm font-medium">{% trans "Anterior" %}</th>
+        <th class="px-4 py-2 text-left text-sm font-medium">{% trans "Novo" %}</th>
+        <th class="px-4 py-2 text-left text-sm font-medium">{% trans "Data" %}</th>
       </tr>
     </thead>
     <tbody class="divide-y divide-neutral-200">
@@ -18,20 +19,20 @@
         <td class="px-4 py-2 text-sm">{{ log.campo_alterado }}</td>
         <td class="px-4 py-2 text-sm">{{ log.valor_antigo }}</td>
         <td class="px-4 py-2 text-sm">{{ log.valor_novo }}</td>
-        <td class="px-4 py-2 text-sm">{{ log.alterado_em|date:"d/m/Y H:i" }}</td>
+        <td class="px-4 py-2 text-sm">{{ log.alterado_em|date:'SHORT_DATETIME_FORMAT' }}</td>
       </tr>
       {% empty %}
-      <tr><td colspan="4" class="px-4 py-2 text-center text-sm">Nenhuma alteração registrada.</td></tr>
+      <tr><td colspan="4" class="px-4 py-2 text-center text-sm">{% trans "Nenhuma alteração registrada." %}</td></tr>
       {% endfor %}
     </tbody>
   </table>
   {% if is_paginated %}
-  <nav class="flex justify-between mt-4" aria-label="Paginação">
+  <nav class="flex justify-between mt-4" aria-label="{% trans 'Paginação' %}">
     {% if page_obj.has_previous %}
-      <a href="?page={{ page_obj.previous_page_number }}" class="px-3 py-1 border rounded">Anterior</a>
+      <a href="?page={{ page_obj.previous_page_number }}" class="px-3 py-1 border rounded">{% trans "Anterior" %}</a>
     {% endif %}
     {% if page_obj.has_next %}
-      <a href="?page={{ page_obj.next_page_number }}" class="px-3 py-1 border rounded">Próxima</a>
+      <a href="?page={{ page_obj.next_page_number }}" class="px-3 py-1 border rounded">{% trans "Próxima" %}</a>
     {% endif %}
   </nav>
   {% endif %}

--- a/feed/locale/en/LC_MESSAGES/django.po
+++ b/feed/locale/en/LC_MESSAGES/django.po
@@ -1,0 +1,215 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-14 16:35+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: templates/feed/_grid.html:7
+#, python-format
+msgid "Feed do Núcleo: %(nome)s"
+msgstr ""
+
+#: templates/feed/_grid.html:9
+#, python-format
+msgid "Feed do Evento: %(titulo)s"
+msgstr ""
+
+#: templates/feed/_grid.html:11
+msgid "Mural do Usuário"
+msgstr ""
+
+#: templates/feed/_grid.html:13
+msgid "Feed Global"
+msgstr ""
+
+#: templates/feed/_grid.html:36 templates/feed/_post_list.html:32
+#: templates/feed/post_update.html:40
+msgid "PDF"
+msgstr ""
+
+#: templates/feed/_grid.html:53
+msgid "comentários"
+msgstr ""
+
+#: templates/feed/_grid.html:57
+msgid "Nenhuma postagem encontrada."
+msgstr ""
+
+#: templates/feed/_like_button.html:2
+msgid "Descurtir"
+msgstr ""
+
+#: templates/feed/_like_button.html:2
+msgid "Curtir"
+msgstr ""
+
+#: templates/feed/_post_list.html:42
+msgid "mídia do post"
+msgstr ""
+
+#: templates/feed/_post_list.html:61
+msgid "Nenhuma postagem ainda"
+msgstr ""
+
+#: templates/feed/_post_list.html:62
+msgid "Seja o primeiro a compartilhar algo!"
+msgstr ""
+
+#: templates/feed/_post_list.html:64
+msgid "Criar postagem"
+msgstr ""
+
+#: templates/feed/feed.html:4
+msgid "Feed"
+msgstr ""
+
+#: templates/feed/feed.html:11
+msgid "Feed de Postagens"
+msgstr ""
+
+#: templates/feed/feed.html:13
+msgid "Mural"
+msgstr ""
+
+#: templates/feed/feed.html:15 templates/feed/feed.html:19
+#: templates/feed/mural.html:16 templates/feed/mural.html:18
+msgid "Nova postagem"
+msgstr ""
+
+#: templates/feed/feed.html:26 templates/feed/nova_postagem.html:55
+msgid "Núcleo"
+msgstr ""
+
+#: templates/feed/feed.html:33
+msgid "Global"
+msgstr ""
+
+#: templates/feed/feed.html:41
+msgid "Buscar postagens…"
+msgstr ""
+
+#: templates/feed/feed.html:48
+msgid "Carregando…"
+msgstr ""
+
+#: templates/feed/mural.html:3 templates/feed/mural.html:12
+msgid "Meu Mural"
+msgstr ""
+
+#: templates/feed/mural.html:14
+msgid "Ver Feed Global"
+msgstr ""
+
+#: templates/feed/nova_postagem.html:4 templates/feed/nova_postagem.html:18
+msgid "Nova Postagem"
+msgstr ""
+
+#: templates/feed/nova_postagem.html:11 templates/feed/nova_postagem.html:15
+#: templates/feed/post_detail.html:8 templates/feed/post_update.html:8
+#: templates/feed/post_update.html:12
+msgid "Voltar"
+msgstr ""
+
+#: templates/feed/nova_postagem.html:19
+msgid "Compartilhe algo com sua comunidade"
+msgstr ""
+
+#: templates/feed/nova_postagem.html:40
+msgid "O que você gostaria de compartilhar?"
+msgstr ""
+
+#: templates/feed/nova_postagem.html:47
+msgid "Compartilhe ideias, atualizações ou conteúdos com sua rede."
+msgstr ""
+
+#: templates/feed/nova_postagem.html:51
+msgid "Tipo de Feed"
+msgstr ""
+
+#: templates/feed/nova_postagem.html:59
+msgid "Evento"
+msgstr ""
+
+#: templates/feed/nova_postagem.html:65 templates/feed/post_update.html:33
+msgid "Arquivo (imagem ou PDF)"
+msgstr ""
+
+#: templates/feed/nova_postagem.html:78 templates/feed/nova_postagem.html:82
+#: templates/feed/post_update.html:55
+msgid "Salvar"
+msgstr ""
+
+#: templates/feed/nova_postagem.html:85 templates/feed/nova_postagem.html:86
+#: templates/feed/post_delete.html:13 templates/feed/post_update.html:54
+msgid "Cancelar"
+msgstr ""
+
+#: templates/feed/post_delete.html:3 templates/feed/post_delete.html:8
+msgid "Remover Postagem"
+msgstr ""
+
+#: templates/feed/post_delete.html:9
+msgid "Tem certeza que deseja remover esta postagem?"
+msgstr ""
+
+#: templates/feed/post_delete.html:14 templates/feed/post_detail.html:80
+msgid "Remover"
+msgstr ""
+
+#: templates/feed/post_detail.html:3
+msgid "Postagem"
+msgstr ""
+
+#: templates/feed/post_detail.html:35
+msgid "Visualizar PDF"
+msgstr ""
+
+#: templates/feed/post_detail.html:39
+msgid "Imagem"
+msgstr ""
+
+#: templates/feed/post_detail.html:60
+msgid "Comentários"
+msgstr ""
+
+#: templates/feed/post_detail.html:67
+msgid "Enviar comentário"
+msgstr ""
+
+#: templates/feed/post_detail.html:67
+msgid "Enviar"
+msgstr ""
+
+#: templates/feed/post_detail.html:79
+msgid "Editar postagem"
+msgstr ""
+
+#: templates/feed/post_detail.html:79
+msgid "Editar"
+msgstr ""
+
+#: templates/feed/post_detail.html:80
+msgid "Remover postagem"
+msgstr ""
+
+#: templates/feed/post_update.html:3 templates/feed/post_update.html:15
+msgid "Editar Postagem"
+msgstr ""
+
+#: templates/feed/post_update.html:16
+msgid "Atualize sua postagem"
+msgstr ""

--- a/feed/locale/pt_BR/LC_MESSAGES/django.po
+++ b/feed/locale/pt_BR/LC_MESSAGES/django.po
@@ -1,0 +1,215 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-14 16:35+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: templates/feed/_grid.html:7
+#, python-format
+msgid "Feed do Núcleo: %(nome)s"
+msgstr ""
+
+#: templates/feed/_grid.html:9
+#, python-format
+msgid "Feed do Evento: %(titulo)s"
+msgstr ""
+
+#: templates/feed/_grid.html:11
+msgid "Mural do Usuário"
+msgstr ""
+
+#: templates/feed/_grid.html:13
+msgid "Feed Global"
+msgstr ""
+
+#: templates/feed/_grid.html:36 templates/feed/_post_list.html:32
+#: templates/feed/post_update.html:40
+msgid "PDF"
+msgstr ""
+
+#: templates/feed/_grid.html:53
+msgid "comentários"
+msgstr ""
+
+#: templates/feed/_grid.html:57
+msgid "Nenhuma postagem encontrada."
+msgstr ""
+
+#: templates/feed/_like_button.html:2
+msgid "Descurtir"
+msgstr ""
+
+#: templates/feed/_like_button.html:2
+msgid "Curtir"
+msgstr ""
+
+#: templates/feed/_post_list.html:42
+msgid "mídia do post"
+msgstr ""
+
+#: templates/feed/_post_list.html:61
+msgid "Nenhuma postagem ainda"
+msgstr ""
+
+#: templates/feed/_post_list.html:62
+msgid "Seja o primeiro a compartilhar algo!"
+msgstr ""
+
+#: templates/feed/_post_list.html:64
+msgid "Criar postagem"
+msgstr ""
+
+#: templates/feed/feed.html:4
+msgid "Feed"
+msgstr ""
+
+#: templates/feed/feed.html:11
+msgid "Feed de Postagens"
+msgstr ""
+
+#: templates/feed/feed.html:13
+msgid "Mural"
+msgstr ""
+
+#: templates/feed/feed.html:15 templates/feed/feed.html:19
+#: templates/feed/mural.html:16 templates/feed/mural.html:18
+msgid "Nova postagem"
+msgstr ""
+
+#: templates/feed/feed.html:26 templates/feed/nova_postagem.html:55
+msgid "Núcleo"
+msgstr ""
+
+#: templates/feed/feed.html:33
+msgid "Global"
+msgstr ""
+
+#: templates/feed/feed.html:41
+msgid "Buscar postagens…"
+msgstr ""
+
+#: templates/feed/feed.html:48
+msgid "Carregando…"
+msgstr ""
+
+#: templates/feed/mural.html:3 templates/feed/mural.html:12
+msgid "Meu Mural"
+msgstr ""
+
+#: templates/feed/mural.html:14
+msgid "Ver Feed Global"
+msgstr ""
+
+#: templates/feed/nova_postagem.html:4 templates/feed/nova_postagem.html:18
+msgid "Nova Postagem"
+msgstr ""
+
+#: templates/feed/nova_postagem.html:11 templates/feed/nova_postagem.html:15
+#: templates/feed/post_detail.html:8 templates/feed/post_update.html:8
+#: templates/feed/post_update.html:12
+msgid "Voltar"
+msgstr ""
+
+#: templates/feed/nova_postagem.html:19
+msgid "Compartilhe algo com sua comunidade"
+msgstr ""
+
+#: templates/feed/nova_postagem.html:40
+msgid "O que você gostaria de compartilhar?"
+msgstr ""
+
+#: templates/feed/nova_postagem.html:47
+msgid "Compartilhe ideias, atualizações ou conteúdos com sua rede."
+msgstr ""
+
+#: templates/feed/nova_postagem.html:51
+msgid "Tipo de Feed"
+msgstr ""
+
+#: templates/feed/nova_postagem.html:59
+msgid "Evento"
+msgstr ""
+
+#: templates/feed/nova_postagem.html:65 templates/feed/post_update.html:33
+msgid "Arquivo (imagem ou PDF)"
+msgstr ""
+
+#: templates/feed/nova_postagem.html:78 templates/feed/nova_postagem.html:82
+#: templates/feed/post_update.html:55
+msgid "Salvar"
+msgstr ""
+
+#: templates/feed/nova_postagem.html:85 templates/feed/nova_postagem.html:86
+#: templates/feed/post_delete.html:13 templates/feed/post_update.html:54
+msgid "Cancelar"
+msgstr ""
+
+#: templates/feed/post_delete.html:3 templates/feed/post_delete.html:8
+msgid "Remover Postagem"
+msgstr ""
+
+#: templates/feed/post_delete.html:9
+msgid "Tem certeza que deseja remover esta postagem?"
+msgstr ""
+
+#: templates/feed/post_delete.html:14 templates/feed/post_detail.html:80
+msgid "Remover"
+msgstr ""
+
+#: templates/feed/post_detail.html:3
+msgid "Postagem"
+msgstr ""
+
+#: templates/feed/post_detail.html:35
+msgid "Visualizar PDF"
+msgstr ""
+
+#: templates/feed/post_detail.html:39
+msgid "Imagem"
+msgstr ""
+
+#: templates/feed/post_detail.html:60
+msgid "Comentários"
+msgstr ""
+
+#: templates/feed/post_detail.html:67
+msgid "Enviar comentário"
+msgstr ""
+
+#: templates/feed/post_detail.html:67
+msgid "Enviar"
+msgstr ""
+
+#: templates/feed/post_detail.html:79
+msgid "Editar postagem"
+msgstr ""
+
+#: templates/feed/post_detail.html:79
+msgid "Editar"
+msgstr ""
+
+#: templates/feed/post_detail.html:80
+msgid "Remover postagem"
+msgstr ""
+
+#: templates/feed/post_update.html:3 templates/feed/post_update.html:15
+msgid "Editar Postagem"
+msgstr ""
+
+#: templates/feed/post_update.html:16
+msgid "Atualize sua postagem"
+msgstr ""

--- a/feed/templates/feed/_comment.html
+++ b/feed/templates/feed/_comment.html
@@ -1,5 +1,6 @@
+{% load i18n %}
 <li class="border border-neutral-200 bg-white rounded-xl shadow-sm p-4" id="comment-{{ comment.id }}">
   <p class="text-sm font-medium">{{ comment.user.get_full_name|default:comment.user.username }}</p>
-  <p class="text-xs text-neutral-500">{{ comment.created|date:"d/m/Y H:i" }}</p>
+  <p class="text-xs text-neutral-500">{{ comment.created|date:"SHORT_DATETIME_FORMAT" }}</p>
   <p class="text-sm text-neutral-800">{{ comment.texto }}</p>
 </li>

--- a/feed/templates/feed/_grid.html
+++ b/feed/templates/feed/_grid.html
@@ -25,7 +25,7 @@
         </a>
         <div>
           <p class="text-sm font-medium text-neutral-800">{{ post.autor.get_full_name|default:post.autor.username }}</p>
-          <p class="text-xs text-neutral-500">{{ post.criado_em|date:"d/m/Y H:i" }}</p>
+          <p class="text-xs text-neutral-500">{{ post.criado_em|date:SHORT_DATETIME_FORMAT }}</p>
         </div>
       </div>
       <div class="text-sm text-neutral-800 whitespace-pre-line">

--- a/feed/templates/feed/_post_list.html
+++ b/feed/templates/feed/_post_list.html
@@ -14,7 +14,7 @@
             {{ post.autor.get_full_name|default:post.autor.username }}
           </p>
           <p class="text-xs text-neutral-500">
-            {{ post.criado_em|date:"d/m/Y H:i" }}
+            {{ post.criado_em|date:SHORT_DATETIME_FORMAT }}
           </p>
         </div>
       </div>

--- a/feed/templates/feed/post_detail.html
+++ b/feed/templates/feed/post_detail.html
@@ -19,7 +19,7 @@
       {% endif %}
       <div>
         <p class="text-sm font-medium text-neutral-800">{{ post.autor.get_full_name|default:post.autor.username }}</p>
-        <p class="text-xs text-neutral-500">{{ post.criado_em|date:"d/m/Y H:i" }}</p>
+        <p class="text-xs text-neutral-500">{{ post.criado_em|date:SHORT_DATETIME_FORMAT }}</p>
       </div>
     </div>
 
@@ -32,7 +32,7 @@
 
     {% if post.pdf %}
       <div class="relative mt-2">
-        <a href="{{ post.pdf.url }}" target="_blank" class="text-blue-500 underline">Visualizar PDF</a>
+        <a href="{{ post.pdf.url }}" target="_blank" class="text-blue-500 underline">{% trans "Visualizar PDF" %}</a>
       </div>
     {% elif post.image %}
       <div class="mt-2">

--- a/financeiro/locale/en/LC_MESSAGES/django.po
+++ b/financeiro/locale/en/LC_MESSAGES/django.po
@@ -1,0 +1,383 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-14 15:05+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+#: templates/financeiro/aportes_form.html:5
+#: templates/financeiro/importar_pagamentos.html:52
+#: templates/financeiro/inadimplencias.html:12
+#: templates/financeiro/inadimplencias.html:45
+#: templates/financeiro/lancamentos_list.html:21
+#: templates/financeiro/lancamentos_list.html:52
+#: templates/financeiro/relatorios.html:12
+msgid "Centro de Custo"
+msgstr ""
+
+#: templates/financeiro/aportes_form.html:13
+#: templates/financeiro/importar_pagamentos.html:52
+#: templates/financeiro/inadimplencias.html:47
+#: templates/financeiro/lancamentos_list.html:55
+msgid "Valor"
+msgstr ""
+
+#: templates/financeiro/aportes_form.html:17
+#: templates/financeiro/centro_form.html:18
+#: templates/financeiro/centros_list.html:19
+#: templates/financeiro/importar_pagamentos.html:52
+#: templates/financeiro/lancamentos_list.html:54
+msgid "Tipo"
+msgstr ""
+
+#: templates/financeiro/aportes_form.html:18
+msgid "Interno"
+msgstr ""
+
+#: templates/financeiro/aportes_form.html:19
+msgid "Externo"
+msgstr ""
+
+#: templates/financeiro/aportes_form.html:22
+msgid "Descrição"
+msgstr ""
+
+#: templates/financeiro/aportes_form.html:25
+msgid "Registrar"
+msgstr ""
+
+#: templates/financeiro/centro_form.html:13
+#: templates/financeiro/centros_list.html:18
+msgid "Nome"
+msgstr ""
+
+#: templates/financeiro/centro_form.html:20
+#: templates/financeiro/centro_form.html:27
+#: templates/financeiro/forecast.html:7
+msgid "Organização"
+msgstr ""
+
+#: templates/financeiro/centro_form.html:21
+#: templates/financeiro/centro_form.html:31
+#: templates/financeiro/forecast.html:8
+#: templates/financeiro/inadimplencias.html:21
+#: templates/financeiro/lancamentos_list.html:30
+#: templates/financeiro/relatorios.html:21
+msgid "Núcleo"
+msgstr ""
+
+#: templates/financeiro/centro_form.html:22
+#: templates/financeiro/centro_form.html:35
+#: templates/financeiro/forecast.html:10
+msgid "Evento"
+msgstr ""
+
+#: templates/financeiro/centro_form.html:38
+msgid "Salvar"
+msgstr ""
+
+#: templates/financeiro/centros_list.html:4
+#: templates/financeiro/centros_list.html:9
+msgid "Centros de Custo"
+msgstr ""
+
+#: templates/financeiro/centros_list.html:11
+msgid "Novo Centro"
+msgstr ""
+
+#: templates/financeiro/centros_list.html:20
+msgid "Organização/Núcleo/Evento"
+msgstr ""
+
+#: templates/financeiro/centros_list.html:21
+#: templates/financeiro/relatorios.html:62
+msgid "Saldo"
+msgstr ""
+
+#: templates/financeiro/centros_list.html:22
+msgid "Ações"
+msgstr ""
+
+#: templates/financeiro/centros_list.html:35
+msgid "Editar"
+msgstr ""
+
+#: templates/financeiro/centros_list.html:36
+msgid "Tem certeza?"
+msgstr ""
+
+#: templates/financeiro/centros_list.html:36
+msgid "Excluir"
+msgstr ""
+
+#: templates/financeiro/centros_list.html:41
+msgid "Nenhum centro encontrado."
+msgstr ""
+
+#: templates/financeiro/centros_list.html:48
+msgid "Anterior"
+msgstr ""
+
+#: templates/financeiro/centros_list.html:51
+msgid "Próximo"
+msgstr ""
+
+#: templates/financeiro/forecast.html:5
+msgid "Escopo"
+msgstr ""
+
+#: templates/financeiro/forecast.html:9
+msgid "Centro"
+msgstr ""
+
+#: templates/financeiro/forecast.html:14
+msgid "Referência"
+msgstr ""
+
+#: templates/financeiro/forecast.html:18
+msgid "Meses"
+msgstr ""
+
+#: templates/financeiro/forecast.html:23
+#, python-format
+msgid "Crescimento Receita (%%)"
+msgstr ""
+
+#: templates/financeiro/forecast.html:27
+#, python-format
+msgid "Redução Despesa (%%)"
+msgstr ""
+
+#: templates/financeiro/forecast.html:31
+msgid "Atualizar"
+msgstr ""
+
+#: templates/financeiro/forecast.html:37
+#: templates/financeiro/inadimplencias.html:56
+#: templates/financeiro/relatorios.html:52
+msgid "Exportar CSV"
+msgstr ""
+
+#: templates/financeiro/forecast.html:38
+#: templates/financeiro/inadimplencias.html:57
+#: templates/financeiro/relatorios.html:53
+msgid "Exportar XLSX"
+msgstr ""
+
+#: templates/financeiro/importar_pagamentos.html:4
+#: templates/financeiro/importar_pagamentos.html:9
+msgid "Importar Pagamentos"
+msgstr ""
+
+#: templates/financeiro/importar_pagamentos.html:12
+msgid "Arquivo"
+msgstr ""
+
+#: templates/financeiro/importar_pagamentos.html:22
+msgid "Pré-visualizar"
+msgstr ""
+
+#: templates/financeiro/importar_pagamentos.html:37
+msgid "Confirmar Importação"
+msgstr ""
+
+#: templates/financeiro/importar_pagamentos.html:39
+msgid "Processando..."
+msgstr ""
+
+#: templates/financeiro/importar_pagamentos.html:52
+#: templates/financeiro/inadimplencias.html:46
+msgid "Conta"
+msgstr ""
+
+#: templates/financeiro/importar_pagamentos.html:52
+#: templates/financeiro/task_logs.html:13
+msgid "Data"
+msgstr ""
+
+#: templates/financeiro/importar_pagamentos.html:63
+msgid "Erro ao processar pré-visualização"
+msgstr ""
+
+#: templates/financeiro/inadimplencias.html:4
+#: templates/financeiro/inadimplencias.html:8
+msgid "Inadimplências"
+msgstr ""
+
+#: templates/financeiro/inadimplencias.html:10
+#: templates/financeiro/lancamentos_list.html:10
+msgid "Filtros"
+msgstr ""
+
+#: templates/financeiro/inadimplencias.html:14
+#: templates/financeiro/lancamentos_list.html:23
+msgid "Todos Centros"
+msgstr ""
+
+#: templates/financeiro/inadimplencias.html:23
+#: templates/financeiro/lancamentos_list.html:32
+msgid "Todos Núcleos"
+msgstr ""
+
+#: templates/financeiro/inadimplencias.html:30
+#: templates/financeiro/lancamentos_list.html:12
+#: templates/financeiro/lancamentos_list.html:57
+#: templates/financeiro/task_log_detail.html:10
+#: templates/financeiro/task_logs.html:14
+msgid "Status"
+msgstr ""
+
+#: templates/financeiro/inadimplencias.html:32
+#: templates/financeiro/lancamentos_list.html:15
+msgid "Pendente"
+msgstr ""
+
+#: templates/financeiro/inadimplencias.html:36
+msgid "Período"
+msgstr ""
+
+#: templates/financeiro/inadimplencias.html:44
+#: templates/financeiro/lancamentos_list.html:51
+msgid "ID"
+msgstr ""
+
+#: templates/financeiro/inadimplencias.html:48
+#: templates/financeiro/lancamentos_list.html:58
+msgid "Data de Vencimento"
+msgstr ""
+
+#: templates/financeiro/inadimplencias.html:49
+msgid "Dias em atraso"
+msgstr ""
+
+#: templates/financeiro/inadimplencias.html:56
+msgid "Exportar inadimplências em CSV"
+msgstr ""
+
+#: templates/financeiro/inadimplencias.html:57
+msgid "Exportar inadimplências em XLSX"
+msgstr ""
+
+#: templates/financeiro/lancamentos_list.html:4
+msgid "Lançamentos Financeiros"
+msgstr ""
+
+#: templates/financeiro/lancamentos_list.html:8
+msgid "Lançamentos"
+msgstr ""
+
+#: templates/financeiro/lancamentos_list.html:14
+msgid "Todos Status"
+msgstr ""
+
+#: templates/financeiro/lancamentos_list.html:16
+msgid "Pago"
+msgstr ""
+
+#: templates/financeiro/lancamentos_list.html:17
+msgid "Cancelado"
+msgstr ""
+
+#: templates/financeiro/lancamentos_list.html:39
+#: templates/financeiro/relatorios.html:32
+msgid "Período inicial"
+msgstr ""
+
+#: templates/financeiro/lancamentos_list.html:43
+#: templates/financeiro/relatorios.html:36
+msgid "Período final"
+msgstr ""
+
+#: templates/financeiro/lancamentos_list.html:53
+msgid "Conta Associada"
+msgstr ""
+
+#: templates/financeiro/lancamentos_list.html:56
+msgid "Data de Lançamento"
+msgstr ""
+
+#: templates/financeiro/relatorios.html:4
+msgid "Relatórios Financeiros"
+msgstr ""
+
+#: templates/financeiro/relatorios.html:8
+msgid "Relatórios"
+msgstr ""
+
+#: templates/financeiro/relatorios.html:14
+#: templates/financeiro/relatorios.html:23
+msgid "Todos"
+msgstr ""
+
+#: templates/financeiro/relatorios.html:46
+msgid "Gerar Relatório"
+msgstr ""
+
+#: templates/financeiro/relatorios.html:52
+msgid "Exportar relatório em CSV"
+msgstr ""
+
+#: templates/financeiro/relatorios.html:53
+msgid "Exportar relatório em XLSX"
+msgstr ""
+
+#: templates/financeiro/relatorios.html:62
+msgid "Saldo atual"
+msgstr ""
+
+#: templates/financeiro/relatorios.html:62
+msgid "Mês"
+msgstr ""
+
+#: templates/financeiro/relatorios.html:62
+msgid "Receitas"
+msgstr ""
+
+#: templates/financeiro/relatorios.html:62
+msgid "Despesas"
+msgstr ""
+
+#: templates/financeiro/task_log_detail.html:4
+msgid "Detalhes da Tarefa Financeira"
+msgstr ""
+
+#: templates/financeiro/task_log_detail.html:9
+msgid "Executada em"
+msgstr ""
+
+#: templates/financeiro/task_log_detail.html:12
+#: templates/financeiro/task_logs.html:15
+msgid "Detalhes"
+msgstr ""
+
+#: templates/financeiro/task_log_detail.html:13
+msgid "Sem detalhes"
+msgstr ""
+
+#: templates/financeiro/task_logs.html:4 templates/financeiro/task_logs.html:8
+msgid "Histórico de Tarefas Financeiras"
+msgstr ""
+
+#: templates/financeiro/task_logs.html:12
+msgid "Tarefa"
+msgstr ""
+
+#: templates/financeiro/task_logs.html:24
+msgid "Ver"
+msgstr ""
+
+#: templates/financeiro/task_logs.html:28
+msgid "Nenhum registro encontrado"
+msgstr ""

--- a/financeiro/locale/pt_BR/LC_MESSAGES/django.po
+++ b/financeiro/locale/pt_BR/LC_MESSAGES/django.po
@@ -1,0 +1,383 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-14 15:05+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+#: templates/financeiro/aportes_form.html:5
+#: templates/financeiro/importar_pagamentos.html:52
+#: templates/financeiro/inadimplencias.html:12
+#: templates/financeiro/inadimplencias.html:45
+#: templates/financeiro/lancamentos_list.html:21
+#: templates/financeiro/lancamentos_list.html:52
+#: templates/financeiro/relatorios.html:12
+msgid "Centro de Custo"
+msgstr ""
+
+#: templates/financeiro/aportes_form.html:13
+#: templates/financeiro/importar_pagamentos.html:52
+#: templates/financeiro/inadimplencias.html:47
+#: templates/financeiro/lancamentos_list.html:55
+msgid "Valor"
+msgstr ""
+
+#: templates/financeiro/aportes_form.html:17
+#: templates/financeiro/centro_form.html:18
+#: templates/financeiro/centros_list.html:19
+#: templates/financeiro/importar_pagamentos.html:52
+#: templates/financeiro/lancamentos_list.html:54
+msgid "Tipo"
+msgstr ""
+
+#: templates/financeiro/aportes_form.html:18
+msgid "Interno"
+msgstr ""
+
+#: templates/financeiro/aportes_form.html:19
+msgid "Externo"
+msgstr ""
+
+#: templates/financeiro/aportes_form.html:22
+msgid "Descrição"
+msgstr ""
+
+#: templates/financeiro/aportes_form.html:25
+msgid "Registrar"
+msgstr ""
+
+#: templates/financeiro/centro_form.html:13
+#: templates/financeiro/centros_list.html:18
+msgid "Nome"
+msgstr ""
+
+#: templates/financeiro/centro_form.html:20
+#: templates/financeiro/centro_form.html:27
+#: templates/financeiro/forecast.html:7
+msgid "Organização"
+msgstr ""
+
+#: templates/financeiro/centro_form.html:21
+#: templates/financeiro/centro_form.html:31
+#: templates/financeiro/forecast.html:8
+#: templates/financeiro/inadimplencias.html:21
+#: templates/financeiro/lancamentos_list.html:30
+#: templates/financeiro/relatorios.html:21
+msgid "Núcleo"
+msgstr ""
+
+#: templates/financeiro/centro_form.html:22
+#: templates/financeiro/centro_form.html:35
+#: templates/financeiro/forecast.html:10
+msgid "Evento"
+msgstr ""
+
+#: templates/financeiro/centro_form.html:38
+msgid "Salvar"
+msgstr ""
+
+#: templates/financeiro/centros_list.html:4
+#: templates/financeiro/centros_list.html:9
+msgid "Centros de Custo"
+msgstr ""
+
+#: templates/financeiro/centros_list.html:11
+msgid "Novo Centro"
+msgstr ""
+
+#: templates/financeiro/centros_list.html:20
+msgid "Organização/Núcleo/Evento"
+msgstr ""
+
+#: templates/financeiro/centros_list.html:21
+#: templates/financeiro/relatorios.html:62
+msgid "Saldo"
+msgstr ""
+
+#: templates/financeiro/centros_list.html:22
+msgid "Ações"
+msgstr ""
+
+#: templates/financeiro/centros_list.html:35
+msgid "Editar"
+msgstr ""
+
+#: templates/financeiro/centros_list.html:36
+msgid "Tem certeza?"
+msgstr ""
+
+#: templates/financeiro/centros_list.html:36
+msgid "Excluir"
+msgstr ""
+
+#: templates/financeiro/centros_list.html:41
+msgid "Nenhum centro encontrado."
+msgstr ""
+
+#: templates/financeiro/centros_list.html:48
+msgid "Anterior"
+msgstr ""
+
+#: templates/financeiro/centros_list.html:51
+msgid "Próximo"
+msgstr ""
+
+#: templates/financeiro/forecast.html:5
+msgid "Escopo"
+msgstr ""
+
+#: templates/financeiro/forecast.html:9
+msgid "Centro"
+msgstr ""
+
+#: templates/financeiro/forecast.html:14
+msgid "Referência"
+msgstr ""
+
+#: templates/financeiro/forecast.html:18
+msgid "Meses"
+msgstr ""
+
+#: templates/financeiro/forecast.html:23
+#, python-format
+msgid "Crescimento Receita (%%)"
+msgstr ""
+
+#: templates/financeiro/forecast.html:27
+#, python-format
+msgid "Redução Despesa (%%)"
+msgstr ""
+
+#: templates/financeiro/forecast.html:31
+msgid "Atualizar"
+msgstr ""
+
+#: templates/financeiro/forecast.html:37
+#: templates/financeiro/inadimplencias.html:56
+#: templates/financeiro/relatorios.html:52
+msgid "Exportar CSV"
+msgstr ""
+
+#: templates/financeiro/forecast.html:38
+#: templates/financeiro/inadimplencias.html:57
+#: templates/financeiro/relatorios.html:53
+msgid "Exportar XLSX"
+msgstr ""
+
+#: templates/financeiro/importar_pagamentos.html:4
+#: templates/financeiro/importar_pagamentos.html:9
+msgid "Importar Pagamentos"
+msgstr ""
+
+#: templates/financeiro/importar_pagamentos.html:12
+msgid "Arquivo"
+msgstr ""
+
+#: templates/financeiro/importar_pagamentos.html:22
+msgid "Pré-visualizar"
+msgstr ""
+
+#: templates/financeiro/importar_pagamentos.html:37
+msgid "Confirmar Importação"
+msgstr ""
+
+#: templates/financeiro/importar_pagamentos.html:39
+msgid "Processando..."
+msgstr ""
+
+#: templates/financeiro/importar_pagamentos.html:52
+#: templates/financeiro/inadimplencias.html:46
+msgid "Conta"
+msgstr ""
+
+#: templates/financeiro/importar_pagamentos.html:52
+#: templates/financeiro/task_logs.html:13
+msgid "Data"
+msgstr ""
+
+#: templates/financeiro/importar_pagamentos.html:63
+msgid "Erro ao processar pré-visualização"
+msgstr ""
+
+#: templates/financeiro/inadimplencias.html:4
+#: templates/financeiro/inadimplencias.html:8
+msgid "Inadimplências"
+msgstr ""
+
+#: templates/financeiro/inadimplencias.html:10
+#: templates/financeiro/lancamentos_list.html:10
+msgid "Filtros"
+msgstr ""
+
+#: templates/financeiro/inadimplencias.html:14
+#: templates/financeiro/lancamentos_list.html:23
+msgid "Todos Centros"
+msgstr ""
+
+#: templates/financeiro/inadimplencias.html:23
+#: templates/financeiro/lancamentos_list.html:32
+msgid "Todos Núcleos"
+msgstr ""
+
+#: templates/financeiro/inadimplencias.html:30
+#: templates/financeiro/lancamentos_list.html:12
+#: templates/financeiro/lancamentos_list.html:57
+#: templates/financeiro/task_log_detail.html:10
+#: templates/financeiro/task_logs.html:14
+msgid "Status"
+msgstr ""
+
+#: templates/financeiro/inadimplencias.html:32
+#: templates/financeiro/lancamentos_list.html:15
+msgid "Pendente"
+msgstr ""
+
+#: templates/financeiro/inadimplencias.html:36
+msgid "Período"
+msgstr ""
+
+#: templates/financeiro/inadimplencias.html:44
+#: templates/financeiro/lancamentos_list.html:51
+msgid "ID"
+msgstr ""
+
+#: templates/financeiro/inadimplencias.html:48
+#: templates/financeiro/lancamentos_list.html:58
+msgid "Data de Vencimento"
+msgstr ""
+
+#: templates/financeiro/inadimplencias.html:49
+msgid "Dias em atraso"
+msgstr ""
+
+#: templates/financeiro/inadimplencias.html:56
+msgid "Exportar inadimplências em CSV"
+msgstr ""
+
+#: templates/financeiro/inadimplencias.html:57
+msgid "Exportar inadimplências em XLSX"
+msgstr ""
+
+#: templates/financeiro/lancamentos_list.html:4
+msgid "Lançamentos Financeiros"
+msgstr ""
+
+#: templates/financeiro/lancamentos_list.html:8
+msgid "Lançamentos"
+msgstr ""
+
+#: templates/financeiro/lancamentos_list.html:14
+msgid "Todos Status"
+msgstr ""
+
+#: templates/financeiro/lancamentos_list.html:16
+msgid "Pago"
+msgstr ""
+
+#: templates/financeiro/lancamentos_list.html:17
+msgid "Cancelado"
+msgstr ""
+
+#: templates/financeiro/lancamentos_list.html:39
+#: templates/financeiro/relatorios.html:32
+msgid "Período inicial"
+msgstr ""
+
+#: templates/financeiro/lancamentos_list.html:43
+#: templates/financeiro/relatorios.html:36
+msgid "Período final"
+msgstr ""
+
+#: templates/financeiro/lancamentos_list.html:53
+msgid "Conta Associada"
+msgstr ""
+
+#: templates/financeiro/lancamentos_list.html:56
+msgid "Data de Lançamento"
+msgstr ""
+
+#: templates/financeiro/relatorios.html:4
+msgid "Relatórios Financeiros"
+msgstr ""
+
+#: templates/financeiro/relatorios.html:8
+msgid "Relatórios"
+msgstr ""
+
+#: templates/financeiro/relatorios.html:14
+#: templates/financeiro/relatorios.html:23
+msgid "Todos"
+msgstr ""
+
+#: templates/financeiro/relatorios.html:46
+msgid "Gerar Relatório"
+msgstr ""
+
+#: templates/financeiro/relatorios.html:52
+msgid "Exportar relatório em CSV"
+msgstr ""
+
+#: templates/financeiro/relatorios.html:53
+msgid "Exportar relatório em XLSX"
+msgstr ""
+
+#: templates/financeiro/relatorios.html:62
+msgid "Saldo atual"
+msgstr ""
+
+#: templates/financeiro/relatorios.html:62
+msgid "Mês"
+msgstr ""
+
+#: templates/financeiro/relatorios.html:62
+msgid "Receitas"
+msgstr ""
+
+#: templates/financeiro/relatorios.html:62
+msgid "Despesas"
+msgstr ""
+
+#: templates/financeiro/task_log_detail.html:4
+msgid "Detalhes da Tarefa Financeira"
+msgstr ""
+
+#: templates/financeiro/task_log_detail.html:9
+msgid "Executada em"
+msgstr ""
+
+#: templates/financeiro/task_log_detail.html:12
+#: templates/financeiro/task_logs.html:15
+msgid "Detalhes"
+msgstr ""
+
+#: templates/financeiro/task_log_detail.html:13
+msgid "Sem detalhes"
+msgstr ""
+
+#: templates/financeiro/task_logs.html:4 templates/financeiro/task_logs.html:8
+msgid "Histórico de Tarefas Financeiras"
+msgstr ""
+
+#: templates/financeiro/task_logs.html:12
+msgid "Tarefa"
+msgstr ""
+
+#: templates/financeiro/task_logs.html:24
+msgid "Ver"
+msgstr ""
+
+#: templates/financeiro/task_logs.html:28
+msgid "Nenhum registro encontrado"
+msgstr ""

--- a/financeiro/templates/financeiro/importar_pagamentos.html
+++ b/financeiro/templates/financeiro/importar_pagamentos.html
@@ -1,15 +1,15 @@
 {% extends "base.html" %}
 {% load i18n %}
 
-{% block title %}{{ _('Importar Pagamentos') }}{% endblock %}
+{% block title %}{% trans "Importar Pagamentos" %}{% endblock %}
 
 {% block content %}
 <main class="max-w-3xl mx-auto p-4">
   <section>
-    <h1 class="text-2xl font-semibold mb-4">{{ _('Importar Pagamentos') }}</h1>
+    <h1 class="text-2xl font-semibold mb-4">{% trans "Importar Pagamentos" %}</h1>
     <form id="upload-form" method="post" enctype="multipart/form-data" class="space-y-4 border p-4 rounded-lg bg-white">
       {% csrf_token %}
-      <label for="file" class="block text-sm font-medium text-gray-700">{{ _('Arquivo') }}</label>
+      <label for="file" class="block text-sm font-medium text-gray-700">{% trans "Arquivo" %}</label>
       <input id="file" type="file" name="file" accept=".csv,.xlsx" class="block w-full border p-2 rounded" required />
     </form>
     <button id="preview-btn"
@@ -19,7 +19,7 @@
             hx-trigger="change from:#file"
             hx-include="#upload-form"
             hx-on="htmx:afterRequest: renderPreview(event)">
-      {{ _('Pré-visualizar') }}
+      {% trans "Pré-visualizar" %}
     </button>
     <div id="preview" class="mt-6" aria-live="polite"></div>
     <div id="messages" class="mt-4 text-sm" aria-live="polite"></div>
@@ -34,9 +34,9 @@
               hx-include="#confirm-form"
               hx-indicator="#loading"
               class="bg-secondary text-white px-4 py-2 rounded">
-        {{ _('Confirmar Importação') }}
+        {% trans "Confirmar Importação" %}
       </button>
-      <span id="loading" class="htmx-indicator text-sm">{{ _('Processando...') }}</span>
+      <span id="loading" class="htmx-indicator text-sm">{% trans "Processando..." %}</span>
     </div>
   </section>
   <script>
@@ -49,7 +49,7 @@
         const data = JSON.parse(evt.detail.xhr.response);
         if (data.preview && data.preview.length) {
           const rows = data.preview.map(r => `<tr><td class="px-2 py-1">${r.centro_custo}</td><td class="px-2 py-1">${r.conta_associado || ''}</td><td class="px-2 py-1">${r.tipo}</td><td class="px-2 py-1">${r.valor}</td><td class="px-2 py-1">${r.data_lancamento}</td></tr>`).join('');
-          preview.innerHTML = `<table class="min-w-full divide-y divide-gray-200"><thead><tr><th class="px-2 py-1 text-left text-xs font-medium text-gray-500">{{ _('Centro de Custo') }}</th><th class="px-2 py-1 text-left text-xs font-medium text-gray-500">{{ _('Conta') }}</th><th class="px-2 py-1 text-left text-xs font-medium text-gray-500">{{ _('Tipo') }}</th><th class="px-2 py-1 text-left text-xs font-medium text-gray-500">{{ _('Valor') }}</th><th class="px-2 py-1 text-left text-xs font-medium text-gray-500">{{ _('Data') }}</th></tr></thead><tbody>${rows}</tbody></table>`;
+          preview.innerHTML = `<table class="min-w-full divide-y divide-gray-200"><thead><tr><th class="px-2 py-1 text-left text-xs font-medium text-gray-500">{% trans "Centro de Custo" %}</th><th class="px-2 py-1 text-left text-xs font-medium text-gray-500">{% trans "Conta" %}</th><th class="px-2 py-1 text-left text-xs font-medium text-gray-500">{% trans "Tipo" %}</th><th class="px-2 py-1 text-left text-xs font-medium text-gray-500">{% trans "Valor" %}</th><th class="px-2 py-1 text-left text-xs font-medium text-gray-500">{% trans "Data" %}</th></tr></thead><tbody>${rows}</tbody></table>`;
           document.getElementById('confirm-id').value = data.id;
           document.getElementById('confirm-btn').disabled = false;
         }
@@ -60,7 +60,7 @@
           }
         }
       } catch (e) {
-        messages.textContent = '{{ _('Erro ao processar pré-visualização') }}';
+        messages.textContent = '{% trans "Erro ao processar pré-visualização" %}';
         document.getElementById('confirm-btn').disabled = true;
       }
     }

--- a/financeiro/templates/financeiro/inadimplencias.html
+++ b/financeiro/templates/financeiro/inadimplencias.html
@@ -1,39 +1,39 @@
 {% extends "base.html" %}
 {% load i18n %}
 
-{% block title %}{{ _('Inadimplências') }}{% endblock %}
+{% block title %}{% trans "Inadimplências" %}{% endblock %}
 
 {% block content %}
 <section class="p-4 max-w-6xl mx-auto">
-  <h1 class="text-2xl font-semibold mb-2">{{ _('Inadimplências') }}</h1>
+  <h1 class="text-2xl font-semibold mb-2">{% trans "Inadimplências" %}</h1>
   <form id="inad-form" class="mb-4 grid grid-cols-1 md:grid-cols-4 gap-4" hx-get="/api/financeiro/inadimplencias/" hx-target="#lista" hx-swap="none" hx-trigger="change from:select,change from:input, load" hx-on="htmx:afterRequest: renderInadimplencias(event)">
-    <legend class="sr-only">{{ _('Filtros') }}</legend>
+    <legend class="sr-only">{% trans "Filtros" %}</legend>
     <div>
-      <label for="filtro-centro" class="block text-sm font-medium text-gray-700">{{ _('Centro de Custo') }}</label>
+      <label for="filtro-centro" class="block text-sm font-medium text-gray-700">{% trans "Centro de Custo" %}</label>
       <select id="filtro-centro" name="centro" class="border p-2 rounded">
-        <option value="">{{ _('Todos Centros') }}</option>
+        <option value="">{% trans "Todos Centros" %}</option>
         {% for c in centros %}
           <option value="{{ c.id }}">{{ c.nome }}</option>
         {% endfor %}
       </select>
     </div>
     <div>
-      <label for="filtro-nucleo" class="block text-sm font-medium text-gray-700">{{ _('Núcleo') }}</label>
+      <label for="filtro-nucleo" class="block text-sm font-medium text-gray-700">{% trans "Núcleo" %}</label>
       <select id="filtro-nucleo" name="nucleo" class="border p-2 rounded">
-        <option value="">{{ _('Todos Núcleos') }}</option>
+        <option value="">{% trans "Todos Núcleos" %}</option>
         {% for n in nucleos %}
           <option value="{{ n.id }}">{{ n.nome }}</option>
         {% endfor %}
       </select>
     </div>
     <div>
-      <label for="filtro-status" class="block text-sm font-medium text-gray-700">{{ _('Status') }}</label>
+      <label for="filtro-status" class="block text-sm font-medium text-gray-700">{% trans "Status" %}</label>
       <select id="filtro-status" name="status" class="border p-2 rounded" disabled>
-        <option>{{ _('Pendente') }}</option>
+        <option>{% trans "Pendente" %}</option>
       </select>
     </div>
     <div>
-      <label for="filtro-periodo" class="block text-sm font-medium text-gray-700">{{ _('Período') }}</label>
+      <label for="filtro-periodo" class="block text-sm font-medium text-gray-700">{% trans "Período" %}</label>
       <input id="filtro-periodo" type="month" name="periodo" class="border p-2 rounded" />
     </div>
   </form>
@@ -41,20 +41,20 @@
     <table class="min-w-full divide-y divide-gray-200">
       <thead>
         <tr class="bg-gray-50">
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{{ _('ID') }}</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{{ _('Centro de Custo') }}</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{{ _('Conta') }}</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{{ _('Valor') }}</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{{ _('Data de Vencimento') }}</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{{ _('Dias em atraso') }}</th>
+          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{% trans "ID" %}</th>
+          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{% trans "Centro de Custo" %}</th>
+          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{% trans "Conta" %}</th>
+          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{% trans "Valor" %}</th>
+          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{% trans "Data de Vencimento" %}</th>
+          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{% trans "Dias em atraso" %}</th>
         </tr>
       </thead>
       <tbody></tbody>
     </table>
   </div>
   <div class="mt-4 flex gap-4">
-    <a href="#" id="inad-export-csv" class="text-primary underline" hx-boost="false" aria-label="{{ _('Exportar inadimplências em CSV') }}">{{ _('Exportar CSV') }}</a>
-    <a href="#" id="inad-export-xlsx" class="text-primary underline" hx-boost="false" aria-label="{{ _('Exportar inadimplências em XLSX') }}">{{ _('Exportar XLSX') }}</a>
+    <a href="#" id="inad-export-csv" class="text-primary underline" hx-boost="false" aria-label="{% trans 'Exportar inadimplências em CSV' %}">{% trans "Exportar CSV" %}</a>
+    <a href="#" id="inad-export-xlsx" class="text-primary underline" hx-boost="false" aria-label="{% trans 'Exportar inadimplências em XLSX' %}">{% trans "Exportar XLSX" %}</a>
   </div>
   <script>
     function renderInadimplencias(evt) {

--- a/financeiro/templates/financeiro/relatorios.html
+++ b/financeiro/templates/financeiro/relatorios.html
@@ -1,26 +1,26 @@
 {% extends "base.html" %}
 {% load i18n %}
 
-{% block title %}{{ _('Relatórios Financeiros') }}{% endblock %}
+{% block title %}{% trans "Relatórios Financeiros" %}{% endblock %}
 
 {% block content %}
 <main class="max-w-5xl mx-auto p-4 space-y-4">
-  <h1 class="text-2xl font-semibold mb-2">{{ _('Relatórios') }}</h1>
+  <h1 class="text-2xl font-semibold mb-2">{% trans "Relatórios" %}</h1>
   <form id="relatorio-form" class="space-y-4">
     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
       <div>
-        <label for="rel-centro" class="block text-sm font-medium text-gray-700">{{ _('Centro de Custo') }}</label>
+        <label for="rel-centro" class="block text-sm font-medium text-gray-700">{% trans "Centro de Custo" %}</label>
         <select id="rel-centro" name="centro" class="mt-1 block w-full border rounded p-2">
-          <option value="">{{ _('Todos') }}</option>
+          <option value="">{% trans "Todos" %}</option>
           {% for c in centros %}
             <option value="{{ c.id }}">{{ c.nome }}</option>
           {% endfor %}
         </select>
       </div>
       <div>
-        <label for="rel-nucleo" class="block text-sm font-medium text-gray-700">{{ _('Núcleo') }}</label>
+        <label for="rel-nucleo" class="block text-sm font-medium text-gray-700">{% trans "Núcleo" %}</label>
         <select id="rel-nucleo" name="nucleo" class="mt-1 block w-full border rounded p-2">
-          <option value="">{{ _('Todos') }}</option>
+          <option value="">{% trans "Todos" %}</option>
           {% for n in nucleos %}
             <option value="{{ n.id }}">{{ n.nome }}</option>
           {% endfor %}
@@ -29,11 +29,11 @@
     </div>
     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
       <div>
-        <label for="rel-periodo-inicial" class="block text-sm font-medium text-gray-700">{{ _('Período inicial') }}</label>
+        <label for="rel-periodo-inicial" class="block text-sm font-medium text-gray-700">{% trans "Período inicial" %}</label>
         <input id="rel-periodo-inicial" type="month" name="periodo_inicial" class="mt-1 block w-full border rounded p-2" />
       </div>
       <div>
-        <label for="rel-periodo-final" class="block text-sm font-medium text-gray-700">{{ _('Período final') }}</label>
+        <label for="rel-periodo-final" class="block text-sm font-medium text-gray-700">{% trans "Período final" %}</label>
         <input id="rel-periodo-final" type="month" name="periodo_final" class="mt-1 block w-full border rounded p-2" />
       </div>
     </div>
@@ -43,14 +43,14 @@
             hx-include="#relatorio-form"
             hx-trigger="click"
             hx-on="htmx:afterRequest: renderRelatorio(event)">
-      {{ _('Gerar Relatório') }}
+      {% trans "Gerar Relatório" %}
     </button>
   </form>
 
   <div id="relatorio" class="mt-6" aria-live="polite"></div>
   <div class="mt-4 flex gap-4">
-    <a href="#" id="export-csv" class="text-primary underline" hx-boost="false" aria-label="{{ _('Exportar relatório em CSV') }}">{{ _('Exportar CSV') }}</a>
-    <a href="#" id="export-xlsx" class="text-primary underline" hx-boost="false" aria-label="{{ _('Exportar relatório em XLSX') }}">{{ _('Exportar XLSX') }}</a>
+    <a href="#" id="export-csv" class="text-primary underline" hx-boost="false" aria-label="{% trans 'Exportar relatório em CSV' %}">{% trans "Exportar CSV" %}</a>
+    <a href="#" id="export-xlsx" class="text-primary underline" hx-boost="false" aria-label="{% trans 'Exportar relatório em XLSX' %}">{% trans "Exportar XLSX" %}</a>
   </div>
   <script>
     function renderRelatorio(evt) {
@@ -59,12 +59,12 @@
       try {
         const data = JSON.parse(evt.detail.xhr.response);
         const rows = data.serie.map(r => `<tr><td class=\"px-2 py-1\">${r.mes}</td><td class=\"px-2 py-1\">${r.receitas}</td><td class=\"px-2 py-1\">${r.despesas}</td><td class=\"px-2 py-1\">${r.saldo}</td></tr>`).join('');
-        container.innerHTML = `<p class=\"mb-2 font-medium\">{{ _('Saldo atual') }}: ${data.saldo_atual}</p><table class=\"min-w-full divide-y divide-gray-200\"><thead><tr><th class=\"px-2 py-1 text-left text-xs font-medium text-gray-500\">{{ _('Mês') }}</th><th class=\"px-2 py-1 text-left text-xs font-medium text-gray-500\">{{ _('Receitas') }}</th><th class=\"px-2 py-1 text-left text-xs font-medium text-gray-500\">{{ _('Despesas') }}</th><th class=\"px-2 py-1 text-left text-xs font-medium text-gray-500\">{{ _('Saldo') }}</th></tr></thead><tbody>${rows}</tbody></table>`;
+        container.innerHTML = `<p class=\"mb-2 font-medium\">{% trans "Saldo atual" %}: ${data.saldo_atual}</p><table class=\"min-w-full divide-y divide-gray-200\"><thead><tr><th class=\"px-2 py-1 text-left text-xs font-medium text-gray-500\">{% trans "Mês" %}</th><th class=\"px-2 py-1 text-left text-xs font-medium text-gray-500\">{% trans "Receitas" %}</th><th class=\"px-2 py-1 text-left text-xs font-medium text-gray-500\">{% trans "Despesas" %}</th><th class=\"px-2 py-1 text-left text-xs font-medium text-gray-500\">{% trans "Saldo" %}</th></tr></thead><tbody>${rows}</tbody></table>`;
         const params = new URLSearchParams(new FormData(document.getElementById('relatorio-form')));
         document.getElementById('export-csv').href = '/api/financeiro/relatorios/?' + params.toString() + '&format=csv';
         document.getElementById('export-xlsx').href = '/api/financeiro/relatorios/?' + params.toString() + '&format=xlsx';
       } catch (e) {
-        container.textContent = 'Erro ao gerar relatório';
+        container.textContent = gettext('Erro ao gerar relatório');
       }
     }
   </script>

--- a/financeiro/templates/financeiro/task_log_detail.html
+++ b/financeiro/templates/financeiro/task_log_detail.html
@@ -6,7 +6,7 @@
 {% block content %}
 <section class="max-w-3xl mx-auto p-4 space-y-4">
   <h1 class="text-2xl font-semibold mb-2">{{ log.nome_tarefa }}</h1>
-  <p><strong>{{ _('Executada em') }}:</strong> {{ log.executada_em|date:"Y-m-d H:i" }}</p>
+  <p><strong>{{ _('Executada em') }}:</strong> {{ log.executada_em|date:SHORT_DATETIME_FORMAT }}</p>
   <p><strong>{{ _('Status') }}:</strong> {{ log.status }}</p>
   <div>
     <h2 class="text-xl font-semibold">{{ _('Detalhes') }}</h2>

--- a/financeiro/templates/financeiro/task_logs.html
+++ b/financeiro/templates/financeiro/task_logs.html
@@ -19,7 +19,7 @@
       {% for log in logs %}
       <tr>
         <td class="border px-4 py-2">{{ log.nome_tarefa }}</td>
-        <td class="border px-4 py-2">{{ log.executada_em|date:"Y-m-d H:i" }}</td>
+        <td class="border px-4 py-2">{{ log.executada_em|date:SHORT_DATETIME_FORMAT }}</td>
         <td class="border px-4 py-2">{{ log.status }}</td>
         <td class="border px-4 py-2"><a class="text-primary underline" href="{% url 'financeiro:task_log_detail' log.id %}">{{ _('Ver') }}</a></td>
       </tr>

--- a/notificacoes/locale/en/LC_MESSAGES/django.po
+++ b/notificacoes/locale/en/LC_MESSAGES/django.po
@@ -1,0 +1,253 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-14 15:05+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+#: templates/notificacoes/historico_list.html:3
+#: templates/notificacoes/historico_list.html:7
+msgid "Histórico de Notificações"
+msgstr ""
+
+#: templates/notificacoes/historico_list.html:11
+#: templates/notificacoes/logs_list.html:11
+msgid "De"
+msgstr ""
+
+#: templates/notificacoes/historico_list.html:15
+#: templates/notificacoes/logs_list.html:15
+msgid "Até"
+msgstr ""
+
+#: templates/notificacoes/historico_list.html:19
+#: templates/notificacoes/historico_list.html:34
+#: templates/notificacoes/logs_list.html:19
+#: templates/notificacoes/logs_list.html:44
+#: templates/notificacoes/template_form.html:39
+#: templates/notificacoes/templates_list.html:29
+msgid "Canal"
+msgstr ""
+
+#: templates/notificacoes/historico_list.html:21
+#: templates/notificacoes/logs_list.html:21
+#: templates/notificacoes/logs_list.html:30
+msgid "Todos"
+msgstr ""
+
+#: templates/notificacoes/historico_list.html:22
+#: templates/notificacoes/logs_list.html:22
+#: templates/notificacoes/metrics.html:10
+#: templates/notificacoes/metrics.html:16
+msgid "E-mail"
+msgstr ""
+
+#: templates/notificacoes/historico_list.html:23
+#: templates/notificacoes/logs_list.html:23
+#: templates/notificacoes/metrics.html:11
+#: templates/notificacoes/metrics.html:17
+msgid "Push"
+msgstr ""
+
+#: templates/notificacoes/historico_list.html:24
+#: templates/notificacoes/logs_list.html:24
+#: templates/notificacoes/metrics.html:12
+#: templates/notificacoes/metrics.html:18
+msgid "WhatsApp"
+msgstr ""
+
+#: templates/notificacoes/historico_list.html:27
+#: templates/notificacoes/logs_list.html:35
+#: templates/notificacoes/metrics.html:6
+msgid "Filtrar"
+msgstr ""
+
+#: templates/notificacoes/historico_list.html:33
+#: templates/notificacoes/logs_list.html:41
+msgid "Data"
+msgstr ""
+
+#: templates/notificacoes/historico_list.html:35
+msgid "Conteúdo"
+msgstr ""
+
+#: templates/notificacoes/historico_list.html:45
+#: templates/notificacoes/logs_list.html:56
+msgid "Anterior"
+msgstr ""
+
+#: templates/notificacoes/historico_list.html:47
+#, python-format
+msgid "Página %(historicos.number)s de %(historicos.paginator.num_pages)s"
+msgstr ""
+
+#: templates/notificacoes/historico_list.html:49
+#: templates/notificacoes/logs_list.html:60
+msgid "Próxima"
+msgstr ""
+
+#: templates/notificacoes/historico_rows.html:10
+msgid "Nenhuma notificação"
+msgstr ""
+
+#: templates/notificacoes/logs_list.html:3
+#: templates/notificacoes/logs_list.html:7
+msgid "Logs de Notificação"
+msgstr ""
+
+#: templates/notificacoes/logs_list.html:28
+#: templates/notificacoes/logs_list.html:45
+msgid "Status"
+msgstr ""
+
+#: templates/notificacoes/logs_list.html:31
+msgid "Enviada"
+msgstr ""
+
+#: templates/notificacoes/logs_list.html:32
+msgid "Falha"
+msgstr ""
+
+#: templates/notificacoes/logs_list.html:42
+msgid "Usuário"
+msgstr ""
+
+#: templates/notificacoes/logs_list.html:43
+msgid "Template"
+msgstr ""
+
+#: templates/notificacoes/logs_list.html:46
+msgid "Erro"
+msgstr ""
+
+#: templates/notificacoes/logs_list.html:58
+#, python-format
+msgid "Página %(logs.number)s de %(logs.paginator.num_pages)s"
+msgstr ""
+
+#: templates/notificacoes/metrics.html:2
+msgid "Métricas de Notificações"
+msgstr ""
+
+#: templates/notificacoes/metrics.html:4
+msgid "Início"
+msgstr ""
+
+#: templates/notificacoes/metrics.html:5
+msgid "Fim"
+msgstr ""
+
+#: templates/notificacoes/metrics.html:8
+msgid "Total por canal"
+msgstr ""
+
+#: templates/notificacoes/metrics.html:14
+msgid "Falhas por canal"
+msgstr ""
+
+#: templates/notificacoes/metrics.html:20
+msgid "Templates ativos"
+msgstr ""
+
+#: templates/notificacoes/metrics.html:21
+msgid "Templates inativos"
+msgstr ""
+
+#: templates/notificacoes/template_form.html:4
+#: templates/notificacoes/template_form.html:8
+msgid "Editar Template"
+msgstr ""
+
+#: templates/notificacoes/template_form.html:4
+#: templates/notificacoes/templates_list.html:12
+msgid "Novo Template"
+msgstr ""
+
+#: templates/notificacoes/template_form.html:8
+msgid "Cadastrar Template"
+msgstr ""
+
+#: templates/notificacoes/template_form.html:20
+#: templates/notificacoes/templates_list.html:27
+msgid "Código"
+msgstr ""
+
+#: templates/notificacoes/template_form.html:29
+#: templates/notificacoes/templates_list.html:28
+msgid "Assunto"
+msgstr ""
+
+#: templates/notificacoes/template_form.html:34
+msgid "Corpo"
+msgstr ""
+
+#: templates/notificacoes/template_form.html:45
+#: templates/notificacoes/templates_list.html:30
+msgid "Ativo"
+msgstr ""
+
+#: templates/notificacoes/template_form.html:48
+msgid "Cancelar"
+msgstr ""
+
+#: templates/notificacoes/template_form.html:49
+msgid "Salvar"
+msgstr ""
+
+#: templates/notificacoes/templates_list.html:3
+#: templates/notificacoes/templates_list.html:8
+msgid "Templates de Notificação"
+msgstr ""
+
+#: templates/notificacoes/templates_list.html:9
+msgid "Gerencie as mensagens utilizadas nos envios."
+msgstr ""
+
+#: templates/notificacoes/templates_list.html:31
+msgid "Ações"
+msgstr ""
+
+#: templates/notificacoes/templates_list.html:42
+msgid "Editar"
+msgstr ""
+
+#: templates/notificacoes/templates_list.html:50
+msgid "Nenhum template cadastrado."
+msgstr ""
+
+#: templates/notificacoes/financeiro/ajuste_lancamento.html:2 templates/notificacoes/financeiro/distribuicao_receita.html:2 templates/notificacoes/financeiro/nova_cobranca.html:2
+#, python-format
+msgid "Olá %(nome)s,"
+msgstr ""
+
+#: templates/notificacoes/financeiro/ajuste_lancamento.html:3
+#, python-format
+msgid "Seu lançamento %(lancamento)s foi ajustado em %(valor)s."
+msgstr ""
+
+#: templates/notificacoes/financeiro/distribuicao_receita.html:3
+#, python-format
+msgid "A receita do evento %(evento)s no valor de %(valor)s foi distribuída."
+msgstr ""
+
+#: templates/notificacoes/financeiro/nova_cobranca.html:3
+#, python-format
+msgid "Você possui uma nova cobrança no valor de %(valor)s com vencimento em %(vencimento)s."
+msgstr ""
+
+#: templates/notificacoes/financeiro/nova_cobranca.html:4
+#, python-format
+msgid "Acesse %(link_pagamento)s para efetuar o pagamento."
+msgstr ""

--- a/notificacoes/locale/pt_BR/LC_MESSAGES/django.po
+++ b/notificacoes/locale/pt_BR/LC_MESSAGES/django.po
@@ -1,0 +1,253 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-14 15:05+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+#: templates/notificacoes/historico_list.html:3
+#: templates/notificacoes/historico_list.html:7
+msgid "Histórico de Notificações"
+msgstr ""
+
+#: templates/notificacoes/historico_list.html:11
+#: templates/notificacoes/logs_list.html:11
+msgid "De"
+msgstr ""
+
+#: templates/notificacoes/historico_list.html:15
+#: templates/notificacoes/logs_list.html:15
+msgid "Até"
+msgstr ""
+
+#: templates/notificacoes/historico_list.html:19
+#: templates/notificacoes/historico_list.html:34
+#: templates/notificacoes/logs_list.html:19
+#: templates/notificacoes/logs_list.html:44
+#: templates/notificacoes/template_form.html:39
+#: templates/notificacoes/templates_list.html:29
+msgid "Canal"
+msgstr ""
+
+#: templates/notificacoes/historico_list.html:21
+#: templates/notificacoes/logs_list.html:21
+#: templates/notificacoes/logs_list.html:30
+msgid "Todos"
+msgstr ""
+
+#: templates/notificacoes/historico_list.html:22
+#: templates/notificacoes/logs_list.html:22
+#: templates/notificacoes/metrics.html:10
+#: templates/notificacoes/metrics.html:16
+msgid "E-mail"
+msgstr ""
+
+#: templates/notificacoes/historico_list.html:23
+#: templates/notificacoes/logs_list.html:23
+#: templates/notificacoes/metrics.html:11
+#: templates/notificacoes/metrics.html:17
+msgid "Push"
+msgstr ""
+
+#: templates/notificacoes/historico_list.html:24
+#: templates/notificacoes/logs_list.html:24
+#: templates/notificacoes/metrics.html:12
+#: templates/notificacoes/metrics.html:18
+msgid "WhatsApp"
+msgstr ""
+
+#: templates/notificacoes/historico_list.html:27
+#: templates/notificacoes/logs_list.html:35
+#: templates/notificacoes/metrics.html:6
+msgid "Filtrar"
+msgstr ""
+
+#: templates/notificacoes/historico_list.html:33
+#: templates/notificacoes/logs_list.html:41
+msgid "Data"
+msgstr ""
+
+#: templates/notificacoes/historico_list.html:35
+msgid "Conteúdo"
+msgstr ""
+
+#: templates/notificacoes/historico_list.html:45
+#: templates/notificacoes/logs_list.html:56
+msgid "Anterior"
+msgstr ""
+
+#: templates/notificacoes/historico_list.html:47
+#, python-format
+msgid "Página %(historicos.number)s de %(historicos.paginator.num_pages)s"
+msgstr ""
+
+#: templates/notificacoes/historico_list.html:49
+#: templates/notificacoes/logs_list.html:60
+msgid "Próxima"
+msgstr ""
+
+#: templates/notificacoes/historico_rows.html:10
+msgid "Nenhuma notificação"
+msgstr ""
+
+#: templates/notificacoes/logs_list.html:3
+#: templates/notificacoes/logs_list.html:7
+msgid "Logs de Notificação"
+msgstr ""
+
+#: templates/notificacoes/logs_list.html:28
+#: templates/notificacoes/logs_list.html:45
+msgid "Status"
+msgstr ""
+
+#: templates/notificacoes/logs_list.html:31
+msgid "Enviada"
+msgstr ""
+
+#: templates/notificacoes/logs_list.html:32
+msgid "Falha"
+msgstr ""
+
+#: templates/notificacoes/logs_list.html:42
+msgid "Usuário"
+msgstr ""
+
+#: templates/notificacoes/logs_list.html:43
+msgid "Template"
+msgstr ""
+
+#: templates/notificacoes/logs_list.html:46
+msgid "Erro"
+msgstr ""
+
+#: templates/notificacoes/logs_list.html:58
+#, python-format
+msgid "Página %(logs.number)s de %(logs.paginator.num_pages)s"
+msgstr ""
+
+#: templates/notificacoes/metrics.html:2
+msgid "Métricas de Notificações"
+msgstr ""
+
+#: templates/notificacoes/metrics.html:4
+msgid "Início"
+msgstr ""
+
+#: templates/notificacoes/metrics.html:5
+msgid "Fim"
+msgstr ""
+
+#: templates/notificacoes/metrics.html:8
+msgid "Total por canal"
+msgstr ""
+
+#: templates/notificacoes/metrics.html:14
+msgid "Falhas por canal"
+msgstr ""
+
+#: templates/notificacoes/metrics.html:20
+msgid "Templates ativos"
+msgstr ""
+
+#: templates/notificacoes/metrics.html:21
+msgid "Templates inativos"
+msgstr ""
+
+#: templates/notificacoes/template_form.html:4
+#: templates/notificacoes/template_form.html:8
+msgid "Editar Template"
+msgstr ""
+
+#: templates/notificacoes/template_form.html:4
+#: templates/notificacoes/templates_list.html:12
+msgid "Novo Template"
+msgstr ""
+
+#: templates/notificacoes/template_form.html:8
+msgid "Cadastrar Template"
+msgstr ""
+
+#: templates/notificacoes/template_form.html:20
+#: templates/notificacoes/templates_list.html:27
+msgid "Código"
+msgstr ""
+
+#: templates/notificacoes/template_form.html:29
+#: templates/notificacoes/templates_list.html:28
+msgid "Assunto"
+msgstr ""
+
+#: templates/notificacoes/template_form.html:34
+msgid "Corpo"
+msgstr ""
+
+#: templates/notificacoes/template_form.html:45
+#: templates/notificacoes/templates_list.html:30
+msgid "Ativo"
+msgstr ""
+
+#: templates/notificacoes/template_form.html:48
+msgid "Cancelar"
+msgstr ""
+
+#: templates/notificacoes/template_form.html:49
+msgid "Salvar"
+msgstr ""
+
+#: templates/notificacoes/templates_list.html:3
+#: templates/notificacoes/templates_list.html:8
+msgid "Templates de Notificação"
+msgstr ""
+
+#: templates/notificacoes/templates_list.html:9
+msgid "Gerencie as mensagens utilizadas nos envios."
+msgstr ""
+
+#: templates/notificacoes/templates_list.html:31
+msgid "Ações"
+msgstr ""
+
+#: templates/notificacoes/templates_list.html:42
+msgid "Editar"
+msgstr ""
+
+#: templates/notificacoes/templates_list.html:50
+msgid "Nenhum template cadastrado."
+msgstr ""
+
+#: templates/notificacoes/financeiro/ajuste_lancamento.html:2 templates/notificacoes/financeiro/distribuicao_receita.html:2 templates/notificacoes/financeiro/nova_cobranca.html:2
+#, python-format
+msgid "Olá %(nome)s,"
+msgstr ""
+
+#: templates/notificacoes/financeiro/ajuste_lancamento.html:3
+#, python-format
+msgid "Seu lançamento %(lancamento)s foi ajustado em %(valor)s."
+msgstr ""
+
+#: templates/notificacoes/financeiro/distribuicao_receita.html:3
+#, python-format
+msgid "A receita do evento %(evento)s no valor de %(valor)s foi distribuída."
+msgstr ""
+
+#: templates/notificacoes/financeiro/nova_cobranca.html:3
+#, python-format
+msgid "Você possui uma nova cobrança no valor de %(valor)s com vencimento em %(vencimento)s."
+msgstr ""
+
+#: templates/notificacoes/financeiro/nova_cobranca.html:4
+#, python-format
+msgid "Acesse %(link_pagamento)s para efetuar o pagamento."
+msgstr ""

--- a/notificacoes/templates/notificacoes/historico_list.html
+++ b/notificacoes/templates/notificacoes/historico_list.html
@@ -19,9 +19,9 @@
       <label for="canal" class="block text-sm font-medium text-neutral-700 mb-1">{% trans 'Canal' %}</label>
       <select name="canal" id="canal" class="form-select" hx-get="{% url 'notificacoes:historico' %}" hx-target="#tabela_historico" hx-include="closest form">
         <option value="" {% if not request.GET.canal %}selected{% endif %}>{% trans 'Todos' %}</option>
-        <option value="email" {% if request.GET.canal == 'email' %}selected{% endif %}>E-mail</option>
-        <option value="push" {% if request.GET.canal == 'push' %}selected{% endif %}>Push</option>
-        <option value="whatsapp" {% if request.GET.canal == 'whatsapp' %}selected{% endif %}>WhatsApp</option>
+        <option value="email" {% if request.GET.canal == 'email' %}selected{% endif %}>{% trans 'E-mail' %}</option>
+        <option value="push" {% if request.GET.canal == 'push' %}selected{% endif %}>{% trans 'Push' %}</option>
+        <option value="whatsapp" {% if request.GET.canal == 'whatsapp' %}selected{% endif %}>{% trans 'WhatsApp' %}</option>
       </select>
     </div>
     <noscript><button type="submit" class="mt-2 sm:mt-0 bg-neutral-200 text-neutral-800 px-4 py-2 rounded-xl text-sm hover:bg-neutral-300">{% trans 'Filtrar' %}</button></noscript>

--- a/notificacoes/templates/notificacoes/logs_list.html
+++ b/notificacoes/templates/notificacoes/logs_list.html
@@ -19,9 +19,9 @@
       <label for="canal" class="block text-sm font-medium text-neutral-700 mb-1">{% trans 'Canal' %}</label>
       <select name="canal" id="canal" class="form-select" hx-get="{% url 'notificacoes:logs_list' %}" hx-target="#tabela_logs" hx-include="closest form">
         <option value="" {% if not request.GET.canal %}selected{% endif %}>{% trans 'Todos' %}</option>
-        <option value="email" {% if request.GET.canal == 'email' %}selected{% endif %}>E-mail</option>
-        <option value="push" {% if request.GET.canal == 'push' %}selected{% endif %}>Push</option>
-        <option value="whatsapp" {% if request.GET.canal == 'whatsapp' %}selected{% endif %}>WhatsApp</option>
+        <option value="email" {% if request.GET.canal == 'email' %}selected{% endif %}>{% trans 'E-mail' %}</option>
+        <option value="push" {% if request.GET.canal == 'push' %}selected{% endif %}>{% trans 'Push' %}</option>
+        <option value="whatsapp" {% if request.GET.canal == 'whatsapp' %}selected{% endif %}>{% trans 'WhatsApp' %}</option>
       </select>
     </div>
     <div>

--- a/notificacoes/templates/notificacoes/logs_rows.html
+++ b/notificacoes/templates/notificacoes/logs_rows.html
@@ -1,6 +1,7 @@
+{% load i18n %}
 {% for log in logs %}
   <tr>
-    <td class="px-4 py-2">{{ log.data_envio|date:'d/m/Y H:i' }}</td>
+    <td class="px-4 py-2">{{ log.data_envio|date:"SHORT_DATETIME_FORMAT" }}</td>
     <td class="px-4 py-2">{{ log.user.get_full_name|default:log.user.username }}</td>
     <td class="px-4 py-2">{{ log.template.codigo }}</td>
     <td class="px-4 py-2">{{ log.get_canal_display }}</td>

--- a/notificacoes/templates/notificacoes/metrics.html
+++ b/notificacoes/templates/notificacoes/metrics.html
@@ -1,20 +1,21 @@
-<h1>Métricas de Notificações</h1>
+{% load i18n %}
+<h1>{% trans "Métricas de Notificações" %}</h1>
 <form method="get">
-  <label>Início: <input type="date" name="inicio" value="{{ request.GET.inicio }}" /></label>
-  <label>Fim: <input type="date" name="fim" value="{{ request.GET.fim }}" /></label>
-  <button type="submit">Filtrar</button>
+  <label>{% trans "Início" %}: <input type="date" name="inicio" value="{{ request.GET.inicio }}" /></label>
+  <label>{% trans "Fim" %}: <input type="date" name="fim" value="{{ request.GET.fim }}" /></label>
+  <button type="submit">{% trans "Filtrar" %}</button>
 </form>
-<h2>Total por canal</h2>
+<h2>{% trans "Total por canal" %}</h2>
 <ul>
-  <li>Email: {{ total_por_canal.email|default:0 }}</li>
-  <li>Push: {{ total_por_canal.push|default:0 }}</li>
-  <li>WhatsApp: {{ total_por_canal.whatsapp|default:0 }}</li>
+  <li>{% trans "E-mail" %}: {{ total_por_canal.email|default:0 }}</li>
+  <li>{% trans "Push" %}: {{ total_por_canal.push|default:0 }}</li>
+  <li>{% trans "WhatsApp" %}: {{ total_por_canal.whatsapp|default:0 }}</li>
 </ul>
-<h2>Falhas por canal</h2>
+<h2>{% trans "Falhas por canal" %}</h2>
 <ul>
-  <li>Email: {{ falhas_por_canal.email|default:0 }}</li>
-  <li>Push: {{ falhas_por_canal.push|default:0 }}</li>
-  <li>WhatsApp: {{ falhas_por_canal.whatsapp|default:0 }}</li>
+  <li>{% trans "E-mail" %}: {{ falhas_por_canal.email|default:0 }}</li>
+  <li>{% trans "Push" %}: {{ falhas_por_canal.push|default:0 }}</li>
+  <li>{% trans "WhatsApp" %}: {{ falhas_por_canal.whatsapp|default:0 }}</li>
 </ul>
-<p>Templates ativos: {{ templates_ativos }}</p>
-<p>Templates inativos: {{ templates_inativos }}</p>
+<p>{% trans "Templates ativos" %}: {{ templates_ativos }}</p>
+<p>{% trans "Templates inativos" %}: {{ templates_inativos }}</p>

--- a/nucleos/locale/en/LC_MESSAGES/django.po
+++ b/nucleos/locale/en/LC_MESSAGES/django.po
@@ -1,0 +1,244 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-14 12:47-0300\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+#: templates/nucleos/convites_modal.html:3
+msgid "Convites do núcleo"
+msgstr ""
+
+#: templates/nucleos/convites_modal.html:4 templates/nucleos/detail.html:99
+msgid "Convites restantes hoje:"
+msgstr ""
+
+#: templates/nucleos/convites_modal.html:7
+msgid "email@example.com"
+msgstr ""
+
+#: templates/nucleos/convites_modal.html:9
+msgid "Membro"
+msgstr ""
+
+#: templates/nucleos/convites_modal.html:10 templates/nucleos/detail.html:23
+msgid "Coordenador"
+msgstr ""
+
+#: templates/nucleos/convites_modal.html:13
+msgid "Fechar"
+msgstr ""
+
+#: templates/nucleos/convites_modal.html:14
+msgid "Enviar convite"
+msgstr ""
+
+#: templates/nucleos/convites_modal.html:21
+msgid "Revogar"
+msgstr ""
+
+#: templates/nucleos/convites_modal.html:24
+msgid "Nenhum convite pendente."
+msgstr ""
+
+#: templates/nucleos/create.html:4
+msgid "Novo Núcleo"
+msgstr ""
+
+#: templates/nucleos/create.html:12 templates/nucleos/delete.html:16
+#: templates/nucleos/delete.html:17 templates/nucleos/postar_modal.html:14
+#: templates/nucleos/solicitar_modal.html:9
+#: templates/nucleos/suplente_form.html:12 templates/nucleos/update.html:12
+msgid "Cancelar"
+msgstr ""
+
+#: templates/nucleos/create.html:13 templates/nucleos/suplente_form.html:13
+#: templates/nucleos/update.html:13
+msgid "Salvar"
+msgstr ""
+
+#: templates/nucleos/delete.html:4
+msgid "Remover Núcleo"
+msgstr ""
+
+#: templates/nucleos/delete.html:9
+msgid "Confirmar remoção"
+msgstr ""
+
+#: templates/nucleos/delete.html:11
+#, python-format
+msgid "Deseja realmente remover o núcleo <strong>%(object.nome)s</strong>?"
+msgstr ""
+
+#: templates/nucleos/delete.html:19 templates/nucleos/delete.html:20
+#: templates/nucleos/detail.html:31 templates/nucleos/detail.html:81
+msgid "Remover"
+msgstr ""
+
+#: templates/nucleos/detail.html:19 templates/nucleos/list.html:27
+msgid "Membros"
+msgstr ""
+
+#: templates/nucleos/detail.html:24
+msgid "Suspenso"
+msgstr ""
+
+#: templates/nucleos/detail.html:28
+msgid "Rebaixar"
+msgstr ""
+
+#: templates/nucleos/detail.html:28
+msgid "Promover"
+msgstr ""
+
+#: templates/nucleos/detail.html:35 templates/nucleos/detail.html:110
+msgid "Reativar"
+msgstr ""
+
+#: templates/nucleos/detail.html:39
+msgid "Suspender"
+msgstr ""
+
+#: templates/nucleos/detail.html:45
+msgid "Sem membros."
+msgstr ""
+
+#: templates/nucleos/detail.html:50
+msgid "Pendentes"
+msgstr ""
+
+#: templates/nucleos/detail.html:53
+msgid "Usuário"
+msgstr ""
+
+#: templates/nucleos/detail.html:53
+msgid "Solicitado em"
+msgstr ""
+
+#: templates/nucleos/detail.html:61
+msgid "Confirmar aprovação?"
+msgstr ""
+
+#: templates/nucleos/detail.html:61
+msgid "Aprovar"
+msgstr ""
+
+#: templates/nucleos/detail.html:62
+msgid "Confirmar recusa?"
+msgstr ""
+
+#: templates/nucleos/detail.html:62
+msgid "Recusar"
+msgstr ""
+
+#: templates/nucleos/detail.html:71
+msgid "Suplentes"
+msgstr ""
+
+#: templates/nucleos/detail.html:77
+msgid "Ativo"
+msgstr ""
+
+#: templates/nucleos/detail.html:77
+msgid "Inativo"
+msgstr ""
+
+#: templates/nucleos/detail.html:90 templates/nucleos/suplente_form.html:4
+msgid "Adicionar Suplente"
+msgstr ""
+
+#: templates/nucleos/detail.html:97
+msgid "Gerenciar convites"
+msgstr ""
+
+#: templates/nucleos/detail.html:105
+msgid "Exportar CSV"
+msgstr ""
+
+#: templates/nucleos/detail.html:106
+msgid "Exportar XLS"
+msgstr ""
+
+#: templates/nucleos/detail.html:110
+msgid "Inativar"
+msgstr ""
+
+#: templates/nucleos/detail.html:117
+msgid "Solicitar participação"
+msgstr ""
+
+#: templates/nucleos/detail.html:122
+msgid "Postar no feed"
+msgstr ""
+
+#: templates/nucleos/list.html:4
+msgid "Núcleos"
+msgstr ""
+
+#: templates/nucleos/list.html:9
+msgid "Buscar..."
+msgstr ""
+
+#: templates/nucleos/list.html:10
+msgid "Buscar"
+msgstr ""
+
+#: templates/nucleos/list.html:14
+msgid "Novo"
+msgstr ""
+
+#: templates/nucleos/list.html:29
+msgid "Detalhes"
+msgstr ""
+
+#: templates/nucleos/list.html:32
+msgid "Excluir"
+msgstr ""
+
+#: templates/nucleos/list.html:38
+msgid "Nenhum núcleo encontrado."
+msgstr ""
+
+#: templates/nucleos/list.html:44
+msgid "Anterior"
+msgstr ""
+
+#: templates/nucleos/list.html:48
+msgid "Próxima"
+msgstr ""
+
+#: templates/nucleos/postar_modal.html:3
+msgid "Postar no feed do núcleo"
+msgstr ""
+
+#: templates/nucleos/postar_modal.html:9
+msgid "Escreva algo..."
+msgstr ""
+
+#: templates/nucleos/postar_modal.html:15
+msgid "Postar"
+msgstr ""
+
+#: templates/nucleos/solicitar_modal.html:3
+msgid "Confirmar solicitação de participação?"
+msgstr ""
+
+#: templates/nucleos/solicitar_modal.html:6
+msgid "Solicitação enviada"
+msgstr ""
+
+#: templates/nucleos/solicitar_modal.html:10
+msgid "Confirmar"
+msgstr ""

--- a/nucleos/locale/pt_BR/LC_MESSAGES/django.po
+++ b/nucleos/locale/pt_BR/LC_MESSAGES/django.po
@@ -1,0 +1,244 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-14 12:47-0300\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+#: templates/nucleos/convites_modal.html:3
+msgid "Convites do núcleo"
+msgstr ""
+
+#: templates/nucleos/convites_modal.html:4 templates/nucleos/detail.html:99
+msgid "Convites restantes hoje:"
+msgstr ""
+
+#: templates/nucleos/convites_modal.html:7
+msgid "email@example.com"
+msgstr ""
+
+#: templates/nucleos/convites_modal.html:9
+msgid "Membro"
+msgstr ""
+
+#: templates/nucleos/convites_modal.html:10 templates/nucleos/detail.html:23
+msgid "Coordenador"
+msgstr ""
+
+#: templates/nucleos/convites_modal.html:13
+msgid "Fechar"
+msgstr ""
+
+#: templates/nucleos/convites_modal.html:14
+msgid "Enviar convite"
+msgstr ""
+
+#: templates/nucleos/convites_modal.html:21
+msgid "Revogar"
+msgstr ""
+
+#: templates/nucleos/convites_modal.html:24
+msgid "Nenhum convite pendente."
+msgstr ""
+
+#: templates/nucleos/create.html:4
+msgid "Novo Núcleo"
+msgstr ""
+
+#: templates/nucleos/create.html:12 templates/nucleos/delete.html:16
+#: templates/nucleos/delete.html:17 templates/nucleos/postar_modal.html:14
+#: templates/nucleos/solicitar_modal.html:9
+#: templates/nucleos/suplente_form.html:12 templates/nucleos/update.html:12
+msgid "Cancelar"
+msgstr ""
+
+#: templates/nucleos/create.html:13 templates/nucleos/suplente_form.html:13
+#: templates/nucleos/update.html:13
+msgid "Salvar"
+msgstr ""
+
+#: templates/nucleos/delete.html:4
+msgid "Remover Núcleo"
+msgstr ""
+
+#: templates/nucleos/delete.html:9
+msgid "Confirmar remoção"
+msgstr ""
+
+#: templates/nucleos/delete.html:11
+#, python-format
+msgid "Deseja realmente remover o núcleo <strong>%(object.nome)s</strong>?"
+msgstr ""
+
+#: templates/nucleos/delete.html:19 templates/nucleos/delete.html:20
+#: templates/nucleos/detail.html:31 templates/nucleos/detail.html:81
+msgid "Remover"
+msgstr ""
+
+#: templates/nucleos/detail.html:19 templates/nucleos/list.html:27
+msgid "Membros"
+msgstr ""
+
+#: templates/nucleos/detail.html:24
+msgid "Suspenso"
+msgstr ""
+
+#: templates/nucleos/detail.html:28
+msgid "Rebaixar"
+msgstr ""
+
+#: templates/nucleos/detail.html:28
+msgid "Promover"
+msgstr ""
+
+#: templates/nucleos/detail.html:35 templates/nucleos/detail.html:110
+msgid "Reativar"
+msgstr ""
+
+#: templates/nucleos/detail.html:39
+msgid "Suspender"
+msgstr ""
+
+#: templates/nucleos/detail.html:45
+msgid "Sem membros."
+msgstr ""
+
+#: templates/nucleos/detail.html:50
+msgid "Pendentes"
+msgstr ""
+
+#: templates/nucleos/detail.html:53
+msgid "Usuário"
+msgstr ""
+
+#: templates/nucleos/detail.html:53
+msgid "Solicitado em"
+msgstr ""
+
+#: templates/nucleos/detail.html:61
+msgid "Confirmar aprovação?"
+msgstr ""
+
+#: templates/nucleos/detail.html:61
+msgid "Aprovar"
+msgstr ""
+
+#: templates/nucleos/detail.html:62
+msgid "Confirmar recusa?"
+msgstr ""
+
+#: templates/nucleos/detail.html:62
+msgid "Recusar"
+msgstr ""
+
+#: templates/nucleos/detail.html:71
+msgid "Suplentes"
+msgstr ""
+
+#: templates/nucleos/detail.html:77
+msgid "Ativo"
+msgstr ""
+
+#: templates/nucleos/detail.html:77
+msgid "Inativo"
+msgstr ""
+
+#: templates/nucleos/detail.html:90 templates/nucleos/suplente_form.html:4
+msgid "Adicionar Suplente"
+msgstr ""
+
+#: templates/nucleos/detail.html:97
+msgid "Gerenciar convites"
+msgstr ""
+
+#: templates/nucleos/detail.html:105
+msgid "Exportar CSV"
+msgstr ""
+
+#: templates/nucleos/detail.html:106
+msgid "Exportar XLS"
+msgstr ""
+
+#: templates/nucleos/detail.html:110
+msgid "Inativar"
+msgstr ""
+
+#: templates/nucleos/detail.html:117
+msgid "Solicitar participação"
+msgstr ""
+
+#: templates/nucleos/detail.html:122
+msgid "Postar no feed"
+msgstr ""
+
+#: templates/nucleos/list.html:4
+msgid "Núcleos"
+msgstr ""
+
+#: templates/nucleos/list.html:9
+msgid "Buscar..."
+msgstr ""
+
+#: templates/nucleos/list.html:10
+msgid "Buscar"
+msgstr ""
+
+#: templates/nucleos/list.html:14
+msgid "Novo"
+msgstr ""
+
+#: templates/nucleos/list.html:29
+msgid "Detalhes"
+msgstr ""
+
+#: templates/nucleos/list.html:32
+msgid "Excluir"
+msgstr ""
+
+#: templates/nucleos/list.html:38
+msgid "Nenhum núcleo encontrado."
+msgstr ""
+
+#: templates/nucleos/list.html:44
+msgid "Anterior"
+msgstr ""
+
+#: templates/nucleos/list.html:48
+msgid "Próxima"
+msgstr ""
+
+#: templates/nucleos/postar_modal.html:3
+msgid "Postar no feed do núcleo"
+msgstr ""
+
+#: templates/nucleos/postar_modal.html:9
+msgid "Escreva algo..."
+msgstr ""
+
+#: templates/nucleos/postar_modal.html:15
+msgid "Postar"
+msgstr ""
+
+#: templates/nucleos/solicitar_modal.html:3
+msgid "Confirmar solicitação de participação?"
+msgstr ""
+
+#: templates/nucleos/solicitar_modal.html:6
+msgid "Solicitação enviada"
+msgstr ""
+
+#: templates/nucleos/solicitar_modal.html:10
+msgid "Confirmar"
+msgstr ""

--- a/nucleos/templates/nucleos/convites_modal.html
+++ b/nucleos/templates/nucleos/convites_modal.html
@@ -4,7 +4,7 @@
   <p class="text-sm text-gray-600">{% trans 'Convites restantes hoje:' %} {{ convites_restantes }}</p>
   <form class="mt-2 flex flex-col gap-2" hx-post="{% url 'nucleos_api:nucleo-convites' nucleo.pk %}" hx-target="#convites-list" hx-swap="afterbegin">
     {% csrf_token %}
-    <input type="email" name="email" class="border rounded px-2 py-1" placeholder="email@example.com" required />
+    <input type="email" name="email" class="border rounded px-2 py-1" placeholder="{% trans 'email@example.com' %}" required />
     <select name="papel" class="border rounded px-2 py-1">
       <option value="membro">{% trans 'Membro' %}</option>
       <option value="coordenador">{% trans 'Coordenador' %}</option>

--- a/nucleos/templates/nucleos/delete.html
+++ b/nucleos/templates/nucleos/delete.html
@@ -1,22 +1,23 @@
 {% extends 'base.html' %}
+{% load i18n %}
 
-{% block title %}Remover Núcleo | Hubx{% endblock %}
+{% block title %}{% trans "Remover Núcleo" %} | Hubx{% endblock %}
 
 {% block content %}
 <section class="max-w-md mx-auto px-4 py-16">
   <div class="bg-white border border-red-200 rounded-2xl shadow-sm p-6 text-center">
-    <h2 class="text-xl font-semibold text-red-700 mb-4">Confirmar remoção</h2>
+    <h2 class="text-xl font-semibold text-red-700 mb-4">{% trans "Confirmar remoção" %}</h2>
     <p class="text-sm text-neutral-700">
-      Deseja realmente remover o núcleo <strong>{{ object.nome }}</strong>?
+      {% blocktrans %}Deseja realmente remover o núcleo <strong>{{ object.nome }}</strong>?{% endblocktrans %}
     </p>
 
     <form method="post" class="mt-6 flex justify-center gap-3">
       {% csrf_token %}
-      <a href="{% url 'nucleos:list' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100">
-        Cancelar
+      <a href="{% url 'nucleos:list' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100" aria-label="{% trans 'Cancelar' %}">
+        {% trans "Cancelar" %}
       </a>
-      <button type="submit" class="text-sm px-4 py-2 rounded-xl bg-red-600 text-white hover:bg-red-700">
-        Remover
+      <button type="submit" class="text-sm px-4 py-2 rounded-xl bg-red-600 text-white hover:bg-red-700" aria-label="{% trans 'Remover' %}">
+        {% trans "Remover" %}
       </button>
     </form>
   </div>

--- a/organizacoes/locale/en/LC_MESSAGES/django.po
+++ b/organizacoes/locale/en/LC_MESSAGES/django.po
@@ -1,0 +1,273 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-14 15:05+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+#: templates/organizacoes/create.html:4 templates/organizacoes/list.html:20
+msgid "Nova Organização"
+msgstr ""
+
+#: templates/organizacoes/create.html:11 templates/organizacoes/create.html:15
+#: templates/organizacoes/detail.html:144 templates/organizacoes/update.html:13
+msgid "Voltar"
+msgstr ""
+
+#: templates/organizacoes/create.html:17
+msgid "Cadastrar Organização"
+msgstr ""
+
+#: templates/organizacoes/create.html:132 templates/organizacoes/delete.html:17
+#: templates/organizacoes/update.html:135
+msgid "Cancelar"
+msgstr ""
+
+#: templates/organizacoes/create.html:135
+#: templates/organizacoes/update.html:136
+msgid "Salvar"
+msgstr ""
+
+#: templates/organizacoes/delete.html:4
+msgid "Remover Organização"
+msgstr ""
+
+#: templates/organizacoes/delete.html:9
+msgid "Confirmar remoção"
+msgstr ""
+
+#: templates/organizacoes/delete.html:11
+#, python-format
+msgid "Tem certeza que deseja remover <strong>%(nome)s</strong>?"
+msgstr ""
+
+#: templates/organizacoes/delete.html:20 templates/organizacoes/list.html:94
+msgid "Remover"
+msgstr ""
+
+#: templates/organizacoes/detail.html:27
+msgid "CNPJ"
+msgstr ""
+
+#: templates/organizacoes/detail.html:31 templates/organizacoes/list.html:27
+#: templates/organizacoes/list.html:46 templates/organizacoes/list.html:61
+msgid "Tipo"
+msgstr ""
+
+#: templates/organizacoes/detail.html:35
+msgid "Endereço"
+msgstr ""
+
+#: templates/organizacoes/detail.html:42
+msgid "Contato"
+msgstr ""
+
+#: templates/organizacoes/detail.html:51
+msgid "Descrição"
+msgstr ""
+
+#: templates/organizacoes/detail.html:59
+msgid "Membros"
+msgstr ""
+
+#: templates/organizacoes/detail.html:64
+msgid "Nenhum usuário associado."
+msgstr ""
+
+#: templates/organizacoes/detail.html:68 templates/organizacoes/detail.html:82
+#: templates/organizacoes/detail.html:96 templates/organizacoes/detail.html:110
+#: templates/organizacoes/detail.html:124
+msgid "Adicionar/Remover"
+msgstr ""
+
+#: templates/organizacoes/detail.html:73
+msgid "Núcleos"
+msgstr ""
+
+#: templates/organizacoes/detail.html:78
+msgid "Nenhum núcleo associado."
+msgstr ""
+
+#: templates/organizacoes/detail.html:87
+msgid "Eventos"
+msgstr ""
+
+#: templates/organizacoes/detail.html:92
+msgid "Nenhum evento associado."
+msgstr ""
+
+#: templates/organizacoes/detail.html:101
+msgid "Empresas"
+msgstr ""
+
+#: templates/organizacoes/detail.html:106
+msgid "Nenhuma empresa associada."
+msgstr ""
+
+#: templates/organizacoes/detail.html:115
+msgid "Posts"
+msgstr ""
+
+#: templates/organizacoes/detail.html:120
+msgid "Nenhum post associado."
+msgstr ""
+
+#: templates/organizacoes/detail.html:130 templates/organizacoes/list.html:91
+msgid "Editar"
+msgstr ""
+
+#: templates/organizacoes/detail.html:133
+msgid "Excluir"
+msgstr ""
+
+#: templates/organizacoes/detail.html:139 templates/organizacoes/list.html:100
+msgid "Reativar"
+msgstr ""
+
+#: templates/organizacoes/detail.html:139 templates/organizacoes/list.html:102
+msgid "Inativar"
+msgstr ""
+
+#: templates/organizacoes/detail.html:142 templates/organizacoes/history.html:3
+#: templates/organizacoes/history.html:6
+msgid "Histórico"
+msgstr ""
+
+#: templates/organizacoes/history.html:7
+msgid "Baixar CSV completo"
+msgstr ""
+
+#: templates/organizacoes/history.html:9
+msgid "Alterações"
+msgstr ""
+
+#: templates/organizacoes/history.html:13
+msgid "Campo"
+msgstr ""
+
+#: templates/organizacoes/history.html:14
+msgid "De"
+msgstr ""
+
+#: templates/organizacoes/history.html:15
+msgid "Para"
+msgstr ""
+
+#: templates/organizacoes/history.html:16
+#: templates/organizacoes/history.html:42
+msgid "Usuário"
+msgstr ""
+
+#: templates/organizacoes/history.html:17
+#: templates/organizacoes/history.html:43 templates/organizacoes/list.html:48
+msgid "Data"
+msgstr ""
+
+#: templates/organizacoes/history.html:31
+#: templates/organizacoes/history.html:55
+msgid "Nenhum log encontrado."
+msgstr ""
+
+#: templates/organizacoes/history.html:37
+msgid "Atividades"
+msgstr ""
+
+#: templates/organizacoes/history.html:41
+msgid "Ação"
+msgstr ""
+
+#: templates/organizacoes/list.html:4 templates/organizacoes/list.html:12
+msgid "Organizações"
+msgstr ""
+
+#: templates/organizacoes/list.html:13
+msgid "Gerencie as organizações cadastradas"
+msgstr ""
+
+#: templates/organizacoes/list.html:25
+msgid "Buscar por nome ou slug"
+msgstr ""
+
+#: templates/organizacoes/list.html:33
+msgid "Cidade"
+msgstr ""
+
+#: templates/organizacoes/list.html:39
+msgid "Estado"
+msgstr ""
+
+#: templates/organizacoes/list.html:45 templates/organizacoes/list.html:60
+msgid "Nome"
+msgstr ""
+
+#: templates/organizacoes/list.html:47
+msgid "Localização"
+msgstr ""
+
+#: templates/organizacoes/list.html:51
+msgid "Filtrar"
+msgstr ""
+
+#: templates/organizacoes/list.html:62
+msgid "Cidade/Estado"
+msgstr ""
+
+#: templates/organizacoes/list.html:63
+msgid "Data de Criação"
+msgstr ""
+
+#: templates/organizacoes/list.html:64
+msgid "Ações"
+msgstr ""
+
+#: templates/organizacoes/list.html:81
+msgid "Inativa"
+msgstr ""
+
+#: templates/organizacoes/list.html:89
+msgid "Visualizar"
+msgstr ""
+
+#: templates/organizacoes/list.html:94
+msgid "Confirmar remoção?"
+msgstr ""
+
+#: templates/organizacoes/list.html:97
+msgid "Tem certeza?"
+msgstr ""
+
+#: templates/organizacoes/list.html:114
+msgid "Anterior"
+msgstr ""
+
+#: templates/organizacoes/list.html:118
+msgid "Próxima"
+msgstr ""
+
+#: templates/organizacoes/list.html:123
+msgid "Nenhuma organização cadastrada."
+msgstr ""
+
+#: templates/organizacoes/list.html:125
+msgid "Cadastrar"
+msgstr ""
+
+#: templates/organizacoes/update.html:4 templates/organizacoes/update.html:15
+msgid "Editar Organização"
+msgstr ""
+
+#: templates/organizacoes/update.html:141
+msgid "Voltar à lista"
+msgstr ""

--- a/organizacoes/locale/pt_BR/LC_MESSAGES/django.po
+++ b/organizacoes/locale/pt_BR/LC_MESSAGES/django.po
@@ -1,0 +1,273 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-14 15:05+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+#: templates/organizacoes/create.html:4 templates/organizacoes/list.html:20
+msgid "Nova Organização"
+msgstr ""
+
+#: templates/organizacoes/create.html:11 templates/organizacoes/create.html:15
+#: templates/organizacoes/detail.html:144 templates/organizacoes/update.html:13
+msgid "Voltar"
+msgstr ""
+
+#: templates/organizacoes/create.html:17
+msgid "Cadastrar Organização"
+msgstr ""
+
+#: templates/organizacoes/create.html:132 templates/organizacoes/delete.html:17
+#: templates/organizacoes/update.html:135
+msgid "Cancelar"
+msgstr ""
+
+#: templates/organizacoes/create.html:135
+#: templates/organizacoes/update.html:136
+msgid "Salvar"
+msgstr ""
+
+#: templates/organizacoes/delete.html:4
+msgid "Remover Organização"
+msgstr ""
+
+#: templates/organizacoes/delete.html:9
+msgid "Confirmar remoção"
+msgstr ""
+
+#: templates/organizacoes/delete.html:11
+#, python-format
+msgid "Tem certeza que deseja remover <strong>%(nome)s</strong>?"
+msgstr ""
+
+#: templates/organizacoes/delete.html:20 templates/organizacoes/list.html:94
+msgid "Remover"
+msgstr ""
+
+#: templates/organizacoes/detail.html:27
+msgid "CNPJ"
+msgstr ""
+
+#: templates/organizacoes/detail.html:31 templates/organizacoes/list.html:27
+#: templates/organizacoes/list.html:46 templates/organizacoes/list.html:61
+msgid "Tipo"
+msgstr ""
+
+#: templates/organizacoes/detail.html:35
+msgid "Endereço"
+msgstr ""
+
+#: templates/organizacoes/detail.html:42
+msgid "Contato"
+msgstr ""
+
+#: templates/organizacoes/detail.html:51
+msgid "Descrição"
+msgstr ""
+
+#: templates/organizacoes/detail.html:59
+msgid "Membros"
+msgstr ""
+
+#: templates/organizacoes/detail.html:64
+msgid "Nenhum usuário associado."
+msgstr ""
+
+#: templates/organizacoes/detail.html:68 templates/organizacoes/detail.html:82
+#: templates/organizacoes/detail.html:96 templates/organizacoes/detail.html:110
+#: templates/organizacoes/detail.html:124
+msgid "Adicionar/Remover"
+msgstr ""
+
+#: templates/organizacoes/detail.html:73
+msgid "Núcleos"
+msgstr ""
+
+#: templates/organizacoes/detail.html:78
+msgid "Nenhum núcleo associado."
+msgstr ""
+
+#: templates/organizacoes/detail.html:87
+msgid "Eventos"
+msgstr ""
+
+#: templates/organizacoes/detail.html:92
+msgid "Nenhum evento associado."
+msgstr ""
+
+#: templates/organizacoes/detail.html:101
+msgid "Empresas"
+msgstr ""
+
+#: templates/organizacoes/detail.html:106
+msgid "Nenhuma empresa associada."
+msgstr ""
+
+#: templates/organizacoes/detail.html:115
+msgid "Posts"
+msgstr ""
+
+#: templates/organizacoes/detail.html:120
+msgid "Nenhum post associado."
+msgstr ""
+
+#: templates/organizacoes/detail.html:130 templates/organizacoes/list.html:91
+msgid "Editar"
+msgstr ""
+
+#: templates/organizacoes/detail.html:133
+msgid "Excluir"
+msgstr ""
+
+#: templates/organizacoes/detail.html:139 templates/organizacoes/list.html:100
+msgid "Reativar"
+msgstr ""
+
+#: templates/organizacoes/detail.html:139 templates/organizacoes/list.html:102
+msgid "Inativar"
+msgstr ""
+
+#: templates/organizacoes/detail.html:142 templates/organizacoes/history.html:3
+#: templates/organizacoes/history.html:6
+msgid "Histórico"
+msgstr ""
+
+#: templates/organizacoes/history.html:7
+msgid "Baixar CSV completo"
+msgstr ""
+
+#: templates/organizacoes/history.html:9
+msgid "Alterações"
+msgstr ""
+
+#: templates/organizacoes/history.html:13
+msgid "Campo"
+msgstr ""
+
+#: templates/organizacoes/history.html:14
+msgid "De"
+msgstr ""
+
+#: templates/organizacoes/history.html:15
+msgid "Para"
+msgstr ""
+
+#: templates/organizacoes/history.html:16
+#: templates/organizacoes/history.html:42
+msgid "Usuário"
+msgstr ""
+
+#: templates/organizacoes/history.html:17
+#: templates/organizacoes/history.html:43 templates/organizacoes/list.html:48
+msgid "Data"
+msgstr ""
+
+#: templates/organizacoes/history.html:31
+#: templates/organizacoes/history.html:55
+msgid "Nenhum log encontrado."
+msgstr ""
+
+#: templates/organizacoes/history.html:37
+msgid "Atividades"
+msgstr ""
+
+#: templates/organizacoes/history.html:41
+msgid "Ação"
+msgstr ""
+
+#: templates/organizacoes/list.html:4 templates/organizacoes/list.html:12
+msgid "Organizações"
+msgstr ""
+
+#: templates/organizacoes/list.html:13
+msgid "Gerencie as organizações cadastradas"
+msgstr ""
+
+#: templates/organizacoes/list.html:25
+msgid "Buscar por nome ou slug"
+msgstr ""
+
+#: templates/organizacoes/list.html:33
+msgid "Cidade"
+msgstr ""
+
+#: templates/organizacoes/list.html:39
+msgid "Estado"
+msgstr ""
+
+#: templates/organizacoes/list.html:45 templates/organizacoes/list.html:60
+msgid "Nome"
+msgstr ""
+
+#: templates/organizacoes/list.html:47
+msgid "Localização"
+msgstr ""
+
+#: templates/organizacoes/list.html:51
+msgid "Filtrar"
+msgstr ""
+
+#: templates/organizacoes/list.html:62
+msgid "Cidade/Estado"
+msgstr ""
+
+#: templates/organizacoes/list.html:63
+msgid "Data de Criação"
+msgstr ""
+
+#: templates/organizacoes/list.html:64
+msgid "Ações"
+msgstr ""
+
+#: templates/organizacoes/list.html:81
+msgid "Inativa"
+msgstr ""
+
+#: templates/organizacoes/list.html:89
+msgid "Visualizar"
+msgstr ""
+
+#: templates/organizacoes/list.html:94
+msgid "Confirmar remoção?"
+msgstr ""
+
+#: templates/organizacoes/list.html:97
+msgid "Tem certeza?"
+msgstr ""
+
+#: templates/organizacoes/list.html:114
+msgid "Anterior"
+msgstr ""
+
+#: templates/organizacoes/list.html:118
+msgid "Próxima"
+msgstr ""
+
+#: templates/organizacoes/list.html:123
+msgid "Nenhuma organização cadastrada."
+msgstr ""
+
+#: templates/organizacoes/list.html:125
+msgid "Cadastrar"
+msgstr ""
+
+#: templates/organizacoes/update.html:4 templates/organizacoes/update.html:15
+msgid "Editar Organização"
+msgstr ""
+
+#: templates/organizacoes/update.html:141
+msgid "Voltar à lista"
+msgstr ""

--- a/organizacoes/templates/organizacoes/create.html
+++ b/organizacoes/templates/organizacoes/create.html
@@ -1,19 +1,20 @@
 {% extends 'base.html' %}
+{% load i18n %}
 
-{% block title %}Nova Organização | Hubx{% endblock %}
+{% block title %}{% trans 'Nova Organização' %} | Hubx{% endblock %}
 
 {% block content %}
 <section class="max-w-2xl mx-auto px-4 py-10">
 
   <!-- Cabeçalho -->
   <div class="mb-6 flex items-center gap-4">
-    <a href="{% url 'organizacoes:list' %}" class="inline-flex items-center text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100">
+    <a href="{% url 'organizacoes:list' %}" class="inline-flex items-center text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100" aria-label="{% trans 'Voltar' %}">
       <svg class="mr-2" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
         <polyline points="15,18 9,12 15,6"/>
       </svg>
-      Voltar
+      {% trans 'Voltar' %}
     </a>
-    <h1 class="text-2xl font-bold text-neutral-900">{% block form_title %}Cadastrar Organização{% endblock %}</h1>
+    <h1 class="text-2xl font-bold text-neutral-900">{% block form_title %}{% trans 'Cadastrar Organização' %}{% endblock %}</h1>
   </div>
 
   <!-- Formulário -->
@@ -128,10 +129,10 @@
 
     <div class="flex justify-end gap-3 pt-4 border-t border-neutral-100">
       <a href="{% url 'organizacoes:list' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100">
-        Cancelar
+        {% trans 'Cancelar' %}
       </a>
       <button type="submit" class="text-sm px-4 py-2 rounded-xl bg-primary-600 text-white hover:bg-primary-700">
-        Salvar
+        {% trans 'Salvar' %}
       </button>
     </div>
   </form>

--- a/organizacoes/templates/organizacoes/delete.html
+++ b/organizacoes/templates/organizacoes/delete.html
@@ -1,22 +1,23 @@
 {% extends 'base.html' %}
+{% load i18n %}
 
-{% block title %}Remover Organização | Hubx{% endblock %}
+{% block title %}{% trans 'Remover Organização' %} | Hubx{% endblock %}
 
 {% block content %}
 <section class="max-w-md mx-auto px-4 py-16">
   <div class="bg-white border border-red-200 rounded-2xl shadow-sm p-6 text-center">
-    <h1 class="text-xl font-semibold text-red-700 mb-4">Confirmar remoção</h1>
+    <h1 class="text-xl font-semibold text-red-700 mb-4">{% trans 'Confirmar remoção' %}</h1>
     <p class="text-sm text-neutral-700">
-      Tem certeza que deseja remover <strong>{{ object.nome }}</strong>?
+      {% blocktrans with nome=object.nome %}Tem certeza que deseja remover <strong>{{ nome }}</strong>?{% endblocktrans %}
     </p>
 
     <form method="post" class="mt-6 flex justify-center gap-3">
       {% csrf_token %}
       <a href="{% url 'organizacoes:list' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100">
-        Cancelar
+        {% trans 'Cancelar' %}
       </a>
       <button type="submit" class="text-sm px-4 py-2 rounded-xl bg-red-600 text-white hover:bg-red-700">
-        Remover
+        {% trans 'Remover' %}
       </button>
     </form>
   </div>

--- a/organizacoes/templates/organizacoes/list.html
+++ b/organizacoes/templates/organizacoes/list.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% load i18n %}
 
-{% block title %}Organizações | Hubx{% endblock %}
+{% block title %}{% trans 'Organizações' %} | Hubx{% endblock %}
 
 {% block content %}
 <section class="max-w-6xl mx-auto px-4 py-10" id="org-list">
@@ -9,46 +9,46 @@
   <!-- Cabeçalho -->
   <div class="flex items-center justify-between mb-8">
     <div>
-      <h1 class="text-2xl font-bold text-neutral-900">Organizações</h1>
-      <p class="text-neutral-600 text-sm">Gerencie as organizações cadastradas</p>
+      <h1 class="text-2xl font-bold text-neutral-900">{% trans 'Organizações' %}</h1>
+      <p class="text-neutral-600 text-sm">{% trans 'Gerencie as organizações cadastradas' %}</p>
     </div>
     <a href="{% url 'organizacoes:create' %}" class="inline-flex items-center gap-2 bg-primary-600 text-white text-sm px-4 py-2 rounded-xl hover:bg-primary-700">
       <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
         <line x1="12" y1="5" x2="12" y2="19"/>
         <line x1="5" y1="12" x2="19" y2="12"/>
       </svg>
-      Nova Organização
+      {% trans 'Nova Organização' %}
     </a>
   </div>
 
   <form hx-get="{% url 'organizacoes:list' %}" hx-target="#org-list" hx-push-url="true" class="mb-6 grid md:grid-cols-5 gap-2">
     <input type="text" name="q" value="{{ request.GET.q }}" placeholder="{% trans 'Buscar por nome ou slug' %}" class="w-full p-2 border rounded-lg" />
     <select name="tipo" class="w-full p-2 border rounded-lg">
-      <option value="">Tipo</option>
+      <option value="">{% trans 'Tipo' %}</option>
       {% for value, label in tipos %}
         <option value="{{ value }}" {% if request.GET.tipo == value %}selected{% endif %}>{{ label }}</option>
       {% endfor %}
     </select>
     <select name="cidade" class="w-full p-2 border rounded-lg">
-      <option value="">Cidade</option>
+      <option value="">{% trans 'Cidade' %}</option>
       {% for c in cidades %}
         <option value="{{ c }}" {% if request.GET.cidade == c %}selected{% endif %}>{{ c }}</option>
       {% endfor %}
     </select>
     <select name="estado" class="w-full p-2 border rounded-lg">
-      <option value="">Estado</option>
+      <option value="">{% trans 'Estado' %}</option>
       {% for e in estados %}
         <option value="{{ e }}" {% if request.GET.estado == e %}selected{% endif %}>{{ e }}</option>
       {% endfor %}
     </select>
     <select name="order" class="w-full p-2 border rounded-lg">
-      <option value="nome" {% if request.GET.order == 'nome' or not request.GET.order %}selected{% endif %}>Nome</option>
-      <option value="tipo" {% if request.GET.order == 'tipo' %}selected{% endif %}>Tipo</option>
-      <option value="cidade" {% if request.GET.order == 'cidade' %}selected{% endif %}>Localização</option>
-      <option value="created_at" {% if request.GET.order == 'created_at' %}selected{% endif %}>Data</option>
+      <option value="nome" {% if request.GET.order == 'nome' or not request.GET.order %}selected{% endif %}>{% trans 'Nome' %}</option>
+      <option value="tipo" {% if request.GET.order == 'tipo' %}selected{% endif %}>{% trans 'Tipo' %}</option>
+      <option value="cidade" {% if request.GET.order == 'cidade' %}selected{% endif %}>{% trans 'Localização' %}</option>
+      <option value="created_at" {% if request.GET.order == 'created_at' %}selected{% endif %}>{% trans 'Data' %}</option>
     </select>
     <div class="md:col-span-5 flex justify-end">
-      <button type="submit" class="px-4 py-2 bg-primary-600 text-white rounded-lg">Filtrar</button>
+      <button type="submit" class="px-4 py-2 bg-primary-600 text-white rounded-lg">{% trans 'Filtrar' %}</button>
     </div>
   </form>
 
@@ -57,11 +57,11 @@
       <table class="min-w-full bg-white border border-neutral-200 rounded-2xl shadow-sm">
         <thead class="bg-neutral-50">
           <tr>
-            <th scope="col" class="px-4 py-2 text-left text-sm font-medium text-neutral-700">Nome</th>
-            <th scope="col" class="px-4 py-2 text-left text-sm font-medium text-neutral-700">Tipo</th>
-            <th scope="col" class="px-4 py-2 text-left text-sm font-medium text-neutral-700">Cidade/Estado</th>
-            <th scope="col" class="px-4 py-2 text-left text-sm font-medium text-neutral-700">Data de Criação</th>
-            <th scope="col" class="px-4 py-2 text-left text-sm font-medium text-neutral-700">Ações</th>
+            <th scope="col" class="px-4 py-2 text-left text-sm font-medium text-neutral-700">{% trans 'Nome' %}</th>
+            <th scope="col" class="px-4 py-2 text-left text-sm font-medium text-neutral-700">{% trans 'Tipo' %}</th>
+            <th scope="col" class="px-4 py-2 text-left text-sm font-medium text-neutral-700">{% trans 'Cidade/Estado' %}</th>
+            <th scope="col" class="px-4 py-2 text-left text-sm font-medium text-neutral-700">{% trans 'Data de Criação' %}</th>
+            <th scope="col" class="px-4 py-2 text-left text-sm font-medium text-neutral-700">{% trans 'Ações' %}</th>
           </tr>
         </thead>
         <tbody class="divide-y divide-neutral-200">
@@ -78,7 +78,7 @@
                 </div>
                 <a href="{% url 'organizacoes:detail' organizacao.id %}" class="text-neutral-900 font-medium hover:underline">{{ organizacao.nome }}</a>
                 {% if organizacao.inativa %}
-                  <span class="ml-2 text-xs bg-yellow-200 text-yellow-800 px-2 py-0.5 rounded">Inativa</span>
+                  <span class="ml-2 text-xs bg-yellow-200 text-yellow-800 px-2 py-0.5 rounded">{% trans 'Inativa' %}</span>
                 {% endif %}
               </div>
             </td>
@@ -111,18 +111,18 @@
     </div>
     <div class="mt-6 flex justify-center gap-2">
       {% if page_obj.has_previous %}
-        <a hx-get="?page={{ page_obj.previous_page_number }}{% if request.GET.q %}&q={{ request.GET.q }}{% endif %}{% if request.GET.tipo %}&tipo={{ request.GET.tipo }}{% endif %}{% if request.GET.cidade %}&cidade={{ request.GET.cidade }}{% endif %}{% if request.GET.estado %}&estado={{ request.GET.estado }}{% endif %}{% if request.GET.order %}&order={{ request.GET.order }}{% endif %}" hx-target="#org-list" hx-push-url="true" class="px-3 py-1 border rounded" aria-label="Anterior">Anterior</a>
+        <a hx-get="?page={{ page_obj.previous_page_number }}{% if request.GET.q %}&q={{ request.GET.q }}{% endif %}{% if request.GET.tipo %}&tipo={{ request.GET.tipo }}{% endif %}{% if request.GET.cidade %}&cidade={{ request.GET.cidade }}{% endif %}{% if request.GET.estado %}&estado={{ request.GET.estado }}{% endif %}{% if request.GET.order %}&order={{ request.GET.order }}{% endif %}" hx-target="#org-list" hx-push-url="true" class="px-3 py-1 border rounded" aria-label="{% trans 'Anterior' %}">{% trans 'Anterior' %}</a>
       {% endif %}
       <span class="px-3 py-1">{{ page_obj.number }} / {{ page_obj.paginator.num_pages }}</span>
       {% if page_obj.has_next %}
-        <a hx-get="?page={{ page_obj.next_page_number }}{% if request.GET.q %}&q={{ request.GET.q }}{% endif %}{% if request.GET.tipo %}&tipo={{ request.GET.tipo }}{% endif %}{% if request.GET.cidade %}&cidade={{ request.GET.cidade }}{% endif %}{% if request.GET.estado %}&estado={{ request.GET.estado }}{% endif %}{% if request.GET.order %}&order={{ request.GET.order }}{% endif %}" hx-target="#org-list" hx-push-url="true" class="px-3 py-1 border rounded" aria-label="Próxima">Próxima</a>
+        <a hx-get="?page={{ page_obj.next_page_number }}{% if request.GET.q %}&q={{ request.GET.q }}{% endif %}{% if request.GET.tipo %}&tipo={{ request.GET.tipo }}{% endif %}{% if request.GET.cidade %}&cidade={{ request.GET.cidade }}{% endif %}{% if request.GET.estado %}&estado={{ request.GET.estado }}{% endif %}{% if request.GET.order %}&order={{ request.GET.order }}{% endif %}" hx-target="#org-list" hx-push-url="true" class="px-3 py-1 border rounded" aria-label="{% trans 'Próxima' %}">{% trans 'Próxima' %}</a>
       {% endif %}
     </div>
   {% else %}
     <div class="text-center border border-neutral-200 rounded-2xl shadow-sm p-10 bg-white">
-      <p class="text-neutral-500 mb-4">Nenhuma organização cadastrada.</p>
+      <p class="text-neutral-500 mb-4">{% trans 'Nenhuma organização cadastrada.' %}</p>
       <a href="{% url 'organizacoes:create' %}" class="inline-block text-sm px-4 py-2 rounded-xl bg-primary-600 text-white hover:bg-primary-700">
-        Cadastrar
+        {% trans 'Cadastrar' %}
       </a>
     </div>
   {% endif %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,7 +1,7 @@
 {% load static i18n %}
 {% get_current_language as LANGUAGE_CODE %}
 <!DOCTYPE html>
-<html lang="{{ LANGUAGE_CODE }}" class="h-full bg-gray-50">
+<html lang="{{ LANGUAGE_CODE }}" dir="{% if LANGUAGE_BIDI %}rtl{% else %}ltr{% endif %}" class="h-full bg-gray-50">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -25,7 +25,8 @@
       }
     })();
   </script>
-  <title>{% block title %}HubX{% endblock %}</title>
+  <title>{% block title %}{% trans "HubX" %}{% endblock %}</title>
+  <script src="{% url 'javascript-catalog' %}"></script>
 
   <link rel="preconnect" href="https://rsms.me/">
   <link rel="stylesheet" href="https://rsms.me/inter/inter.css">
@@ -93,38 +94,38 @@
         </div>
         {% endif %}
         <a href="{% url 'dashboard:dashboard' %}" class="flex items-center gap-x-2 hover:text-primary transition">
-          <i class="fas fa-tachometer-alt"></i> Dashboard
+          <i class="fas fa-tachometer-alt"></i> {% trans "Dashboard" %}
         </a>
         <a href="{% url 'empresas:lista' %}" class="flex items-center gap-x-2 hover:text-primary transition">
-          <i class="fas fa-building"></i> Empresas
+          <i class="fas fa-building"></i> {% trans "Empresas" %}
         </a>
         <a href="{% url 'agenda:calendario' %}" class="flex items-center gap-x-2 hover:text-primary transition">
-          <i class="fas fa-calendar-alt"></i> Agenda
+          <i class="fas fa-calendar-alt"></i> {% trans "Agenda" %}
         </a>
         <a href="{% url 'discussao:categorias' %}" class="flex items-center gap-x-2 hover:text-primary transition">
-          <i class="fas fa-comments"></i> Discussão
+          <i class="fas fa-comments"></i> {% trans "Discussão" %}
         </a>
         <a href="{% url 'feed:listar' %}" class="flex items-center gap-x-2 hover:text-primary transition">
-          <i class="fas fa-rss"></i> Feed
+          <i class="fas fa-rss"></i> {% trans "Feed" %}
         </a>
         <a href="{% url 'nucleos:list' %}" class="flex items-center gap-x-2 hover:text-primary transition">
-          <i class="fas fa-users"></i> Núcleos
+          <i class="fas fa-users"></i> {% trans "Núcleos" %}
         </a>
         {% if user.is_authenticated and user.user_type == 'root' %}
         <a href="{% url 'organizacoes:list' %}" class="flex items-center gap-x-2 hover:text-primary transition">
-          <i class="fas fa-sitemap"></i> Organizações
+          <i class="fas fa-sitemap"></i> {% trans "Organizações" %}
         </a>
         {% endif %}
         <a href="{% url 'tokens:gerar_token' %}" class="flex items-center gap-x-2 hover:text-primary transition">
-          <i class="fas fa-key"></i> Token
+          <i class="fas fa-key"></i> {% trans "Token" %}
         </a>
         {% if user.is_authenticated %}
-          <span class="text-gray-600">Olá, {{ user.username }}</span>
-          <a href="{% url 'accounts:logout' %}" class="hover:text-primary transition">Sair</a>
+          <span class="text-gray-600">{% blocktrans %}Olá, {{ user.username }}{% endblocktrans %}</span>
+          <a href="{% url 'accounts:logout' %}" class="hover:text-primary transition">{% trans "Sair" %}</a>
         {% else %}
-          <a href="{% url 'accounts:login' %}" class="hover:text-primary transition">Entrar</a>
+          <a href="{% url 'accounts:login' %}" class="hover:text-primary transition">{% trans "Entrar" %}</a>
           <a href="{% url 'accounts:onboarding' %}" class="bg-primary text-white py-2 px-4 rounded-xl hover:bg-primary/90 transition">
-            Cadastrar
+            {% trans "Cadastrar" %}
           </a>
         {% endif %}
       </nav>
@@ -139,7 +140,7 @@
   <!-- Rodapé -->
   <footer class="bg-white border-t mt-10">
     <div class="container mx-auto px-4 py-6 text-sm text-gray-500 flex flex-col items-center gap-2 md:flex-row md:justify-between">
-      <p>© {{ now|date:"Y" }} HubX. Todos os direitos reservados.</p>
+      <p>{% blocktrans with year=now|date:"Y" %}© {{ year }} HubX. Todos os direitos reservados.{% endblocktrans %}</p>
       <nav class="flex gap-4">
         <a href="{% url 'core:about' %}" class="hover:text-primary">{% trans "Sobre" %}</a>
         <a href="mailto:contato@hubx.space" class="hover:text-primary">{% trans "Contato" %}</a>

--- a/templates/notificacoes/financeiro/ajuste_lancamento.html
+++ b/templates/notificacoes/financeiro/ajuste_lancamento.html
@@ -1,2 +1,3 @@
-<p>Olá {{ nome }},</p>
-<p>Seu lançamento {{ lancamento }} foi ajustado em {{ valor }}.</p>
+{% load i18n %}
+<p>{% blocktrans trimmed with nome=nome %}Olá {{ nome }},{% endblocktrans %}</p>
+<p>{% blocktrans trimmed with lancamento=lancamento valor=valor %}Seu lançamento {{ lancamento }} foi ajustado em {{ valor }}.{% endblocktrans %}</p>

--- a/templates/notificacoes/financeiro/distribuicao_receita.html
+++ b/templates/notificacoes/financeiro/distribuicao_receita.html
@@ -1,2 +1,3 @@
-<p>Olá {{ nome }},</p>
-<p>A receita do evento {{ evento }} no valor de {{ valor }} foi distribuída.</p>
+{% load i18n %}
+<p>{% blocktrans trimmed with nome=nome %}Olá {{ nome }},{% endblocktrans %}</p>
+<p>{% blocktrans trimmed with evento=evento valor=valor %}A receita do evento {{ evento }} no valor de {{ valor }} foi distribuída.{% endblocktrans %}</p>

--- a/templates/notificacoes/financeiro/nova_cobranca.html
+++ b/templates/notificacoes/financeiro/nova_cobranca.html
@@ -1,3 +1,4 @@
-<p>Olá {{ nome }},</p>
-<p>Você possui uma nova cobrança no valor de {{ valor }} com vencimento em {{ vencimento }}.</p>
-<p>Acesse {{ link_pagamento }} para efetuar o pagamento.</p>
+{% load i18n %}
+<p>{% blocktrans trimmed with nome=nome %}Olá {{ nome }},{% endblocktrans %}</p>
+<p>{% blocktrans trimmed with valor=valor vencimento=vencimento %}Você possui uma nova cobrança no valor de {{ valor }} com vencimento em {{ vencimento }}.{% endblocktrans %}</p>
+<p>{% blocktrans trimmed with link_pagamento=link_pagamento|safe %}Acesse {{ link_pagamento }} para efetuar o pagamento.{% endblocktrans %}</p>

--- a/tokens/locale/en/LC_MESSAGES/django.po
+++ b/tokens/locale/en/LC_MESSAGES/django.po
@@ -1,0 +1,124 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-14 16:24+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+#: templates/tokens/_resultado.html:4
+msgid "Código gerado:"
+msgstr ""
+
+#: templates/tokens/_resultado.html:8
+msgid "Token:"
+msgstr ""
+
+#: templates/tokens/ativar_2fa.html:4
+msgid "Ativar 2FA"
+msgstr ""
+
+#: templates/tokens/ativar_2fa.html:9
+msgid "Ativar Autenticação de Dois Fatores"
+msgstr ""
+
+#: templates/tokens/ativar_2fa.html:10
+msgid ""
+"Escaneie o QR Code no aplicativo autenticador ou digite o código exibido."
+msgstr ""
+
+#: templates/tokens/ativar_2fa.html:26
+msgid "QR Code"
+msgstr ""
+
+#: templates/tokens/ativar_2fa.html:40
+msgid "Ativar"
+msgstr ""
+
+#: templates/tokens/ativar_2fa.html:45 templates/tokens/desativar_2fa.html:24
+msgid "Voltar ao perfil de segurança"
+msgstr ""
+
+#: templates/tokens/desativar_2fa.html:4
+msgid "Desativar 2FA"
+msgstr ""
+
+#: templates/tokens/desativar_2fa.html:9
+msgid "Desativar Autenticação de Dois Fatores"
+msgstr ""
+
+#: templates/tokens/desativar_2fa.html:11
+msgid "Confirme para desativar a autenticação em duas etapas."
+msgstr ""
+
+#: templates/tokens/desativar_2fa.html:18
+msgid "Desativar"
+msgstr ""
+
+#: templates/tokens/gerar_codigo_autenticacao.html:4
+#: templates/tokens/gerar_codigo_autenticacao.html:9
+msgid "Gerar Código de Autenticação"
+msgstr ""
+
+#: templates/tokens/gerar_codigo_autenticacao.html:10
+msgid "Gere um código temporário para validar sua identidade."
+msgstr ""
+
+#: templates/tokens/gerar_codigo_autenticacao.html:36
+msgid "Gerar Código"
+msgstr ""
+
+#: templates/tokens/gerar_codigo_autenticacao.html:43
+#: templates/tokens/gerar_token.html:52
+#: templates/tokens/validar_codigo_autenticacao.html:33
+#: templates/tokens/validar_token.html:33
+msgid "Voltar ao painel de segurança"
+msgstr ""
+
+#: templates/tokens/gerar_token.html:3 templates/tokens/gerar_token.html:8
+msgid "Gerar Token de Acesso"
+msgstr ""
+
+#: templates/tokens/gerar_token.html:9
+msgid "Use este token para convidar novos membros ou recuperar o acesso."
+msgstr ""
+
+#: templates/tokens/gerar_token.html:40
+msgid "Gerar Token"
+msgstr ""
+
+#: templates/tokens/validar_codigo_autenticacao.html:4
+#: templates/tokens/validar_codigo_autenticacao.html:9
+msgid "Validar Código de Autenticação"
+msgstr ""
+
+#: templates/tokens/validar_codigo_autenticacao.html:10
+msgid "Informe o código recebido para concluir a validação."
+msgstr ""
+
+#: templates/tokens/validar_codigo_autenticacao.html:26
+msgid "Validar Código"
+msgstr ""
+
+#: templates/tokens/validar_token.html:4 templates/tokens/validar_token.html:9
+msgid "Validar Token de Convite"
+msgstr ""
+
+#: templates/tokens/validar_token.html:10
+msgid "Informe o token recebido para concluir o convite."
+msgstr ""
+
+#: templates/tokens/validar_token.html:26
+msgid "Validar Token"
+msgstr ""

--- a/tokens/locale/pt_BR/LC_MESSAGES/django.po
+++ b/tokens/locale/pt_BR/LC_MESSAGES/django.po
@@ -1,0 +1,124 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-14 16:24+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+#: templates/tokens/_resultado.html:4
+msgid "Código gerado:"
+msgstr ""
+
+#: templates/tokens/_resultado.html:8
+msgid "Token:"
+msgstr ""
+
+#: templates/tokens/ativar_2fa.html:4
+msgid "Ativar 2FA"
+msgstr ""
+
+#: templates/tokens/ativar_2fa.html:9
+msgid "Ativar Autenticação de Dois Fatores"
+msgstr ""
+
+#: templates/tokens/ativar_2fa.html:10
+msgid ""
+"Escaneie o QR Code no aplicativo autenticador ou digite o código exibido."
+msgstr ""
+
+#: templates/tokens/ativar_2fa.html:26
+msgid "QR Code"
+msgstr ""
+
+#: templates/tokens/ativar_2fa.html:40
+msgid "Ativar"
+msgstr ""
+
+#: templates/tokens/ativar_2fa.html:45 templates/tokens/desativar_2fa.html:24
+msgid "Voltar ao perfil de segurança"
+msgstr ""
+
+#: templates/tokens/desativar_2fa.html:4
+msgid "Desativar 2FA"
+msgstr ""
+
+#: templates/tokens/desativar_2fa.html:9
+msgid "Desativar Autenticação de Dois Fatores"
+msgstr ""
+
+#: templates/tokens/desativar_2fa.html:11
+msgid "Confirme para desativar a autenticação em duas etapas."
+msgstr ""
+
+#: templates/tokens/desativar_2fa.html:18
+msgid "Desativar"
+msgstr ""
+
+#: templates/tokens/gerar_codigo_autenticacao.html:4
+#: templates/tokens/gerar_codigo_autenticacao.html:9
+msgid "Gerar Código de Autenticação"
+msgstr ""
+
+#: templates/tokens/gerar_codigo_autenticacao.html:10
+msgid "Gere um código temporário para validar sua identidade."
+msgstr ""
+
+#: templates/tokens/gerar_codigo_autenticacao.html:36
+msgid "Gerar Código"
+msgstr ""
+
+#: templates/tokens/gerar_codigo_autenticacao.html:43
+#: templates/tokens/gerar_token.html:52
+#: templates/tokens/validar_codigo_autenticacao.html:33
+#: templates/tokens/validar_token.html:33
+msgid "Voltar ao painel de segurança"
+msgstr ""
+
+#: templates/tokens/gerar_token.html:3 templates/tokens/gerar_token.html:8
+msgid "Gerar Token de Acesso"
+msgstr ""
+
+#: templates/tokens/gerar_token.html:9
+msgid "Use este token para convidar novos membros ou recuperar o acesso."
+msgstr ""
+
+#: templates/tokens/gerar_token.html:40
+msgid "Gerar Token"
+msgstr ""
+
+#: templates/tokens/validar_codigo_autenticacao.html:4
+#: templates/tokens/validar_codigo_autenticacao.html:9
+msgid "Validar Código de Autenticação"
+msgstr ""
+
+#: templates/tokens/validar_codigo_autenticacao.html:10
+msgid "Informe o código recebido para concluir a validação."
+msgstr ""
+
+#: templates/tokens/validar_codigo_autenticacao.html:26
+msgid "Validar Código"
+msgstr ""
+
+#: templates/tokens/validar_token.html:4 templates/tokens/validar_token.html:9
+msgid "Validar Token de Convite"
+msgstr ""
+
+#: templates/tokens/validar_token.html:10
+msgid "Informe o token recebido para concluir o convite."
+msgstr ""
+
+#: templates/tokens/validar_token.html:26
+msgid "Validar Token"
+msgstr ""

--- a/tokens/templates/tokens/ativar_2fa.html
+++ b/tokens/templates/tokens/ativar_2fa.html
@@ -23,7 +23,7 @@
   <main>
     {% if qr_code %}
       <div class="flex flex-col items-center mb-4">
-        <img src="data:image/png;base64,{{ qr_code }}" alt="QR Code" class="w-40 h-40" />
+        <img src="data:image/png;base64,{{ qr_code }}" alt="{% trans 'QR Code' %}" class="w-40 h-40" />
         <p class="mt-2 text-sm font-mono">{{ secret }}</p>
       </div>
     {% endif %}


### PR DESCRIPTION
## Summary
- localize feed post pdf link and home footer brand label
- translate finance notification templates using blocktrans and add catalog entries
- update locale catalogs for feed, core and notification messages
- internationalize remaining registration templates and add tokens locale with QR code translation
- localize date formats across media, chat, feed, agenda, discussion and finance templates
- localize dashboard PDF export with dynamic language and number formatting

## Testing
- `python - <<'PY'
import os, sys
sys.path.insert(0, '/workspace/ProjetoHubx')
os.chdir('/workspace/ProjetoHubx/dashboard')
from django.core import management
management.execute_from_command_line(['manage.py','makemessages','-l','pt_BR','-l','en','-e','html'])
PY`
- `python manage.py compilemessages`
- `pytest` *(ModuleNotFoundError: No module named 'pywebpush')*

------
https://chatgpt.com/codex/tasks/task_e_689d134829a483259cb462cacaeb2728