### PR TITLE
feat: audit filter and layout operations

### DIFF
--- a/dashboard/urls.py
+++ b/dashboard/urls.py
@@ -24,6 +24,7 @@ urlpatterns = [
     path("configs/<uuid:pk>/apply/", views.DashboardConfigApplyView.as_view(), name="config-apply"),
     path("filters/", views.DashboardFilterListView.as_view(), name="filters"),
     path("filters/create/", views.DashboardFilterCreateView.as_view(), name="filter-create"),
+    path("filters/<int:pk>/edit/", views.DashboardFilterUpdateView.as_view(), name="filter-edit"),
     path("filters/<int:pk>/apply/", views.DashboardFilterApplyView.as_view(), name="filter-apply"),
     path("filters/<int:pk>/delete/", views.DashboardFilterDeleteView.as_view(), name="filter-delete"),
 

--- a/tests/dashboard/test_filters.py
+++ b/tests/dashboard/test_filters.py
@@ -1,0 +1,30 @@
+import pytest
+from django.urls import reverse
+
+from audit.models import AuditLog
+from dashboard.models import DashboardFilter
+
+pytestmark = pytest.mark.urls("tests.dashboard.urls")
+
+
+@pytest.mark.django_db
+def test_filter_crud_with_audit(client, admin_user):
+    client.force_login(admin_user)
+    url = reverse("dashboard:filter-create") + "?periodo=mensal"
+    resp = client.post(url, {"nome": "F1", "publico": False})
+    assert resp.status_code == 302
+    filtro = DashboardFilter.objects.get(nome="F1")
+    assert AuditLog.objects.filter(action="CREATE_FILTER", object_id=str(filtro.pk)).exists()
+
+    url_edit = reverse("dashboard:filter-edit", args=[filtro.pk]) + "?periodo=anual"
+    resp = client.post(url_edit, {"nome": "F2", "publico": True})
+    assert resp.status_code == 302
+    filtro.refresh_from_db()
+    assert filtro.nome == "F2"
+    assert AuditLog.objects.filter(action="UPDATE_FILTER", object_id=str(filtro.pk)).exists()
+
+    resp = client.post(reverse("dashboard:filter-delete", args=[filtro.pk]))
+    assert resp.status_code == 302
+    assert not DashboardFilter.objects.filter(pk=filtro.pk).exists()
+    assert AuditLog.objects.filter(action="DELETE_FILTER", object_id=str(filtro.pk)).exists()
+

--- a/tests/dashboard/urls.py
+++ b/tests/dashboard/urls.py
@@ -1,0 +1,5 @@
+from django.urls import include, path
+
+urlpatterns = [
+    path("", include(("dashboard.urls", "dashboard"), namespace="dashboard")),
+]


### PR DESCRIPTION
## Summary
- add service helpers to log dashboard filters and layouts
- enable editing and deleting filters and layouts with audit trail
- test filter and layout CRUD with audit logging

## Testing
- `pytest tests/dashboard/test_filters.py tests/dashboard/test_layouts.py::test_layout_audit tests/dashboard/test_layouts.py::test_layout_crud --no-cov -q`

------
https://chatgpt.com/codex/tasks/task_e_68a4d7a8cdd48325ab60b9f5f7e56d40