### PR TITLE
Use trans tag in centros list template and update locales

### DIFF
--- a/financeiro/locale/en/LC_MESSAGES/django.po
+++ b/financeiro/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-14 15:05+0000\n"
+"POT-Creation-Date: 2025-08-14 19:42+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,6 +17,63 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: serializers/__init__.py:45
+msgid "Evento é obrigatório para centros do tipo evento"
+msgstr ""
+
+#: serializers/__init__.py:92
+msgid "Vencimento não pode ser anterior à data de lançamento"
+msgstr ""
+
+#: serializers/__init__.py:96 services/importacao.py:234
+msgid "Valor negativo não permitido para este tipo"
+msgstr ""
+
+#: serializers/__init__.py:142
+msgid "Valor deve ser positivo"
+msgstr ""
+
+#: serializers/__init__.py:151
+msgid "Tipo de aporte inválido"
+msgstr ""
+
+#: serializers/__init__.py:199
+msgid "Formato inválido. Envie CSV ou XLSX"
+msgstr ""
+
+#: services/importacao.py:57 services/importacao.py:76
+msgid "Colunas faltantes: {', '.join(missing)}"
+msgstr ""
+
+#: services/importacao.py:59 services/importacao.py:78
+msgid "Coluna conta_associado_id ou email obrigatória"
+msgstr ""
+
+#: services/importacao.py:66 views/__init__.py:302 views/__init__.py:361
+msgid "openpyxl não disponível"
+msgstr ""
+
+#: services/importacao.py:83
+msgid "Formato não suportado"
+msgstr ""
+
+#: services/importacao.py:219
+msgid "Conta do associado não encontrada"
+msgstr ""
+
+#: services/importacao.py:229
+msgid "data_vencimento anterior a data_lancamento"
+msgstr ""
+
+#: services/notificacoes.py:41
+msgid "Inadimplência"
+msgstr ""
+
+#: services/notificacoes.py:42
+msgid "Você possui lançamentos vencidos."
+msgstr ""
+
 #: templates/financeiro/aportes_form.html:5
 #: templates/financeiro/importar_pagamentos.html:52
 #: templates/financeiro/inadimplencias.html:12
@@ -380,4 +437,44 @@ msgstr ""
 
 #: templates/financeiro/task_logs.html:28
 msgid "Nenhum registro encontrado"
+msgstr ""
+
+#: views/__init__.py:207 views/__init__.py:228
+msgid "Arquivo não encontrado"
+msgstr ""
+
+#: views/__init__.py:221
+msgid "Importação iniciada"
+msgstr ""
+
+#: views/__init__.py:231
+msgid "Arquivo ausente"
+msgstr ""
+
+#: views/__init__.py:239
+msgid "Reprocessamento concluído"
+msgstr ""
+
+#: views/__init__.py:258 views/__init__.py:263
+msgid "Sem permissão"
+msgstr ""
+
+#: viewsets.py:102
+msgid "Status inválido"
+msgstr ""
+
+#: viewsets.py:105
+msgid "Apenas lançamentos pendentes podem ser alterados"
+msgstr ""
+
+#: viewsets.py:216
+msgid "Parâmetros obrigatórios"
+msgstr ""
+
+#: viewsets.py:220 viewsets.py:222
+msgid "periodos inválido"
+msgstr ""
+
+#: viewsets.py:237
+msgid "escopo inválido"
 msgstr ""

