### PR TITLE
Add templates for reply and topic delete confirmation

### DIFF
--- a/discussao/templates/discussao/resposta_form.html
+++ b/discussao/templates/discussao/resposta_form.html
@@ -1,0 +1,30 @@
+{% extends 'base.html' %}
+{% load widget_tweaks i18n %}
+{% block title %}{% trans 'Responder Tópico' %} | HubX{% endblock %}
+{% block content %}
+<section class="max-w-2xl mx-auto px-4 py-10">
+  <h1 class="text-2xl font-bold text-neutral-900 mb-6">{% trans 'Responder Tópico' %}</h1>
+  <form method="post" enctype="multipart/form-data" class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 space-y-6">
+    {% csrf_token %}
+    <div>
+      <label for="{{ form.conteudo.id_for_label }}" class="block text-sm font-medium text-neutral-700 mb-1">{{ form.conteudo.label }}</label>
+      {{ form.conteudo|add_class:'form-textarea' }}
+      {% if form.conteudo.errors %}<p class="text-sm text-red-600 mt-1">{{ form.conteudo.errors.0 }}</p>{% endif %}
+    </div>
+    <div>
+      <label for="{{ form.arquivo.id_for_label }}" class="block text-sm font-medium text-neutral-700 mb-1">{{ form.arquivo.label }}</label>
+      {{ form.arquivo|add_class:'form-input' }}
+      {% if form.arquivo.errors %}<p class="text-sm text-red-600 mt-1">{{ form.arquivo.errors.0 }}</p>{% endif %}
+    </div>
+    <div>
+      <label for="{{ form.reply_to.id_for_label }}" class="block text-sm font-medium text-neutral-700 mb-1">{{ form.reply_to.label }}</label>
+      {{ form.reply_to|add_class:'form-select' }}
+      {% if form.reply_to.errors %}<p class="text-sm text-red-600 mt-1">{{ form.reply_to.errors.0 }}</p>{% endif %}
+    </div>
+    <div class="flex justify-end gap-3 pt-4 border-t border-neutral-100">
+      <a href="{% url 'discussao:topico_detalhe' topico.categoria.slug topico.slug %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100">{% trans 'Cancelar' %}</a>
+      <button type="submit" class="text-sm px-4 py-2 rounded-xl bg-primary-600 text-white hover:bg-primary-700">{% trans 'Publicar' %}</button>
+    </div>
+  </form>
+</section>
+{% endblock %}

--- a/discussao/templates/discussao/topico_confirm_delete.html
+++ b/discussao/templates/discussao/topico_confirm_delete.html
@@ -1,0 +1,13 @@
+{% extends 'base.html' %}
+{% load i18n %}
+{% block title %}{% trans 'Remover Tópico' %} | HubX{% endblock %}
+{% block content %}
+<div class="max-w-md mx-auto px-4 py-10 text-center">
+  <h1 class="text-xl font-bold mb-4">{% trans 'Remover Tópico' %}</h1>
+  <p class="mb-6">{% trans 'Tem certeza que deseja remover este tópico?' %}</p>
+  <form method="post">
+    {% csrf_token %}
+    <button type="submit" class="bg-red-600 hover:bg-red-700 text-white font-semibold py-2 px-4 rounded-xl">{% trans 'Confirmar' %}</button>
+  </form>
+</div>
+{% endblock %}

--- a/discussao/views.py
+++ b/discussao/views.py
@@ -321,6 +321,9 @@ class TopicoDeleteView(LoginRequiredMixin, DeleteView):
     def delete(self, request, *args, **kwargs):  # type: ignore[override]
         response = super().delete(request, *args, **kwargs)
         cache.clear()
+        if request.headers.get("Hx-Request"):
+            return HttpResponse("")
+        messages.success(request, gettext_lazy("Tópico removido"))
         return response
 
 
@@ -335,6 +338,11 @@ class RespostaCreateView(LoginRequiredMixin, CreateView):
         if request.user.user_type != UserType.ROOT and request.user.organizacao != self.categoria.organizacao:
             return HttpResponseForbidden()
         return super().dispatch(request, *args, **kwargs)
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["topico"] = self.topico
+        return context
 
     def form_valid(self, form):
         if self.topico.fechado:


### PR DESCRIPTION
## Summary
- add reply and topic delete templates
- wire views to serve templates and show messages when needed
- support `topico_remover` without HTMX

## Testing
- `pytest tests/discussao/test_views.py::test_topico_delete_view tests/discussao/test_views.py::test_topico_delete_view_rejects_late_deletion tests/discussao/test_views.py::test_resposta_create tests/discussao/test_views.py::test_resposta_create_reply -q --disable-warnings --maxfail=1 --no-cov`

------
https://chatgpt.com/codex/tasks/task_e_68a504d489c4832595da5eb4133d997c