### PR TITLE
Delete user media files on hard delete

### DIFF
--- a/accounts/README.md
+++ b/accounts/README.md
@@ -12,6 +12,8 @@ class Exemplo(TimeStampedModel, SoftDeleteModel):
 ```
 
 A exclusão padrão é lógica, basta chamar `instance.delete()`. Para remover definitivamente, use `instance.delete(soft=False)`.
+Para o modelo `User`, ao excluir definitivamente (`soft=False`), os arquivos `avatar` e `cover`
+associados ao usuário também são removidos do armazenamento.
 
 ## Documentação
 

--- a/accounts/models.py
+++ b/accounts/models.py
@@ -219,6 +219,23 @@ class User(AbstractUser, TimeStampedModel, SoftDeleteModel):
             self.nucleo = None  # Garantir que usuários root não interajam com núcleos
         super().save(*args, **kwargs)
 
+    def delete(
+        self,
+        using: str | None = None,
+        keep_parents: bool = False,
+        *,
+        soft: bool = True,
+    ) -> None:  # type: ignore[override]
+        """Remove avatar e cover ao excluir definitivamente o usuário."""
+
+        if not soft:
+            if self.avatar:
+                self.avatar.delete(save=False)
+            if self.cover:
+                self.cover.delete(save=False)
+
+        super().delete(using=using, keep_parents=keep_parents, soft=soft)
+
     # Relacionamentos sociais
     connections = models.ManyToManyField("self", blank=True)
     followers = models.ManyToManyField(

--- a/tests/accounts/test_user_delete_files.py
+++ b/tests/accounts/test_user_delete_files.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.core.files.uploadedfile import SimpleUploadedFile
+
+User = get_user_model()
+
+IMAGE = (
+    b'\x47\x49\x46\x38\x39\x61\x01\x00\x01\x00\x80\x00\x00\x00\x00\x00'
+    b'\xff\xff\xff!\xf9\x04\x01\x0a\x00\x01\x00,\x00\x00\x00\x00\x01\x00'
+    b'\x01\x00\x00\x02\x02L\x01\x00;'
+)
+
+
+@pytest.mark.django_db
+def test_user_delete_removes_avatar_and_cover(tmp_path, settings):
+    settings.MEDIA_ROOT = tmp_path
+    avatar = SimpleUploadedFile("avatar.gif", IMAGE, content_type="image/gif")
+    cover = SimpleUploadedFile("cover.gif", IMAGE, content_type="image/gif")
+    user = User.objects.create_user(
+        email="u@example.com",
+        username="u",
+        password="pass",
+        avatar=avatar,
+        cover=cover,
+    )
+
+    avatar_path = Path(user.avatar.path)
+    cover_path = Path(user.cover.path)
+    assert avatar_path.exists()
+    assert cover_path.exists()
+
+    user.delete(soft=False)
+
+    assert not avatar_path.exists()
+    assert not cover_path.exists()
+    assert not User.all_objects.filter(pk=user.pk).exists()


### PR DESCRIPTION
## Summary
- ensure hard deletion of `User` removes avatar and cover files
- document user media cleanup
- test physical removal of avatar and cover files on hard delete

## Testing
- `pytest tests/accounts/test_user_delete_files.py -q --override-ini="addopts="`


------
https://chatgpt.com/codex/tasks/task_e_68a4d78d2f30832587289f739ddc40b0