--- a/financeiro/locale/pt_BR/LC_MESSAGES/django.po
+++ b/financeiro/locale/pt_BR/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-14 15:05+0000\n"
+"POT-Creation-Date: 2025-08-14 19:42+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,6 +17,63 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: serializers/__init__.py:45
+msgid "Evento é obrigatório para centros do tipo evento"
+msgstr ""
+
+#: serializers/__init__.py:92
+msgid "Vencimento não pode ser anterior à data de lançamento"
+msgstr ""
+
+#: serializers/__init__.py:96 services/importacao.py:234
+msgid "Valor negativo não permitido para este tipo"
+msgstr ""
+
+#: serializers/__init__.py:142
+msgid "Valor deve ser positivo"
+msgstr ""
+
+#: serializers/__init__.py:151
+msgid "Tipo de aporte inválido"
+msgstr ""
+
+#: serializers/__init__.py:199
+msgid "Formato inválido. Envie CSV ou XLSX"
+msgstr ""
+
+#: services/importacao.py:57 services/importacao.py:76
+msgid "Colunas faltantes: {', '.join(missing)}"
+msgstr ""
+
+#: services/importacao.py:59 services/importacao.py:78
+msgid "Coluna conta_associado_id ou email obrigatória"
+msgstr ""
+
+#: services/importacao.py:66 views/__init__.py:302 views/__init__.py:361
+msgid "openpyxl não disponível"
+msgstr ""
+
+#: services/importacao.py:83
+msgid "Formato não suportado"
+msgstr ""
+
+#: services/importacao.py:219
+msgid "Conta do associado não encontrada"
+msgstr ""
+
+#: services/importacao.py:229
+msgid "data_vencimento anterior a data_lancamento"
+msgstr ""
+
+#: services/notificacoes.py:41
+msgid "Inadimplência"
+msgstr ""
+
+#: services/notificacoes.py:42
+msgid "Você possui lançamentos vencidos."
+msgstr ""
+
 #: templates/financeiro/aportes_form.html:5
 #: templates/financeiro/importar_pagamentos.html:52
 #: templates/financeiro/inadimplencias.html:12
@@ -380,4 +437,44 @@ msgstr ""
 
 #: templates/financeiro/task_logs.html:28
 msgid "Nenhum registro encontrado"
+msgstr ""
+
+#: views/__init__.py:207 views/__init__.py:228
+msgid "Arquivo não encontrado"
+msgstr ""
+
+#: views/__init__.py:221
+msgid "Importação iniciada"
+msgstr ""
+
+#: views/__init__.py:231
+msgid "Arquivo ausente"
+msgstr ""
+
+#: views/__init__.py:239
+msgid "Reprocessamento concluído"
+msgstr ""
+
+#: views/__init__.py:258 views/__init__.py:263
+msgid "Sem permissão"
+msgstr ""
+
+#: viewsets.py:102
+msgid "Status inválido"
+msgstr ""
+
+#: viewsets.py:105
+msgid "Apenas lançamentos pendentes podem ser alterados"
+msgstr ""
+
+#: viewsets.py:216
+msgid "Parâmetros obrigatórios"
+msgstr ""
+
+#: viewsets.py:220 viewsets.py:222
+msgid "periodos inválido"
+msgstr ""
+
+#: viewsets.py:237
+msgid "escopo inválido"
 msgstr ""

--- a/financeiro/templates/financeiro/centros_list.html
+++ b/financeiro/templates/financeiro/centros_list.html
@@ -1,25 +1,25 @@
 {% extends "base.html" %}
 {% load i18n %}
 
-{% block title %}{{ _('Centros de Custo') }}{% endblock %}
+{% block title %}{% trans "Centros de Custo" %}{% endblock %}
 
 {% block content %}
 <main class="p-4 max-w-5xl mx-auto">
   <header class="flex items-center justify-between mb-4">
-    <h1 class="text-2xl font-semibold">{{ _('Centros de Custo') }}</h1>
+    <h1 class="text-2xl font-semibold">{% trans "Centros de Custo" %}</h1>
     <button class="bg-blue-600 text-white px-4 py-2 rounded" hx-get="/financeiro/centro/new/" hx-target="#modal" hx-trigger="click">
-      {{ _('Novo Centro') }}
+      {% trans "Novo Centro" %}
     </button>
   </header>
   <section id="centros-list" class="overflow-x-auto" aria-live="polite">
     <table class="min-w-full divide-y divide-gray-200">
       <thead class="bg-gray-50">
         <tr>
