### PR TITLE
feat(discussao): add report buttons

### DIFF
--- a/discussao/templates/discussao/comentario_item.html
+++ b/discussao/templates/discussao/comentario_item.html
@@ -18,10 +18,18 @@
         <button type="submit" class="text-green-600 text-xs">{% trans "Marcar como resolvido" %}</button>
       </form>
     {% endif %}
+    <button type="button" class="text-red-600 text-xs" onclick="document.getElementById('denuncia-comentario-{{ comentario.id }}').classList.toggle('hidden')">{% trans "Denunciar" %}</button>
     </div>
   </header>
   <div class="prose max-w-none text-sm">{{ comentario.conteudo|linebreaks }}</div>
   {% if topico.melhor_resposta_id == comentario.id %}
     <div class="text-xs text-green-700 font-semibold mt-2">{% trans "Melhor resposta" %}</div>
   {% endif %}
+  <form id="denuncia-comentario-{{ comentario.id }}" class="hidden mt-2" hx-post="{% url 'discussao_api:denuncia-list' %}" hx-swap="none" hx-on:afterRequest="this.reset(); this.classList.add('hidden'); alert('{% trans "Denúncia enviada" %}');" hx-on:error="alert('{% trans "Erro ao enviar denúncia" %}');">
+    {% csrf_token %}
+    <input type="hidden" name="content_type_id" value="{{ resposta_content_type_id }}">
+    <input type="hidden" name="object_id" value="{{ comentario.id }}">
+    <textarea name="motivo" required class="form-textarea w-full" placeholder="{% trans "Motivo da denúncia" %}"></textarea>
+    <button type="submit" class="mt-1 bg-red-600 text-white px-3 py-1 text-xs rounded">{% trans "Enviar" %}</button>
+  </form>
 </article>

--- a/discussao/templates/discussao/topico_detail.html
+++ b/discussao/templates/discussao/topico_detail.html
@@ -1,6 +1,6 @@
 {% if partial %}
   {% for comentario in comentarios %}
-    {% include 'discussao/comentario_item.html' with comentario=comentario user=user topico=topico %}
+    {% include 'discussao/comentario_item.html' with comentario=comentario user=user topico=topico resposta_content_type_id=resposta_content_type_id %}
   {% endfor %}
 {% else %}
 {% extends 'base.html' %}
@@ -31,15 +31,25 @@
       <span id="topic-score">{{ topico.score }}</span>
       <button hx-post="{% url 'discussao:interacao' content_type_id topico.id 'down' %}" hx-swap="none" hx-on:afterRequest="document.getElementById('topic-score').innerText = event.detail.xhr.responseJSON.score">&#9660;</button>
     </div>
+    <div class="mt-2">
+      <button type="button" class="text-xs text-red-600" onclick="document.getElementById('denuncia-topico-form').classList.toggle('hidden')">{% trans "Denunciar" %}</button>
+      <form id="denuncia-topico-form" class="hidden mt-2" hx-post="{% url 'discussao_api:denuncia-list' %}" hx-swap="none" hx-on:afterRequest="this.reset(); this.classList.add('hidden'); alert('{% trans "Denúncia enviada" %}');" hx-on:error="alert('{% trans "Erro ao enviar denúncia" %}');">
+        {% csrf_token %}
+        <input type="hidden" name="content_type_id" value="{{ content_type_id }}">
+        <input type="hidden" name="object_id" value="{{ topico.id }}">
+        <textarea name="motivo" required class="form-textarea w-full" placeholder="{% trans "Motivo da denúncia" %}"></textarea>
+        <button type="submit" class="mt-1 bg-red-600 text-white px-3 py-1 text-xs rounded">{% trans "Enviar" %}</button>
+      </form>
+    </div>
   </header>
   <div class="prose max-w-none mb-10">{{ topico.conteudo|linebreaks }}</div>
   <section aria-labelledby="comentarios" class="space-y-4">
     <h2 id="comentarios" class="text-xl font-semibold">{% trans "Coment\u00e1rios" %}</h2>
     {% if melhor_resposta %}
-      {% include 'discussao/comentario_item.html' with comentario=melhor_resposta user=user topico=topico melhor=True %}
+      {% include 'discussao/comentario_item.html' with comentario=melhor_resposta user=user topico=topico melhor=True resposta_content_type_id=resposta_content_type_id %}
     {% endif %}
     <div id="lista-comentarios">
-      {% include 'discussao/topico_detail.html' with partial=True topico=topico user=user only %}
+      {% include 'discussao/topico_detail.html' with partial=True topico=topico user=user resposta_content_type_id=resposta_content_type_id only %}
     </div>
     {% if comentarios.has_previous or comentarios.has_next %}
     <div class="flex justify-center gap-3 text-sm">

--- a/discussao/views.py
+++ b/discussao/views.py
@@ -246,6 +246,7 @@ class TopicoDetailView(LoginRequiredMixin, DetailView):
         context["comentarios"] = comentarios
         context["melhor_resposta"] = melhor
         context["content_type_id"] = ContentType.objects.get_for_model(TopicoDiscussao).id
+        context["resposta_content_type_id"] = ContentType.objects.get_for_model(RespostaDiscussao).id
         return context
 
 


### PR DESCRIPTION
## Summary
- add "Denunciar" form to topic detail view
- allow reporting individual comments
- expose comment content type id for Denuncia API

## Testing
- `pytest tests/discussao/test_denuncia_api.py -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68a504ce708c8325931403bbda592b2f