### PR TITLE
Exibe erros nos campos de preferências

### DIFF
--- a/configuracoes/templates/configuracoes/partials/preferencias.html
+++ b/configuracoes/templates/configuracoes/partials/preferencias.html
@@ -12,7 +12,9 @@
         {% endwith %}
         <span class="text-sm font-medium">{% trans 'Receber notificações por e-mail' %}</span>
       </label>
+      {{ preferencias_form.receber_notificacoes_email.errors }}
       {{ preferencias_form.frequencia_notificacoes_email|add_class:'form-select mt-2' }}
+      {{ preferencias_form.frequencia_notificacoes_email.errors }}
       {% if preferencias_form.frequencia_notificacoes_email.help_text %}
         <p class="text-xs text-gray-500">{{ preferencias_form.frequencia_notificacoes_email.help_text }}</p>
       {% endif %}
@@ -24,7 +26,9 @@
         {% endwith %}
         <span class="text-sm font-medium">{% trans 'Receber notificações por WhatsApp' %}</span>
       </label>
+      {{ preferencias_form.receber_notificacoes_whatsapp.errors }}
       {{ preferencias_form.frequencia_notificacoes_whatsapp|add_class:'form-select mt-2' }}
+      {{ preferencias_form.frequencia_notificacoes_whatsapp.errors }}
       {% if preferencias_form.frequencia_notificacoes_whatsapp.help_text %}
         <p class="text-xs text-gray-500">{{ preferencias_form.frequencia_notificacoes_whatsapp.help_text }}</p>
       {% endif %}
@@ -37,7 +41,9 @@
         {% endwith %}
         <span class="text-sm font-medium">{% trans 'Receber notificações push' %}</span>
       </label>
+      {{ preferencias_form.receber_notificacoes_push.errors }}
       {{ preferencias_form.frequencia_notificacoes_push|add_class:'form-select mt-2' }}
+      {{ preferencias_form.frequencia_notificacoes_push.errors }}
       {% if preferencias_form.frequencia_notificacoes_push.help_text %}
         <p class="text-xs text-gray-500">{{ preferencias_form.frequencia_notificacoes_push.help_text }}</p>
       {% endif %}
@@ -45,6 +51,7 @@
     <div id="campo-hora-diaria" class="hidden">
       <label for="{{ preferencias_form.hora_notificacao_diaria.id_for_label }}" class="block text-sm font-medium">{% trans 'Horário diário' %}</label>
       {{ preferencias_form.hora_notificacao_diaria|add_class:'form-input mt-1'|attr:'type:time' }}
+      {{ preferencias_form.hora_notificacao_diaria.errors }}
       {% if preferencias_form.hora_notificacao_diaria.help_text %}
         <p class="text-xs text-gray-500">{{ preferencias_form.hora_notificacao_diaria.help_text }}</p>
       {% endif %}
@@ -52,6 +59,7 @@
     <div id="campo-hora-semanal" class="hidden">
       <label for="{{ preferencias_form.hora_notificacao_semanal.id_for_label }}" class="block text-sm font-medium">{% trans 'Horário semanal' %}</label>
       {{ preferencias_form.hora_notificacao_semanal|add_class:'form-input mt-1'|attr:'type:time' }}
+      {{ preferencias_form.hora_notificacao_semanal.errors }}
       {% if preferencias_form.hora_notificacao_semanal.help_text %}
         <p class="text-xs text-gray-500">{{ preferencias_form.hora_notificacao_semanal.help_text }}</p>
       {% endif %}
@@ -59,6 +67,7 @@
     <div id="campo-dia-semanal" class="hidden">
       <label for="{{ preferencias_form.dia_semana_notificacao.id_for_label }}" class="block text-sm font-medium">{% trans 'Dia da semana' %}</label>
       {{ preferencias_form.dia_semana_notificacao|add_class:'form-select mt-1' }}
+      {{ preferencias_form.dia_semana_notificacao.errors }}
       {% if preferencias_form.dia_semana_notificacao.help_text %}
         <p class="text-xs text-gray-500">{{ preferencias_form.dia_semana_notificacao.help_text }}</p>
       {% endif %}
@@ -67,11 +76,13 @@
   <div>
     <label for="{{ preferencias_form.idioma.id_for_label }}" class="block text-sm font-medium">{% trans 'Idioma' %}</label>
     {{ preferencias_form.idioma|add_class:'form-select mt-1'|attr:'tabindex:0' }}
+    {{ preferencias_form.idioma.errors }}
     <p class="text-xs text-gray-500">{% blocktrans %}Idioma atual: {{ LANGUAGE_CODE }}{% endblocktrans %}</p>
   </div>
   <div>
     <label for="{{ preferencias_form.tema.id_for_label }}" class="block text-sm font-medium">{% trans 'Tema' %}</label>
     {{ preferencias_form.tema|add_class:'form-select mt-1'|attr:'tabindex:0' }}
+    {{ preferencias_form.tema.errors }}
   </div>
   <div class="text-right pt-2">
     <button type="submit" aria-label="{% trans 'Salvar Alterações' %}" class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500">{% trans 'Salvar Alterações' %}</button>
@@ -85,9 +96,12 @@
       const freqPush = document.getElementById('{{ preferencias_form.frequencia_notificacoes_push.auto_id }}').value;
       const showDaily = freqEmail === 'diaria' || freqWhats === 'diaria' || freqPush === 'diaria';
       const showWeekly = freqEmail === 'semanal' || freqWhats === 'semanal' || freqPush === 'semanal';
-      document.getElementById('campo-hora-diaria').classList.toggle('hidden', !showDaily);
-      document.getElementById('campo-hora-semanal').classList.toggle('hidden', !showWeekly);
-      document.getElementById('campo-dia-semanal').classList.toggle('hidden', !showWeekly);
+      const hasHoraDiariaError = document.querySelector('#campo-hora-diaria .errorlist') !== null;
+      const hasHoraSemanalError = document.querySelector('#campo-hora-semanal .errorlist') !== null;
+      const hasDiaSemanalError = document.querySelector('#campo-dia-semanal .errorlist') !== null;
+      document.getElementById('campo-hora-diaria').classList.toggle('hidden', !(showDaily || hasHoraDiariaError));
+      document.getElementById('campo-hora-semanal').classList.toggle('hidden', !(showWeekly || hasHoraSemanalError));
+      document.getElementById('campo-dia-semanal').classList.toggle('hidden', !(showWeekly || hasDiaSemanalError));
     }
     const selEmail = document.getElementById('{{ preferencias_form.frequencia_notificacoes_email.auto_id }}');
     const selWhats = document.getElementById('{{ preferencias_form.frequencia_notificacoes_whatsapp.auto_id }}');


### PR DESCRIPTION
## Summary
- mostra mensagens de erro após cada campo de preferências
- mantém campos dinâmicos visíveis quando possuem erros

## Testing
- `pytest` *(fails: tests/feed/test_services.py - SyntaxError: invalid syntax)*

------
https://chatgpt.com/codex/tasks/task_e_68a4fdd1dd5483259bd942628afd3245