### PR TITLE
Enable voting on discussion replies

### DIFF
--- a/discussao/templates/discussao/comentario_item.html
+++ b/discussao/templates/discussao/comentario_item.html
@@ -18,6 +18,12 @@
         <button type="submit" class="text-green-600 text-xs">{% trans "Marcar como resolvido" %}</button>
       </form>
     {% endif %}
+      <div class="flex items-center gap-1">
+        <button hx-post="{% url 'discussao:interacao' resposta_content_type_id comentario.id 'up' %}" hx-swap="none" hx-on:afterRequest="document.getElementById('comment-score-{{ comentario.id }}').innerText = event.detail.xhr.responseJSON.score; document.getElementById('comment-votes-{{ comentario.id }}').innerText = event.detail.xhr.responseJSON.num_votos">&#9650;</button>
+        <span id="comment-score-{{ comentario.id }}">{{ comentario.score }}</span>
+        <span class="text-xs">(<span id="comment-votes-{{ comentario.id }}">{{ comentario.num_votos }}</span>)</span>
+        <button hx-post="{% url 'discussao:interacao' resposta_content_type_id comentario.id 'down' %}" hx-swap="none" hx-on:afterRequest="document.getElementById('comment-score-{{ comentario.id }}').innerText = event.detail.xhr.responseJSON.score; document.getElementById('comment-votes-{{ comentario.id }}').innerText = event.detail.xhr.responseJSON.num_votos">&#9660;</button>
+      </div>
     </div>
   </header>
   <div class="prose max-w-none text-sm">{{ comentario.conteudo|linebreaks }}</div>

--- a/discussao/templates/discussao/topico_detail.html
+++ b/discussao/templates/discussao/topico_detail.html
@@ -1,6 +1,6 @@
 {% if partial %}
   {% for comentario in comentarios %}
-    {% include 'discussao/comentario_item.html' with comentario=comentario user=user topico=topico %}
+    {% include 'discussao/comentario_item.html' with comentario=comentario user=user topico=topico resposta_content_type_id=resposta_content_type_id %}
   {% endfor %}
 {% else %}
 {% extends 'base.html' %}
@@ -36,10 +36,10 @@
   <section aria-labelledby="comentarios" class="space-y-4">
     <h2 id="comentarios" class="text-xl font-semibold">{% trans "Coment\u00e1rios" %}</h2>
     {% if melhor_resposta %}
-      {% include 'discussao/comentario_item.html' with comentario=melhor_resposta user=user topico=topico melhor=True %}
+      {% include 'discussao/comentario_item.html' with comentario=melhor_resposta user=user topico=topico melhor=True resposta_content_type_id=resposta_content_type_id %}
     {% endif %}
     <div id="lista-comentarios">
-      {% include 'discussao/topico_detail.html' with partial=True topico=topico user=user only %}
+      {% include 'discussao/topico_detail.html' with partial=True topico=topico user=user resposta_content_type_id=resposta_content_type_id only %}
     </div>
     {% if comentarios.has_previous or comentarios.has_next %}
     <div class="flex justify-center gap-3 text-sm">

--- a/discussao/views.py
+++ b/discussao/views.py
@@ -246,6 +246,7 @@ class TopicoDetailView(LoginRequiredMixin, DetailView):
         context["comentarios"] = comentarios
         context["melhor_resposta"] = melhor
         context["content_type_id"] = ContentType.objects.get_for_model(TopicoDiscussao).id
+        context["resposta_content_type_id"] = ContentType.objects.get_for_model(RespostaDiscussao).id
         return context
 
 


### PR DESCRIPTION
## Summary
- show up/downvote controls with score and vote count on each comment
- supply RespostaDiscussao content type in topic detail for voting

## Testing
- `pytest tests/discussao/test_api.py -q` *(fails: NoReverseMatch: 'dashboard' is not a registered namespace)*

------
https://chatgpt.com/codex/tasks/task_e_68a504b7e48c8325adaee478497cb14f