### PR TITLE
Add admin CRUD and API endpoints for custom dashboard metrics

### DIFF
--- a/dashboard/api.py
+++ b/dashboard/api.py
@@ -20,6 +20,7 @@ from .models import DashboardFilter, DashboardCustomMetric
 from .serializers import DashboardFilterSerializer, DashboardCustomMetricSerializer
 from .services import DashboardMetricsService, DashboardService, check_achievements
 from .custom_metrics import DashboardCustomMetricService
+from core.permissions import IsModeratorUser
 
 
 
@@ -146,10 +147,16 @@ class DashboardFilterViewSet(viewsets.ModelViewSet):
         check_achievements(self.request.user)
 
 
-class DashboardCustomMetricViewSet(viewsets.ReadOnlyModelViewSet):
+class DashboardCustomMetricViewSet(viewsets.ModelViewSet):
     queryset = DashboardCustomMetric.objects.all()
     serializer_class = DashboardCustomMetricSerializer
-    permission_classes = [permissions.IsAuthenticated]
+
+    def get_permissions(self):  # type: ignore[override]
+        if self.action in {"list", "retrieve", "execute"}:
+            self.permission_classes = [permissions.IsAuthenticated]
+        else:
+            self.permission_classes = [IsModeratorUser]
+        return super().get_permissions()
 
     @action(detail=True, methods=["get"])
     def execute(self, request, pk=None):

--- a/dashboard/forms.py
+++ b/dashboard/forms.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 from django import forms
 
-from .models import DashboardConfig, DashboardFilter, DashboardLayout
+from .models import (
+    DashboardConfig,
+    DashboardCustomMetric,
+    DashboardFilter,
+    DashboardLayout,
+)
 
 
 class DashboardConfigForm(forms.ModelForm):
@@ -46,3 +51,9 @@ class DashboardLayoutForm(forms.ModelForm):
         if commit:
             instance.save()
         return instance
+
+
+class DashboardCustomMetricForm(forms.ModelForm):
+    class Meta:
+        model = DashboardCustomMetric
+        fields = ["code", "nome", "descricao", "query_spec", "escopo"]

--- a/dashboard/templates/dashboard/admin.html
+++ b/dashboard/templates/dashboard/admin.html
@@ -94,6 +94,10 @@
   <section class="mb-8">
     <h2 class="text-xl font-semibold mb-4">{% trans "Ações Rápidas" %}</h2>
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+      <a href="{% url 'dashboard:custom-metrics' %}" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50">
+        <i class="fa-solid fa-chart-line mb-2"></i>
+        <span class="block">{% trans "Métricas Personalizadas" %}</span>
+      </a>
       <a href="#" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50">
         <i class="fa-solid fa-user-gear mb-2"></i>
         <span class="block">{% trans "Administrar Usuários" %}</span>

--- a/dashboard/templates/dashboard/custom_metric_confirm_delete.html
+++ b/dashboard/templates/dashboard/custom_metric_confirm_delete.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+{% load i18n %}
+{% block title %}{% trans 'Excluir métrica' %}{% endblock %}
+{% block content %}
+<main class="max-w-md mx-auto p-4" role="main">
+  <h1 class="text-2xl font-semibold mb-4">{% trans 'Excluir métrica' %}</h1>
+  <p class="mb-4">{% blocktrans %}Tem certeza que deseja excluir a métrica "{{ object.nome }}"?{% endblocktrans %}</p>
+  <form method="post">
+    {% csrf_token %}
+    <button type="submit" class="px-4 py-2 bg-danger-600 text-white rounded" aria-label="{% trans 'Confirmar exclusão' %}">{% trans 'Excluir' %}</button>
+    <a href="{% url 'dashboard:custom-metrics' %}" class="ml-2 underline" aria-label="{% trans 'Cancelar exclusão' %}">{% trans 'Cancelar' %}</a>
+  </form>
+</main>
+{% endblock %}
+

