### PR TITLE
Add organization filter to empresa list

### DIFF
--- a/empresas/templates/empresas/lista.html
+++ b/empresas/templates/empresas/lista.html
@@ -34,6 +34,15 @@
       <input type="text" id="estado" name="estado" value="{{ request.GET.estado }}" class="w-full p-2 border rounded" />
     </div>
     <div>
+      <label for="organizacao" class="block text-sm font-medium text-neutral-700">{% translate "Organização" %}</label>
+      <select id="organizacao" name="organizacao" class="w-full p-2 border rounded">
+        <option value="">{% translate "Todas" %}</option>
+        {% for org in organizacoes %}
+          <option value="{{ org.id }}" {% if request.GET.organizacao == org.id|stringformat:'s' %}selected{% endif %}>{{ org.nome }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div>
       <label for="tags" class="block text-sm font-medium text-neutral-700">{% translate "Tags" %}</label>
       <select id="tags" name="tags" multiple class="w-full p-2 border rounded select2">
         {% for tag in tags %}


### PR DESCRIPTION
## Summary
- add organization dropdown to empresa list search form
- expose available organizations in EmpresaListView context
- map organizacao querystring to organizacao_id for search service

## Testing
- ⚠️ `pytest tests/empresas/test_search.py::test_filter_by_single_tag -vv` *(KeyboardInterrupt: tests did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68a50fd075b88325833d7ab34e097372