### PR TITLE
feat: track api token revocation

### DIFF
--- a/tests/tokens/test_api_tokens.py
+++ b/tests/tokens/test_api_tokens.py
@@ -1,5 +1,4 @@
-import pytest
-pytestmark = pytest.mark.skip(reason="legacy tests")
+import hashlib
 from datetime import timedelta
 
 import pytest
@@ -35,10 +34,12 @@ def test_api_token_authentication_and_revocation():
     assert client.get(url).status_code == 200
 
     token = ApiToken.objects.get(token_hash=token_hash)
-    revoke_token(token.id)
+    revoke_token(token.id, user)
+    revoke_token(token.id, user)
     token_db = ApiToken.all_objects.get(id=token.id)
     assert token_db.deleted is True
     assert token_db.revoked_at is not None
+    assert token_db.revogado_por == user
     resp = client.get(url)
     assert resp.status_code in {status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN}
 
@@ -71,3 +72,5 @@ def test_api_view_create_and_destroy():
 
     del_resp = client.delete(reverse("tokens_api:api-token-detail", args=[token_id]))
     assert del_resp.status_code == status.HTTP_204_NO_CONTENT
+    token_db = ApiToken.all_objects.get(id=token_id)
+    assert token_db.revogado_por == user

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -20,6 +20,11 @@ urlpatterns = [
         include(("organizacoes.api_urls", "organizacoes_api"), namespace="organizacoes_api"),
     ),
 
+    path(
+        "api/tokens/",
+        include(("tokens.api_urls", "tokens_api"), namespace="tokens_api"),
+    ),
+
 
     path("jsi18n/", JavaScriptCatalog.as_view(), name="javascript-catalog"),
 

--- a/tokens/api_views.py
+++ b/tokens/api_views.py
@@ -39,5 +39,5 @@ class ApiTokenViewSet(viewsets.ViewSet):
         token = get_object_or_404(ApiToken, pk=pk)
         if not request.user.is_superuser and token.user != request.user:
             return Response(status=status.HTTP_404_NOT_FOUND)
-        revoke_token(token.id)
+        revoke_token(token.id, request.user)
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/tokens/migrations/0006_apitoken_revogado_por.py
+++ b/tokens/migrations/0006_apitoken_revogado_por.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("tokens", "0005_tokens_hardening"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="apitoken",
+            name="revogado_por",
+            field=models.ForeignKey(
+                null=True,
+                blank=True,
+                on_delete=models.SET_NULL,
+                related_name="api_tokens_revogados",
+                to=settings.AUTH_USER_MODEL,
+            ),
+        ),
+    ]

--- a/tokens/models.py
+++ b/tokens/models.py
@@ -36,6 +36,13 @@ class ApiToken(TimeStampedModel, SoftDeleteModel):
     )
     expires_at = models.DateTimeField()
     revoked_at = models.DateTimeField(null=True, blank=True)
+    revogado_por = models.ForeignKey(
+        User,
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="api_tokens_revogados",
+    )
     last_used_at = models.DateTimeField(null=True, blank=True)
 
     @property

--- a/tokens/services.py
+++ b/tokens/services.py
@@ -35,13 +35,16 @@ def generate_token(
     return raw_token
 
 
-def revoke_token(token_id: uuid.UUID) -> None:
-    token = ApiToken.objects.get(id=token_id, revoked_at__isnull=True)
+def revoke_token(token_id: uuid.UUID, revogado_por: User | None = None) -> None:
+    token = ApiToken.all_objects.get(id=token_id)
+    if token.revoked_at:
+        return
     now = timezone.now()
     token.revoked_at = now
+    token.revogado_por = revogado_por
     token.deleted = True
     token.deleted_at = now
-    token.save(update_fields=["revoked_at", "deleted", "deleted_at"])
+    token.save(update_fields=["revoked_at", "revogado_por", "deleted", "deleted_at"])
 
 
 def list_tokens(user: User) -> Iterable[ApiToken]:


### PR DESCRIPTION
## Summary
- add `revogado_por` to `ApiToken` and include migration
- allow `revoke_token` to record the revoking user and ignore already revoked tokens
- forward request user from `ApiTokenViewSet.destroy`

## Testing
- `pytest --no-cov tests/tokens/test_api_tokens.py`


------
https://chatgpt.com/codex/tasks/task_e_68a3bcd062f083258581d4aca3298e0b