--- a/dashboard/templates/dashboard/custom_metric_form.html
+++ b/dashboard/templates/dashboard/custom_metric_form.html
@@ -1,0 +1,33 @@
+{% extends 'base.html' %}
+{% load i18n %}
+{% block title %}{% trans 'Métrica personalizada' %}{% endblock %}
+{% block content %}
+<main class="max-w-md mx-auto p-4" role="main">
+  <h1 class="text-2xl font-semibold mb-4">{% trans 'Métrica personalizada' %}</h1>
+  <form method="post" class="space-y-4" aria-label="{% trans 'Formulário de métrica personalizada' %}">
+    {% csrf_token %}
+    <div>
+      <label for="id_code" class="block text-sm font-medium text-neutral-700">{% trans 'Código' %}</label>
+      {{ form.code }}
+    </div>
+    <div>
+      <label for="id_nome" class="block text-sm font-medium text-neutral-700">{% trans 'Nome' %}</label>
+      {{ form.nome }}
+    </div>
+    <div>
+      <label for="id_descricao" class="block text-sm font-medium text-neutral-700">{% trans 'Descrição' %}</label>
+      {{ form.descricao }}
+    </div>
+    <div>
+      <label for="id_query_spec" class="block text-sm font-medium text-neutral-700">{% trans 'Query spec' %}</label>
+      {{ form.query_spec }}
+    </div>
+    <div>
+      <label for="id_escopo" class="block text-sm font-medium text-neutral-700">{% trans 'Escopo' %}</label>
+      {{ form.escopo }}
+    </div>
+    <button type="submit" class="px-4 py-2 bg-primary-600 text-white rounded" aria-label="{% trans 'Salvar métrica' %}">{% trans 'Salvar' %}</button>
+  </form>
+</main>
+{% endblock %}
+

--- a/dashboard/templates/dashboard/custom_metric_list.html
+++ b/dashboard/templates/dashboard/custom_metric_list.html
@@ -1,0 +1,24 @@
+{% extends 'base.html' %}
+{% load i18n %}
+{% block title %}{% trans 'Métricas personalizadas' %}{% endblock %}
+{% block content %}
+<main class="max-w-2xl mx-auto p-4" role="main">
+  <h1 class="text-2xl font-semibold mb-4">{% trans 'Métricas personalizadas' %}</h1>
+  {% include 'dashboard/partials/messages.html' %}
+  <a href="{% url 'dashboard:custom-metric-create' %}" class="inline-block mb-4 px-4 py-2 bg-primary-600 text-white rounded" aria-label="{% trans 'Nova métrica' %}">{% trans 'Nova métrica' %}</a>
+  <ul class="space-y-2">
+    {% for m in object_list %}
+      <li class="flex justify-between items-center p-2 bg-white rounded shadow">
+        <span>{{ m.nome }}</span>
+        <div class="space-x-2">
+          <a href="{% url 'dashboard:custom-metric-edit' m.pk %}" class="text-primary-600 underline" aria-label="{% trans 'Editar métrica' %}">{% trans 'Editar' %}</a>
+          <a href="{% url 'dashboard:custom-metric-delete' m.pk %}" class="text-danger-600 underline" aria-label="{% trans 'Excluir métrica' %}">{% trans 'Excluir' %}</a>
+        </div>
+      </li>
+    {% empty %}
+      <li>{% trans 'Nenhuma métrica cadastrada.' %}</li>
+    {% endfor %}
+  </ul>
+</main>
+{% endblock %}
+

--- a/dashboard/templates/dashboard/root.html
+++ b/dashboard/templates/dashboard/root.html
@@ -58,6 +58,10 @@
         <i class="fa-solid fa-wrench mb-2"></i>
         <span class="block">{% trans "Django Admin" %}</span>
       </a>
