### PR TITLE
Usa TimeStampedModel do core nas discussões

### DIFF
--- a/discussao/api.py
+++ b/discussao/api.py
@@ -84,7 +84,7 @@ class TopicoViewSet(viewsets.ModelViewSet):
         cache.clear()
 
     def _can_edit(self, obj: TopicoDiscussao) -> bool:
-        if timezone.now() - obj.created > timedelta(minutes=15):
+        if timezone.now() - obj.created_at > timedelta(minutes=15):
             return self.request.user.get_tipo_usuario in {
                 UserType.ADMIN.value,
                 UserType.ROOT.value,
@@ -189,7 +189,7 @@ class RespostaViewSet(viewsets.ModelViewSet):
         cache.clear()
 
     def _can_edit(self, obj: RespostaDiscussao) -> bool:
-        if timezone.now() - obj.created > timedelta(minutes=15):
+        if timezone.now() - obj.created_at > timedelta(minutes=15):
             return self.request.user.get_tipo_usuario in {
                 UserType.ADMIN.value,
                 UserType.ROOT.value,

--- a/discussao/migrations/0003_timestamp_fields.py
+++ b/discussao/migrations/0003_timestamp_fields.py
@@ -1,0 +1,168 @@
+from django.db import migrations, models
+import django.utils.timezone
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("discussao", "0002_interacao_denuncia_softdelete"),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name="categoriadiscussao",
+            old_name="created",
+            new_name="created_at",
+        ),
+        migrations.RenameField(
+            model_name="categoriadiscussao",
+            old_name="modified",
+            new_name="updated_at",
+        ),
+        migrations.AlterField(
+            model_name="categoriadiscussao",
+            name="created_at",
+            field=models.DateTimeField(default=django.utils.timezone.now, editable=False),
+        ),
+        migrations.AlterField(
+            model_name="categoriadiscussao",
+            name="updated_at",
+            field=models.DateTimeField(auto_now=True),
+        ),
+        migrations.RenameField(
+            model_name="tag",
+            old_name="created",
+            new_name="created_at",
+        ),
+        migrations.RenameField(
+            model_name="tag",
+            old_name="modified",
+            new_name="updated_at",
+        ),
+        migrations.AlterField(
+            model_name="tag",
+            name="created_at",
+            field=models.DateTimeField(default=django.utils.timezone.now, editable=False),
+        ),
+        migrations.AlterField(
+            model_name="tag",
+            name="updated_at",
+            field=models.DateTimeField(auto_now=True),
+        ),
+        migrations.RenameField(
+            model_name="topicodiscussao",
+            old_name="created",
+            new_name="created_at",
+        ),
+        migrations.RenameField(
+            model_name="topicodiscussao",
+            old_name="modified",
+            new_name="updated_at",
+        ),
+        migrations.AlterField(
+            model_name="topicodiscussao",
+            name="created_at",
+            field=models.DateTimeField(default=django.utils.timezone.now, editable=False),
+        ),
+        migrations.AlterField(
+            model_name="topicodiscussao",
+            name="updated_at",
+            field=models.DateTimeField(auto_now=True),
+        ),
+        migrations.RenameField(
+            model_name="respostadiscussao",
+            old_name="created",
+            new_name="created_at",
+        ),
+        migrations.RenameField(
+            model_name="respostadiscussao",
+            old_name="modified",
+            new_name="updated_at",
+        ),
+        migrations.AlterField(
+            model_name="respostadiscussao",
+            name="created_at",
+            field=models.DateTimeField(default=django.utils.timezone.now, editable=False),
+        ),
+        migrations.AlterField(
+            model_name="respostadiscussao",
+            name="updated_at",
+            field=models.DateTimeField(auto_now=True),
+        ),
+        migrations.RenameField(
+            model_name="interacaodiscussao",
+            old_name="created",
+            new_name="created_at",
+        ),
+        migrations.RenameField(
+            model_name="interacaodiscussao",
+            old_name="modified",
+            new_name="updated_at",
+        ),
+        migrations.AlterField(
+            model_name="interacaodiscussao",
+            name="created_at",
+            field=models.DateTimeField(default=django.utils.timezone.now, editable=False),
+        ),
+        migrations.AlterField(
+            model_name="interacaodiscussao",
+            name="updated_at",
+            field=models.DateTimeField(auto_now=True),
+        ),
+        migrations.RenameField(
+            model_name="denuncia",
+            old_name="created",
+            new_name="created_at",
+        ),
+        migrations.RenameField(
+            model_name="denuncia",
+            old_name="modified",
+            new_name="updated_at",
+        ),
+        migrations.AlterField(
+            model_name="denuncia",
+            name="created_at",
+            field=models.DateTimeField(default=django.utils.timezone.now, editable=False),
+        ),
+        migrations.AlterField(
+            model_name="denuncia",
+            name="updated_at",
+            field=models.DateTimeField(auto_now=True),
+        ),
+        migrations.RenameField(
+            model_name="discussionmoderationlog",
+            old_name="created",
+            new_name="created_at",
+        ),
+        migrations.RenameField(
+            model_name="discussionmoderationlog",
+            old_name="modified",
+            new_name="updated_at",
+        ),
+        migrations.AlterField(
+            model_name="discussionmoderationlog",
+            name="created_at",
+            field=models.DateTimeField(default=django.utils.timezone.now, editable=False),
+        ),
+        migrations.AlterField(
+            model_name="discussionmoderationlog",
+            name="updated_at",
+            field=models.DateTimeField(auto_now=True),
+        ),
+        migrations.AlterModelOptions(
+            name="topicodiscussao",
+            options={
+                "ordering": ["-created_at"],
+                "verbose_name": "Tópico de Discussão",
+                "verbose_name_plural": "Tópicos de Discussão",
+                "indexes": [models.Index(fields=["slug", "categoria"], name="discussao_t_slug_f19f97_idx")],
+            },
+        ),
+        migrations.AlterModelOptions(
+            name="respostadiscussao",
+            options={
+                "ordering": ["created_at"],
+                "verbose_name": "Resposta de Discussão",
+                "verbose_name_plural": "Respostas de Discussão",
+            },
+        ),
+    ]

