### PR TITLE
Remove duplicate structlog import in discussão tasks

### DIFF
--- a/discussao/tasks.py
+++ b/discussao/tasks.py
@@ -3,14 +3,9 @@ from __future__ import annotations
 import structlog
 from celery import shared_task  # type: ignore
 
-import structlog
 from notificacoes.services.notificacoes import enviar_para_usuario
 
 from .models import RespostaDiscussao, TopicoDiscussao
-
-
-logger = structlog.get_logger(__name__)
-
 
 logger = structlog.get_logger(__name__)
 


### PR DESCRIPTION
## Summary
- remove redundant structlog import and duplicate logger definition in discussion tasks

## Testing
- `isort --check-only -v discussao/tasks.py`
- `ruff check discussao/tasks.py`


------
https://chatgpt.com/codex/tasks/task_e_68a47c35a9308325bc870a90b0bb6fac