### PR TITLE
Translate default dash in notification logs

### DIFF
--- a/notificacoes/templates/notificacoes/logs_rows.html
+++ b/notificacoes/templates/notificacoes/logs_rows.html
@@ -6,6 +6,6 @@
     <td class="px-4 py-2">{{ log.template.codigo }}</td>
     <td class="px-4 py-2">{{ log.get_canal_display }}</td>
     <td class="px-4 py-2">{{ log.get_status_display }}</td>
-    <td class="px-4 py-2 text-sm">{{ log.erro|default:'-' }}</td>
+    <td class="px-4 py-2 text-sm">{{ log.erro|default:_("-") }}</td>
   </tr>
 {% endfor %}


### PR DESCRIPTION
## Summary
- localize dash placeholder in notification logs template

## Testing
- `python manage.py makemessages -l en -l pt_BR -e html -i templates`
- `python manage.py compilemessages`
- `pytest` *(fails: ModuleNotFoundError: No module named 'axe_core_python', No module named 'twilio')*

------
https://chatgpt.com/codex/tasks/task_e_689e3b3a02588325a64b6e2a7fac8fed