--- a/discussao/models.py
+++ b/discussao/models.py
@@ -8,9 +8,8 @@ from django.contrib.contenttypes.models import ContentType
 from django.db import connection, models
 from django.utils import timezone
 from django.utils.text import slugify
-from model_utils.models import TimeStampedModel
 
-from core.models import SoftDeleteManager, SoftDeleteModel
+from core.models import SoftDeleteManager, SoftDeleteModel, TimeStampedModel
 
 
 class SearchVectorField(models.TextField):
@@ -138,7 +137,7 @@ class TopicoDiscussao(TimeStampedModel, SoftDeleteModel):
             )
 
     class Meta:
-        ordering = ["-created"]
+        ordering = ["-created_at"]
         indexes = [models.Index(fields=["slug", "categoria"])]
         verbose_name = "Tópico de Discussão"
         verbose_name_plural = "Tópicos de Discussão"
@@ -186,7 +185,7 @@ class RespostaDiscussao(TimeStampedModel, SoftDeleteModel):
     all_objects = models.Manager()
 
     class Meta:
-        ordering = ["created"]
+        ordering = ["created_at"]
         verbose_name = "Resposta de Discussão"
         verbose_name_plural = "Respostas de Discussão"
 

--- a/discussao/serializers.py
+++ b/discussao/serializers.py
@@ -27,10 +27,10 @@ class RespostaDiscussaoSerializer(serializers.ModelSerializer):
             "editado",
             "editado_em",
             "motivo_edicao",
-            "created",
-            "modified",
+            "created_at",
+            "updated_at",
         ]
-        read_only_fields = ["autor", "editado", "created", "modified", "editado_em"]
+        read_only_fields = ["autor", "editado", "created_at", "updated_at", "editado_em"]
 
 
 class TopicoDiscussaoSerializer(serializers.ModelSerializer):
@@ -54,8 +54,8 @@ class TopicoDiscussaoSerializer(serializers.ModelSerializer):
             "resolvido",
             "melhor_resposta",
             "numero_visualizacoes",
-            "created",
-            "modified",
+            "created_at",
+            "updated_at",
         ]
         read_only_fields = ["autor", "numero_visualizacoes", "slug", "resolvido"]
 

--- a/discussao/views.py
+++ b/discussao/views.py
@@ -149,7 +149,7 @@ class TopicoListView(LoginRequiredMixin, ListView):
             .prefetch_related("respostas")
             .annotate(
                 num_comentarios=Count("respostas"),
-                last_activity=Max("respostas__created"),
+                last_activity=Max("respostas__created_at"),
             )
         )
         tags_param = self.request.GET.get("tags")
@@ -180,7 +180,7 @@ class TopicoListView(LoginRequiredMixin, ListView):
         if ordenacao == "comentados":
             qs = qs.order_by("-num_comentarios")
         else:
-            qs = qs.order_by("-created")
+            qs = qs.order_by("-created_at")
         return qs
 
     def get_context_data(self, **kwargs):
@@ -279,7 +279,7 @@ class TopicoUpdateView(LoginRequiredMixin, UpdateView):
         self.object = get_object_or_404(TopicoDiscussao, categoria=self.categoria, slug=kwargs["topico_slug"])
         if request.user != self.object.autor and request.user.user_type not in {UserType.ADMIN, UserType.ROOT}:
             return HttpResponseForbidden()
-        if timezone.now() - self.object.created > timedelta(minutes=15) and request.user.user_type not in {
+        if timezone.now() - self.object.created_at > timedelta(minutes=15) and request.user.user_type not in {
             UserType.ADMIN,
             UserType.ROOT,
         }:
@@ -380,7 +380,7 @@ class RespostaUpdateView(LoginRequiredMixin, UpdateView):
             UserType.ROOT,
         }:
             return HttpResponseForbidden()
-        if timezone.now() - self.object.created > timedelta(minutes=15) and request.user.user_type not in {
+        if timezone.now() - self.object.created_at > timedelta(minutes=15) and request.user.user_type not in {
             UserType.ADMIN,
             UserType.ROOT,
         }:

--- a/tests/discussao/test_models.py
+++ b/tests/discussao/test_models.py
@@ -58,8 +58,8 @@ def test_resposta_editar_e_reply(topico, admin_user):
 
 
 def test_timestamp_and_softdelete(topico):
-    assert topico.created is not None
-    assert topico.modified is not None
+    assert topico.created_at is not None
+    assert topico.updated_at is not None
     topico.delete()
     assert not TopicoDiscussao.objects.filter(pk=topico.pk).exists()
     assert TopicoDiscussao.all_objects.filter(pk=topico.pk).exists()


### PR DESCRIPTION
## Summary
- remove dependência do `model_utils` em discussões
- renomeia campos `created`/`modified` para `created_at`/`updated_at`
- ajusta serializers, views, API e testes

## Testing
- `python manage.py makemigrations --check --dry-run`
- `python manage.py migrate`
- `pytest tests/discussao -q` *(falhou: redis.exceptions.ConnectionError)*

------
https://chatgpt.com/codex/tasks/task_e_689e4af14b848325aeb7be762204784c