### PR TITLE
feat(accounts): schedule purge task + token expiry tests + onboarding UX docs

### DIFF
--- a/Hubx/settings.py
+++ b/Hubx/settings.py
@@ -285,6 +285,13 @@ CELERY_BEAT_SCHEDULE = {
     },
 }
 
+CELERY_BEAT_SCHEDULE |= {
+    "accounts.purge_soft_deleted_daily": {
+        "task": "accounts.tasks.purge_soft_deleted",
+        "schedule": crontab(minute=0, hour=3),
+    }
+}
+
 # Notificações
 # Configurações de notificação – usar valores de ambiente quando definidos,
 # senão definir um valor fictício para evitar ImproperlyConfigured

--- a/accounts/README.md
+++ b/accounts/README.md
@@ -12,3 +12,7 @@ class Exemplo(TimeStampedModel, SoftDeleteModel):
 ```
 
 A exclusão padrão é lógica, basta chamar `instance.delete()`. Para remover definitivamente, use `instance.delete(soft=False)`.
+
+## Documentação
+
+- [Registro multietapas](../docs/accounts/registro_multietapas.md)

--- a/accounts/management/commands/purge_soft_deleted.py
+++ b/accounts/management/commands/purge_soft_deleted.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from django.core.management.base import BaseCommand
+
+from accounts.tasks import purge_soft_deleted
+
+
+class Command(BaseCommand):
+    help = "Executa a purga de contas soft-deleted imediatamente"
+
+    def handle(self, *args, **options):
+        purge_soft_deleted()
+        self.stdout.write(self.style.SUCCESS("Purga concluída"))
+

--- a/accounts/tasks.py
+++ b/accounts/tasks.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
+import logging
+
 from celery import shared_task
 from django.conf import settings
+from django.db import transaction
 from django.utils import timezone
 
 from notificacoes.services.notificacoes import enviar_para_usuario
 
 from .models import AccountToken, User
+
+logger = logging.getLogger(__name__)
 
 
 @shared_task
@@ -36,8 +41,32 @@ def send_confirmation_email(token_id: int) -> None:
 
 
 @shared_task
-def purge_soft_deleted() -> None:
+def purge_soft_deleted(batch_size: int = 500) -> None:
+    """Remove definitivamente usuários soft-deleted há mais de 30 dias."""
     limit = timezone.now() - timezone.timedelta(days=30)
-    qs = User.objects.filter(deleted=True, deleted_at__lt=limit, exclusao_confirmada=True)
-    for user in qs:
-        user.delete(soft=False)
+    total_purged = 0
+    try:
+        while True:
+            ids: list[int] = list(
+                User.all_objects.filter(
+                    deleted=True,
+                    deleted_at__lte=limit,
+                    exclusao_confirmada=True,
+                )
+                .order_by("pk")
+                .values_list("pk", flat=True)[:batch_size]
+            )
+            if not ids:
+                break
+            with transaction.atomic():
+                # ``soft=False`` remove definitivamente
+                for user in User.all_objects.filter(pk__in=ids):
+                    user.delete(soft=False)
+            total_purged += len(ids)
+    except Exception:
+        logger.exception("accounts.purge_soft_deleted.error")
+        raise
+    if total_purged:
+        logger.info("accounts.purge_soft_deleted", extra={"count": total_purged})
+    else:
+        logger.warning("accounts.purge_soft_deleted.noop")

--- a/accounts/templates/register/cpf.html
+++ b/accounts/templates/register/cpf.html
@@ -25,8 +25,9 @@
       {% csrf_token %}
       <div>
         <label for="cpf" class="mb-1 block text-sm font-medium text-neutral-700">{% trans "CPF" %}</label>
-        <input type="text" id="cpf" name="cpf" maxlength="14" class="w-full rounded-lg border border-neutral-300 px-4 py-2 placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder="{% trans '000.000.000-00' %}" required autofocus>
+        <input type="text" id="cpf" name="cpf" maxlength="14" class="w-full rounded-lg border border-neutral-300 px-4 py-2 placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder="{% trans '000.000.000-00' %}" required autofocus aria-describedby="cpf_help cpf_validation">
         <div class="text-sm text-red-600" id="cpf_validation"></div>
+        <small id="cpf_help" class="text-sm text-neutral-500">{% trans "Formato 000.000.000-00" %}</small>
       </div>
 
       <div class="flex gap-4">

--- a/accounts/templates/register/email.html
+++ b/accounts/templates/register/email.html
@@ -25,8 +25,9 @@
       {% csrf_token %}
       <div>
         <label for="email" class="mb-1 block text-sm font-medium text-neutral-700">{% trans "Email" %}</label>
-        <input type="email" id="email" name="email" class="w-full rounded-lg border border-neutral-300 px-4 py-2 placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder="{% trans 'Digite seu email' %}" required autofocus>
+        <input type="email" id="email" name="email" class="w-full rounded-lg border border-neutral-300 px-4 py-2 placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder="{% trans 'Digite seu email' %}" required autofocus aria-describedby="email_help email_validation">
         <div class="text-sm text-red-600" id="email_validation"></div>
+        <small id="email_help" class="text-sm text-neutral-500">{% trans "Enviaremos um link de confirmação" %}</small>
       </div>
 
       <div class="flex gap-4">

--- a/accounts/templates/register/senha.html
+++ b/accounts/templates/register/senha.html
@@ -25,14 +25,16 @@
       {% csrf_token %}
       <div>
         <label for="senha" class="mb-1 block text-sm font-medium text-neutral-700">{% trans "Senha" %}</label>
-        <input type="password" id="senha" name="senha" class="w-full rounded-lg border border-neutral-300 px-4 py-2 placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder="{% trans 'Digite sua senha' %}" required autofocus>
+        <input type="password" id="senha" name="senha" class="w-full rounded-lg border border-neutral-300 px-4 py-2 placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder="{% trans 'Digite sua senha' %}" required autofocus aria-describedby="senha_help senha_validation">
         <div class="text-sm text-red-600" id="senha_validation"></div>
+        <small id="senha_help" class="text-sm text-neutral-500">{% trans "Use ao menos 8 caracteres com letras e números" %}</small>
       </div>
 
       <div>
         <label for="confirmar_senha" class="mb-1 block text-sm font-medium text-neutral-700">{% trans "Confirmar Senha" %}</label>
-        <input type="password" id="confirmar_senha" name="confirmar_senha" class="w-full rounded-lg border border-neutral-300 px-4 py-2 placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder="{% trans 'Confirme sua senha' %}" required>
+        <input type="password" id="confirmar_senha" name="confirmar_senha" class="w-full rounded-lg border border-neutral-300 px-4 py-2 placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder="{% trans 'Confirme sua senha' %}" required aria-describedby="confirmar_senha_help confirmar_senha_validation">
         <div class="text-sm text-red-600" id="confirmar_senha_validation"></div>
+        <small id="confirmar_senha_help" class="text-sm text-neutral-500">{% trans "Repita a senha para confirmação" %}</small>
       </div>
 
       <div class="flex gap-4">

--- a/accounts/templates/register/usuario.html
+++ b/accounts/templates/register/usuario.html
@@ -25,9 +25,9 @@
       {% csrf_token %}
       <div>
         <label for="usuario" class="mb-1 block text-sm font-medium text-neutral-700">{% trans "Nome de Usuário" %}</label>
-        <input type="text" id="usuario" name="usuario" class="w-full rounded-lg border border-neutral-300 px-4 py-2 placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder="{% trans 'Digite seu nome de usuário' %}" required autofocus>
+        <input type="text" id="usuario" name="usuario" class="w-full rounded-lg border border-neutral-300 px-4 py-2 placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder="{% trans 'Digite seu nome de usuário' %}" required autofocus aria-describedby="usuario_help usuario_validation">
         <div class="text-sm text-red-600" id="usuario_validation"></div>
-        <small class="text-sm text-neutral-500">{% trans "Use apenas letras, números e underscore (_)" %}</small>
+        <small id="usuario_help" class="text-sm text-neutral-500">{% trans "Use apenas letras, números e underscore (_)" %}</small>
       </div>
 
       <div class="flex gap-4">

--- a/docs/accounts/registro_multietapas.md
+++ b/docs/accounts/registro_multietapas.md
@@ -1,0 +1,42 @@
+# Registro multietapas via convite
+
+Este fluxo guia o novo usuário convidado em etapas sequenciais. A pré‑condição é
+possuir um **token de convite válido** (`TokenAcesso`) que define o tipo de
+usuário e, opcionalmente, o núcleo de destino.
+
+## Etapas
+
+1. **Nome de usuário** – identificação única. Validar caracteres permitidos.
+2. **Nome completo** – texto livre obrigatório.
+3. **CPF** – deve ser válido e único (`RegexValidator`).
+4. **E‑mail** – usado para comunicação e confirmação. Deve ser único.
+5. **Senha** – validação de força com `validate_password`.
+6. **Foto** – opcional; arquivo temporário salvo em `storage`.
+7. **Aceite de termos** – finaliza cadastro, cria usuário inativo e envia
+   e‑mail de confirmação.
+
+## Validações e mensagens
+
+| Etapa | Validação | Erro/Sucesso |
+|-------|-----------|--------------|
+| Token | estado `NOVO`, não expirado | `Token inválido` / segue fluxo |
+| CPF   | formato `000.000.000-00`, único | `CPF inválido` |
+| E‑mail| formato válido e único | `E‑mail já cadastrado` |
+| Senha | `validate_password` | mensagens do validador |
+| Termos| checkbox obrigatório | `Você deve aceitar os termos` |
+
+Após o aceite, o usuário é criado com `is_active=False` e um `AccountToken` de
+confirmação (24 h) é enviado por e‑mail. Mensagens de feedback utilizam
+`django.contrib.messages` e novos textos são marcados com `gettext`.
+
+### Acessibilidade
+
+Campos críticos possuem `aria-describedby` apontando para `help_text` com
+informações adicionais. Títulos das etapas utilizam headings (`<h1>`) e a ordem
+dos elementos segue fluxo lógico para navegação assistida.
+
+### Reenvio de confirmação
+
+Após concluir o cadastro, o usuário pode solicitar novo e‑mail de confirmação.
+Tokens antigos são marcados como usados e não podem ser reutilizados.
+

--- a/tests/accounts/test_onboarding_wizard.py
+++ b/tests/accounts/test_onboarding_wizard.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import pytest
+from django.urls import reverse
+from django.utils import timezone
+
+from accounts.models import AccountToken, User
+from tokens.factories import TokenAcessoFactory
+
+
+@pytest.mark.django_db
+def test_onboarding_wizard_flow(client, mocker):
+    convite = TokenAcessoFactory(
+        estado="novo",
+        data_expiracao=timezone.now() + timezone.timedelta(hours=1),
+    )
+    mocker.patch("accounts.tasks.send_confirmation_email.delay")
+    mocker.patch("accounts.views.login")
+    session = client.session
+    session["invite_token"] = convite.codigo
+    session.save()
+
+    resp = client.post(reverse("accounts:usuario"), {"usuario": "wizard"})
+    assert resp.status_code == 302
+    resp = client.post(reverse("accounts:nome"), {"nome": "Wizard Test"})
+    assert resp.status_code == 302
+    resp = client.post(reverse("accounts:cpf"), {"cpf": "123.456.789-00"})
+    assert resp.status_code == 302
+    resp = client.post(reverse("accounts:email"), {"email": "wizard@example.com"})
+    assert resp.status_code == 302
+    resp = client.post(
+        reverse("accounts:senha"),
+        {"senha": "Strong123!", "confirmar_senha": "Strong123!"},
+    )
+    assert resp.status_code == 302
+    resp = client.post(reverse("accounts:foto"))
+    assert resp.status_code == 302
+    resp = client.post(reverse("accounts:termos"), {"aceitar_termos": "on"})
+    assert resp.status_code == 302
+
+    user = User.objects.get(username="wizard")
+    assert not user.is_active
+    assert AccountToken.objects.filter(
+        usuario=user, tipo=AccountToken.Tipo.EMAIL_CONFIRMATION
+    ).exists()
+

--- a/tests/accounts/test_purge_soft_deleted.py
+++ b/tests/accounts/test_purge_soft_deleted.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import pytest
+from django.utils import timezone
+
+from accounts.models import User
+from accounts.tasks import purge_soft_deleted
+
+
+def _create_deleted_user(**kwargs) -> User:
+    return User.objects.create_user(
+        email=f"{timezone.now().timestamp()}@example.com",
+        username=str(timezone.now().timestamp()),
+        password="x",
+        deleted=True,
+        deleted_at=timezone.now() - timezone.timedelta(days=31),
+        exclusao_confirmada=True,
+        **kwargs,
+    )
+
+
+@pytest.mark.django_db
+def test_purge_removes_old_users():
+    user = _create_deleted_user()
+    purge_soft_deleted()
+    assert not User.all_objects.filter(pk=user.pk).exists()
+
+
+@pytest.mark.django_db
+def test_purge_keeps_recent_users():
+    user = User.objects.create_user(
+        email="recent@example.com",
+        username="recent",
+        password="x",
+        deleted=True,
+        deleted_at=timezone.now() - timezone.timedelta(days=10),
+        exclusao_confirmada=True,
+    )
+    purge_soft_deleted()
+    assert User.all_objects.filter(pk=user.pk).exists()
+
+
+@pytest.mark.django_db
+def test_purge_idempotent():
+    user = _create_deleted_user()
+    purge_soft_deleted()
+    purge_soft_deleted()
+    assert not User.all_objects.filter(pk=user.pk).exists()
+
+
+@pytest.mark.django_db
+def test_purge_batches(mocker):
+    users = [_create_deleted_user() for _ in range(3)]
+    atomic = mocker.patch("accounts.tasks.transaction.atomic")
+    purge_soft_deleted(batch_size=2)
+    assert atomic.call_count >= 2
+    for user in users:
+        assert not User.all_objects.filter(pk=user.pk).exists()
+

--- a/tests/accounts/test_token_expiry.py
+++ b/tests/accounts/test_token_expiry.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from django.utils import timezone
+
+from accounts.models import AccountToken, SecurityEvent
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+def test_confirmation_token_expiry(client):
+    user = User.objects.create_user(email="exp@example.com", username="exp", is_active=False)
+    token = AccountToken.objects.create(
+        usuario=user,
+        tipo=AccountToken.Tipo.EMAIL_CONFIRMATION,
+        expires_at=timezone.now() - timezone.timedelta(seconds=1),
+    )
+    url = reverse("accounts:confirmar_email", args=[token.codigo])
+    client.get(url)
+    assert SecurityEvent.objects.filter(usuario=user, evento="email_confirmacao_falha").exists()
+
+
+@pytest.mark.django_db
+def test_password_reset_token_expiry(client):
+    user = User.objects.create_user(email="reset@example.com", username="reset")
+    token = AccountToken.objects.create(
+        usuario=user,
+        tipo=AccountToken.Tipo.PASSWORD_RESET,
+        expires_at=timezone.now() - timezone.timedelta(seconds=1),
+    )
+    url = reverse("accounts:password_reset_confirm", args=[token.codigo])
+    client.get(url, follow=True)
+    assert SecurityEvent.objects.filter(usuario=user, evento="senha_redefinicao_falha").exists()
+
+
+@pytest.mark.django_db
+def test_confirmation_token_not_reusable(client):
+    user = User.objects.create_user(email="n@example.com", username="n", is_active=False)
+    token = AccountToken.objects.create(
+        usuario=user,
+        tipo=AccountToken.Tipo.EMAIL_CONFIRMATION,
+        expires_at=timezone.now() + timezone.timedelta(hours=1),
+    )
+    url = reverse("accounts:confirmar_email", args=[token.codigo])
+    client.get(url)
+    client.get(url)
+    assert SecurityEvent.objects.filter(usuario=user, evento="email_confirmado").count() == 1
+    assert SecurityEvent.objects.filter(usuario=user, evento="email_confirmacao_falha").count() == 1
+
+
+@pytest.mark.django_db
+def test_password_reset_token_not_reusable(client):
+    user = User.objects.create_user(email="pr@example.com", username="pr", password="old")
+    token = AccountToken.objects.create(
+        usuario=user,
+        tipo=AccountToken.Tipo.PASSWORD_RESET,
+        expires_at=timezone.now() + timezone.timedelta(hours=1),
+    )
+    url = reverse("accounts:password_reset_confirm", args=[token.codigo])
+    client.post(url, {"new_password1": "Newpass123!", "new_password2": "Newpass123!"})
+    assert SecurityEvent.objects.filter(usuario=user, evento="senha_redefinida").count() == 1
+    client.post(url, {"new_password1": "Other123!", "new_password2": "Other123!"})
+    assert SecurityEvent.objects.filter(usuario=user, evento="senha_redefinicao_falha").count() == 1
+
+
+@pytest.mark.django_db
+def test_resend_confirmation_invalidates_previous(client, mocker):
+    user = User.objects.create_user(email="r@example.com", username="r", is_active=False)
+    old = AccountToken.objects.create(
+        usuario=user,
+        tipo=AccountToken.Tipo.EMAIL_CONFIRMATION,
+        expires_at=timezone.now() + timezone.timedelta(hours=1),
+    )
+    mocker.patch("accounts.tasks.send_confirmation_email.delay")
+    client.post(reverse("accounts:resend_confirmation"), {"email": user.email})
+    assert AccountToken.objects.filter(usuario=user, tipo=AccountToken.Tipo.EMAIL_CONFIRMATION, used_at__isnull=True).count() == 1
+    old.refresh_from_db()
+    assert old.used_at is not None
+


### PR DESCRIPTION
## Summary
- purge soft-deleted accounts in daily batches via Celery beat
- cover email/password token expiry, resend and non-reuse
- document multi-step onboarding with a11y hints

## Testing
- `ruff check accounts/tasks.py accounts/views.py accounts/management/commands/purge_soft_deleted.py tests/accounts/test_purge_soft_deleted.py tests/accounts/test_token_expiry.py tests/accounts/test_onboarding_wizard.py Hubx/settings.py`
- `mypy --strict accounts/tasks.py accounts/views.py accounts/management/commands/purge_soft_deleted.py tests/accounts/test_purge_soft_deleted.py tests/accounts/test_token_expiry.py tests/accounts/test_onboarding_wizard.py Hubx/settings.py` *(fails: missing type hints in project dependencies)*
- `pytest tests/accounts/test_purge_soft_deleted.py tests/accounts/test_token_expiry.py tests/accounts/test_onboarding_wizard.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689fbbcb121c83259b9a5a7b7c2399ce