### PR TITLE
Optimize invite token lookup via hashed code

### DIFF
--- a/tests/tokens/test_find_token_by_code.py
+++ b/tests/tokens/test_find_token_by_code.py
@@ -1,0 +1,34 @@
+import base64
+import hashlib
+import secrets
+
+import pytest
+
+from accounts.factories import UserFactory
+from accounts.models import UserType
+from tokens.models import TokenAcesso
+from tokens.services import create_invite_token, find_token_by_code
+
+pytestmark = pytest.mark.django_db
+
+
+def test_find_token_by_code_uses_hash():
+    user = UserFactory(user_type=UserType.ADMIN.value)
+    token, codigo = create_invite_token(
+        gerado_por=user, tipo_destino=TokenAcesso.TipoUsuario.ASSOCIADO
+    )
+    encontrado = find_token_by_code(codigo)
+    assert encontrado.id == token.id
+
+
+def test_find_token_by_code_legacy():
+    user = UserFactory(user_type=UserType.ADMIN.value)
+    codigo = TokenAcesso.generate_code()
+    token = TokenAcesso(gerado_por=user, tipo_destino=TokenAcesso.TipoUsuario.ASSOCIADO)
+    salt = secrets.token_bytes(16)
+    digest = hashlib.pbkdf2_hmac("sha256", codigo.encode(), salt, 120000)
+    token.codigo_salt = base64.b64encode(salt).decode()
+    token.codigo_hash = base64.b64encode(digest).decode()
+    token.save()
+    encontrado = find_token_by_code(codigo)
+    assert encontrado.id == token.id

--- a/tests/tokens/test_invite_code_hashing.py
+++ b/tests/tokens/test_invite_code_hashing.py
@@ -1,3 +1,4 @@
+import hashlib
 import pytest
 
 from accounts.factories import UserFactory
@@ -17,4 +18,6 @@ def test_invite_code_hashing():
     assert not token.check_codigo("wrong")
     assert len(codigo) >= 32
     assert codigo not in token.codigo_hash
+    assert token.codigo_hash == hashlib.sha256(codigo.encode()).hexdigest()
+    assert len(token.codigo_hash) == 64
     assert "codigo" not in [f.name for f in TokenAcesso._meta.fields]

--- a/tokens/factories.py
+++ b/tokens/factories.py
@@ -25,6 +25,14 @@ class TokenAcessoFactory(DjangoModelFactory):
         elements=[choice.value for choice in TokenAcesso.Estado],
     )
     data_expiracao = factory.LazyFunction(lambda: timezone.now() + timezone.timedelta(days=30))
+    codigo = factory.LazyFunction(TokenAcesso.generate_code)
+
+    @factory.post_generation
+    def _setup_codigo(self, create, extracted, **kwargs):
+        """Gera ``codigo_hash`` automaticamente."""
+        self.set_codigo(self.codigo)
+        if create:
+            self.save()
 
     @factory.post_generation
     def nucleos(self, create, extracted, **kwargs):


### PR DESCRIPTION
## Summary
- store SHA256 hash for invite tokens and support legacy salted hashes
- search tokens by hashed code in `find_token_by_code`
- cover hashed lookup with new tests

## Testing
- `pytest -q -o addopts="" --nomigrations tests/tokens/test_invite_code_hashing.py::test_invite_code_hashing tests/tokens/test_find_token_by_code.py::test_find_token_by_code_uses_hash tests/tokens/test_find_token_by_code.py::test_find_token_by_code_legacy`


------
https://chatgpt.com/codex/tasks/task_e_68a3bcd2a6508325b420457ef4573ba3