### PR TITLE
feat: add event check-in templates and localize dashboard

### DIFF
--- a/Hubx/urls.py
+++ b/Hubx/urls.py
@@ -6,6 +6,7 @@ from django.contrib import admin
 from django.contrib.staticfiles.views import serve as static_serve
 from django.urls import include, path
 from django.views.generic import RedirectView
+from django.views.i18n import JavaScriptCatalog
 
 from configuracoes.views import ConfiguracoesView
 
@@ -34,6 +35,7 @@ urlpatterns = [
     path("notificacoes/", include(("notificacoes.urls", "notificacoes"), namespace="notificacoes")),
     path("configuracoes/", ConfiguracoesView.as_view(), name="configuracoes"),
     path("financeiro/", include(("financeiro.urls", "financeiro"), namespace="financeiro")),
+    path("jsi18n/", JavaScriptCatalog.as_view(), name="javascript-catalog"),
     path("select2/", include("django_select2.urls")),
     # APIs REST (subcaminhos específicos)
     path(

--- a/accounts/locale/en/LC_MESSAGES/django.po
+++ b/accounts/locale/en/LC_MESSAGES/django.po
@@ -844,3 +844,14 @@ msgstr ""
 #: templates/register/usuario.html:30
 msgid "Use apenas letras, números e underscore (_)"
 msgstr ""
+#: templates/register/cpf.html:28
+msgid "000.000.000-00"
+msgstr "000.000.000-00"
+
+#: templates/perfil/informacoes_pessoais.html:81 templates/perfil/informacoes_pessoais.html:87
+msgid "(00) 00000-0000"
+msgstr "(000) 000-0000"
+
+#: templates/perfil/informacoes_pessoais.html:119
+msgid "00000-000"
+msgstr "00000"

--- a/accounts/locale/pt_BR/LC_MESSAGES/django.po
+++ b/accounts/locale/pt_BR/LC_MESSAGES/django.po
@@ -844,3 +844,14 @@ msgstr ""
 #: templates/register/usuario.html:30
 msgid "Use apenas letras, números e underscore (_)"
 msgstr ""
+#: templates/register/cpf.html:28
+msgid "000.000.000-00"
+msgstr "000.000.000-00"
+
+#: templates/perfil/informacoes_pessoais.html:81 templates/perfil/informacoes_pessoais.html:87
+msgid "(00) 00000-0000"
+msgstr "(00) 00000-0000"
+
+#: templates/perfil/informacoes_pessoais.html:119
+msgid "00000-000"
+msgstr "00000-000"

--- a/accounts/templates/perfil/informacoes_pessoais.html
+++ b/accounts/templates/perfil/informacoes_pessoais.html
@@ -78,13 +78,13 @@
         <label for="fone" class="block text-sm font-medium text-gray-700">{% trans "Telefone" %}</label>
         <input type="tel" id="fone" name="fone"
                class="mt-1 block w-full border rounded-lg p-2 text-sm"
-               value="{{ user.fone }}" placeholder="(00) 00000-0000">
+               value="{{ user.fone }}" placeholder="{% trans '(00) 00000-0000' %}">
       </div>
       <div>
         <label for="whatsapp" class="block text-sm font-medium text-gray-700">{% trans "WhatsApp" %}</label>
         <input type="tel" id="whatsapp" name="whatsapp"
                class="mt-1 block w-full border rounded-lg p-2 text-sm"
-               value="{{ user.whatsapp }}" placeholder="(00) 00000-0000">
+               value="{{ user.whatsapp }}" placeholder="{% trans '(00) 00000-0000' %}">
       </div>
     </div>
 
@@ -116,7 +116,7 @@
         <label for="cep" class="block text-sm font-medium text-gray-700">{% trans "CEP" %}</label>
         <input type="text" id="cep" name="cep"
                class="mt-1 block w-full border rounded-lg p-2 text-sm"
-               value="{{ user.cep }}" placeholder="00000-000">
+               value="{{ user.cep }}" placeholder="{% trans '00000-000' %}">
       </div>
     </div>
 

--- a/accounts/templates/register/cpf.html
+++ b/accounts/templates/register/cpf.html
@@ -25,7 +25,7 @@
       {% csrf_token %}
       <div>
         <label for="cpf" class="mb-1 block text-sm font-medium text-neutral-700">{% trans "CPF" %}</label>
-        <input type="text" id="cpf" name="cpf" maxlength="14" class="w-full rounded-lg border border-neutral-300 px-4 py-2 placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder="000.000.000-00" required autofocus>
+        <input type="text" id="cpf" name="cpf" maxlength="14" class="w-full rounded-lg border border-neutral-300 px-4 py-2 placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder="{% trans '000.000.000-00' %}" required autofocus>
         <div class="text-sm text-red-600" id="cpf_validation"></div>
       </div>
 

--- a/agenda/locale/en/LC_MESSAGES/django.po
+++ b/agenda/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-14 11:28-0300\n"
+"POT-Creation-Date: 2025-08-14 15:01-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,277 +17,331 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-#: templates/agenda/_lista_eventos_dia.html:3
+
+#: agenda/templates/agenda/_lista_eventos_dia.html:3
 #, python-format
 msgid "Eventos de %(date)s"
 msgstr ""
 
-#: templates/agenda/_lista_eventos_dia.html:18
+#: agenda/templates/agenda/_lista_eventos_dia.html:18
 msgid "Sem eventos."
 msgstr ""
 
-#: templates/agenda/briefing_form.html:3 templates/agenda/briefing_form.html:8
+#: agenda/templates/agenda/avaliacao_form.html:3
+#: agenda/templates/agenda/avaliacao_form.html:7
+msgid "Avaliar evento"
+msgstr ""
+
+#: agenda/templates/agenda/avaliacao_form.html:11
+msgid "Nota"
+msgstr ""
+
+#: agenda/templates/agenda/avaliacao_form.html:19
+msgid "Comentário"
+msgstr ""
+
+#: agenda/templates/agenda/avaliacao_form.html:20
+msgid "Opcional"
+msgstr ""
+
+#: agenda/templates/agenda/avaliacao_form.html:23
+msgid "Enviar avaliação"
+msgstr ""
+
+#: agenda/templates/agenda/briefing_form.html:3
+#: agenda/templates/agenda/briefing_form.html:8
 msgid "Editar Briefing"
 msgstr ""
 
-#: templates/agenda/briefing_form.html:3 templates/agenda/briefing_form.html:8
-#: templates/agenda/briefing_list.html:13
+#: agenda/templates/agenda/briefing_form.html:3
+#: agenda/templates/agenda/briefing_form.html:8
+#: agenda/templates/agenda/briefing_list.html:13
 msgid "Novo Briefing"
 msgstr ""
 
-#: templates/agenda/briefing_form.html:14 templates/agenda/create.html:15
-#: templates/agenda/delete.html:13
-#: templates/agenda/parceria_confirm_delete.html:13
-#: templates/agenda/parceria_form.html:13 templates/agenda/update.html:26
+#: agenda/templates/agenda/briefing_form.html:14
+#: agenda/templates/agenda/create.html:15
+#: agenda/templates/agenda/delete.html:13
+#: agenda/templates/agenda/parceria_confirm_delete.html:13
+#: agenda/templates/agenda/parceria_form.html:13
+#: agenda/templates/agenda/update.html:26
 msgid "Cancelar"
 msgstr ""
 
-#: templates/agenda/briefing_form.html:15 templates/agenda/create.html:16
-#: templates/agenda/parceria_form.html:14 templates/agenda/update.html:27
+#: agenda/templates/agenda/briefing_form.html:15
+#: agenda/templates/agenda/create.html:16
+#: agenda/templates/agenda/parceria_form.html:14
+#: agenda/templates/agenda/update.html:27
 msgid "Salvar"
 msgstr ""
 
-#: templates/agenda/briefing_list.html:4
+#: agenda/templates/agenda/briefing_list.html:4
 msgid "Briefings"
 msgstr ""
 
-#: templates/agenda/briefing_list.html:9
+#: agenda/templates/agenda/briefing_list.html:9
 msgid "Briefings de Eventos"
 msgstr ""
 
-#: templates/agenda/briefing_list.html:34
+#: agenda/templates/agenda/briefing_list.html:34
 msgid "Buscar por evento"
 msgstr ""
 
-#: templates/agenda/briefing_list.html:41
-#: templates/agenda/inscricao_list.html:37
-#: templates/agenda/material_list.html:37
+#: agenda/templates/agenda/briefing_list.html:41
+#: agenda/templates/agenda/inscricao_list.html:37
+#: agenda/templates/agenda/material_list.html:37
 msgid "Filtrar"
 msgstr ""
 
-#: templates/agenda/briefing_list.html:50
-#: templates/agenda/inscricao_list.html:47
-#: templates/agenda/parceria_list.html:18
+#: agenda/templates/agenda/briefing_list.html:50
+#: agenda/templates/agenda/inscricao_list.html:47
+#: agenda/templates/agenda/parceria_list.html:18
 msgid "Evento"
 msgstr ""
 
-#: templates/agenda/briefing_list.html:51
+#: agenda/templates/agenda/briefing_list.html:51
 msgid "Objetivos"
 msgstr ""
 
-#: templates/agenda/briefing_list.html:52
+#: agenda/templates/agenda/briefing_list.html:52
 msgid "Público Alvo"
 msgstr ""
 
-#: templates/agenda/briefing_list.html:53
+#: agenda/templates/agenda/briefing_list.html:53
 msgid "Requisitos Técnicos"
 msgstr ""
 
-#: templates/agenda/briefing_list.html:54
+#: agenda/templates/agenda/briefing_list.html:54
 msgid "Cronograma Resumido"
 msgstr ""
 
-#: templates/agenda/briefing_list.html:55
+#: agenda/templates/agenda/briefing_list.html:55
 msgid "Conteúdo Programático"
 msgstr ""
 
-#: templates/agenda/briefing_list.html:56
+#: agenda/templates/agenda/briefing_list.html:56
 msgid "Observações"
 msgstr ""
 
-#: templates/agenda/briefing_list.html:57
-#: templates/agenda/inscricao_list.html:53
-#: templates/agenda/material_list.html:49
-#: templates/agenda/parceria_list.html:20
+#: agenda/templates/agenda/briefing_list.html:57
+#: agenda/templates/agenda/inscricao_list.html:53
+#: agenda/templates/agenda/material_list.html:49
+#: agenda/templates/agenda/parceria_list.html:20
 msgid "Ações"
 msgstr ""
 
-#: templates/agenda/briefing_list.html:74
-#: templates/agenda/parceria_list.html:30
+#: agenda/templates/agenda/briefing_list.html:74
+#: agenda/templates/agenda/parceria_list.html:30
 msgid "Editar"
 msgstr ""
 
-#: templates/agenda/briefing_list.html:82
+#: agenda/templates/agenda/briefing_list.html:82
 msgid "Orçar"
 msgstr ""
 
-#: templates/agenda/briefing_list.html:92
+#: agenda/templates/agenda/briefing_list.html:92
 msgid "Aprovar"
 msgstr ""
 
-#: templates/agenda/briefing_list.html:102
+#: agenda/templates/agenda/briefing_list.html:102
 msgid "Recusar"
 msgstr ""
 
-#: templates/agenda/briefing_list.html:109
+#: agenda/templates/agenda/briefing_list.html:109
 msgid "Nenhum briefing encontrado."
 msgstr ""
 
-#: templates/agenda/briefing_list.html:118
-#: templates/agenda/inscricao_list.html:86
-#: templates/agenda/material_list.html:78
+#: agenda/templates/agenda/briefing_list.html:118
+#: agenda/templates/agenda/inscricao_list.html:86
+#: agenda/templates/agenda/material_list.html:78
 msgid "Voltar à agenda"
 msgstr ""
 
-#: templates/agenda/calendario.html:15 templates/agenda/calendario.html:19
-#: templates/agenda/create.html:3
+#: agenda/templates/agenda/calendario.html:15
+#: agenda/templates/agenda/calendario.html:19
+#: agenda/templates/agenda/create.html:3
 msgid "Novo Evento"
 msgstr ""
 
-#: templates/agenda/create.html:7
+#: agenda/templates/agenda/checkin_form.html:3
+msgid "Check-in"
+msgstr ""
+
+#: agenda/templates/agenda/checkin_form.html:7
+msgid "Check-in do evento"
+msgstr ""
+
+#: agenda/templates/agenda/checkin_form.html:10
+msgid "Código do check-in"
+msgstr ""
+
+#: agenda/templates/agenda/checkin_form.html:11
+msgid "Escaneie ou digite o código"
+msgstr ""
+
+#: agenda/templates/agenda/checkin_form.html:13
+msgid "Confirmar presença"
+msgstr ""
+
+#: agenda/templates/agenda/create.html:7
 msgid "Cadastrar Evento"
 msgstr ""
 
-#: templates/agenda/delete.html:3 templates/agenda/delete.html:8
+#: agenda/templates/agenda/delete.html:3 agenda/templates/agenda/delete.html:8
 msgid "Remover Evento"
 msgstr ""
 
-#: templates/agenda/delete.html:9
+#: agenda/templates/agenda/delete.html:9
 #, python-format
 msgid "Tem certeza que deseja remover <strong>%(title)s</strong>?"
 msgstr ""
 
-#: templates/agenda/delete.html:14
-#: templates/agenda/parceria_confirm_delete.html:14
-#: templates/agenda/update.html:45
+#: agenda/templates/agenda/delete.html:14
+#: agenda/templates/agenda/parceria_confirm_delete.html:14
+#: agenda/templates/agenda/update.html:45
 msgid "Remover"
 msgstr ""
 
-#: templates/agenda/detail.html:21
+#: agenda/templates/agenda/detail.html:21
 msgid "Início"
 msgstr ""
 
-#: templates/agenda/detail.html:22
+#: agenda/templates/agenda/detail.html:22
 msgid "Fim"
 msgstr ""
 
-#: templates/agenda/detail.html:30
+#: agenda/templates/agenda/detail.html:30
 msgid "Cancelar inscrição"
 msgstr ""
 
-#: templates/agenda/detail.html:32
+#: agenda/templates/agenda/detail.html:32
 msgid "Inscrever-se"
 msgstr ""
 
-#: templates/agenda/detail.html:38 templates/agenda/update.html:32
+#: agenda/templates/agenda/detail.html:38
+#: agenda/templates/agenda/update.html:32
 msgid "Inscritos"
 msgstr ""
 
-#: templates/agenda/detail.html:61 templates/agenda/update.html:53
+#: agenda/templates/agenda/detail.html:61
+#: agenda/templates/agenda/update.html:53
 msgid "Nenhum inscrito."
 msgstr ""
 
-#: templates/agenda/detail.html:66
+#: agenda/templates/agenda/detail.html:66
 msgid "Voltar"
 msgstr ""
 
-#: templates/agenda/inscricao_list.html:4
+#: agenda/templates/agenda/inscricao_list.html:4
 msgid "Inscrições"
 msgstr ""
 
-#: templates/agenda/inscricao_list.html:9
+#: agenda/templates/agenda/inscricao_list.html:9
 msgid "Lista de Inscrições"
 msgstr ""
 
-#: templates/agenda/inscricao_list.html:30
+#: agenda/templates/agenda/inscricao_list.html:30
 msgid "Buscar por usuário ou evento"
 msgstr ""
 
-#: templates/agenda/inscricao_list.html:46
+#: agenda/templates/agenda/inscricao_list.html:46
 msgid "Usuário"
 msgstr ""
 
-#: templates/agenda/inscricao_list.html:48
+#: agenda/templates/agenda/inscricao_list.html:48
 msgid "Status"
 msgstr ""
 
-#: templates/agenda/inscricao_list.html:49
+#: agenda/templates/agenda/inscricao_list.html:49
 msgid "Presente"
 msgstr ""
 
-#: templates/agenda/inscricao_list.html:50
+#: agenda/templates/agenda/inscricao_list.html:50
 msgid "Valor Pago"
 msgstr ""
 
-#: templates/agenda/inscricao_list.html:51
+#: agenda/templates/agenda/inscricao_list.html:51
 msgid "Método de Pagamento"
 msgstr ""
 
-#: templates/agenda/inscricao_list.html:52
+#: agenda/templates/agenda/inscricao_list.html:52
 msgid "Observação"
 msgstr ""
 
-#: templates/agenda/inscricao_list.html:71
+#: agenda/templates/agenda/inscricao_list.html:71
 msgid "Ver"
 msgstr ""
 
-#: templates/agenda/inscricao_list.html:77
+#: agenda/templates/agenda/inscricao_list.html:77
 msgid "Nenhuma inscrição encontrada."
 msgstr ""
 
-#: templates/agenda/material_list.html:4 templates/agenda/material_list.html:9
+#: agenda/templates/agenda/material_list.html:4
+#: agenda/templates/agenda/material_list.html:9
 msgid "Materiais de Divulgação"
 msgstr ""
 
-#: templates/agenda/material_list.html:30
+#: agenda/templates/agenda/material_list.html:30
 msgid "Buscar por título"
 msgstr ""
 
-#: templates/agenda/material_list.html:46
+#: agenda/templates/agenda/material_list.html:46
 msgid "Título"
 msgstr ""
 
-#: templates/agenda/material_list.html:47
+#: agenda/templates/agenda/material_list.html:47
 msgid "Descrição"
 msgstr ""
 
-#: templates/agenda/material_list.html:48
+#: agenda/templates/agenda/material_list.html:48
 msgid "Arquivo"
 msgstr ""
 
-#: templates/agenda/material_list.html:63
+#: agenda/templates/agenda/material_list.html:63
 msgid "Download"
 msgstr ""
 
-#: templates/agenda/material_list.html:69
+#: agenda/templates/agenda/material_list.html:69
 msgid "Nenhum material disponível."
 msgstr ""
 
-#: templates/agenda/parceria_confirm_delete.html:4
-#: templates/agenda/parceria_confirm_delete.html:9
+#: agenda/templates/agenda/parceria_confirm_delete.html:4
+#: agenda/templates/agenda/parceria_confirm_delete.html:9
 msgid "Remover Parceria"
 msgstr ""
 
-#: templates/agenda/parceria_confirm_delete.html:10
+#: agenda/templates/agenda/parceria_confirm_delete.html:10
 #, python-format
 msgid ""
 "Tem certeza que deseja remover <strong>%(object.empresa.nome)s</strong>?"
 msgstr ""
 
-#: templates/agenda/parceria_form.html:4 templates/agenda/parceria_form.html:8
+#: agenda/templates/agenda/parceria_form.html:4
+#: agenda/templates/agenda/parceria_form.html:8
 msgid "Parceria"
 msgstr ""
 
-#: templates/agenda/parceria_list.html:4 templates/agenda/parceria_list.html:9
+#: agenda/templates/agenda/parceria_list.html:4
+#: agenda/templates/agenda/parceria_list.html:9
 msgid "Parcerias"
 msgstr ""
 
-#: templates/agenda/parceria_list.html:17
+#: agenda/templates/agenda/parceria_list.html:17
 msgid "Empresa"
 msgstr ""
 
-#: templates/agenda/parceria_list.html:19
+#: agenda/templates/agenda/parceria_list.html:19
 msgid "Tipo"
 msgstr ""
 
-#: templates/agenda/parceria_list.html:31
+#: agenda/templates/agenda/parceria_list.html:31
 msgid "Excluir"
 msgstr ""
 
-#: templates/agenda/parceria_list.html:36
+#: agenda/templates/agenda/parceria_list.html:36
 msgid "Nenhuma parceria encontrada."
 msgstr ""
 
-#: templates/agenda/update.html:3 templates/agenda/update.html:7
+#: agenda/templates/agenda/update.html:3 agenda/templates/agenda/update.html:7
 msgid "Editar Evento"
 msgstr ""

--- a/agenda/locale/pt_BR/LC_MESSAGES/django.po
+++ b/agenda/locale/pt_BR/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-14 11:28-0300\n"
+"POT-Creation-Date: 2025-08-14 15:01-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,277 +17,331 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
-#: templates/agenda/_lista_eventos_dia.html:3
+
+#: agenda/templates/agenda/_lista_eventos_dia.html:3
 #, python-format
 msgid "Eventos de %(date)s"
 msgstr ""
 
-#: templates/agenda/_lista_eventos_dia.html:18
+#: agenda/templates/agenda/_lista_eventos_dia.html:18
 msgid "Sem eventos."
 msgstr ""
 
-#: templates/agenda/briefing_form.html:3 templates/agenda/briefing_form.html:8
+#: agenda/templates/agenda/avaliacao_form.html:3
+#: agenda/templates/agenda/avaliacao_form.html:7
+msgid "Avaliar evento"
+msgstr ""
+
+#: agenda/templates/agenda/avaliacao_form.html:11
+msgid "Nota"
+msgstr ""
+
+#: agenda/templates/agenda/avaliacao_form.html:19
+msgid "Comentário"
+msgstr ""
+
+#: agenda/templates/agenda/avaliacao_form.html:20
+msgid "Opcional"
+msgstr ""
+
+#: agenda/templates/agenda/avaliacao_form.html:23
+msgid "Enviar avaliação"
+msgstr ""
+
+#: agenda/templates/agenda/briefing_form.html:3
+#: agenda/templates/agenda/briefing_form.html:8
 msgid "Editar Briefing"
 msgstr ""
 
-#: templates/agenda/briefing_form.html:3 templates/agenda/briefing_form.html:8
-#: templates/agenda/briefing_list.html:13
+#: agenda/templates/agenda/briefing_form.html:3
+#: agenda/templates/agenda/briefing_form.html:8
+#: agenda/templates/agenda/briefing_list.html:13
 msgid "Novo Briefing"
 msgstr ""
 
-#: templates/agenda/briefing_form.html:14 templates/agenda/create.html:15
-#: templates/agenda/delete.html:13
-#: templates/agenda/parceria_confirm_delete.html:13
-#: templates/agenda/parceria_form.html:13 templates/agenda/update.html:26
+#: agenda/templates/agenda/briefing_form.html:14
+#: agenda/templates/agenda/create.html:15
+#: agenda/templates/agenda/delete.html:13
+#: agenda/templates/agenda/parceria_confirm_delete.html:13
+#: agenda/templates/agenda/parceria_form.html:13
+#: agenda/templates/agenda/update.html:26
 msgid "Cancelar"
 msgstr ""
 
-#: templates/agenda/briefing_form.html:15 templates/agenda/create.html:16
-#: templates/agenda/parceria_form.html:14 templates/agenda/update.html:27
+#: agenda/templates/agenda/briefing_form.html:15
+#: agenda/templates/agenda/create.html:16
+#: agenda/templates/agenda/parceria_form.html:14
+#: agenda/templates/agenda/update.html:27
 msgid "Salvar"
 msgstr ""
 
-#: templates/agenda/briefing_list.html:4
+#: agenda/templates/agenda/briefing_list.html:4
 msgid "Briefings"
 msgstr ""
 
-#: templates/agenda/briefing_list.html:9
+#: agenda/templates/agenda/briefing_list.html:9
 msgid "Briefings de Eventos"
 msgstr ""
 
-#: templates/agenda/briefing_list.html:34
+#: agenda/templates/agenda/briefing_list.html:34
 msgid "Buscar por evento"
 msgstr ""
 
-#: templates/agenda/briefing_list.html:41
-#: templates/agenda/inscricao_list.html:37
-#: templates/agenda/material_list.html:37
+#: agenda/templates/agenda/briefing_list.html:41
+#: agenda/templates/agenda/inscricao_list.html:37
+#: agenda/templates/agenda/material_list.html:37
 msgid "Filtrar"
 msgstr ""
 
-#: templates/agenda/briefing_list.html:50
-#: templates/agenda/inscricao_list.html:47
-#: templates/agenda/parceria_list.html:18
+#: agenda/templates/agenda/briefing_list.html:50
+#: agenda/templates/agenda/inscricao_list.html:47
+#: agenda/templates/agenda/parceria_list.html:18
 msgid "Evento"
 msgstr ""
 
-#: templates/agenda/briefing_list.html:51
+#: agenda/templates/agenda/briefing_list.html:51
 msgid "Objetivos"
 msgstr ""
 
-#: templates/agenda/briefing_list.html:52
+#: agenda/templates/agenda/briefing_list.html:52
 msgid "Público Alvo"
 msgstr ""
 
-#: templates/agenda/briefing_list.html:53
+#: agenda/templates/agenda/briefing_list.html:53
 msgid "Requisitos Técnicos"
 msgstr ""
 
-#: templates/agenda/briefing_list.html:54
+#: agenda/templates/agenda/briefing_list.html:54
 msgid "Cronograma Resumido"
 msgstr ""
 
-#: templates/agenda/briefing_list.html:55
+#: agenda/templates/agenda/briefing_list.html:55
 msgid "Conteúdo Programático"
 msgstr ""
 
-#: templates/agenda/briefing_list.html:56
+#: agenda/templates/agenda/briefing_list.html:56
 msgid "Observações"
 msgstr ""
 
-#: templates/agenda/briefing_list.html:57
-#: templates/agenda/inscricao_list.html:53
-#: templates/agenda/material_list.html:49
-#: templates/agenda/parceria_list.html:20
+#: agenda/templates/agenda/briefing_list.html:57
+#: agenda/templates/agenda/inscricao_list.html:53
+#: agenda/templates/agenda/material_list.html:49
+#: agenda/templates/agenda/parceria_list.html:20
 msgid "Ações"
 msgstr ""
 
-#: templates/agenda/briefing_list.html:74
-#: templates/agenda/parceria_list.html:30
+#: agenda/templates/agenda/briefing_list.html:74
+#: agenda/templates/agenda/parceria_list.html:30
 msgid "Editar"
 msgstr ""
 
-#: templates/agenda/briefing_list.html:82
+#: agenda/templates/agenda/briefing_list.html:82
 msgid "Orçar"
 msgstr ""
 
-#: templates/agenda/briefing_list.html:92
+#: agenda/templates/agenda/briefing_list.html:92
 msgid "Aprovar"
 msgstr ""
 
-#: templates/agenda/briefing_list.html:102
+#: agenda/templates/agenda/briefing_list.html:102
 msgid "Recusar"
 msgstr ""
 
-#: templates/agenda/briefing_list.html:109
+#: agenda/templates/agenda/briefing_list.html:109
 msgid "Nenhum briefing encontrado."
 msgstr ""
 
-#: templates/agenda/briefing_list.html:118
-#: templates/agenda/inscricao_list.html:86
-#: templates/agenda/material_list.html:78
+#: agenda/templates/agenda/briefing_list.html:118
+#: agenda/templates/agenda/inscricao_list.html:86
+#: agenda/templates/agenda/material_list.html:78
 msgid "Voltar à agenda"
 msgstr ""
 
-#: templates/agenda/calendario.html:15 templates/agenda/calendario.html:19
-#: templates/agenda/create.html:3
+#: agenda/templates/agenda/calendario.html:15
+#: agenda/templates/agenda/calendario.html:19
+#: agenda/templates/agenda/create.html:3
 msgid "Novo Evento"
 msgstr ""
 
-#: templates/agenda/create.html:7
+#: agenda/templates/agenda/checkin_form.html:3
+msgid "Check-in"
+msgstr ""
+
+#: agenda/templates/agenda/checkin_form.html:7
+msgid "Check-in do evento"
+msgstr ""
+
+#: agenda/templates/agenda/checkin_form.html:10
+msgid "Código do check-in"
+msgstr ""
+
+#: agenda/templates/agenda/checkin_form.html:11
+msgid "Escaneie ou digite o código"
+msgstr ""
+
+#: agenda/templates/agenda/checkin_form.html:13
+msgid "Confirmar presença"
+msgstr ""
+
+#: agenda/templates/agenda/create.html:7
 msgid "Cadastrar Evento"
 msgstr ""
 
-#: templates/agenda/delete.html:3 templates/agenda/delete.html:8
+#: agenda/templates/agenda/delete.html:3 agenda/templates/agenda/delete.html:8
 msgid "Remover Evento"
 msgstr ""
 
-#: templates/agenda/delete.html:9
+#: agenda/templates/agenda/delete.html:9
 #, python-format
 msgid "Tem certeza que deseja remover <strong>%(title)s</strong>?"
 msgstr ""
 
-#: templates/agenda/delete.html:14
-#: templates/agenda/parceria_confirm_delete.html:14
-#: templates/agenda/update.html:45
+#: agenda/templates/agenda/delete.html:14
+#: agenda/templates/agenda/parceria_confirm_delete.html:14
+#: agenda/templates/agenda/update.html:45
 msgid "Remover"
 msgstr ""
 
-#: templates/agenda/detail.html:21
+#: agenda/templates/agenda/detail.html:21
 msgid "Início"
 msgstr ""
 
-#: templates/agenda/detail.html:22
+#: agenda/templates/agenda/detail.html:22
 msgid "Fim"
 msgstr ""
 
-#: templates/agenda/detail.html:30
+#: agenda/templates/agenda/detail.html:30
 msgid "Cancelar inscrição"
 msgstr ""
 
-#: templates/agenda/detail.html:32
+#: agenda/templates/agenda/detail.html:32
 msgid "Inscrever-se"
 msgstr ""
 
-#: templates/agenda/detail.html:38 templates/agenda/update.html:32
+#: agenda/templates/agenda/detail.html:38
+#: agenda/templates/agenda/update.html:32
 msgid "Inscritos"
 msgstr ""
 
-#: templates/agenda/detail.html:61 templates/agenda/update.html:53
+#: agenda/templates/agenda/detail.html:61
+#: agenda/templates/agenda/update.html:53
 msgid "Nenhum inscrito."
 msgstr ""
 
-#: templates/agenda/detail.html:66
+#: agenda/templates/agenda/detail.html:66
 msgid "Voltar"
 msgstr ""
 
-#: templates/agenda/inscricao_list.html:4
+#: agenda/templates/agenda/inscricao_list.html:4
 msgid "Inscrições"
 msgstr ""
 
-#: templates/agenda/inscricao_list.html:9
+#: agenda/templates/agenda/inscricao_list.html:9
 msgid "Lista de Inscrições"
 msgstr ""
 
-#: templates/agenda/inscricao_list.html:30
+#: agenda/templates/agenda/inscricao_list.html:30
 msgid "Buscar por usuário ou evento"
 msgstr ""
 
-#: templates/agenda/inscricao_list.html:46
+#: agenda/templates/agenda/inscricao_list.html:46
 msgid "Usuário"
 msgstr ""
 
-#: templates/agenda/inscricao_list.html:48
+#: agenda/templates/agenda/inscricao_list.html:48
 msgid "Status"
 msgstr ""
 
-#: templates/agenda/inscricao_list.html:49
+#: agenda/templates/agenda/inscricao_list.html:49
 msgid "Presente"
 msgstr ""
 
-#: templates/agenda/inscricao_list.html:50
+#: agenda/templates/agenda/inscricao_list.html:50
 msgid "Valor Pago"
 msgstr ""
 
-#: templates/agenda/inscricao_list.html:51
+#: agenda/templates/agenda/inscricao_list.html:51
 msgid "Método de Pagamento"
 msgstr ""
 
-#: templates/agenda/inscricao_list.html:52
+#: agenda/templates/agenda/inscricao_list.html:52
 msgid "Observação"
 msgstr ""
 
-#: templates/agenda/inscricao_list.html:71
+#: agenda/templates/agenda/inscricao_list.html:71
 msgid "Ver"
 msgstr ""
 
-#: templates/agenda/inscricao_list.html:77
+#: agenda/templates/agenda/inscricao_list.html:77
 msgid "Nenhuma inscrição encontrada."
 msgstr ""
 
-#: templates/agenda/material_list.html:4 templates/agenda/material_list.html:9
+#: agenda/templates/agenda/material_list.html:4
+#: agenda/templates/agenda/material_list.html:9
 msgid "Materiais de Divulgação"
 msgstr ""
 
-#: templates/agenda/material_list.html:30
+#: agenda/templates/agenda/material_list.html:30
 msgid "Buscar por título"
 msgstr ""
 
-#: templates/agenda/material_list.html:46
+#: agenda/templates/agenda/material_list.html:46
 msgid "Título"
 msgstr ""
 
-#: templates/agenda/material_list.html:47
+#: agenda/templates/agenda/material_list.html:47
 msgid "Descrição"
 msgstr ""
 
-#: templates/agenda/material_list.html:48
+#: agenda/templates/agenda/material_list.html:48
 msgid "Arquivo"
 msgstr ""
 
-#: templates/agenda/material_list.html:63
+#: agenda/templates/agenda/material_list.html:63
 msgid "Download"
 msgstr ""
 
-#: templates/agenda/material_list.html:69
+#: agenda/templates/agenda/material_list.html:69
 msgid "Nenhum material disponível."
 msgstr ""
 
-#: templates/agenda/parceria_confirm_delete.html:4
-#: templates/agenda/parceria_confirm_delete.html:9
+#: agenda/templates/agenda/parceria_confirm_delete.html:4
+#: agenda/templates/agenda/parceria_confirm_delete.html:9
 msgid "Remover Parceria"
 msgstr ""
 
-#: templates/agenda/parceria_confirm_delete.html:10
+#: agenda/templates/agenda/parceria_confirm_delete.html:10
 #, python-format
 msgid ""
 "Tem certeza que deseja remover <strong>%(object.empresa.nome)s</strong>?"
 msgstr ""
 
-#: templates/agenda/parceria_form.html:4 templates/agenda/parceria_form.html:8
+#: agenda/templates/agenda/parceria_form.html:4
+#: agenda/templates/agenda/parceria_form.html:8
 msgid "Parceria"
 msgstr ""
 
-#: templates/agenda/parceria_list.html:4 templates/agenda/parceria_list.html:9
+#: agenda/templates/agenda/parceria_list.html:4
+#: agenda/templates/agenda/parceria_list.html:9
 msgid "Parcerias"
 msgstr ""
 
-#: templates/agenda/parceria_list.html:17
+#: agenda/templates/agenda/parceria_list.html:17
 msgid "Empresa"
 msgstr ""
 
-#: templates/agenda/parceria_list.html:19
+#: agenda/templates/agenda/parceria_list.html:19
 msgid "Tipo"
 msgstr ""
 
-#: templates/agenda/parceria_list.html:31
+#: agenda/templates/agenda/parceria_list.html:31
 msgid "Excluir"
 msgstr ""
 
-#: templates/agenda/parceria_list.html:36
+#: agenda/templates/agenda/parceria_list.html:36
 msgid "Nenhuma parceria encontrada."
 msgstr ""
 
-#: templates/agenda/update.html:3 templates/agenda/update.html:7
+#: agenda/templates/agenda/update.html:3 agenda/templates/agenda/update.html:7
 msgid "Editar Evento"
 msgstr ""

--- a/agenda/templates/agenda/avaliacao_form.html
+++ b/agenda/templates/agenda/avaliacao_form.html
@@ -1,0 +1,27 @@
+{% extends 'base.html' %}
+{% load i18n %}
+{% block title %}{% trans "Avaliar evento" %}{% endblock %}
+
+{% block content %}
+<main class="max-w-md mx-auto py-8 px-4">
+  <h1 class="text-xl font-semibold mb-4">{% trans "Avaliar evento" %}</h1>
+  <form method="post" class="space-y-4">
+    {% csrf_token %}
+    <div>
+      <label for="nota" class="block text-sm font-medium">{% trans "Nota" %}</label>
+      <select id="nota" name="nota" class="form-select w-full" required>
+        {% for n in '12345' %}
+        <option value="{{ n }}">{{ n }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div>
+      <label for="comentario" class="block text-sm font-medium">{% trans "Comentário" %}</label>
+      <textarea id="comentario" name="comentario" rows="4" class="form-textarea w-full" placeholder="{% trans 'Opcional' %}"></textarea>
+    </div>
+    <div class="text-right">
+      <button type="submit" class="btn-primary" aria-label="{% trans 'Enviar avaliação' %}">{% trans 'Enviar avaliação' %}</button>
+    </div>
+  </form>
+</main>
+{% endblock %}

--- a/agenda/templates/agenda/checkin_form.html
+++ b/agenda/templates/agenda/checkin_form.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+{% load i18n %}
+{% block title %}{% trans "Check-in" %}{% endblock %}
+
+{% block content %}
+<main class="max-w-md mx-auto py-8 px-4">
+  <h1 class="text-xl font-semibold mb-4">{% trans "Check-in do evento" %}</h1>
+  <form method="post" class="space-y-4">
+    {% csrf_token %}
+    <label for="codigo" class="block text-sm font-medium">{% trans "Código do check-in" %}</label>
+    <input type="text" id="codigo" name="codigo" class="form-input w-full" placeholder="{% trans 'Escaneie ou digite o código' %}" required>
+    <div class="text-right">
+      <button type="submit" class="btn-primary" aria-label="{% trans 'Confirmar presença' %}">{% trans 'Confirmar presença' %}</button>
+    </div>
+  </form>
+</main>
+{% endblock %}

--- a/chat/locale/en/LC_MESSAGES/django.po
+++ b/chat/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-14 11:48-0300\n"
+"POT-Creation-Date: 2025-08-14 15:01-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,350 +17,366 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-#: templates/chat/conversation_detail.html:8
-#: templates/chat/conversation_detail.html:113
+
+#: chat/templates/chat/conversation_detail.html:8
+#: chat/templates/chat/conversation_detail.html:113
 msgid "Nenhum resultado encontrado."
 msgstr ""
 
-#: templates/chat/conversation_detail.html:8
-#: templates/chat/conversation_detail.html:132
+#: chat/templates/chat/conversation_detail.html:8
+#: chat/templates/chat/conversation_detail.html:132
 msgid "Carregar mais"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:8
-#: templates/chat/conversation_detail.html:55
+#: chat/templates/chat/conversation_detail.html:8
+#: chat/templates/chat/conversation_detail.html:55
 msgid "Limpar"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:8
-#: templates/chat/partials/message.html:35
+#: chat/templates/chat/conversation_detail.html:8
+#: chat/templates/chat/partials/message.html:36
 msgid "Adicionar reação"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:8
+#: chat/templates/chat/conversation_detail.html:8
 msgid "Reagir com"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:8
+#: chat/templates/chat/conversation_detail.html:8
 msgid "Fixar"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:8
+#: chat/templates/chat/conversation_detail.html:8
 msgid "Desafixar"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:8
-#: templates/chat/partials/message.html:68
+#: chat/templates/chat/conversation_detail.html:8
+#: chat/templates/chat/partials/message.html:69
 msgid "Fixar mensagem"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:8
+#: chat/templates/chat/conversation_detail.html:8
 msgid "Desafixar mensagem"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:8
+#: chat/templates/chat/conversation_detail.html:8
 msgid "Editar"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:8
+#: chat/templates/chat/conversation_detail.html:8
 msgid "Erro no upload"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:8
-#: templates/chat/partials/message.html:23
+#: chat/templates/chat/conversation_detail.html:8
+#: chat/templates/chat/partials/message.html:24
 msgid "Player de vídeo"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:32
+#: chat/templates/chat/partials/message.html:26
+msgid "Baixar arquivo"
+msgstr "Download file"
+
+#: chat/templates/chat/conversation_detail.html:32
 msgid "participantes"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:34
+#: chat/templates/chat/conversation_detail.html:34
 msgid "Sair do canal"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:34
+#: chat/templates/chat/conversation_detail.html:34
 msgid "Sair"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:37
+#: chat/templates/chat/conversation_detail.html:37
 msgid "Exportar histórico"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:42
-#: templates/chat/conversation_detail.html:43
+#: chat/templates/chat/conversation_detail.html:42
+#: chat/templates/chat/conversation_detail.html:43
 msgid "Buscar mensagens"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:44
-#: templates/chat/conversation_detail.html:54
+#: chat/templates/chat/conversation_detail.html:44
+#: chat/templates/chat/conversation_detail.html:54
 msgid "Buscar"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:48
+#: chat/templates/chat/conversation_detail.html:48
 msgid "Todos"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:49
-#: templates/chat/partials/export_modal.html:18
+#: chat/templates/chat/conversation_detail.html:49
+#: chat/templates/chat/partials/export_modal.html:18
 msgid "Texto"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:50
-#: templates/chat/partials/export_modal.html:19
+#: chat/templates/chat/conversation_detail.html:50
+#: chat/templates/chat/partials/export_modal.html:19
 msgid "Imagem"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:51
-#: templates/chat/partials/export_modal.html:20
+#: chat/templates/chat/conversation_detail.html:51
+#: chat/templates/chat/partials/export_modal.html:20
 msgid "Vídeo"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:52
-#: templates/chat/partials/export_modal.html:21
+#: chat/templates/chat/conversation_detail.html:52
+#: chat/templates/chat/partials/export_modal.html:21
 msgid "Arquivo"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:61
-#: templates/chat/conversation_detail.html:62
+#: chat/templates/chat/conversation_detail.html:61
+#: chat/templates/chat/conversation_detail.html:62
 msgid "Mensagens fixadas"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:73 templates/chat/modal_room.html:27
+#: chat/templates/chat/conversation_detail.html:73
+#: chat/templates/chat/modal_room.html:27
 msgid "Nenhuma mensagem."
 msgstr ""
 
-#: templates/chat/conversation_detail.html:77
-#: templates/chat/conversation_detail.html:82
+#: chat/templates/chat/conversation_detail.html:77
+#: chat/templates/chat/conversation_detail.html:82
 msgid "Enviar mensagem"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:79
+#: chat/templates/chat/conversation_detail.html:79
 msgid "Mensagem"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:81
+#: chat/templates/chat/conversation_detail.html:81
 msgid "Enviar arquivo"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:82
+#: chat/templates/chat/conversation_detail.html:82
 msgid "Enviar"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:88
+#: chat/templates/chat/conversation_detail.html:88
 msgid "Editar mensagem"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:91
+#: chat/templates/chat/conversation_detail.html:91
 msgid "Cancelar edição"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:91
+#: chat/templates/chat/conversation_detail.html:91
 msgid "Cancelar"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:92
+#: chat/templates/chat/conversation_detail.html:92
 msgid "Salvar mensagem editada"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:92
+#: chat/templates/chat/conversation_detail.html:92
 msgid "Salvar"
 msgstr ""
 
-#: templates/chat/conversation_form.html:4
-#: templates/chat/conversation_form.html:8
-#: templates/chat/conversation_list.html:13
-#: templates/chat/conversation_list.html:15
+#: chat/templates/chat/conversation_form.html:4
+#: chat/templates/chat/conversation_form.html:8
+#: chat/templates/chat/conversation_list.html:13
+#: chat/templates/chat/conversation_list.html:15
 msgid "Nova conversa"
 msgstr ""
 
-#: templates/chat/conversation_form.html:55
+#: chat/templates/chat/conversation_form.html:55
 msgid "Criar"
 msgstr ""
 
-#: templates/chat/conversation_list.html:4
+#: chat/templates/chat/conversation_list.html:4
 msgid "Conversas"
 msgstr ""
 
-#: templates/chat/conversation_list.html:9
+#: chat/templates/chat/conversation_list.html:9
 msgid "Minhas conversas"
 msgstr ""
 
-#: templates/chat/conversation_list.html:18
+#: chat/templates/chat/conversation_list.html:18
 msgid "Canais de chat"
 msgstr ""
 
-#: templates/chat/conversation_list.html:22
+#: chat/templates/chat/conversation_list.html:22
 msgid "Privado"
 msgstr ""
 
-#: templates/chat/conversation_list.html:22
+#: chat/templates/chat/conversation_list.html:22
 msgid "Núcleo"
 msgstr ""
 
-#: templates/chat/conversation_list.html:22
+#: chat/templates/chat/conversation_list.html:22
 msgid "Evento"
 msgstr ""
 
-#: templates/chat/conversation_list.html:22
+#: chat/templates/chat/conversation_list.html:22
 msgid "Organização"
 msgstr ""
 
-#: templates/chat/conversation_list.html:24
+#: chat/templates/chat/conversation_list.html:24
 msgid "Lista de conversas"
 msgstr ""
 
-#: templates/chat/conversation_list.html:51
+#: chat/templates/chat/conversation_list.html:51
 msgid "Nenhuma conversa."
 msgstr ""
 
-#: templates/chat/historico_edicoes.html:5
-#: templates/chat/partials/message.html:77
+#: chat/templates/chat/historico_edicoes.html:5
+#: chat/templates/chat/partials/message.html:78
 msgid "Histórico de edições"
 msgstr ""
 
-#: templates/chat/historico_edicoes.html:9
-#: templates/chat/partials/export_modal.html:10
+#: chat/templates/chat/historico_edicoes.html:9
+#: chat/templates/chat/partials/export_modal.html:10
 msgid "Início"
 msgstr ""
 
-#: templates/chat/historico_edicoes.html:13
-#: templates/chat/partials/export_modal.html:13
+#: chat/templates/chat/historico_edicoes.html:13
+#: chat/templates/chat/partials/export_modal.html:13
 msgid "Fim"
 msgstr ""
 
-#: templates/chat/historico_edicoes.html:16
+#: chat/templates/chat/historico_edicoes.html:16
 msgid "Filtrar"
 msgstr ""
 
-#: templates/chat/historico_edicoes.html:17
+#: chat/templates/chat/historico_edicoes.html:17
 msgid "Exportar CSV"
 msgstr ""
 
-#: templates/chat/historico_edicoes.html:23
+#: chat/templates/chat/historico_edicoes.html:23
 msgid "Data"
 msgstr ""
 
-#: templates/chat/historico_edicoes.html:24
+#: chat/templates/chat/historico_edicoes.html:24
 msgid "Moderador"
 msgstr ""
 
-#: templates/chat/historico_edicoes.html:25
+#: chat/templates/chat/historico_edicoes.html:25
 msgid "Conteúdo anterior"
 msgstr ""
 
-#: templates/chat/historico_edicoes.html:26
+#: chat/templates/chat/historico_edicoes.html:26
 msgid "Ações"
 msgstr ""
 
-#: templates/chat/historico_edicoes.html:39
+#: chat/templates/chat/historico_edicoes.html:39
 msgid "Restaurar"
 msgstr ""
 
-#: templates/chat/historico_edicoes.html:45
+#: chat/templates/chat/historico_edicoes.html:45
 msgid "Nenhum registro"
 msgstr ""
 
-#: templates/chat/historico_edicoes.html:54
+#: chat/templates/chat/historico_edicoes.html:54
 msgid "Anterior"
 msgstr ""
 
-#: templates/chat/historico_edicoes.html:60
+#: chat/templates/chat/historico_edicoes.html:60
 msgid "Próxima"
 msgstr ""
 
-#: templates/chat/modal_room.html:15 templates/chat/modal_user_list.html:15
+#: chat/templates/chat/modal_room.html:15
+#: chat/templates/chat/modal_user_list.html:15
 msgid "Fechar"
 msgstr ""
 
-#: templates/chat/modal_user_list.html:17
+#: chat/templates/chat/modal_user_list.html:17
 msgid "Escolha um usuário para conversar"
 msgstr ""
 
-#: templates/chat/modal_user_list.html:40
+#: chat/templates/chat/modal_user_list.html:40
 msgid "Nenhum outro membro encontrado."
 msgstr ""
 
-#: templates/chat/moderacao.html:5
+#: chat/templates/chat/moderacao.html:5
 msgid "Moderação"
 msgstr ""
 
-#: templates/chat/moderacao.html:10
+#: chat/templates/chat/moderacao.html:10
 msgid "Flags"
 msgstr ""
 
-#: templates/chat/moderacao.html:11
+#: chat/templates/chat/moderacao.html:11
 msgid "Aprovar"
 msgstr ""
 
-#: templates/chat/moderacao.html:12
+#: chat/templates/chat/moderacao.html:12
 msgid "Remover"
 msgstr ""
 
-#: templates/chat/moderacao.html:15
+#: chat/templates/chat/moderacao.html:15
 msgid "Nenhuma mensagem sinalizada."
 msgstr ""
 
-#: templates/chat/partials/export_modal.html:4
+#: chat/templates/chat/partials/export_modal.html:4
 msgid "Formato"
 msgstr ""
 
-#: templates/chat/partials/export_modal.html:6
+#: chat/templates/chat/partials/export_modal.html:6
 msgid "JSON"
 msgstr ""
 
-#: templates/chat/partials/export_modal.html:7
+#: chat/templates/chat/partials/export_modal.html:7
 msgid "CSV"
 msgstr ""
 
-#: templates/chat/partials/export_modal.html:17
+#: chat/templates/chat/partials/export_modal.html:17
 msgid "Tipos"
 msgstr ""
 
-#: templates/chat/partials/export_modal.html:23
+#: chat/templates/chat/partials/export_modal.html:23
 msgid "Exportar"
 msgstr ""
 
-#: templates/chat/partials/export_modal.html:24
+#: chat/templates/chat/partials/export_modal.html:24
 msgid "Gerando..."
 msgstr ""
 
-#: templates/chat/partials/message.html:14
+#: chat/templates/chat/partials/message.html:5
+#, python-format
+msgid "Avatar de %(username)s"
+msgstr ""
+
+#: chat/templates/chat/partials/message.html:15
 msgid "Mensagem fixada"
 msgstr ""
 
-#: templates/chat/partials/message.html:15
+#: chat/templates/chat/partials/message.html:16
 msgid "Oculta"
 msgstr ""
 
-#: templates/chat/partials/message.html:42
+#: chat/templates/chat/partials/message.html:22
+msgid "Imagem enviada"
+msgstr ""
+
+#: chat/templates/chat/partials/message.html:43
 msgid "Reagir com 🙂"
 msgstr ""
 
-#: templates/chat/partials/message.html:45
+#: chat/templates/chat/partials/message.html:46
 msgid "Reagir com ❤️"
 msgstr ""
 
-#: templates/chat/partials/message.html:48
+#: chat/templates/chat/partials/message.html:49
 msgid "Reagir com 👍"
 msgstr ""
 
-#: templates/chat/partials/message.html:51
+#: chat/templates/chat/partials/message.html:52
 msgid "Reagir com 😂"
 msgstr ""
 
-#: templates/chat/partials/message.html:54
+#: chat/templates/chat/partials/message.html:55
 msgid "Reagir com 🎉"
 msgstr ""
 
-#: templates/chat/partials/message.html:57
+#: chat/templates/chat/partials/message.html:58
 msgid "Reagir com 😢"
 msgstr ""
 
-#: templates/chat/partials/message.html:60
+#: chat/templates/chat/partials/message.html:61
 msgid "Reagir com 😡"
 msgstr ""
 
-#: templates/chat/partials/message.html:80
+#: chat/templates/chat/partials/message.html:81
 msgid "Histórico"
 msgstr ""

--- a/chat/locale/pt_BR/LC_MESSAGES/django.po
+++ b/chat/locale/pt_BR/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-14 11:48-0300\n"
+"POT-Creation-Date: 2025-08-14 15:01-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,350 +17,366 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
-#: templates/chat/conversation_detail.html:8
-#: templates/chat/conversation_detail.html:113
+
+#: chat/templates/chat/conversation_detail.html:8
+#: chat/templates/chat/conversation_detail.html:113
 msgid "Nenhum resultado encontrado."
 msgstr ""
 
-#: templates/chat/conversation_detail.html:8
-#: templates/chat/conversation_detail.html:132
+#: chat/templates/chat/conversation_detail.html:8
+#: chat/templates/chat/conversation_detail.html:132
 msgid "Carregar mais"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:8
-#: templates/chat/conversation_detail.html:55
+#: chat/templates/chat/conversation_detail.html:8
+#: chat/templates/chat/conversation_detail.html:55
 msgid "Limpar"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:8
-#: templates/chat/partials/message.html:35
+#: chat/templates/chat/conversation_detail.html:8
+#: chat/templates/chat/partials/message.html:36
 msgid "Adicionar reação"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:8
+#: chat/templates/chat/conversation_detail.html:8
 msgid "Reagir com"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:8
+#: chat/templates/chat/conversation_detail.html:8
 msgid "Fixar"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:8
+#: chat/templates/chat/conversation_detail.html:8
 msgid "Desafixar"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:8
-#: templates/chat/partials/message.html:68
+#: chat/templates/chat/conversation_detail.html:8
+#: chat/templates/chat/partials/message.html:69
 msgid "Fixar mensagem"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:8
+#: chat/templates/chat/conversation_detail.html:8
 msgid "Desafixar mensagem"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:8
+#: chat/templates/chat/conversation_detail.html:8
 msgid "Editar"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:8
+#: chat/templates/chat/conversation_detail.html:8
 msgid "Erro no upload"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:8
-#: templates/chat/partials/message.html:23
+#: chat/templates/chat/conversation_detail.html:8
+#: chat/templates/chat/partials/message.html:24
 msgid "Player de vídeo"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:32
+#: chat/templates/chat/partials/message.html:26
+msgid "Baixar arquivo"
+msgstr "Baixar arquivo"
+
+#: chat/templates/chat/conversation_detail.html:32
 msgid "participantes"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:34
+#: chat/templates/chat/conversation_detail.html:34
 msgid "Sair do canal"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:34
+#: chat/templates/chat/conversation_detail.html:34
 msgid "Sair"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:37
+#: chat/templates/chat/conversation_detail.html:37
 msgid "Exportar histórico"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:42
-#: templates/chat/conversation_detail.html:43
+#: chat/templates/chat/conversation_detail.html:42
+#: chat/templates/chat/conversation_detail.html:43
 msgid "Buscar mensagens"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:44
-#: templates/chat/conversation_detail.html:54
+#: chat/templates/chat/conversation_detail.html:44
+#: chat/templates/chat/conversation_detail.html:54
 msgid "Buscar"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:48
+#: chat/templates/chat/conversation_detail.html:48
 msgid "Todos"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:49
-#: templates/chat/partials/export_modal.html:18
+#: chat/templates/chat/conversation_detail.html:49
+#: chat/templates/chat/partials/export_modal.html:18
 msgid "Texto"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:50
-#: templates/chat/partials/export_modal.html:19
+#: chat/templates/chat/conversation_detail.html:50
+#: chat/templates/chat/partials/export_modal.html:19
 msgid "Imagem"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:51
-#: templates/chat/partials/export_modal.html:20
+#: chat/templates/chat/conversation_detail.html:51
+#: chat/templates/chat/partials/export_modal.html:20
 msgid "Vídeo"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:52
-#: templates/chat/partials/export_modal.html:21
+#: chat/templates/chat/conversation_detail.html:52
+#: chat/templates/chat/partials/export_modal.html:21
 msgid "Arquivo"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:61
-#: templates/chat/conversation_detail.html:62
+#: chat/templates/chat/conversation_detail.html:61
+#: chat/templates/chat/conversation_detail.html:62
 msgid "Mensagens fixadas"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:73 templates/chat/modal_room.html:27
+#: chat/templates/chat/conversation_detail.html:73
+#: chat/templates/chat/modal_room.html:27
 msgid "Nenhuma mensagem."
 msgstr ""
 
-#: templates/chat/conversation_detail.html:77
-#: templates/chat/conversation_detail.html:82
+#: chat/templates/chat/conversation_detail.html:77
+#: chat/templates/chat/conversation_detail.html:82
 msgid "Enviar mensagem"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:79
+#: chat/templates/chat/conversation_detail.html:79
 msgid "Mensagem"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:81
+#: chat/templates/chat/conversation_detail.html:81
 msgid "Enviar arquivo"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:82
+#: chat/templates/chat/conversation_detail.html:82
 msgid "Enviar"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:88
+#: chat/templates/chat/conversation_detail.html:88
 msgid "Editar mensagem"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:91
+#: chat/templates/chat/conversation_detail.html:91
 msgid "Cancelar edição"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:91
+#: chat/templates/chat/conversation_detail.html:91
 msgid "Cancelar"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:92
+#: chat/templates/chat/conversation_detail.html:92
 msgid "Salvar mensagem editada"
 msgstr ""
 
-#: templates/chat/conversation_detail.html:92
+#: chat/templates/chat/conversation_detail.html:92
 msgid "Salvar"
 msgstr ""
 
-#: templates/chat/conversation_form.html:4
-#: templates/chat/conversation_form.html:8
-#: templates/chat/conversation_list.html:13
-#: templates/chat/conversation_list.html:15
+#: chat/templates/chat/conversation_form.html:4
+#: chat/templates/chat/conversation_form.html:8
+#: chat/templates/chat/conversation_list.html:13
+#: chat/templates/chat/conversation_list.html:15
 msgid "Nova conversa"
 msgstr ""
 
-#: templates/chat/conversation_form.html:55
+#: chat/templates/chat/conversation_form.html:55
 msgid "Criar"
 msgstr ""
 
-#: templates/chat/conversation_list.html:4
+#: chat/templates/chat/conversation_list.html:4
 msgid "Conversas"
 msgstr ""
 
-#: templates/chat/conversation_list.html:9
+#: chat/templates/chat/conversation_list.html:9
 msgid "Minhas conversas"
 msgstr ""
 
-#: templates/chat/conversation_list.html:18
+#: chat/templates/chat/conversation_list.html:18
 msgid "Canais de chat"
 msgstr ""
 
-#: templates/chat/conversation_list.html:22
+#: chat/templates/chat/conversation_list.html:22
 msgid "Privado"
 msgstr ""
 
-#: templates/chat/conversation_list.html:22
+#: chat/templates/chat/conversation_list.html:22
 msgid "Núcleo"
 msgstr ""
 
-#: templates/chat/conversation_list.html:22
+#: chat/templates/chat/conversation_list.html:22
 msgid "Evento"
 msgstr ""
 
-#: templates/chat/conversation_list.html:22
+#: chat/templates/chat/conversation_list.html:22
 msgid "Organização"
 msgstr ""
 
-#: templates/chat/conversation_list.html:24
+#: chat/templates/chat/conversation_list.html:24
 msgid "Lista de conversas"
 msgstr ""
 
-#: templates/chat/conversation_list.html:51
+#: chat/templates/chat/conversation_list.html:51
 msgid "Nenhuma conversa."
 msgstr ""
 
-#: templates/chat/historico_edicoes.html:5
-#: templates/chat/partials/message.html:77
+#: chat/templates/chat/historico_edicoes.html:5
+#: chat/templates/chat/partials/message.html:78
 msgid "Histórico de edições"
 msgstr ""
 
-#: templates/chat/historico_edicoes.html:9
-#: templates/chat/partials/export_modal.html:10
+#: chat/templates/chat/historico_edicoes.html:9
+#: chat/templates/chat/partials/export_modal.html:10
 msgid "Início"
 msgstr ""
 
-#: templates/chat/historico_edicoes.html:13
-#: templates/chat/partials/export_modal.html:13
+#: chat/templates/chat/historico_edicoes.html:13
+#: chat/templates/chat/partials/export_modal.html:13
 msgid "Fim"
 msgstr ""
 
-#: templates/chat/historico_edicoes.html:16
+#: chat/templates/chat/historico_edicoes.html:16
 msgid "Filtrar"
 msgstr ""
 
-#: templates/chat/historico_edicoes.html:17
+#: chat/templates/chat/historico_edicoes.html:17
 msgid "Exportar CSV"
 msgstr ""
 
-#: templates/chat/historico_edicoes.html:23
+#: chat/templates/chat/historico_edicoes.html:23
 msgid "Data"
 msgstr ""
 
-#: templates/chat/historico_edicoes.html:24
+#: chat/templates/chat/historico_edicoes.html:24
 msgid "Moderador"
 msgstr ""
 
-#: templates/chat/historico_edicoes.html:25
+#: chat/templates/chat/historico_edicoes.html:25
 msgid "Conteúdo anterior"
 msgstr ""
 
-#: templates/chat/historico_edicoes.html:26
+#: chat/templates/chat/historico_edicoes.html:26
 msgid "Ações"
 msgstr ""
 
-#: templates/chat/historico_edicoes.html:39
+#: chat/templates/chat/historico_edicoes.html:39
 msgid "Restaurar"
 msgstr ""
 
-#: templates/chat/historico_edicoes.html:45
+#: chat/templates/chat/historico_edicoes.html:45
 msgid "Nenhum registro"
 msgstr ""
 
-#: templates/chat/historico_edicoes.html:54
+#: chat/templates/chat/historico_edicoes.html:54
 msgid "Anterior"
 msgstr ""
 
-#: templates/chat/historico_edicoes.html:60
+#: chat/templates/chat/historico_edicoes.html:60
 msgid "Próxima"
 msgstr ""
 
-#: templates/chat/modal_room.html:15 templates/chat/modal_user_list.html:15
+#: chat/templates/chat/modal_room.html:15
+#: chat/templates/chat/modal_user_list.html:15
 msgid "Fechar"
 msgstr ""
 
-#: templates/chat/modal_user_list.html:17
+#: chat/templates/chat/modal_user_list.html:17
 msgid "Escolha um usuário para conversar"
 msgstr ""
 
-#: templates/chat/modal_user_list.html:40
+#: chat/templates/chat/modal_user_list.html:40
 msgid "Nenhum outro membro encontrado."
 msgstr ""
 
-#: templates/chat/moderacao.html:5
+#: chat/templates/chat/moderacao.html:5
 msgid "Moderação"
 msgstr ""
 
-#: templates/chat/moderacao.html:10
+#: chat/templates/chat/moderacao.html:10
 msgid "Flags"
 msgstr ""
 
-#: templates/chat/moderacao.html:11
+#: chat/templates/chat/moderacao.html:11
 msgid "Aprovar"
 msgstr ""
 
-#: templates/chat/moderacao.html:12
+#: chat/templates/chat/moderacao.html:12
 msgid "Remover"
 msgstr ""
 
-#: templates/chat/moderacao.html:15
+#: chat/templates/chat/moderacao.html:15
 msgid "Nenhuma mensagem sinalizada."
 msgstr ""
 
-#: templates/chat/partials/export_modal.html:4
+#: chat/templates/chat/partials/export_modal.html:4
 msgid "Formato"
 msgstr ""
 
-#: templates/chat/partials/export_modal.html:6
+#: chat/templates/chat/partials/export_modal.html:6
 msgid "JSON"
 msgstr ""
 
-#: templates/chat/partials/export_modal.html:7
+#: chat/templates/chat/partials/export_modal.html:7
 msgid "CSV"
 msgstr ""
 
-#: templates/chat/partials/export_modal.html:17
+#: chat/templates/chat/partials/export_modal.html:17
 msgid "Tipos"
 msgstr ""
 
-#: templates/chat/partials/export_modal.html:23
+#: chat/templates/chat/partials/export_modal.html:23
 msgid "Exportar"
 msgstr ""
 
-#: templates/chat/partials/export_modal.html:24
+#: chat/templates/chat/partials/export_modal.html:24
 msgid "Gerando..."
 msgstr ""
 
-#: templates/chat/partials/message.html:14
+#: chat/templates/chat/partials/message.html:5
+#, python-format
+msgid "Avatar de %(username)s"
+msgstr ""
+
+#: chat/templates/chat/partials/message.html:15
 msgid "Mensagem fixada"
 msgstr ""
 
-#: templates/chat/partials/message.html:15
+#: chat/templates/chat/partials/message.html:16
 msgid "Oculta"
 msgstr ""
 
-#: templates/chat/partials/message.html:42
+#: chat/templates/chat/partials/message.html:22
+msgid "Imagem enviada"
+msgstr ""
+
+#: chat/templates/chat/partials/message.html:43
 msgid "Reagir com 🙂"
 msgstr ""
 
-#: templates/chat/partials/message.html:45
+#: chat/templates/chat/partials/message.html:46
 msgid "Reagir com ❤️"
 msgstr ""
 
-#: templates/chat/partials/message.html:48
+#: chat/templates/chat/partials/message.html:49
 msgid "Reagir com 👍"
 msgstr ""
 
-#: templates/chat/partials/message.html:51
+#: chat/templates/chat/partials/message.html:52
 msgid "Reagir com 😂"
 msgstr ""
 
-#: templates/chat/partials/message.html:54
+#: chat/templates/chat/partials/message.html:55
 msgid "Reagir com 🎉"
 msgstr ""
 
-#: templates/chat/partials/message.html:57
+#: chat/templates/chat/partials/message.html:58
 msgid "Reagir com 😢"
 msgstr ""
 
-#: templates/chat/partials/message.html:60
+#: chat/templates/chat/partials/message.html:61
 msgid "Reagir com 😡"
 msgstr ""
 
-#: templates/chat/partials/message.html:80
+#: chat/templates/chat/partials/message.html:81
 msgid "Histórico"
 msgstr ""

--- a/chat/templates/chat/conversation_detail.html
+++ b/chat/templates/chat/conversation_detail.html
@@ -19,7 +19,7 @@
     <header class="mb-4 flex items-center justify-between gap-3">
       <div class="flex items-center gap-3">
         {% if conversation.imagem %}
-          <img src="{{ conversation.imagem.url }}" alt="" class="w-12 h-12 rounded-full" />
+          <img src="{{ conversation.imagem.url }}" alt="{{ conversation.titulo }}" class="w-12 h-12 rounded-full" />
         {% endif %}
         <div>
           <h2 class="text-lg font-semibold">{{ conversation.titulo }}</h2>

--- a/chat/templates/chat/conversation_list.html
+++ b/chat/templates/chat/conversation_list.html
@@ -28,7 +28,7 @@
               <a href="{% url 'chat:conversation_detail' conv.id %}" class="flex items-center justify-between py-2 px-4 hover:bg-gray-100 focus:outline-none focus:ring">
                 <div class="flex items-center gap-3">
                   {% if conv.imagem %}
-                    <img src="{{ conv.imagem.url }}" alt="" class="w-8 h-8 rounded-full" />
+                    <img src="{{ conv.imagem.url }}" alt="{{ conv.titulo|default:conv.id }}" class="w-8 h-8 rounded-full" />
                   {% endif %}
                   <div>
                     <p class="font-medium">{{ conv.titulo|default:conv.id }}</p>

--- a/chat/templates/chat/partials/message.html
+++ b/chat/templates/chat/partials/message.html
@@ -2,15 +2,16 @@
 <article role="article" data-message-id="{{ m.id }}" class="flex gap-2 p-2 rounded-lg bg-gray-50 {% if m.pinned_at %}border-l-4 border-yellow-400 bg-yellow-50{% endif %} {% if m.hidden_at %}opacity-60{% endif %}" tabindex="0">
   <div class="flex-shrink-0">
     {% if m.remetente.profile.avatar %}
-      <img src="{{ m.remetente.profile.avatar.url }}" alt="" class="w-8 h-8 rounded-full" />
-    {% else %}
+      {% blocktrans with username=m.remetente.username asvar alt_text %}Avatar de {{ username }}{% endblocktrans %}
+      <img src="{{ m.remetente.profile.avatar.url }}" alt="{{ alt_text }}" class="w-8 h-8 rounded-full" />
+      {% else %}
       <span class="inline-block w-8 h-8 rounded-full bg-gray-300 text-sm flex items-center justify-center">{{ m.remetente.username|first|upper }}</span>
     {% endif %}
   </div>
   <div class="flex-1">
     <header class="flex items-center gap-2 text-xs text-gray-500">
       <span class="font-semibold text-gray-700">{{ m.remetente.username }}</span>
-      <time datetime="{{ m.created|date:'c' }}">{{ m.created|date:SHORT_DATETIME_FORMAT }}</time>
+      <time datetime="{{ m.created|date:'c' }}">{{ m.created|date:'SHORT_DATETIME_FORMAT' }}</time>
       {% if m.pinned_at %}<span class="text-primary" aria-label="{% trans 'Mensagem fixada' %}">📌</span>{% endif %}
       {% if m.hidden_at %}<span class="text-red-500">{% trans "Oculta" %}</span>{% endif %}
     </header>
@@ -18,11 +19,13 @@
       {% if m.tipo == 'text' %}
         <p>{{ m.conteudo|linebreaksbr }}</p>
       {% elif m.tipo == 'image' %}
-        <img src="{{ m.arquivo.url }}" alt="" class="w-full max-w-xs h-auto rounded" />
+        <img src="{{ m.arquivo.url }}" alt="{% trans 'Imagem enviada' %}" class="w-full max-w-xs h-auto rounded" />
       {% elif m.tipo == 'video' %}
         <video src="{{ m.arquivo.url }}" controls class="w-full max-w-xs h-auto" aria-label="{% trans 'Player de vídeo' %}"></video>
       {% elif m.tipo == 'file' %}
-        <a href="{{ m.arquivo.url }}" class="text-primary underline">{{ m.arquivo.name }}</a>
+        <a href="{{ m.arquivo.url }}" class="text-primary underline" download aria-label="{% trans 'Baixar arquivo' %}">
+          {{ m.arquivo.name }}
+        </a>
       {% endif %}
     </div>
     <div class="mt-2 flex items-center gap-2">

--- a/dashboard/templates/dashboard/cliente.html
+++ b/dashboard/templates/dashboard/cliente.html
@@ -5,7 +5,7 @@
 {% block title %}{% trans "Dashboard Cliente" %} | Hubx{% endblock %}
 
 {% block content %}
-<main class="max-w-7xl mx-auto px-4 py-10" role="main" aria-label="Dashboard">
+<main class="max-w-7xl mx-auto px-4 py-10" role="main" aria-label="{% trans 'Dashboard' %}">
   <h1 class="text-3xl font-semibold text-neutral-900 text-center mb-10">{% trans "Dashboard Cliente" %}</h1>
 
   {% include 'dashboard/partials/messages.html' %}

--- a/dashboard/templates/dashboard/gerente.html
+++ b/dashboard/templates/dashboard/gerente.html
@@ -5,7 +5,7 @@
 {% block title %}{% trans "Dashboard Gerente" %} | Hubx{% endblock %}
 
 {% block content %}
-<main class="max-w-7xl mx-auto px-4 py-10" role="main" aria-label="Dashboard">
+<main class="max-w-7xl mx-auto px-4 py-10" role="main" aria-label="{% trans 'Dashboard' %}">
   <h1 class="text-3xl font-semibold text-neutral-900 text-center mb-10">{% trans "Dashboard Gerente" %}</h1>
 
   {% include 'dashboard/partials/messages.html' %}

--- a/feed/locale/en/LC_MESSAGES/django.po
+++ b/feed/locale/en/LC_MESSAGES/django.po
@@ -59,7 +59,7 @@ msgstr ""
 
 #: templates/feed/_post_list.html:42
 msgid "mídia do post"
-msgstr ""
+msgstr "post media"
 
 #: templates/feed/_post_list.html:61
 msgid "Nenhuma postagem ainda"

--- a/feed/locale/pt_BR/LC_MESSAGES/django.po
+++ b/feed/locale/pt_BR/LC_MESSAGES/django.po
@@ -59,7 +59,7 @@ msgstr ""
 
 #: templates/feed/_post_list.html:42
 msgid "mídia do post"
-msgstr ""
+msgstr "mídia do post"
 
 #: templates/feed/_post_list.html:61
 msgid "Nenhuma postagem ainda"

--- a/feed/templates/feed/_grid.html
+++ b/feed/templates/feed/_grid.html
@@ -43,7 +43,7 @@
         </div>
       {% elif post.image %}
         <div>
-          <img src="{{ post.image.url }}" class="w-full rounded" alt="">
+          <img src="{{ post.image.url }}" class="w-full rounded" alt="{% trans 'mídia do post' %}">
         </div>
       {% endif %}
       <div class="flex items-center justify-between text-sm text-neutral-600">

--- a/feed/templates/feed/post_update.html
+++ b/feed/templates/feed/post_update.html
@@ -46,7 +46,7 @@
           </a>
         </div>
       {% elif post.image %}
-        <img src="{{ post.image.url }}" alt="" class="max-w-xs rounded-xl shadow-sm mt-2">
+        <img src="{{ post.image.url }}" alt="{% trans 'mídia do post' %}" class="max-w-xs rounded-xl shadow-sm mt-2">
       {% endif %}
     </div>
 

--- a/tests/test_i18n_templates.py
+++ b/tests/test_i18n_templates.py
@@ -1,0 +1,57 @@
+import pytest
+from django.template.loader import render_to_string
+from django.test import RequestFactory
+from django.utils import translation, timezone
+from types import SimpleNamespace
+from bs4 import BeautifulSoup
+
+
+@pytest.mark.parametrize("lang, direction", [("en", "ltr"), ("pt-br", "ltr")])
+def test_base_template_has_lang_and_dir(lang, direction):
+    rf = RequestFactory()
+    request = rf.get("/")
+    with translation.override(lang):
+        html = render_to_string("base.html", {"request": request})
+    soup = BeautifulSoup(html, "html.parser")
+    assert soup.html.get("lang") == lang
+    assert soup.html.get("dir") == direction
+
+
+@pytest.mark.parametrize("template", [
+    "dashboard/cliente.html",
+    "dashboard/gerente.html",
+])
+def test_dashboard_templates_aria_label_translated(template):
+    rf = RequestFactory()
+    request = rf.get("/")
+    with translation.override("en"):
+        html = render_to_string(template, {"request": request})
+    soup = BeautifulSoup(html, "html.parser")
+    main = soup.select_one("main[aria-label]")
+    assert main is not None
+    assert main.get("aria-label") == "Dashboard"
+
+
+def test_chat_file_attachment_has_translated_aria_label():
+    rf = RequestFactory()
+    request = rf.get("/")
+    file = SimpleNamespace(name="report.pdf", url="/media/report.pdf")
+    user = SimpleNamespace(username="john", profile=SimpleNamespace(avatar=None))
+    message = SimpleNamespace(
+        id=1,
+        tipo="file",
+        arquivo=file,
+        remetente=user,
+        created=timezone.now(),
+        pinned_at=None,
+        hidden_at=None,
+        reaction_counts={},
+    )
+    with translation.override("en"):
+        html = render_to_string(
+            "chat/partials/message.html",
+            {"m": message, "is_admin": False, "request": request},
+        )
+    soup = BeautifulSoup(html, "html.parser")
+    link = soup.find("a", {"href": "/media/report.pdf"})
+    assert link.get("aria-label") == "Download file"


### PR DESCRIPTION
## Summary
- add check-in and evaluation forms for events with translated labels
- expose JavaScript i18n catalog and translate chat file download links
- localize account contact placeholders and dashboard regions
- add alt text to chat conversation avatars and feed post images with translated labels

## Testing
- `python manage.py makemessages -l pt_BR -l en -e html -i templates`
- `python manage.py compilemessages`
- `pytest tests/test_i18n_templates.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'playwright', 'pywebpush')*

------
https://chatgpt.com/codex/tasks/task_e_689e1e4aa1048325987eed349f025d48