### PR TITLE
fix: enhance base logo a11y and localize dashboard values

### DIFF
--- a/dashboard/templates/dashboard/partials/latest_transactions.html
+++ b/dashboard/templates/dashboard/partials/latest_transactions.html
@@ -1,10 +1,10 @@
-{% load i18n %}
+{% load i18n l10n %}
 <section class="mb-8" id="lancamentos">
   <h2 class="text-xl font-semibold mb-4">{% trans "Últimos Lançamentos" %}</h2>
   <ul class="space-y-2">
     {% for lanc in lancamentos %}
     <li class="p-4 bg-white rounded-lg shadow flex justify-between">
-      <span>{{ lanc.get_tipo_display }} - {{ lanc.valor }}</span>
+      <span>{{ lanc.get_tipo_display }} - {{ lanc.valor|localize }}</span>
       <time datetime="{{ lanc.data_lancamento|date:'c' }}" class="text-sm text-neutral-600">{{ lanc.data_lancamento|date:'d/m/Y' }}</time>
     </li>
     {% empty %}

--- a/dashboard/templates/dashboard/partials/pending_tasks.html
+++ b/dashboard/templates/dashboard/partials/pending_tasks.html
@@ -1,10 +1,10 @@
-{% load i18n %}
+{% load i18n l10n %}
 <section class="mb-8" id="tasks">
   <h2 class="text-xl font-semibold mb-4">{% trans "Tarefas Pendentes" %}</h2>
   <ul class="space-y-2">
     {% for task in tarefas %}
     <li class="p-4 bg-white rounded-lg shadow flex justify-between">
-      <span>{{ task.get_tipo_display }} - {{ task.valor }}</span>
+      <span>{{ task.get_tipo_display }} - {{ task.valor|localize }}</span>
       <time datetime="{{ task.data_vencimento|date:'c' }}" class="text-sm text-neutral-600">{{ task.data_vencimento|date:'d/m/Y' }}</time>
     </li>
     {% empty %}

--- a/locale/pt_BR/LC_MESSAGES/django.po
+++ b/locale/pt_BR/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-14 16:44-0300\n"
+"POT-Creation-Date: 2025-08-14 20:18-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,6 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
 #: templates/404.html:4
 msgid "Página não encontrada"
 msgstr ""
@@ -43,6 +44,10 @@ msgstr ""
 #: templates/base.html:39
 msgid "Pular para o conteúdo principal"
 msgstr "Pular para o conteúdo principal"
+
+#: templates/base.html:60
+msgid "Página inicial"
+msgstr "Página inicial"
 
 #: templates/base.html:64
 msgid "Abrir menu"

--- a/templates/base.html
+++ b/templates/base.html
@@ -57,7 +57,7 @@
   <!-- Navbar -->
   <header class="bg-white shadow">
     <div class="container mx-auto px-4 py-4 flex justify-between items-center">
-      <a href="/" class="text-2xl font-bold text-primary">HubX</a>
+      <a href="/" class="text-2xl font-bold text-primary" aria-label="{% trans 'Página inicial' %}">HubX</a>
       <button
         id="menu-toggle"
         class="md:hidden text-gray-800"


### PR DESCRIPTION
## Summary
- add aria-label to base logo link
- localize dashboard pending tasks and transactions values

## Testing
- `python manage.py makemessages -l pt_BR`
- `python manage.py compilemessages`
- `pytest` *(fail: multiple tests)*

------
https://chatgpt.com/codex/tasks/task_e_689e5b613644832589f3d5d7a1ee436c