### PR TITLE
Link chat messages to uploaded attachments

### DIFF
--- a/chat/api.py
+++ b/chat/api.py
@@ -39,6 +39,7 @@ def create_message(**kwargs):
     reply_to = kwargs.get("reply_to")
     if not reply_to and kwargs.get("reply_to_id"):
         reply_to = ChatMessage.objects.get(pk=kwargs["reply_to_id"])
+    attachment_id = kwargs.get("attachment_id")
     return enviar_mensagem(
         canal=channel,
         remetente=remetente,
@@ -49,6 +50,7 @@ def create_message(**kwargs):
         conteudo_cifrado=conteudo_cifrado,
         alg=alg,
         key_version=key_version,
+        attachment_id=attachment_id,
     )
 
 

--- a/chat/api_views.py
+++ b/chat/api_views.py
@@ -144,6 +144,12 @@ class UploadArquivoAPIView(APIView):
         attachment.save()
         chat_attachments_total.inc()
 
+        # Remove orphan attachments older than 1 hour
+        ChatAttachment.objects.filter(
+            mensagem__isnull=True,
+            created_at__lt=timezone.now() - timedelta(hours=1),
+        ).delete()
+
         tipo = "file"
         if content_type.startswith("image"):
             tipo = "image"

--- a/chat/consumers.py
+++ b/chat/consumers.py
@@ -72,6 +72,7 @@ class ChatConsumer(AsyncJsonWebsocketConsumer):
         if message_type in {"text", "image", "video", "file"}:
             conteudo = data.get("conteudo", "")
             arquivo = None
+            attachment_id = data.get("attachment_id")
             reply_to_id = data.get("reply_to")
             reply_to = None
             if reply_to_id:
@@ -103,6 +104,7 @@ class ChatConsumer(AsyncJsonWebsocketConsumer):
                     conteudo_cifrado=cipher,
                     alg=alg,
                     key_version=key_version,
+                    attachment_id=attachment_id,
                 )
             else:
                 msg = await database_sync_to_async(enviar_mensagem)(
@@ -112,6 +114,7 @@ class ChatConsumer(AsyncJsonWebsocketConsumer):
                     conteudo,
                     arquivo,
                     reply_to,
+                    attachment_id=attachment_id,
                 )
             payload = {
                 "type": "chat.message",

--- a/chat/migrations/0015_remove_orphan_attachments.py
+++ b/chat/migrations/0015_remove_orphan_attachments.py
@@ -1,0 +1,17 @@
+from django.db import migrations
+
+
+def remove_orphan_attachments(apps, schema_editor):
+    ChatAttachment = apps.get_model('chat', 'ChatAttachment')
+    ChatAttachment.objects.filter(mensagem__isnull=True).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('chat', '0014_relatoriochatexport_arquivo_path'),
+    ]
+
+    operations = [
+        migrations.RunPython(remove_orphan_attachments, migrations.RunPython.noop),
+    ]

--- a/chat/serializers.py
+++ b/chat/serializers.py
@@ -190,11 +190,6 @@ class ChatMessageSerializer(serializers.ModelSerializer):
         alg = validated_data.get("alg", "")
         key_version = validated_data.get("key_version", "")
         attachment_id = validated_data.pop("attachment_id", None)
-        attachment = None
-        if attachment_id:
-            attachment = ChatAttachment.objects.filter(id=attachment_id).first()
-            if attachment:
-                arquivo = attachment.arquivo
         if channel.e2ee_habilitado:
             msg = enviar_mensagem(
                 canal=channel,
@@ -206,6 +201,7 @@ class ChatMessageSerializer(serializers.ModelSerializer):
                 conteudo_cifrado=validated_data.get("conteudo_cifrado", ""),
                 alg=alg,
                 key_version=key_version,
+                attachment_id=attachment_id,
             )
         else:
             msg = enviar_mensagem(
@@ -215,10 +211,8 @@ class ChatMessageSerializer(serializers.ModelSerializer):
                 conteudo=conteudo,
                 arquivo=arquivo,
                 reply_to=reply_to,
+                attachment_id=attachment_id,
             )
-        if attachment:
-            attachment.mensagem = msg
-            attachment.save(update_fields=["mensagem"])
         return msg
 
     def to_representation(self, instance: ChatMessage) -> dict[str, Any]:


### PR DESCRIPTION
## Summary
- associate uploaded attachments with chat messages by `attachment_id`
- clean up orphan chat attachments and expose attachment ID in upload response
- data migration to purge unattached chat files

## Testing
- `pytest tests/chat/test_services.py::test_enviar_mensagem_com_attachment_id --no-cov -q`
- `pytest tests/chat/test_api_views.py::test_send_message_with_attachment --no-cov -q` *(fails: NoReverseMatch: 'chat_api' is not a registered namespace)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b5d7b2f483258b0612ef04039bb8