-          <th scope="col" class="px-3 py-2 text-left text-xs font-medium text-gray-500">{{ _('Nome') }}</th>
-          <th scope="col" class="px-3 py-2 text-left text-xs font-medium text-gray-500">{{ _('Tipo') }}</th>
-          <th scope="col" class="px-3 py-2 text-left text-xs font-medium text-gray-500">{{ _('Organização/Núcleo/Evento') }}</th>
-          <th scope="col" class="px-3 py-2 text-left text-xs font-medium text-gray-500">{{ _('Saldo') }}</th>
-          <th scope="col" class="px-3 py-2 text-right text-xs font-medium text-gray-500">{{ _('Ações') }}</th>
+          <th scope="col" class="px-3 py-2 text-left text-xs font-medium text-gray-500">{% trans "Nome" %}</th>
+          <th scope="col" class="px-3 py-2 text-left text-xs font-medium text-gray-500">{% trans "Tipo" %}</th>
+          <th scope="col" class="px-3 py-2 text-left text-xs font-medium text-gray-500">{% trans "Organização/Núcleo/Evento" %}</th>
+          <th scope="col" class="px-3 py-2 text-left text-xs font-medium text-gray-500">{% trans "Saldo" %}</th>
+          <th scope="col" class="px-3 py-2 text-right text-xs font-medium text-gray-500">{% trans "Ações" %}</th>
         </tr>
       </thead>
       <tbody>
@@ -32,23 +32,23 @@
           </td>
           <td class="px-3 py-2">{{ c.saldo }}</td>
           <td class="px-3 py-2 text-right space-x-2">
-            <button class="text-primary underline" hx-get="/financeiro/centro/{{ c.id }}/edit/" hx-target="#modal" hx-trigger="click">{{ _('Editar') }}</button>
-            <button class="text-red-600 underline" hx-delete="/api/financeiro/centros/{{ c.id }}/" hx-target="closest tr" hx-confirm="{{ _('Tem certeza?') }}">{{ _('Excluir') }}</button>
+            <button class="text-primary underline" hx-get="/financeiro/centro/{{ c.id }}/edit/" hx-target="#modal" hx-trigger="click">{% trans "Editar" %}</button>
+            <button class="text-red-600 underline" hx-delete="/api/financeiro/centros/{{ c.id }}/" hx-target="closest tr" hx-confirm='{% trans "Tem certeza?" %}'>{% trans "Excluir" %}</button>
           </td>
         </tr>
         {% empty %}
         <tr>
-          <td colspan="5" class="px-3 py-2 text-center text-sm text-gray-500">{{ _('Nenhum centro encontrado.') }}</td>
+          <td colspan="5" class="px-3 py-2 text-center text-sm text-gray-500">{% trans "Nenhum centro encontrado." %}</td>
         </tr>
         {% endfor %}
       </tbody>
     </table>
     <div class="mt-4 flex justify-between">
       {% if prev %}
-        <button class="px-3 py-1 text-sm bg-gray-200 rounded" hx-get="?offset={{ prev }}" hx-target="#centros-list" hx-trigger="click" hx-swap="outerHTML">{{ _('Anterior') }}</button>
+        <button class="px-3 py-1 text-sm bg-gray-200 rounded" hx-get="?offset={{ prev }}" hx-target="#centros-list" hx-trigger="click" hx-swap="outerHTML">{% trans "Anterior" %}</button>
       {% endif %}
       {% if next %}
-        <button class="px-3 py-1 text-sm bg-gray-200 rounded ml-auto" hx-get="?offset={{ next }}" hx-target="#centros-list" hx-trigger="click" hx-swap="outerHTML">{{ _('Próximo') }}</button>
+        <button class="px-3 py-1 text-sm bg-gray-200 rounded ml-auto" hx-get="?offset={{ next }}" hx-target="#centros-list" hx-trigger="click" hx-swap="outerHTML">{% trans "Próximo" %}</button>
       {% endif %}
     </div>
   </section>


### PR DESCRIPTION
## Summary
- replace `_()` calls with `{% trans %}` in `centros_list.html`
- update English and Portuguese message catalogs

## Testing
- `django-admin makemessages -l en -l pt_BR`
- `django-admin compilemessages`
- `pytest tests/test_financeiro_routes.py tests/test_i18n_templates.py -q` *(fails: KeyError: 'SHORT_DATETIME_FORMAT'; AssertionError: 'Baixar arquivo' == 'Download file')*


------
https://chatgpt.com/codex/tasks/task_e_689e3b38e3508325979c5b9f9aa58271