### PR TITLE
Improve accessibility on nucleus list page

### DIFF
--- a/nucleos/templates/nucleos/list.html
+++ b/nucleos/templates/nucleos/list.html
@@ -5,47 +5,48 @@
 
 {% block content %}
 <section class="max-w-5xl mx-auto py-8">
+  <h1 class="text-2xl font-bold mb-4">{% trans "Núcleos" %}</h1>
   <form method="get" class="mb-4 flex gap-2">
     <input type="text" name="q" value="{{ form.q.value }}" placeholder="{% trans 'Buscar...' %}" class="border rounded px-2 py-1 flex-1" />
-    <button class="px-3 py-1 bg-blue-600 text-white rounded">{% trans 'Buscar' %}</button>
+    <button class="px-3 py-1 bg-blue-600 text-white rounded" aria-label="{% trans 'Buscar núcleos' %}">{% trans 'Buscar' %}</button>
   </form>
   {% if request.user.user_type == 'admin' or request.user.user_type == 'coordenador' %}
   <div class="mb-4">
-    <a href="{% url 'nucleos:create' %}" class="px-3 py-2 bg-green-600 text-white rounded">{% trans 'Novo' %}</a>
+    <a href="{% url 'nucleos:create' %}" class="px-3 py-2 bg-green-600 text-white rounded" aria-label="{% trans 'Criar novo núcleo' %}">{% trans 'Novo' %}</a>
   </div>
   {% endif %}
-  <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+  <ul role="list" class="grid grid-cols-1 md:grid-cols-2 gap-4">
     {% for nucleo in object_list %}
-    <div class="border rounded p-4">
+    <li role="listitem" class="border rounded p-4">
       <div class="flex items-center gap-3">
         {% if nucleo.avatar %}<img src="{{ nucleo.avatar.url }}" class="w-12 h-12 rounded-full" />{% endif %}
         <div>
-          <h3 class="font-semibold">{{ nucleo.nome }}</h3>
+          <h2 class="font-semibold">{{ nucleo.nome }}</h2>
           <p class="text-sm text-gray-500">{{ nucleo.slug }}</p>
         </div>
       </div>
       <p class="text-sm mt-2">{% trans "Membros" %}: {{ nucleo.membros.count }}</p>
       <div class="mt-2">
-        <a href="{% url 'nucleos:detail' nucleo.pk %}" class="text-blue-600">{% trans 'Detalhes' %}</a>
+        <a href="{% url 'nucleos:detail' nucleo.pk %}" class="text-blue-600" aria-label="{% blocktrans with nome=nucleo.nome %}Ver detalhes do núcleo {{ nome }}{% endblocktrans %}">{% trans 'Detalhes' %}</a>
         {% if request.user.user_type == 'admin' or request.user.user_type == 'coordenador' or request.user.user_type == 'root' %}
         <form method="post" action="{% url 'nucleos:delete' nucleo.pk %}" class="inline">{% csrf_token %}
-          <button class="text-red-600 ml-2">{% trans 'Excluir' %}</button>
+          <button class="text-red-600 ml-2" aria-label="{% blocktrans with nome=nucleo.nome %}Excluir núcleo {{ nome }}{% endblocktrans %}">{% trans 'Excluir' %}</button>
         </form>
         {% endif %}
       </div>
-    </div>
+    </li>
     {% empty %}
     <p>{% trans "Nenhum núcleo encontrado." %}</p>
     {% endfor %}
-  </div>
+  </ul>
   {% if is_paginated %}
     <div class="mt-4">
       {% if page_obj.has_previous %}
-        <a href="?page={{ page_obj.previous_page_number }}" class="mr-2">{% trans 'Anterior' %}</a>
+        <a href="?page={{ page_obj.previous_page_number }}" class="mr-2" aria-label="{% trans 'Página anterior' %}">{% trans 'Anterior' %}</a>
       {% endif %}
       <span class="mr-2">{{ page_obj.number }} / {{ page_obj.paginator.num_pages }}</span>
       {% if page_obj.has_next %}
-        <a href="?page={{ page_obj.next_page_number }}">{% trans 'Próxima' %}</a>
+        <a href="?page={{ page_obj.next_page_number }}" aria-label="{% trans 'Próxima página' %}">{% trans 'Próxima' %}</a>
       {% endif %}
     </div>
   {% endif %}


### PR DESCRIPTION
## Summary
- add semantic heading hierarchy and list roles on nucleus list
- provide descriptive aria-labels for action buttons and links

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'axe_core_python')*

------
https://chatgpt.com/codex/tasks/task_e_689e4c369120832594b657182457ffb3