### PR TITLE
Hash auth codes and encrypt TOTP secrets

### DIFF
--- a/tests/tokens/test_views.py
+++ b/tests/tokens/test_views.py
@@ -73,9 +73,10 @@ def test_gerar_codigo_autenticacao_view(client):
 def test_validar_codigo_autenticacao_view(client):
     user = UserFactory()
     _login(client, user)
-    codigo = CodigoAutenticacao.objects.create(
-        usuario=user, codigo="123456", expira_em=timezone.now() + timezone.timedelta(minutes=10)
-    )
+    codigo = CodigoAutenticacao(usuario=user)
+    codigo.set_codigo("123456")
+    codigo.expira_em = timezone.now() + timezone.timedelta(minutes=10)
+    codigo.save()
     resp = client.post(reverse("tokens:validar_codigo"), {"codigo": codigo.codigo})
     assert resp.status_code == 200
     codigo.refresh_from_db()

--- a/tokens/admin.py
+++ b/tokens/admin.py
@@ -14,7 +14,7 @@ class TokenAcessoAdmin(admin.ModelAdmin):
         "data_expiracao",
     )
     list_filter = ("estado", "tipo_destino")
-    search_fields = ("codigo",)
+    search_fields = ("codigo_hash",)
 
 
 @admin.register(CodigoAutenticacao)

--- a/tokens/forms.py
+++ b/tokens/forms.py
@@ -78,7 +78,7 @@ class ValidarCodigoAutenticacaoForm(forms.Form):
             raise forms.ValidationError("Código bloqueado")
         if auth.is_expirado():
             raise forms.ValidationError("Código expirado")
-        if codigo != auth.codigo:
+        if not auth.check_codigo(codigo):
             auth.tentativas += 1
             auth.save(update_fields=["tentativas"])
             raise forms.ValidationError("Código incorreto")

--- a/tokens/migrations/0006_codigoautenticacao_hash_totpdevice_encrypt.py
+++ b/tokens/migrations/0006_codigoautenticacao_hash_totpdevice_encrypt.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import secrets
+
+import core.fields
+from django.db import migrations, models
+
+
+def hash_existing_codes(apps, schema_editor):
+    CodigoAutenticacao = apps.get_model("tokens", "CodigoAutenticacao")
+    for codigo in CodigoAutenticacao.objects.all():
+        raw = getattr(codigo, "codigo", "")
+        if not raw:
+            continue
+        salt = secrets.token_bytes(16)
+        digest = hashlib.pbkdf2_hmac("sha256", raw.encode(), salt, 120000)
+        codigo.codigo_salt = base64.b64encode(salt).decode()
+        codigo.codigo_hash = base64.b64encode(digest).decode()
+        codigo.save(update_fields=["codigo_salt", "codigo_hash"])
+
+
+def encrypt_totp_secrets(apps, schema_editor):
+    TOTPDevice = apps.get_model("tokens", "TOTPDevice")
+    for device in TOTPDevice.objects.all():
+        secret = device.secret
+        if secret and not secret.startswith("gAAAA"):
+            device.secret = secret
+            device.save(update_fields=["secret"])
+
+
+def noop(apps, schema_editor):
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("tokens", "0005_tokens_hardening"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="codigoautenticacao",
+            name="codigo_hash",
+            field=models.CharField(default="", max_length=64),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name="codigoautenticacao",
+            name="codigo_salt",
+            field=models.CharField(default="", max_length=32),
+            preserve_default=False,
+        ),
+        migrations.RunPython(hash_existing_codes, noop),
+        migrations.RemoveField(
+            model_name="codigoautenticacao",
+            name="codigo",
+        ),
+        migrations.AlterField(
+            model_name="totpdevice",
+            name="secret",
+            field=core.fields.EncryptedCharField(max_length=128),
+        ),
+        migrations.RunPython(encrypt_totp_secrets, noop),
+    ]


### PR DESCRIPTION
## Summary
- Store authentication codes as PBKDF2 hashes with salt
- Encrypt TOTP secrets using EncryptedCharField
- Adjust form validation and add migration for updated fields

## Testing
- `pytest tests/tokens/test_forms.py::test_validar_codigo_autenticacao_form_flow --no-cov`
- `pytest` *(fails: ModuleNotFoundError: No module named 'axe_core_python', 'twilio', 'bs4', 'playwright', 'pywebpush')*

------
https://chatgpt.com/codex/tasks/task_e_68a3bcd04d3083258d90dc362a1766fc