### PR TITLE
feat(feed): schedule plugin execution

### DIFF
--- a/Hubx/settings.py
+++ b/Hubx/settings.py
@@ -264,6 +264,9 @@ MENSALIDADE_VENCIMENTO_DIA = 10
 
 # Celery Beat
 
+# Intervalo (em minutos) para execução dos plugins do feed pelo celery beat
+FEED_PLUGINS_INTERVAL_MINUTES = int(os.getenv("FEED_PLUGINS_INTERVAL_MINUTES", "1"))
+
 CELERY_BEAT_SCHEDULE = {
     "notificar_inadimplencia": {
         "task": "financeiro.tasks.inadimplencia.notificar_inadimplencia",
@@ -295,7 +298,9 @@ CELERY_BEAT_SCHEDULE = {
     },
     "executar_feed_plugins": {  # executa plugins do feed periodicamente
         "task": "feed.tasks.executar_plugins",
-        "schedule": crontab(minute="*"),
+        "schedule": crontab(
+            minute="*" if FEED_PLUGINS_INTERVAL_MINUTES == 1 else f"*/{FEED_PLUGINS_INTERVAL_MINUTES}"
+        ),
     },
 }
 

--- a/README/infra.md
+++ b/README/infra.md
@@ -1,0 +1,18 @@
+# Infra
+
+## Celery Beat - Feed Plugins
+
+A execução periódica dos plugins do feed é realizada pela tarefa
+`feed.tasks.executar_plugins`, agendada no `celery beat` pela entrada
+`executar_feed_plugins`.
+
+O intervalo padrão é de 1 minuto, mas pode ser personalizado definindo a
+variável de ambiente `FEED_PLUGINS_INTERVAL_MINUTES` com o número desejado de
+minutos. Exemplo:
+
+```bash
+export FEED_PLUGINS_INTERVAL_MINUTES=5
+```
+
+Com isso, o `celery beat` chamará `feed.tasks.executar_plugins` a cada 5
+minutos.


### PR DESCRIPTION
## Summary
- parameterize celery beat to run feed plugins with custom interval
- document feed plugin scheduling
- test periodic plugin execution

## Testing
- `pytest --no-cov feed/tests/test_plugin_schedule.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4d02de9708325a6d31941d345d958