### PR TITLE
Fix notification metric increments and tests

### DIFF
--- a/feed/tasks.py
+++ b/feed/tasks.py
@@ -32,14 +32,10 @@ def notificar_autor_sobre_interacao(post_id: str, tipo: str) -> None:
     event = "feed_like" if tipo == "like" else "feed_comment"
     try:
         enviar_para_usuario(post.autor, event, {"post_id": str(post.id)})
-
+        NOTIFICATIONS_SENT.inc()
     except Exception as exc:  # pragma: no cover - melhor esforço
         capture_exception(exc)
         raise
-
-        NOTIFICATIONS_SENT.inc()
-    except Exception:  # pragma: no cover - melhor esforço
-        pass
 
 
 
@@ -74,7 +70,7 @@ def notify_post_moderated(post_id: str, status: str) -> None:
         enviar_para_usuario(
             post.autor, "feed_post_moderated", {"post_id": str(post.id), "status": status}
         )
-
+        NOTIFICATIONS_SENT.inc()
     except Exception as exc:  # pragma: no cover - melhor esforço
         capture_exception(exc)
         raise

--- a/feed/tests/test_notifications.py
+++ b/feed/tests/test_notifications.py
@@ -34,18 +34,32 @@ class FeedNotificationTest(TestCase):
     def test_notificar_autor_capture_exception(self, enviar, capture) -> None:
         from django.conf import settings
         from feed.factories import PostFactory
-        from feed.tasks import notificar_autor_sobre_interacao
+        from feed.tasks import NOTIFICATIONS_SENT, notificar_autor_sobre_interacao
 
         settings.CELERY_TASK_EAGER_PROPAGATES = False
         post = PostFactory(autor=self.user, organizacao=self.user.organizacao)
 
+        NOTIFICATIONS_SENT._value.set(0)
         result = notificar_autor_sobre_interacao.delay(str(post.id), "like")
 
         with self.assertRaises(Exception):
             result.get()
 
+        self.assertEqual(NOTIFICATIONS_SENT._value.get(), 0)
         self.assertEqual(enviar.call_count, 4)
         self.assertEqual(capture.call_count, 4)
+
+    @patch("feed.tasks.enviar_para_usuario")
+    def test_notificar_autor_increments_metric(self, enviar) -> None:
+        from feed.factories import PostFactory
+        from feed.tasks import NOTIFICATIONS_SENT, notificar_autor_sobre_interacao
+
+        NOTIFICATIONS_SENT._value.set(0)
+        post = PostFactory(autor=self.user, organizacao=self.user.organizacao)
+
+        notificar_autor_sobre_interacao(str(post.id), "like")
+
+        self.assertEqual(NOTIFICATIONS_SENT._value.get(), 1.0)
 
     @patch("feed.tasks.enviar_para_usuario")
     def test_notify_like_once(self, enviar) -> None:


### PR DESCRIPTION
## Summary
- increment NOTIFICATIONS_SENT after delivering notifications and remove redundant exception handler
- count notifications for moderated posts
- add tests for metric increment and exception handling

## Testing
- `pytest feed/tests/test_notifications.py tests/feed/test_notifications.py --no-cov -q`

------
https://chatgpt.com/codex/tasks/task_e_68a498aaad4c8325b7c5342fd430ebb6