### PR TITLE
Enable draggable dashboard layout editing

### DIFF
--- a/dashboard/templates/dashboard/layout_form.html
+++ b/dashboard/templates/dashboard/layout_form.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
-{% load i18n %}
+{% load i18n static %}
 {% block title %}{% trans "Layout" %} | Hubx{% endblock %}
 {% block content %}
-<main class="max-w-xl mx-auto p-4" role="main" aria-label="{% trans 'Layout form' %}">
+<main class="max-w-7xl mx-auto p-4" role="main" aria-label="{% trans 'Layout form' %}">
   <h1 class="text-2xl mb-4">{% trans "Layout" %}</h1>
   <form method="post">
     {% csrf_token %}
@@ -14,8 +14,17 @@
       <label for="id_publico" class="block">{{ form.publico.label }}</label>
       {{ form.publico }}
     </div>
-    <input type="hidden" name="layout_json" id="layout_json" value="{}">
+    <input type="hidden" name="layout_json" id="layout_json" value="{{ object.layout_json|default:'{}' }}">
     <button type="submit" class="btn btn-primary">{% trans "Salvar" %}</button>
   </form>
+  {% if layout_save_url %}
+    {% include 'dashboard/partials/metrics_list.html' %}
+  {% endif %}
 </main>
+{% endblock %}
+
+{% block extra_js %}
+  {% if layout_save_url %}
+    <script src="{% static 'dashboard/layout.js' %}"></script>
+  {% endif %}
 {% endblock %}

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -1,5 +1,6 @@
 import csv
 import io
+import json
 import shutil
 from datetime import datetime
 from pathlib import Path
@@ -813,8 +814,38 @@ class DashboardLayoutUpdateView(LoginRequiredMixin, UpdateView):
             return HttpResponse(status=403)
         return super().dispatch(request, *args, **kwargs)
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        layout = self.object
+        context["layout_save_url"] = reverse("dashboard:layout-save", args=[layout.pk])
+        layout_data = layout.layout_json
+        if isinstance(layout_data, str):
+            try:
+                metricas = json.loads(layout_data)
+            except Exception:
+                metricas = []
+        else:
+            metricas = layout_data or []
+        if not metricas:
+            metricas = list(METRICAS_INFO.keys())
+        metrics = DashboardMetricsService.get_metrics(self.request.user, metricas=metricas)
+        context["metricas_iter"] = [
+            {
+                "key": m,
+                "data": metrics[m],
+                "label": METRICAS_INFO[m]["label"],
+                "icon": METRICAS_INFO[m]["icon"],
+            }
+            for m in metricas
+            if m in metrics
+        ]
+        context["metricas_selecionadas"] = metricas
+        return context
+
     def form_valid(self, form):
-        layout_data = self.request.POST.get("layout_json", "{}")
+        layout_data = self.request.POST.get("layout_json")
+        if not layout_data:
+            layout_data = self.get_object().layout_json
         self.object = form.save(self.request.user, layout_data)
         log_layout_action(
             user=self.request.user,


### PR DESCRIPTION
## Summary
- Add layout_save_url and metrics data to DashboardLayoutUpdateView
- Render metrics list and load layout.js for layout editing
- Preserve layout_json via async save endpoint

## Testing
- `pytest --no-cov tests/dashboard/test_layouts.py::test_layout_crud -vv`


------
https://chatgpt.com/codex/tasks/task_e_68a50160f85c83258a80264c196fc6e8