### PR TITLE
Adiciona handlers de aceitação e recusa de conexões

### DIFF
--- a/accounts/templates/perfil/conexoes.html
+++ b/accounts/templates/perfil/conexoes.html
@@ -62,28 +62,27 @@
     <!-- SOLICITAÇÕES -->
     <div class="tab-pane hidden" id="solicitacoes">
       <div class="space-y-4">
-        {% for request in connection_requests %}
+        {% for solicitante in connection_requests %}
         <div class="flex items-start justify-between p-4 border rounded-xl bg-white shadow-sm">
           <div class="flex items-center gap-3">
-            {% if request.avatar %}
-              <img src="{{ request.avatar.url }}" alt="{{ request.username }}" class="w-10 h-10 rounded-full object-cover" />
+            {% if solicitante.avatar %}
+              <img src="{{ solicitante.avatar.url }}" alt="{{ solicitante.username }}" class="w-10 h-10 rounded-full object-cover" />
             {% else %}
               <div class="w-10 h-10 rounded-full bg-gray-200 flex items-center justify-center text-sm font-semibold text-gray-600">
-                {{ request.username|first|upper }}
+                {{ solicitante.username|first|upper }}
               </div>
             {% endif %}
             <div>
-              <p class="font-medium">{{ request.get_full_name }}</p>
-              <p class="text-sm text-gray-500">@{{ request.username }}</p>
-              <p class="text-sm text-gray-400 mt-1">{{ request.message }}</p>
+              <p class="font-medium">{{ solicitante.get_full_name }}</p>
+              <p class="text-sm text-gray-500">@{{ solicitante.username }}</p>
             </div>
           </div>
           <div class="flex flex-col gap-1">
-            <form method="post" action="{% url 'accounts:aceitar_conexao' request.id %}">
+            <form method="post" action="{% url 'accounts:aceitar_conexao' solicitante.id %}">
               {% csrf_token %}
               <button class="text-sm bg-green-100 text-green-700 px-3 py-1 rounded">{% trans "Aceitar" %}</button>
             </form>
-            <form method="post" action="{% url 'accounts:recusar_conexao' request.id %}">
+            <form method="post" action="{% url 'accounts:recusar_conexao' solicitante.id %}">
               {% csrf_token %}
               <button class="text-sm bg-red-100 text-red-600 px-3 py-1 rounded">{% trans "Recusar" %}</button>
             </form>

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -42,6 +42,16 @@ urlpatterns = [
         views.remover_conexao,
         name="remover_conexao",
     ),
+    path(
+        "perfil/conexoes/<int:id>/aceitar/",
+        views.aceitar_conexao,
+        name="aceitar_conexao",
+    ),
+    path(
+        "perfil/conexoes/<int:id>/recusar/",
+        views.recusar_conexao,
+        name="recusar_conexao",
+    ),
     # Mídias
     path("perfil/midias/", views.perfil_midias, name="midias"),
     path("perfil/midias/<int:pk>/", views.perfil_midia_detail, name="midia_detail"),

--- a/tests/accounts/test_connections.py
+++ b/tests/accounts/test_connections.py
@@ -1,0 +1,33 @@
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+def test_aceitar_conexao(client):
+    user = User.objects.create_user(email="a@example.com", username="a", password="x")
+    other = User.objects.create_user(email="b@example.com", username="b", password="x")
+    user.followers.add(other)
+
+    client.force_login(user)
+    url = reverse("accounts:aceitar_conexao", args=[other.id])
+    resp = client.post(url)
+    assert resp.status_code == 302
+    assert user.connections.filter(id=other.id).exists()
+    assert not user.followers.filter(id=other.id).exists()
+
+
+@pytest.mark.django_db
+def test_recusar_conexao(client):
+    user = User.objects.create_user(email="a@example.com", username="a", password="x")
+    other = User.objects.create_user(email="b@example.com", username="b", password="x")
+    user.followers.add(other)
+
+    client.force_login(user)
+    url = reverse("accounts:recusar_conexao", args=[other.id])
+    resp = client.post(url)
+    assert resp.status_code == 302
+    assert not user.connections.filter(id=other.id).exists()
+    assert not user.followers.filter(id=other.id).exists()

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -2,6 +2,7 @@ from django.urls import include, path
 from django.views.i18n import JavaScriptCatalog
 
 urlpatterns = [
+    path("", include(("accounts.urls", "accounts"), namespace="accounts")),
     path("api/notificacoes/", include("notificacoes.api_urls")),
     path("financeiro/", include(("financeiro.urls", "financeiro"), namespace="financeiro")),
 


### PR DESCRIPTION
## Summary
- implementa `aceitar_conexao` e `recusar_conexao`
- exibe solicitações reais na página de conexões
- cobre aceitação e recusa com testes

## Testing
- `pytest tests/accounts/test_connections.py -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68a4e7d867308325880a6ae9b1c723cf