### PR TITLE
Add conditional edit links and deadline validation tests

### DIFF
--- a/discussao/templates/discussao/comentario_item.html
+++ b/discussao/templates/discussao/comentario_item.html
@@ -5,6 +5,9 @@
       {{ comentario.autor.get_full_name|default:comentario.autor.username }} - {{ comentario.created|date:"SHORT_DATETIME_FORMAT" }}
     </div>
     <div class="flex items-center gap-2">
+    {% if comentario.pode_editar %}
+      <a href="{% url 'discussao:resposta_editar' comentario.id %}" class="text-blue-600 text-xs">{% trans "Editar" %}</a>
+    {% endif %}
     {% if user == comentario.autor or user.get_tipo_usuario in ['admin','coordenador','root'] %}
       <form method="post" hx-delete="{% url 'discussao:delete_comment' comentario.id %}" hx-target="#coment-{{ comentario.id }}" hx-swap="delete">
         {% csrf_token %}

--- a/discussao/templates/discussao/topico_detail.html
+++ b/discussao/templates/discussao/topico_detail.html
@@ -16,6 +16,9 @@
       {% endif %}
     </h1>
     <p class="text-sm text-neutral-600">{% trans "Por" %} {{ topico.autor.get_full_name|default:topico.autor.username }} · {{ topico.created|date:SHORT_DATETIME_FORMAT }}</p>
+    {% if pode_editar_topico %}
+      <a href="{% url 'discussao:topico_editar' topico.categoria.slug topico.slug %}" class="text-sm text-blue-600">{% trans "Editar" %}</a>
+    {% endif %}
     {% if user == topico.autor or user.get_tipo_usuario in ['admin','root'] %}
     <form method="post" hx-post="{% url 'discussao:topico_resolver' topico.categoria.slug topico.slug %}" hx-target="#topico-container" hx-swap="outerHTML" class="mt-2">
       {% csrf_token %}


### PR DESCRIPTION
## Summary
- Show edit links in topic and comment templates when within edit window
- Redirect with feedback when edit time expires
- Cover edit deadline behavior with tests

## Testing
- `pytest tests/discussao/test_views.py::test_resposta_edicao_limite tests/discussao/test_views.py::test_topico_edicao_limite --no-cov -q`

------
https://chatgpt.com/codex/tasks/task_e_68a504c254a48325a44bcd72937415f9