### PR TITLE
Consolida rotas de empresas em único router

### DIFF
--- a/empresas/api_urls.py
+++ b/empresas/api_urls.py
@@ -1,19 +1,14 @@
 from rest_framework.routers import DefaultRouter
-from .api import EmpresaViewSet, TagViewSet
+
+from .api import ContatoEmpresaViewSet, EmpresaViewSet, TagViewSet
 
 router = DefaultRouter()
-router.register(r"empresas", EmpresaViewSet, basename="empresa")
-router.register("empresas/tags", TagViewSet)
-
-from .api import ContatoEmpresaViewSet, EmpresaViewSet
-
-router = DefaultRouter()
+router.register("empresas/tags", TagViewSet, basename="tag")
 router.register(r"empresas", EmpresaViewSet, basename="empresa")
 router.register(
     r"empresas/(?P<empresa_pk>[^/.]+)/contatos",
     ContatoEmpresaViewSet,
     basename="contato-empresa",
 )
-
 
 urlpatterns = router.urls

--- a/tests/empresas/test_api_urls.py
+++ b/tests/empresas/test_api_urls.py
@@ -1,0 +1,28 @@
+import pytest
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from empresas.factories import EmpresaFactory
+
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+
+@pytest.mark.django_db
+def test_tag_list_endpoint(api_client, admin_user, tag_factory):
+    api_client.force_authenticate(user=admin_user)
+    tag_factory(nome="servico", categoria="serv")
+    url = reverse("empresas_api:tag-list")
+    resp = api_client.get(url)
+    assert resp.status_code == 200
+
+
+@pytest.mark.django_db
+def test_contato_list_endpoint(api_client, admin_user):
+    empresa = EmpresaFactory(usuario=admin_user, organizacao=admin_user.organizacao)
+    api_client.force_authenticate(user=admin_user)
+    url = reverse("empresas_api:contato-empresa-list", kwargs={"empresa_pk": empresa.pk})
+    resp = api_client.get(url)
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- consolidate EmpresaViewSet, TagViewSet e ContatoEmpresaViewSet em um único DefaultRouter
- adicionar testes para endpoints de tags e contatos

## Testing
- `pytest tests/empresas/test_api_urls.py --no-cov -q`
- `pytest tests/empresas/test_api.py::test_crud_empresa --no-cov -q`


------
https://chatgpt.com/codex/tasks/task_e_68a50fd93af083258b3304e9a05f4713