+      <a href="{% url 'dashboard:custom-metrics' %}" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50">
+        <i class="fa-solid fa-chart-line mb-2"></i>
+        <span class="block">{% trans "Métricas Personalizadas" %}</span>
+      </a>
     </div>
   </section>
 

--- a/dashboard/urls.py
+++ b/dashboard/urls.py
@@ -36,4 +36,9 @@ urlpatterns = [
     path("layouts/<int:pk>/delete/", views.DashboardLayoutDeleteView.as_view(), name="layout-delete"),
     path("layouts/<int:pk>/save/", views.DashboardLayoutSaveView.as_view(), name="layout-save"),
 
+    path("custom-metrics/", views.DashboardCustomMetricListView.as_view(), name="custom-metrics"),
+    path("custom-metrics/create/", views.DashboardCustomMetricCreateView.as_view(), name="custom-metric-create"),
+    path("custom-metrics/<int:pk>/edit/", views.DashboardCustomMetricUpdateView.as_view(), name="custom-metric-edit"),
+    path("custom-metrics/<int:pk>/delete/", views.DashboardCustomMetricDeleteView.as_view(), name="custom-metric-delete"),
+
 ]

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -40,10 +40,16 @@ from core.permissions import (
     SuperadminRequiredMixin,
 )
 
-from .forms import DashboardConfigForm, DashboardFilterForm, DashboardLayoutForm
+from .forms import (
+    DashboardConfigForm,
+    DashboardCustomMetricForm,
+    DashboardFilterForm,
+    DashboardLayoutForm,
+)
 from .models import (
     Achievement,
     DashboardConfig,
+    DashboardCustomMetric,
     DashboardFilter,
     DashboardLayout,
     UserAchievement,
@@ -860,3 +866,34 @@ class DashboardLayoutSaveView(LoginRequiredMixin, View):
                 ip_address=request.META.get("REMOTE_ADDR", ""),
             )
         return HttpResponse(status=204)
+
+
+class DashboardCustomMetricListView(AdminRequiredMixin, LoginRequiredMixin, ListView):
+    model = DashboardCustomMetric
+    template_name = "dashboard/custom_metric_list.html"
+
+
+class DashboardCustomMetricCreateView(AdminRequiredMixin, LoginRequiredMixin, CreateView):
+    model = DashboardCustomMetric
+    form_class = DashboardCustomMetricForm
+    template_name = "dashboard/custom_metric_form.html"
+
+    def get_success_url(self):
+        return reverse("dashboard:custom-metrics")
+
+
+class DashboardCustomMetricUpdateView(AdminRequiredMixin, LoginRequiredMixin, UpdateView):
+    model = DashboardCustomMetric
+    form_class = DashboardCustomMetricForm
+    template_name = "dashboard/custom_metric_form.html"
+
+    def get_success_url(self):
+        return reverse("dashboard:custom-metrics")
+
+
+class DashboardCustomMetricDeleteView(AdminRequiredMixin, LoginRequiredMixin, DeleteView):
+    model = DashboardCustomMetric
+    template_name = "dashboard/custom_metric_confirm_delete.html"
+
+    def get_success_url(self):
+        return reverse("dashboard:custom-metrics")

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -50,6 +50,11 @@ urlpatterns = [
         include(("agenda.api_urls", "agenda_api"), namespace="agenda_api"),
     ),
 
+    path(
+        "api/dashboard/",
+        include(("dashboard.api_urls", "dashboard_api"), namespace="dashboard_api"),
+    ),
+
 
     path("jsi18n/", JavaScriptCatalog.as_view(), name="javascript-catalog"),
 


### PR DESCRIPTION
## Summary
- add Django views/templates for admins to manage custom dashboard metrics
- expand API `DashboardCustomMetricViewSet` to full CRUD with admin-only write access
- link metric management from admin and root dashboards

## Testing
- `pytest tests/dashboard/test_custom_metrics.py -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68a50164d6a48325a47853c28561d563