### PR TITLE
Restrict dashboard export actions by user type

### DIFF
--- a/dashboard/templates/dashboard/partials/filters_form.html
+++ b/dashboard/templates/dashboard/partials/filters_form.html
@@ -52,6 +52,7 @@
   </fieldset>
   <div class="flex gap-2 mt-4">
     <button type="submit" class="px-4 py-2 bg-primary-600 text-white rounded focus:outline-none focus:ring" aria-label="{% trans 'Aplicar filtros' %}">{% trans 'Filtrar' %}</button>
+    {% if can_export %}
     <select name="formato" class="border-gray-300 rounded" aria-label="{% trans 'Formato de exportação' %}">
       <option value="csv">{% trans 'CSV' %}</option>
       <option value="pdf">{% trans 'PDF' %}</option>
@@ -59,6 +60,7 @@
       <option value="png">{% trans 'PNG' %}</option>
     </select>
     <button type="submit" formaction="{% url 'dashboard:export' %}" class="px-4 py-2 bg-neutral-200 text-neutral-800 rounded focus:outline-none focus:ring" aria-label="{% trans 'Exportar métricas' %}">{% trans 'Exportar' %}</button>
+    {% endif %}
     <a href="{% url 'dashboard:filter-create' %}?{{ request.GET.urlencode }}" class="px-4 py-2 bg-neutral-200 text-neutral-800 rounded focus:outline-none focus:ring" aria-label="{% trans 'Salvar filtro rápido' %}">{% trans 'Salvar filtro' %}</a>
     <a href="{% url 'dashboard:filters' %}" class="px-4 py-2 bg-neutral-200 text-neutral-800 rounded focus:outline-none focus:ring" aria-label="{% trans 'Ver filtros salvos' %}">{% trans 'Meus filtros' %}</a>
     <a href="{% url 'dashboard:config-create' %}?{{ request.GET.urlencode }}" class="px-4 py-2 bg-neutral-200 text-neutral-800 rounded focus:outline-none focus:ring" aria-label="{% trans 'Salvar configuração' %}">{% trans 'Salvar configuração' %}</a>

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -169,6 +169,11 @@ class DashboardBaseView(LoginRequiredMixin, TemplateView):
         context["periodo"] = getattr(self, "periodo", "mensal")
         context["escopo"] = getattr(self, "escopo", "auto")
         context["filtros"] = getattr(self, "filters", {})
+        context["can_export"] = self.request.user.user_type in {
+            UserType.ROOT,
+            UserType.ADMIN,
+            UserType.COORDENADOR,
+        }
         metricas = self.filters.get("metricas") if hasattr(self, "filters") else None
         metricas = metricas or [
             "num_users",

--- a/tests/dashboard/test_views.py
+++ b/tests/dashboard/test_views.py
@@ -93,6 +93,27 @@ def test_cliente_dashboard_view(client, cliente_user):
     assert "Dashboard Cliente" in resp.content.decode()
 
 
+@pytest.mark.parametrize(
+    "user_fixture, url_name",
+    [
+        ("root_user", "dashboard:root"),
+        ("admin_user", "dashboard:admin"),
+        ("gerente_user", "dashboard:gerente"),
+    ],
+)
+def test_can_export_true_for_privileged_users(client, request, user_fixture, url_name):
+    user = request.getfixturevalue(user_fixture)
+    client.force_login(user)
+    resp = client.get(reverse(url_name))
+    assert resp.context["can_export"] is True
+
+
+def test_can_export_false_for_cliente(client, cliente_user):
+    client.force_login(cliente_user)
+    resp = client.get(reverse("dashboard:cliente"))
+    assert resp.context["can_export"] is False
+
+
 def test_base_view_accepts_params(monkeypatch, client, admin_user):
     client.force_login(admin_user)
 


### PR DESCRIPTION
## Summary
- expose `can_export` context flag for dashboards when user is ROOT, ADMIN or COORDENADOR
- render export controls only when `can_export`
- add tests for export permission flag

## Testing
- `python manage.py check`
- `pytest tests/dashboard/test_views.py::test_can_export_true_for_privileged_users tests/dashboard/test_views.py::test_can_export_false_for_cliente -q` *(fails: ModuleNotFoundError: No module named 'django_redis')*


------
https://chatgpt.com/codex/tasks/task_e_68a5016742d083258f830b300495d757