### PR TITLE
feat: style contextual configuration templates

### DIFF
--- a/configuracoes/templates/configuracoes/contextual_confirm_delete.html
+++ b/configuracoes/templates/configuracoes/contextual_confirm_delete.html
@@ -1,7 +1,18 @@
+{% extends 'base.html' %}
 {% load i18n %}
-<h1>{% trans "Excluir Configuração" %}</h1>
-<form method="post">
-  {% csrf_token %}
-  <p>{% trans "Tem certeza que deseja excluir esta configuração?" %}</p>
-  <button type="submit">{% trans "Confirmar" %}</button>
-</form>
+
+{% block title %}{% trans "Excluir Configuração" %}{% endblock %}
+
+{% block content %}
+<div class="max-w-4xl mx-auto px-4 py-8">
+  <h1 class="text-2xl font-bold mb-4">{% trans "Excluir Configuração" %}</h1>
+  <form method="post" class="bg-white p-6 rounded-md shadow space-y-4">
+    {% csrf_token %}
+    <p>{% trans "Tem certeza que deseja excluir esta configuração?" %}</p>
+    <div class="flex justify-between pt-4">
+      <a href="{% url 'configuracoes' %}" class="px-4 py-2 bg-gray-200 rounded-lg text-gray-700 hover:bg-gray-300">{% trans "Cancelar" %}</a>
+      <button type="submit" class="px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded-lg">{% trans "Confirmar" %}</button>
+    </div>
+  </form>
+</div>
+{% endblock %}

--- a/configuracoes/templates/configuracoes/contextual_form.html
+++ b/configuracoes/templates/configuracoes/contextual_form.html
@@ -1,7 +1,26 @@
-{% load i18n %}
-<h1>{% trans "Configuração Contextual" %}</h1>
-<form method="post">
-  {% csrf_token %}
-  {{ form.as_p }}
-  <button type="submit">{% trans "Salvar" %}</button>
-</form>
+{% extends 'base.html' %}
+{% load i18n widget_tweaks %}
+
+{% block title %}{% trans "Configuração Contextual" %}{% endblock %}
+
+{% block content %}
+<div class="max-w-4xl mx-auto px-4 py-8">
+  <h1 class="text-2xl font-bold mb-4">{% trans "Configuração Contextual" %}</h1>
+  <form method="post" class="bg-white p-6 rounded-md shadow space-y-4">
+    {% csrf_token %}
+    {% for field in form %}
+      <div>
+        <label for="{{ field.id_for_label }}" class="block text-sm font-medium">{{ field.label }}</label>
+        {{ field|add_class:'w-full p-2 border rounded-lg' }}
+        {% for error in field.errors %}
+          <p role="alert" class="text-red-600 text-sm">{{ error }}</p>
+        {% endfor %}
+      </div>
+    {% endfor %}
+    <div class="flex justify-between pt-4">
+      <a href="{% url 'configuracoes' %}" class="px-4 py-2 bg-gray-200 rounded-lg text-gray-700 hover:bg-gray-300">{% trans "Cancelar" %}</a>
+      <button type="submit" class="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg">{% trans "Salvar" %}</button>
+    </div>
+  </form>
+</div>
+{% endblock %}

--- a/configuracoes/templates/configuracoes/contextual_list.html
+++ b/configuracoes/templates/configuracoes/contextual_list.html
@@ -1,9 +1,20 @@
+{% extends 'base.html' %}
 {% load i18n %}
-<h1>{% trans "Configurações Contextuais" %}</h1>
-<ul>
-  {% for cfg in object_list %}
-    <li>{{ cfg.escopo_tipo }} {{ cfg.escopo_id }} - {{ cfg.tema }}</li>
-  {% empty %}
-    <li>{% trans "Nenhuma configuração" %}</li>
-  {% endfor %}
-</ul>
+
+{% block title %}{% trans "Configurações Contextuais" %}{% endblock %}
+
+{% block content %}
+<div class="max-w-4xl mx-auto px-4 py-8">
+  <h1 class="text-2xl font-bold mb-4">{% trans "Configurações Contextuais" %}</h1>
+  <ul class="space-y-2">
+    {% for cfg in object_list %}
+      <li class="p-4 bg-white rounded-lg shadow">{{ cfg.escopo_tipo }} {{ cfg.escopo_id }} - {{ cfg.tema }}</li>
+    {% empty %}
+      <li class="text-gray-600">{% trans "Nenhuma configuração" %}</li>
+    {% endfor %}
+  </ul>
+  <div class="mt-4">
+    <a href="{% url 'configuracoes' %}" class="text-blue-600 hover:underline">{% trans "Voltar para Configurações" %}</a>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- style contextual list, form, and delete templates with Tailwind and base layout

## Testing
- `pytest tests/configuracoes -k 'not accessibility' -q` *(fails: ModuleNotFoundError: No module named 'django_redis')*


------
https://chatgpt.com/codex/tasks/task_e_68a4fde3f4a88325ab2b9b103ec25a5e