### PR TITLE
Add payment details to event registrations

### DIFF
--- a/agenda/templates/agenda/detail.html
+++ b/agenda/templates/agenda/detail.html
@@ -24,14 +24,16 @@
 
   <!-- Inscrição -->
   {% if user.is_authenticated and user.user_type not in ('admin','root') %}
-    <form method="post" action="{% url 'agenda:evento_subscribe' object.pk %}" class="mb-10">
-      {% csrf_token %}
-      {% if object.inscricoes.filter(user=user, status='confirmada').exists %}
+    {% if object.inscricoes.filter(user=user, status='confirmada').exists %}
+      <form method="post" action="{% url 'agenda:evento_subscribe' object.pk %}" class="mb-10">
+        {% csrf_token %}
         <button type="submit" class="btn-secondary" aria-label="{% trans 'Cancelar inscrição' %}">{% trans "Cancelar inscrição" %}</button>
-      {% else %}
-        <button type="submit" class="btn-primary" aria-label="{% trans 'Inscrever-se' %}">{% trans "Inscrever-se" %}</button>
-      {% endif %}
-    </form>
+      </form>
+    {% else %}
+      <div class="mb-10">
+        <a href="{% url 'agenda:inscricao_criar' object.pk %}" class="btn-primary" aria-label="{% trans 'Inscrever-se' %}">{% trans "Inscrever-se" %}</a>
+      </div>
+    {% endif %}
   {% endif %}
 
   <!-- Lista de Inscritos -->

--- a/agenda/templates/agenda/inscricao_form.html
+++ b/agenda/templates/agenda/inscricao_form.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Inscrição" %} | Hubx{% endblock %}
+
+{% block content %}
+<section class="max-w-screen-xl mx-auto pt-8 px-6 lg:px-8">
+  <h1 class="text-2xl font-bold text-neutral-900 mb-6">{% trans "Inscrição" %}</h1>
+  <form method="post" enctype="multipart/form-data" class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 space-y-6">
+    {% csrf_token %}
+    <div>
+      {{ form.metodo_pagamento.label_tag }}
+      {{ form.metodo_pagamento }}
+    </div>
+    <div>
+      {{ form.comprovante_pagamento.label_tag }}
+      {{ form.comprovante_pagamento }}
+    </div>
+    <div>
+      {{ form.observacao.label_tag }}
+      {{ form.observacao }}
+    </div>
+    <div class="flex justify-end gap-3 pt-4 border-t border-neutral-100">
+      <a href="{% url 'agenda:evento_detalhe' evento.pk %}" class="btn-secondary" aria-label="{% trans 'Cancelar' %}">{% trans "Cancelar" %}</a>
+      <button type="submit" class="btn-primary" aria-label="{% trans 'Salvar' %}">{% trans "Salvar" %}</button>
+    </div>
+  </form>
+</section>
+{% endblock %}

--- a/agenda/templates/agenda/inscricao_list.html
+++ b/agenda/templates/agenda/inscricao_list.html
@@ -49,6 +49,7 @@
             <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Presente" %}</th>
             <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Valor Pago" %}</th>
             <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Método de Pagamento" %}</th>
+            <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Comprovante" %}</th>
             <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Observação" %}</th>
             <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Ações" %}</th>
           </tr>
@@ -62,6 +63,13 @@
               <td class="px-4 py-2">{{ inscricao.presente }}</td>
               <td class="px-4 py-2">{{ inscricao.valor_pago }}</td>
               <td class="px-4 py-2">{{ inscricao.get_metodo_pagamento_display }}</td>
+              <td class="px-4 py-2">
+                {% if inscricao.comprovante_pagamento %}
+                  <a href="{{ inscricao.comprovante_pagamento.url }}" class="text-blue-600 hover:underline" target="_blank">{% trans "Ver" %}</a>
+                {% else %}
+                  -
+                {% endif %}
+              </td>
               <td class="px-4 py-2">{{ inscricao.observacao }}</td>
               <td class="px-4 py-2">
                 <a
@@ -74,7 +82,7 @@
             </tr>
           {% empty %}
             <tr>
-              <td colspan="8" class="px-4 py-4 text-center text-neutral-500">{% trans "Nenhuma inscrição encontrada." %}</td>
+              <td colspan="9" class="px-4 py-4 text-center text-neutral-500">{% trans "Nenhuma inscrição encontrada." %}</td>
             </tr>
           {% endfor %}
         </tbody>

--- a/agenda/urls.py
+++ b/agenda/urls.py
@@ -13,6 +13,7 @@ from .views import (
     EventoRemoveInscritoView,
     EventoSubscribeView,
     EventoUpdateView,
+    InscricaoEventoCreateView,
     InscricaoEventoListView,
     MaterialDivulgacaoEventoListView,
     ParceriaEventoCreateView,
@@ -33,6 +34,11 @@ urlpatterns = [
     path("evento/<uuid:pk>/", EventoDetailView.as_view(), name="evento_detalhe"),
     path("evento/<uuid:pk>/editar/", EventoUpdateView.as_view(), name="evento_editar"),
     path("evento/<uuid:pk>/excluir/", EventoDeleteView.as_view(), name="evento_excluir"),
+    path(
+        "evento/<uuid:pk>/inscricao/",
+        InscricaoEventoCreateView.as_view(),
+        name="inscricao_criar",
+    ),
     path(
         "evento/<uuid:pk>/inscrever/",
         EventoSubscribeView.as_view(),


### PR DESCRIPTION
## Summary
- add dedicated view and form for event registrations with payment details
- separate cancellation flow from subscription
- show payment receipt link in registration list

## Testing
- `pytest agenda -q` *(fails: Coverage failure: total of 10 is less than fail-under=90)*
- `pytest agenda --no-cov -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4ed10f4188325a2deb29d7a208baf