### PR TITLE
Remove redundant token revocation logging

### DIFF
--- a/tokens/api_views.py
+++ b/tokens/api_views.py
@@ -60,17 +60,5 @@ class ApiTokenViewSet(viewsets.ViewSet):
                 ip=request.META.get("REMOTE_ADDR", ""),
                 user_agent=request.META.get("HTTP_USER_AGENT", ""),
             )
-
             return Response(status=status.HTTP_204_NO_CONTENT)
-
-        revoke_token(token.id)
-        ApiTokenLog.objects.create(
-            token=token,
-            usuario=request.user,
-            acao=ApiTokenLog.Acao.REVOGACAO,
-            ip=request.META.get("REMOTE_ADDR", ""),
-            user_agent=request.META.get("HTTP_USER_AGENT", ""),
-        )
-
-        return Response(status=status.HTTP_204_NO_CONTENT)
 


### PR DESCRIPTION
## Summary
- Avoid double revocation and duplicate logs in `ApiTokenViewSet.destroy`

## Testing
- `pytest tests/tokens -q` *(fails: KeyError: 'tokens', NameError: 'pyotp')*

------
https://chatgpt.com/codex/tasks/task_e_68a498ab2e408325ab16e8ad7e626e67