### PR TITLE
Add dashboard filter options

### DIFF
--- a/dashboard/templates/dashboard/partials/filters_form.html
+++ b/dashboard/templates/dashboard/partials/filters_form.html
@@ -21,15 +21,27 @@
   </div>
   <div>
     <label for="organizacao_id" class="block text-sm font-medium text-neutral-700">{% trans 'Organização' %}</label>
-    <select id="organizacao_id" name="organizacao_id" class="mt-1 block border-gray-300 rounded" aria-label="{% trans 'Selecionar organização' %}"></select>
+    <select id="organizacao_id" name="organizacao_id" class="mt-1 block border-gray-300 rounded" aria-label="{% trans 'Selecionar organização' %}">
+      {% for org in organizacoes_permitidas %}
+      <option value="{{ org.id }}" {% if filtros.organizacao_id|default:'' == org.id|stringformat:'s' %}selected{% endif %}>{{ org.nome }}</option>
+      {% endfor %}
+    </select>
   </div>
   <div>
     <label for="nucleo_id" class="block text-sm font-medium text-neutral-700">{% trans 'Núcleo' %}</label>
-    <select id="nucleo_id" name="nucleo_id" class="mt-1 block border-gray-300 rounded" aria-label="{% trans 'Selecionar núcleo' %}"></select>
+    <select id="nucleo_id" name="nucleo_id" class="mt-1 block border-gray-300 rounded" aria-label="{% trans 'Selecionar núcleo' %}">
+      {% for nucleo in nucleos_permitidos %}
+      <option value="{{ nucleo.id }}" {% if filtros.nucleo_id|default:'' == nucleo.id|stringformat:'s' %}selected{% endif %}>{{ nucleo.nome }}</option>
+      {% endfor %}
+    </select>
   </div>
   <div>
     <label for="evento_id" class="block text-sm font-medium text-neutral-700">{% trans 'Evento' %}</label>
-    <select id="evento_id" name="evento_id" class="mt-1 block border-gray-300 rounded" aria-label="{% trans 'Selecionar evento' %}"></select>
+    <select id="evento_id" name="evento_id" class="mt-1 block border-gray-300 rounded" aria-label="{% trans 'Selecionar evento' %}">
+      {% for evento in eventos_permitidos %}
+      <option value="{{ evento.id }}" {% if filtros.evento_id|default:'' == evento.id|stringformat:'s' %}selected{% endif %}>{{ evento.titulo }}</option>
+      {% endfor %}
+    </select>
   </div>
   <div>
     <label for="data_inicio" class="block text-sm font-medium text-neutral-700">{% trans 'Data início' %}</label>


### PR DESCRIPTION
## Summary
- expose allowed organizations, nuclei, and events in dashboard context
- render filter select options from permitted objects

## Testing
- `make test` *(fails: tests/configuracoes/test_accessibility.py, tests/dashboard/test_views.py, tests/e2e/test_notificacoes_e2e.py, tests/e2e/test_pwa_offline.py, tests/feed/test_services.py, tests/notificacoes/test_push_sender.py, tests/test_i18n_templates.py, tests/tokens/test_metrics.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a5015ae41c8325ae66199957ee5149