### PR TITLE
Add QR check-in form with QR code reader and feedback

### DIFF
--- a/agenda/templates/agenda/checkin_form.html
+++ b/agenda/templates/agenda/checkin_form.html
@@ -5,13 +5,70 @@
 {% block content %}
 <main class="max-w-md mx-auto py-8 px-4">
   <h1 class="text-xl font-semibold mb-4">{% trans "Check-in do evento" %}</h1>
-  <form method="post" class="space-y-4">
+  <form method="post" action="{% url 'agenda:inscricao_checkin' inscricao.id %}" id="checkin-form" class="space-y-4">
     {% csrf_token %}
     <label for="codigo" class="block text-sm font-medium">{% trans "Código do check-in" %}</label>
     <input type="text" id="codigo" name="codigo" class="form-input w-full" placeholder="{% trans 'Escaneie ou digite o código' %}" required>
+    <div id="feedback" class="text-sm"></div>
+    <div id="reader" class="w-full mb-4"></div>
     <div class="text-right">
       <button type="submit" class="btn-primary" aria-label="{% trans 'Confirmar presença' %}">{% trans 'Confirmar presença' %}</button>
     </div>
   </form>
 </main>
+
+<script src="https://unpkg.com/html5-qrcode" defer></script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const form = document.getElementById("checkin-form");
+  const codigoInput = document.getElementById("codigo");
+  const feedback = document.getElementById("feedback");
+  const successMessage = "{% trans 'Check-in realizado com sucesso!' %}";
+  const readerEl = document.getElementById("reader");
+
+  // Inicializa o leitor de QR code
+  if (window.Html5Qrcode && readerEl) {
+    const qr = new Html5Qrcode("reader");
+    qr.start(
+      { facingMode: "environment" },
+      { fps: 10, qrbox: 250 },
+      (decoded) => {
+        codigoInput.value = decoded;
+        qr.stop();
+      },
+      () => {}
+    ).catch(() => {});
+  }
+
+  form.addEventListener("submit", function (e) {
+    e.preventDefault();
+    feedback.textContent = "";
+    const csrf = form.querySelector('input[name="csrfmiddlewaretoken"]').value;
+    fetch(form.action, {
+      method: "POST",
+      headers: { "X-CSRFToken": csrf },
+      body: new FormData(form),
+    })
+      .then((response) => {
+        if (!response.ok) {
+          return response.text().then((text) => {
+            throw new Error(text || "{% trans 'Erro ao realizar check-in' %}");
+          });
+        }
+        return response.json();
+      })
+      .then(() => {
+        feedback.classList.remove("text-red-600");
+        feedback.classList.add("text-green-600");
+        feedback.textContent = successMessage;
+        form.reset();
+      })
+      .catch((err) => {
+        feedback.classList.remove("text-green-600");
+        feedback.classList.add("text-red-600");
+        feedback.textContent = err.message;
+      });
+  });
+});
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Post check-in form to `agenda:inscricao_checkin`
- Auto-fill check-in code using html5-qrcode scanner
- Show success or error message after submitting code

## Testing
- `pytest tests/agenda/test_inscricoes.py::test_qrcode_and_checkin -q --override-ini addopts=''`


------
https://chatgpt.com/codex/tasks/task_e_68a4ed34564c8325902a5d673256ddb7