### PR TITLE
Add parent field with autocomplete to tag management

### DIFF
--- a/empresas/forms.py
+++ b/empresas/forms.py
@@ -102,6 +102,15 @@ class TagForm(forms.ModelForm):
         model = Tag
         fields = ["nome", "categoria", "parent"]
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["parent"].widget = TagWidget(
+            attrs={
+                "data-placeholder": _("Buscar item pai..."),
+                "data-minimum-input-length": 2,
+            }
+        )
+
 
 class EmpresaWidget(s2forms.ModelSelect2Widget):
     search_fields = [

--- a/empresas/templates/empresas/tag_form.html
+++ b/empresas/templates/empresas/tag_form.html
@@ -19,6 +19,11 @@
       {{ form.categoria|add_class:'w-full p-2 border rounded' }}
       {% if form.categoria.errors %}<p class="text-sm text-red-600">{{ form.categoria.errors }}</p>{% endif %}
     </div>
+    <div>
+      <label for="{{ form.parent.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.parent.label }}</label>
+      {{ form.parent|add_class:'w-full p-2 border rounded' }}
+      {% if form.parent.errors %}<p class="text-sm text-red-600">{{ form.parent.errors }}</p>{% endif %}
+    </div>
     <div class="flex justify-end gap-3 border-t pt-4">
       <a href="{% url 'empresas:tags_list' %}" class="px-4 py-2 text-sm border rounded">{% translate 'Cancelar' %}</a>
       <button type="submit" class="px-4 py-2 text-sm bg-primary-600 text-white rounded hover:bg-primary-700">{% translate 'Salvar' %}</button>

--- a/empresas/templates/empresas/tags_list.html
+++ b/empresas/templates/empresas/tags_list.html
@@ -32,6 +32,7 @@
       <tr>
         <th class="px-3 py-2 text-left font-semibold">{% translate 'Nome' %}</th>
         <th class="px-3 py-2 text-left font-semibold">{% translate 'Categoria' %}</th>
+        <th class="px-3 py-2 text-left font-semibold">{% translate 'Item Pai' %}</th>
         <th class="px-3 py-2 text-center font-semibold">{% translate 'Ações' %}</th>
       </tr>
     </thead>
@@ -40,6 +41,7 @@
       <tr>
         <td class="px-3 py-2">{{ tag.nome }}</td>
         <td class="px-3 py-2">{{ tag.get_categoria_display }}</td>
+        <td class="px-3 py-2">{{ tag.parent }}</td>
         <td class="px-3 py-2 text-center space-x-2">
           <a href="{% url 'empresas:tags_update' tag.id %}" class="text-blue-600 hover:underline">{% translate 'Editar' %}</a>
           <a href="{% url 'empresas:tags_delete' tag.id %}" class="text-red-600 hover:underline">{% translate 'Remover' %}</a>


### PR DESCRIPTION
## Summary
- add select2 widget for parent tag in form
- show parent tag in tag list view
- render parent field in tag form

## Testing
- `pytest empresas/tests/test_forms.py empresas/tests/test_search_tags.py --no-cov`

------
https://chatgpt.com/codex/tasks/task_e_68a50fd5ac4883259354fef00379395c