### PR TITLE
Renderiza partial ao salvar contatos via HTMX

### DIFF
--- a/empresas/templates/empresas/contato_form.html
+++ b/empresas/templates/empresas/contato_form.html
@@ -3,33 +3,44 @@
 {% block title %}{% translate 'Contato' %}{% endblock %}
 {% block content %}
 <section class="max-w-md mx-auto py-8">
-  <form method="post" class="space-y-4 bg-white border border-neutral-200 p-6 rounded-md" hx-post="" hx-target="closest form" hx-swap="outerHTML">
-    {% csrf_token %}
-    <div>
-      <label for="{{ form.nome.id_for_label }}" class="block text-sm font-medium text-neutral-700">{% translate 'Nome' %}</label>
-      {{ form.nome|add_class:'w-full p-2 border rounded' }}
-      {{ form.nome.errors }}
+  {% if message %}
+    <div class="bg-green-100 border border-green-300 text-green-800 p-4 rounded">{{ message }}</div>
+  {% elif contato %}
+    <div class="space-y-1 bg-white border border-neutral-200 p-6 rounded-md">
+      <p class="text-sm font-medium text-neutral-700">{{ contato.nome }}</p>
+      <p class="text-sm text-neutral-700">{{ contato.email }}</p>
+      <p class="text-sm text-neutral-700">{{ contato.telefone }}</p>
+      <p class="text-sm text-neutral-700">{{ contato.cargo }}</p>
     </div>
-    <div>
-      <label for="{{ form.email.id_for_label }}" class="block text-sm font-medium text-neutral-700">{% translate 'E-mail' %}</label>
-      {{ form.email|add_class:'w-full p-2 border rounded' }}
-      {{ form.email.errors }}
-    </div>
-    <div>
-      <label for="{{ form.telefone.id_for_label }}" class="block text-sm font-medium text-neutral-700">{% translate 'Telefone' %}</label>
-      {{ form.telefone|add_class:'w-full p-2 border rounded' }}
-      {{ form.telefone.errors }}
-    </div>
-    <div>
-      <label for="{{ form.cargo.id_for_label }}" class="block text-sm font-medium text-neutral-700">{% translate 'Cargo' %}</label>
-      {{ form.cargo|add_class:'w-full p-2 border rounded' }}
-      {{ form.cargo.errors }}
-    </div>
-    <div class="flex items-center gap-2">
-      {{ form.principal }}
-      <label for="{{ form.principal.id_for_label }}" class="text-sm text-neutral-700">{% translate 'Contato principal' %}</label>
-    </div>
-    <button class="bg-primary-600 text-white px-4 py-2 rounded" type="submit">{% translate 'Salvar' %}</button>
-  </form>
+  {% else %}
+    <form method="post" class="space-y-4 bg-white border border-neutral-200 p-6 rounded-md" hx-post="" hx-target="closest form" hx-swap="outerHTML">
+      {% csrf_token %}
+      <div>
+        <label for="{{ form.nome.id_for_label }}" class="block text-sm font-medium text-neutral-700">{% translate 'Nome' %}</label>
+        {{ form.nome|add_class:'w-full p-2 border rounded' }}
+        {{ form.nome.errors }}
+      </div>
+      <div>
+        <label for="{{ form.email.id_for_label }}" class="block text-sm font-medium text-neutral-700">{% translate 'E-mail' %}</label>
+        {{ form.email|add_class:'w-full p-2 border rounded' }}
+        {{ form.email.errors }}
+      </div>
+      <div>
+        <label for="{{ form.telefone.id_for_label }}" class="block text-sm font-medium text-neutral-700">{% translate 'Telefone' %}</label>
+        {{ form.telefone|add_class:'w-full p-2 border rounded' }}
+        {{ form.telefone.errors }}
+      </div>
+      <div>
+        <label for="{{ form.cargo.id_for_label }}" class="block text-sm font-medium text-neutral-700">{% translate 'Cargo' %}</label>
+        {{ form.cargo|add_class:'w-full p-2 border rounded' }}
+        {{ form.cargo.errors }}
+      </div>
+      <div class="flex items-center gap-2">
+        {{ form.principal }}
+        <label for="{{ form.principal.id_for_label }}" class="text-sm text-neutral-700">{% translate 'Contato principal' %}</label>
+      </div>
+      <button class="bg-primary-600 text-white px-4 py-2 rounded" type="submit">{% translate 'Salvar' %}</button>
+    </form>
+  {% endif %}
 </section>
 {% endblock %}

--- a/empresas/views.py
+++ b/empresas/views.py
@@ -301,6 +301,13 @@ def adicionar_contato(request, empresa_id):
             contato = form.save(commit=False)
             contato.empresa = empresa
             contato.save()
+            if request.headers.get("HX-Request"):
+                context = {
+                    "contato": contato,
+                    "empresa": empresa,
+                    "message": "Contato adicionado",
+                }
+                return render(request, "empresas/contato_form.html", context, status=HTTP_201_CREATED)
             return JsonResponse({"message": "Contato adicionado"}, status=HTTP_201_CREATED)
     else:
         form = ContatoEmpresaForm()
@@ -316,7 +323,14 @@ def editar_contato(request, pk):
     if request.method == "POST":
         form = ContatoEmpresaForm(request.POST, instance=contato)
         if form.is_valid():
-            form.save()
+            contato = form.save()
+            if request.headers.get("HX-Request"):
+                context = {
+                    "contato": contato,
+                    "empresa": contato.empresa,
+                    "message": "Contato atualizado",
+                }
+                return render(request, "empresas/contato_form.html", context)
             return JsonResponse({"message": "Contato atualizado"}, status=200)
     else:
         form = ContatoEmpresaForm(instance=contato)


### PR DESCRIPTION
## Summary
- trata requisições HTMX nas views de adicionar e editar contato
- mostra mensagem ou dados do contato salvo em respostas HTMX

## Testing
- `pytest -m "not slow"` (errors: ModuleNotFoundError: No module named 'axe_core_python', No module named 'bs4', No module named 'playwright', No module named 'pywebpush', No module named 'django_redis')
- `pytest tests/empresas -m "not slow"` (errors: ModuleNotFoundError: No module named 'django_redis')


------
https://chatgpt.com/codex/tasks/task_e_68a50fe1e7a88325bb9ede32a805034d