### PR TITLE
feat(chat): add preferences modal for chat theme and summaries

### DIFF
--- a/chat/api_views.py
+++ b/chat/api_views.py
@@ -211,6 +211,9 @@ class UserChatPreferenceView(APIView):
         serializer.save()
         return Response(serializer.data)
 
+    def post(self, request: Request, *args, **kwargs) -> Response:
+        return self.patch(request, *args, **kwargs)
+
 
 class ChatChannelViewSet(viewsets.ModelViewSet):
     """ViewSet para gerenciamento de canais de chat.

--- a/chat/static/chat/js/preferences.js
+++ b/chat/static/chat/js/preferences.js
@@ -1,0 +1,74 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const modal = document.getElementById('preferences-modal');
+  const openBtn = document.getElementById('open-preferences');
+  const cancelBtn = document.getElementById('pref-cancel');
+  const form = document.getElementById('preferences-form');
+  const themeSelect = document.getElementById('pref-theme');
+  const dailyCheckbox = document.getElementById('pref-daily');
+  const weeklyCheckbox = document.getElementById('pref-weekly');
+  const searchesInput = document.getElementById('pref-searches');
+
+  function getCookie(name) {
+    const match = document.cookie.match(new RegExp('(^| )' + name + '=([^;]+)'));
+    return match ? match[2] : null;
+  }
+
+  function applyTheme(theme) {
+    document.documentElement.classList.toggle('dark', theme === 'escuro');
+    localStorage.setItem('tema', theme);
+    document.cookie = `tema=${theme};path=/`;
+  }
+
+  function loadPreferences() {
+    fetch('/api/chat/preferences/')
+      .then(resp => resp.json())
+      .then(data => {
+        themeSelect.value = data.tema || 'claro';
+        dailyCheckbox.checked = !!data.resumo_diario;
+        weeklyCheckbox.checked = !!data.resumo_semanal;
+        searchesInput.value = (data.buscas_salvas || []).join(', ');
+        applyTheme(data.tema);
+      });
+  }
+
+  if (openBtn) {
+    openBtn.addEventListener('click', () => {
+      modal.classList.remove('hidden');
+    });
+  }
+
+  if (cancelBtn) {
+    cancelBtn.addEventListener('click', () => {
+      modal.classList.add('hidden');
+    });
+  }
+
+  if (form) {
+    form.addEventListener('submit', e => {
+      e.preventDefault();
+      const payload = {
+        tema: themeSelect.value,
+        resumo_diario: dailyCheckbox.checked,
+        resumo_semanal: weeklyCheckbox.checked,
+        buscas_salvas: searchesInput.value
+          ? searchesInput.value.split(',').map(s => s.trim()).filter(Boolean)
+          : []
+      };
+      fetch('/api/chat/preferences/', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRFToken': getCookie('csrftoken'),
+        },
+        body: JSON.stringify(payload),
+      })
+        .then(resp => resp.json())
+        .then(data => {
+          applyTheme(data.tema);
+          modal.classList.add('hidden');
+        });
+    });
+  }
+
+  loadPreferences();
+});

--- a/chat/templates/chat/base_chat.html
+++ b/chat/templates/chat/base_chat.html
@@ -9,8 +9,12 @@
 
 {% block content %}
 <section class="max-w-6xl mx-auto px-4 py-10">
+  <div class="flex justify-end mb-4">
+    <button id="open-preferences" class="p-2 border rounded" aria-label="{% trans 'Preferências do chat' %}">⚙️</button>
+  </div>
   {% block chat_content %}{% endblock %}
 </section>
+{% include "chat/modal_preferences.html" %}
 {% endblock %}
 
 {% block extra_js %}
@@ -18,4 +22,5 @@
 <script src="{% static 'chat/js/i18n.js' %}"></script>
 <script src="{% static 'chat/js/chat_socket.js' %}"></script>
 <script src="{% static 'chat/js/notifications_socket.js' %}"></script>
+<script src="{% static 'chat/js/preferences.js' %}"></script>
 {% endblock %}

--- a/chat/templates/chat/modal_preferences.html
+++ b/chat/templates/chat/modal_preferences.html
@@ -1,0 +1,27 @@
+{% load i18n %}
+<aside id="preferences-modal" class="fixed inset-0 hidden items-center justify-center bg-black bg-opacity-50" role="dialog" aria-modal="true">
+  <section class="bg-white rounded-lg max-w-md w-full p-6 space-y-4">
+    <h2 class="text-lg font-semibold">{% trans "Preferências do Chat" %}</h2>
+    <form id="preferences-form" class="space-y-4">
+      <div>
+        <label for="pref-theme" class="block text-sm font-medium">{% trans "Tema" %}</label>
+        <select id="pref-theme" name="tema" class="mt-1 block w-full border rounded p-2">
+          <option value="claro">{% trans "Claro" %}</option>
+          <option value="escuro">{% trans "Escuro" %}</option>
+        </select>
+      </div>
+      <div class="space-y-2">
+        <label class="flex items-center gap-2"><input type="checkbox" id="pref-daily" /> {% trans "Resumo diário" %}</label>
+        <label class="flex items-center gap-2"><input type="checkbox" id="pref-weekly" /> {% trans "Resumo semanal" %}</label>
+      </div>
+      <div>
+        <label for="pref-searches" class="block text-sm font-medium">{% trans "Buscas salvas (separadas por vírgula)" %}</label>
+        <input type="text" id="pref-searches" class="mt-1 block w-full border rounded p-2" />
+      </div>
+      <div class="flex justify-end gap-2">
+        <button type="button" id="pref-cancel" class="px-3 py-1 border rounded">{% trans "Cancelar" %}</button>
+        <button type="submit" class="px-3 py-1 bg-primary text-white rounded">{% trans "Salvar" %}</button>
+      </div>
+    </form>
+  </section>
+</aside>


### PR DESCRIPTION
## Summary
- add modal for configuring chat theme, summaries and saved searches
- load and save preferences via /api/chat/preferences/
- allow POST updates on preferences API

## Testing
- `pytest tests/chat/test_preferences_api.py::test_get_and_patch_preferences -q` *(fails: django.urls.exceptions.NoReverseMatch: 'chat_api' is not a registered namespace)*

------
https://chatgpt.com/codex/tasks/task_e_68a4f8006c308325b2f5760b58a3a2ec