### PR TITLE
Add filtering selects to discussao categories view with HTMX updates

### DIFF
--- a/discussao/templates/discussao/categorias.html
+++ b/discussao/templates/discussao/categorias.html
@@ -1,14 +1,5 @@
-{% extends 'base.html' %}
 {% load i18n %}
-{% block title %}{% trans 'Categorias' %} | HubX{% endblock %}
-{% block content %}
-<div class="max-w-4xl mx-auto px-4 py-10">
-  <div class="flex items-center mb-6">
-    <h1 class="text-2xl font-bold text-neutral-900">{% trans 'Categorias' %}</h1>
-    {% if user.user_type in ('admin','coordenador','root') %}
-    <a href="{% url 'discussao:categoria_criar' %}" class="ml-auto bg-primary-600 hover:bg-primary-700 text-white font-semibold py-2 px-4 rounded-xl">{% trans 'Novo' %}</a>
-    {% endif %}
-  </div>
+{% if partial %}
   <ul class="space-y-3">
     {% for categoria in categorias %}
     <li class="p-4 bg-white border border-neutral-200 rounded-xl flex justify-between items-center">
@@ -24,5 +15,45 @@
     {% include 'pagination.html' %}
   </div>
   {% endif %}
+{% else %}
+{% extends 'base.html' %}
+{% load i18n %}
+{% block title %}{% trans 'Categorias' %} | HubX{% endblock %}
+{% block content %}
+<div class="max-w-4xl mx-auto px-4 py-10">
+  <div class="flex items-center mb-6">
+    <h1 class="text-2xl font-bold text-neutral-900">{% trans 'Categorias' %}</h1>
+    {% if user.user_type == 'admin' or user.user_type == 'coordenador' or user.user_type == 'root' %}
+    <a href="{% url 'discussao:categoria_criar' %}" class="ml-auto bg-primary-600 hover:bg-primary-700 text-white font-semibold py-2 px-4 rounded-xl">{% trans 'Novo' %}</a>
+    {% endif %}
+  </div>
+  <form id="filtros" class="mb-6 flex flex-col sm:flex-row gap-3">
+    {% if user.user_type == 'root' %}
+    <select name="organizacao" class="form-select" hx-get="?" hx-target="#lista-categorias" hx-include="#filtros">
+      <option value="">{% trans 'Organização' %}</option>
+      {% for o in organizacoes %}
+      <option value="{{ o.id }}" {% if organizacao_id == o.id %}selected{% endif %}>{{ o.nome }}</option>
+      {% endfor %}
+    </select>
+    {% endif %}
+    <select name="nucleo" class="form-select" hx-get="?" hx-target="#lista-categorias" hx-include="#filtros">
+      <option value="">{% trans 'Núcleo' %}</option>
+      {% for n in nucleos %}
+      <option value="{{ n.id }}" {% if nucleo_id == n.id %}selected{% endif %}>{{ n.nome }}</option>
+      {% endfor %}
+    </select>
+    <select name="evento" class="form-select" hx-get="?" hx-target="#lista-categorias" hx-include="#filtros">
+      <option value="">{% trans 'Evento' %}</option>
+      {% for e in eventos %}
+      <option value="{{ e.id }}" {% if evento_id == e.id %}selected{% endif %}>{{ e.titulo }}</option>
+      {% endfor %}
+    </select>
+    <noscript><button type="submit" class="bg-neutral-200 text-neutral-800 px-4 py-2 rounded-xl text-sm hover:bg-neutral-300">{% trans 'Filtrar' %}</button></noscript>
+  </form>
+  <div id="lista-categorias">
+    {% include 'discussao/categorias.html' with partial=True %}
+  </div>
 </div>
 {% endblock %}
+{% endif %}
+


### PR DESCRIPTION
## Summary
- add organization, nucleus and event filtering UI for categories
- support HTMX-powered category list updates
- expose related choices in CategoriaListView

## Testing
- `pytest tests/discussao/test_views.py::test_categoria_list_view_org_filter tests/discussao/test_views.py::test_categoria_list_view_root_sees_all -q` *(fails: 'empresas' is not a registered namespace)*

------
https://chatgpt.com/codex/tasks/task_e_68a504ca5ca88325b9a50e5c0302e436