### PR TITLE
Soft delete API tokens instead of hard deletion

### DIFF
--- a/tests/tokens/test_api_tokens.py
+++ b/tests/tokens/test_api_tokens.py
@@ -35,6 +35,9 @@ def test_api_token_authentication_and_revocation():
 
     token = ApiToken.objects.get(token_hash=token_hash)
     revoke_token(token.id)
+    token_db = ApiToken.all_objects.get(id=token.id)
+    assert token_db.deleted is True
+    assert token_db.revoked_at is not None
     resp = client.get(url)
     assert resp.status_code in {status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN}
 
@@ -47,8 +50,9 @@ def test_revogar_tokens_expirados():
     token.expires_at = timezone.now() - timezone.timedelta(days=1)
     token.save(update_fields=["expires_at"])
     revogar_tokens_expirados()
-    token.refresh_from_db()
-    assert token.revoked_at is not None
+    token_db = ApiToken.all_objects.get(id=token.id)
+    assert token_db.revoked_at is not None
+    assert token_db.deleted is True
 
 
 def test_api_view_create_and_destroy():

--- a/tokens/services.py
+++ b/tokens/services.py
@@ -37,8 +37,11 @@ def generate_token(
 
 def revoke_token(token_id: uuid.UUID) -> None:
     token = ApiToken.objects.get(id=token_id, revoked_at__isnull=True)
-    token.revoked_at = timezone.now()
-    token.save(update_fields=["revoked_at"])
+    now = timezone.now()
+    token.revoked_at = now
+    token.deleted = True
+    token.deleted_at = now
+    token.save(update_fields=["revoked_at", "deleted", "deleted_at"])
 
 
 def list_tokens(user: User) -> Iterable[ApiToken]:

--- a/tokens/tasks.py
+++ b/tokens/tasks.py
@@ -15,4 +15,6 @@ def remover_logs_antigos() -> None:
 @shared_task
 def revogar_tokens_expirados() -> None:
     now = timezone.now()
-    ApiToken.objects.filter(expires_at__lt=now, revoked_at__isnull=True).update(revoked_at=now)
+    ApiToken.objects.filter(expires_at__lt=now, revoked_at__isnull=True).update(
+        revoked_at=now, deleted=True, deleted_at=now
+    )


### PR DESCRIPTION
## Summary
- Mark API tokens as deleted when revoked
- Ensure expired token cleanup also soft deletes
- Test token revocation preserves record without physical deletion

## Testing
- `pytest tests/tokens -q --nomigrations`
- `python manage.py makemigrations` *(fails: Conflicting migrations detected)*
- `python manage.py migrate` *(fails: Conflicting migrations detected)*

------
https://chatgpt.com/codex/tasks/task_e_689e69326ae4832591fa8b3b28953d4b