### PR TITLE
Add summaries and trending topics to conversation view

### DIFF
--- a/chat/templates/chat/conversation_detail.html
+++ b/chat/templates/chat/conversation_detail.html
@@ -39,6 +39,21 @@
       </div>
     </header>
 
+    <section id="resumos" class="mb-4" aria-label="{% trans 'Resumos disponíveis' %}">
+      <div class="flex items-center justify-between">
+        <h3 class="text-sm font-semibold text-neutral-600">{% trans 'Resumos' %}</h3>
+        {% if is_admin %}
+          <button id="resumo-gerar" class="text-blue-600 hover:underline text-sm" type="button">{% trans 'Gerar resumo' %}</button>
+        {% endif %}
+      </div>
+      <ul id="resumos-list" class="pl-5 list-disc text-sm text-neutral-700"></ul>
+    </section>
+
+    <section id="trending" class="mb-4" aria-label="{% trans 'Tópicos em alta' %}">
+      <h3 class="text-sm font-semibold text-neutral-600">{% trans 'Tópicos em alta' %}</h3>
+      <ul id="trending-list" class="pl-5 list-disc text-sm text-neutral-700"></ul>
+    </section>
+
     <form id="search-form" data-channel="{{ conversation.id }}" class="mb-4 flex flex-wrap items-end gap-2" aria-label="{% trans 'Buscar mensagens' %}">
       <label for="search-q" class="sr-only">{% trans 'Buscar mensagens' %}</label>
       <input type="search" id="search-q" name="q" class="w-full sm:flex-1 border rounded p-2" placeholder="{% trans 'Buscar' %}" />
@@ -107,6 +122,53 @@
     const feedback = document.getElementById('search-feedback');
     const clearBtn = document.getElementById('search-clear');
     let nextUrl = null;
+    const chatContainer = document.getElementById('chat-container');
+    const channelId = chatContainer.dataset.destId;
+    const csrfToken = chatContainer.dataset.csrfToken;
+    const isAdmin = chatContainer.dataset.isAdmin === 'true';
+    const resumosList = document.getElementById('resumos-list');
+    const trendingList = document.getElementById('trending-list');
+    const gerarBtn = document.getElementById('resumo-gerar');
+
+    function carregarResumos(){
+      fetch(`/api/chat/channels/${channelId}/resumos/`)
+        .then(r=>r.json())
+        .then(data=>{
+          resumosList.innerHTML='';
+          data.forEach(item=>{
+            const li=document.createElement('li');
+            const dt=new Date(item.created_at).toLocaleString();
+            li.textContent=`${item.periodo} - ${dt}`;
+            resumosList.appendChild(li);
+          });
+        });
+    }
+
+    function carregarTrending(){
+      fetch(`/api/chat/trending/?canal=${channelId}`)
+        .then(r=>r.json())
+        .then(data=>{
+          trendingList.innerHTML='';
+          data.forEach(item=>{
+            const li=document.createElement('li');
+            li.textContent=`${item.palavra} (${item.frequencia})`;
+            trendingList.appendChild(li);
+          });
+        });
+    }
+
+    if(isAdmin && gerarBtn){
+      gerarBtn.addEventListener('click', function(){
+        fetch(`/api/chat/channels/${channelId}/gerar-resumo/`, {
+          method:'POST',
+          headers:{'Content-Type':'application/json','X-CSRFToken':csrfToken},
+          body: JSON.stringify({periodo:'diario'})
+        }).then(r=>{ if(r.ok){carregarResumos();} });
+      });
+    }
+
+    carregarResumos();
+    carregarTrending();
     function render(data, append){
       if(!append){ results.innerHTML=''; }
       if(data.results.length === 0 && !append){


### PR DESCRIPTION
## Summary
- list summaries and trending topics in conversation detail view
- fetch summaries and trending data from API and allow admins to generate new summaries

## Testing
- `pytest tests/chat/test_trending.py::test_calcular_trending_topics_endpoint -q --disable-warnings --maxfail=1 --no-cov` *(fails: django.urls.exceptions.NoReverseMatch: 'chat_api' is not a registered namespace)*
- `pytest tests/chat/test_api_views.py::test_list_resumos -q --disable-warnings --maxfail=1 --no-cov` *(fails: django.urls.exceptions.NoReverseMatch: 'chat_api' is not a registered namespace)*

------
https://chatgpt.com/codex/tasks/task_e_68a4f8065ee48325a00b696dd09cd9a4