### PR TITLE
Prevent duplicate registration data and add tests

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -15,7 +15,7 @@ from django.contrib.auth.password_validation import validate_password
 from django.core.exceptions import ValidationError
 from django.core.files.base import ContentFile, File
 from django.core.files.storage import default_storage
-from django.db import transaction
+from django.db import IntegrityError, transaction
 from django.db.models import Q
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
@@ -481,8 +481,12 @@ def cpf(request):
         if valor:
             try:
                 cpf_validator(valor)
-                request.session["cpf"] = valor
-                return redirect("accounts:email")
+                if User.objects.filter(cpf=valor).exists():
+                    messages.error(request, _("CPF já cadastrado."))
+                    return redirect("accounts:cpf")
+                else:
+                    request.session["cpf"] = valor
+                    return redirect("accounts:email")
             except ValidationError:
                 messages.error(request, "CPF inválido.")
     return render(request, "register/cpf.html")
@@ -492,8 +496,12 @@ def email(request):
     if request.method == "POST":
         val = request.POST.get("email")
         if val:
-            request.session["email"] = val
-            return redirect("accounts:senha")
+            if User.objects.filter(email__iexact=val).exists():
+                messages.error(request, _("Este e-mail já está em uso."))
+                return redirect("accounts:email")
+            else:
+                request.session["email"] = val
+                return redirect("accounts:senha")
     return render(request, "register/email.html")
 
 
@@ -501,8 +509,12 @@ def usuario(request):
     if request.method == "POST":
         usr = request.POST.get("usuario")
         if usr:
-            request.session["usuario"] = usr
-            return redirect("accounts:nome")
+            if User.objects.filter(username__iexact=usr).exists():
+                messages.error(request, _("Nome de usuário já cadastrado."))
+                return redirect("accounts:usuario")
+            else:
+                request.session["usuario"] = usr
+                return redirect("accounts:nome")
     return render(request, "register/usuario.html")
 
 
@@ -564,18 +576,27 @@ def termos(request):
                 TokenAcesso.TipoUsuario.ASSOCIADO: UserType.ASSOCIADO,
                 TokenAcesso.TipoUsuario.CONVIDADO: UserType.CONVIDADO,
             }
-            user = User.objects.create(
-                username=username,
-                email=email_val,
-                first_name=first_name,
-                last_name=last_name,
-                nome_completo=nome_completo,
-                password=pwd_hash,
-                cpf=cpf_val,
-                user_type=tipo_mapping[token_obj.tipo_destino],
-                is_active=False,
-                email_confirmed=False,
-            )
+            try:
+                with transaction.atomic():
+                    user = User.objects.create(
+                        username=username,
+                        email=email_val,
+                        first_name=first_name,
+                        last_name=last_name,
+                        nome_completo=nome_completo,
+                        password=pwd_hash,
+                        cpf=cpf_val,
+                        user_type=tipo_mapping[token_obj.tipo_destino],
+                        is_active=False,
+                        email_confirmed=False,
+                    )
+            except IntegrityError:
+                messages.error(
+                    request,
+                    _("Não foi possível criar o usuário. Dados já cadastrados."),
+                )
+                return redirect("accounts:usuario")
+
             primeiro_nucleo = token_obj.nucleos.first()
             if primeiro_nucleo:
                 user.nucleo = primeiro_nucleo

--- a/tests/accounts/test_onboarding_wizard_duplicates.py
+++ b/tests/accounts/test_onboarding_wizard_duplicates.py
@@ -1,0 +1,36 @@
+import pytest
+from django.contrib.messages import get_messages
+from django.urls import reverse
+
+from django.contrib.auth import get_user_model
+
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+def test_cpf_step_rejects_duplicate(client):
+    User.objects.create_user(email="a@example.com", username="a", cpf="123.456.789-09")
+    resp = client.post(reverse("accounts:cpf"), {"cpf": "123.456.789-09"})
+    assert resp.status_code == 302
+    messages = list(get_messages(resp.wsgi_request))
+    assert any("CPF já cadastrado." in m.message for m in messages)
+
+
+@pytest.mark.django_db
+def test_email_step_rejects_duplicate(client):
+    User.objects.create_user(email="dup@example.com", username="dup")
+    resp = client.post(reverse("accounts:email"), {"email": "dup@example.com"})
+    assert resp.status_code == 302
+    messages = list(get_messages(resp.wsgi_request))
+    assert any("e-mail já está em uso" in m.message.lower() for m in messages)
+
+
+@pytest.mark.django_db
+def test_usuario_step_rejects_duplicate(client):
+    User.objects.create_user(email="u@example.com", username="existente")
+    resp = client.post(reverse("accounts:usuario"), {"usuario": "existente"})
+    assert resp.status_code == 302
+    messages = list(get_messages(resp.wsgi_request))
+    assert any("nome de usuário já cadastrado" in m.message.lower() for m in messages)
+

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -4,6 +4,15 @@ from django.views.i18n import JavaScriptCatalog
 urlpatterns = [
     path("api/notificacoes/", include("notificacoes.api_urls")),
     path("financeiro/", include(("financeiro.urls", "financeiro"), namespace="financeiro")),
+    path("accounts/", include(("accounts.urls", "accounts"), namespace="accounts")),
+    path("dashboard/", include(("dashboard.urls", "dashboard"), namespace="dashboard")),
+    path("empresas/", include(("empresas.urls", "empresas"), namespace="empresas")),
+    path("agenda/", include(("agenda.urls", "agenda"), namespace="agenda")),
+    path("discussao/", include(("discussao.urls", "discussao"), namespace="discussao")),
+    path("feed/", include(("feed.urls", "feed"), namespace="feed")),
+    path("nucleos/", include(("nucleos.urls", "nucleos"), namespace="nucleos")),
+    path("organizacoes/", include(("organizacoes.urls", "organizacoes"), namespace="organizacoes")),
+    path("tokens/", include(("tokens.urls", "tokens"), namespace="tokens")),
 
     path(
         "api/financeiro/",


### PR DESCRIPTION
## Summary
- validate CPF, email, and username against existing users during onboarding
- handle IntegrityError when creating user via invite token
- add tests ensuring duplicate steps show appropriate errors

## Testing
- `pytest tests/accounts/test_onboarding_wizard_duplicates.py -q --no-cov`
- `pytest tests/accounts/test_onboarding_wizard.py -q --no-cov` *(fails: 'dashboard' namespace not registered)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e7d8b2448325a30905de7581dfbf