### PR TITLE
Use search service for empresa filtering

### DIFF
--- a/tests/urls.py
+++ b/tests/urls.py
@@ -21,6 +21,11 @@ urlpatterns = [
     ),
 
     path(
+        "api/empresas/",
+        include(("empresas.api_urls", "empresas_api"), namespace="empresas_api"),
+    ),
+
+    path(
         "api/tokens/",
         include(("tokens.api_urls", "tokens_api"), namespace="tokens_api"),
     ),


### PR DESCRIPTION
## Summary
- Delegate empresa queryset filtering to `search_empresas` and support `organizacao`, `municipio` and `estado` params
- Add API tests for organization filter and combined search

## Testing
- `pytest tests/empresas/test_api.py::test_busca_por_organizacao_superuser tests/empresas/test_api.py::test_busca_combinada tests/empresas/test_api.py::test_busca_por_uma_tag tests/empresas/test_api.py::test_busca_por_multiplas_tags_and tests/empresas/test_api.py::test_busca_multiplas_tags_sem_and tests/empresas/test_api.py::test_busca_palavras_chave -q --cov-fail-under=0`


------
https://chatgpt.com/codex/tasks/task_e_68a3c77f91d88325a2197a5da663daef