### PR TITLE
Load JavaScript i18n catalog for inline translations

### DIFF
--- a/accounts/templates/perfil/seguranca.html
+++ b/accounts/templates/perfil/seguranca.html
@@ -64,8 +64,9 @@
   </div>
 </div>
 
-<!-- Script simples de força de senha (opcional) -->
-<script>
+  <!-- Script simples de força de senha (opcional) -->
+  <script src="{% url 'javascript-catalog' %}"></script>
+  <script>
   const senhaInput = document.getElementById('nova_senha');
   const strengthFill = document.getElementById('strengthFill');
   const strengthText = document.getElementById('strengthText');

--- a/financeiro/templates/financeiro/relatorios.html
+++ b/financeiro/templates/financeiro/relatorios.html
@@ -51,8 +51,9 @@
   <div class="mt-4 flex gap-4">
     <a href="#" id="export-csv" class="text-primary underline" hx-boost="false" aria-label="{% trans 'Exportar relatório em CSV' %}">{% trans "Exportar CSV" %}</a>
     <a href="#" id="export-xlsx" class="text-primary underline" hx-boost="false" aria-label="{% trans 'Exportar relatório em XLSX' %}">{% trans "Exportar XLSX" %}</a>
-  </div>
-  <script>
+    </div>
+    <script src="{% url 'javascript-catalog' %}"></script>
+    <script>
     function renderRelatorio(evt) {
       const container = document.getElementById('relatorio');
       container.innerHTML = '';


### PR DESCRIPTION
## Summary
- load Django's `javascript-catalog` before inline scripts using `gettext`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_689e4c374a308325839953d571187501