### PR TITLE
Add restore and purge options for soft-deleted companies

### DIFF
--- a/empresas/services.py
+++ b/empresas/services.py
@@ -21,14 +21,17 @@ def search_empresas(user, params):
 
     Parâmetros aceitos: ``nome``, ``municipio``, ``estado``, ``tags``,
     ``organizacao_id`` e ``q`` (busca textual). O parâmetro
-    ``mostrar_excluidas`` só é respeitado para administradores, exibindo
-    registros com ``deleted=True``.
+    ``mostrar_excluidas`` só é respeitado para administradores ou usuários
+    ``root``, exibindo registros com ``deleted=True``.
     """
 
-    qs = Empresa.objects.select_related("organizacao", "usuario").prefetch_related("tags")
-
     mostrar_excluidas = params.get("mostrar_excluidas")
-    if not (mostrar_excluidas == "1" and user.user_type == UserType.ADMIN):
+    if mostrar_excluidas == "1" and user.user_type in {UserType.ADMIN, UserType.ROOT}:
+        qs = Empresa.all_objects.select_related("organizacao", "usuario").prefetch_related("tags")
+    else:
+        qs = (
+            Empresa.objects.select_related("organizacao", "usuario").prefetch_related("tags")
+        )
         qs = qs.filter(deleted=False)
 
     if user.is_superuser:

--- a/empresas/templates/empresas/includes/empresas_table.html
+++ b/empresas/templates/empresas/includes/empresas_table.html
@@ -29,9 +29,22 @@
       </td>
       <td class="px-3 py-2 text-center space-x-2">
         <a href="{% url 'empresas:empresa_editar' empresa.pk %}" class="text-blue-600 hover:underline">{% translate "Editar" %}</a>
-        <a href="{% url 'empresas:remover' empresa.pk %}" class="text-red-600 hover:underline">
-          {% translate "Remover" %}
-        </a>
+        {% if empresa.deleted %}
+          <form hx-post="{% url 'empresas_api:empresa-restaurar' empresa.pk %}" hx-on="htmx:afterRequest: location.reload()" class="inline">
+            {% csrf_token %}
+            <button type="submit" class="text-green-600 hover:underline">{% translate "Restaurar" %}</button>
+          </form>
+          {% if request.user.user_type == 'admin' or request.user.user_type == 'root' %}
+            <button hx-delete="{% url 'empresas_api:empresa-purgar' empresa.pk %}"
+                    hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+                    hx-on="htmx:afterRequest: location.reload()"
+                    class="text-red-600 hover:underline">{% translate "Purgar" %}</button>
+          {% endif %}
+        {% else %}
+          <a href="{% url 'empresas:remover' empresa.pk %}" class="text-red-600 hover:underline">
+            {% translate "Remover" %}
+          </a>
+        {% endif %}
       </td>
     </tr>
     {% endfor %}

--- a/empresas/views.py
+++ b/empresas/views.py
@@ -37,7 +37,13 @@ class EmpresaListView(LoginRequiredMixin, ListView):
         return HttpResponseForbidden("Usuário não autorizado.")
 
     def get_queryset(self):
-        return search_empresas(self.request.user, self.request.GET)
+        qs = search_empresas(self.request.user, self.request.GET)
+        if (
+            self.request.GET.get("mostrar_excluidas") == "1"
+            and self.request.user.user_type in {UserType.ADMIN, UserType.ROOT}
+        ):
+            return qs
+        return qs.filter(deleted=False)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)


### PR DESCRIPTION
## Summary
- show restore option and purge for admins in company table
- add HTMX calls to EmpresaViewSet actions
- allow listing deleted companies via mostrar_excluidas flag

## Testing
- `pytest empresas/tests` *(fails: Required test coverage of 90% not reached. Total coverage: 24.12%)*


------
https://chatgpt.com/codex/tasks/task_e_68a50fdf16a883258a84f0f85725b93a