### PR TITLE
Add standalone company search view and link

### DIFF
--- a/empresas/urls.py
+++ b/empresas/urls.py
@@ -6,6 +6,7 @@ app_name = "empresas"
 
 urlpatterns = [
     path("", views.EmpresaListView.as_view(), name="lista"),
+    path("buscar/", views.buscar, name="buscar"),
     path("nova/", views.EmpresaCreateView.as_view(), name="empresa_criar"),
     path("<uuid:pk>/editar/", views.EmpresaUpdateView.as_view(), name="empresa_editar"),
     path("<uuid:pk>/", views.detalhes_empresa, name="detail"),

--- a/empresas/views.py
+++ b/empresas/views.py
@@ -22,6 +22,15 @@ from .models import AvaliacaoEmpresa, ContatoEmpresa, Empresa, EmpresaChangeLog,
 from .services import list_all_tags, search_empresas
 
 
+@login_required
+def buscar(request):
+    empresas = search_empresas(request.user, request.GET)
+    context = {"empresas": empresas, "q": request.GET.get("q", "")}
+    if request.headers.get("HX-Request"):
+        return render(request, "empresas/includes/empresas_table.html", context)
+    return render(request, "empresas/busca.html", context)
+
+
 class EmpresaListView(LoginRequiredMixin, ListView):
     model = Empresa
     template_name = "empresas/lista.html"

--- a/templates/base.html
+++ b/templates/base.html
@@ -100,6 +100,9 @@
         <a href="{% url 'empresas:lista' %}" class="flex items-center gap-x-2 hover:text-primary transition">
           <i class="fas fa-building"></i> {% trans "Empresas" %}
         </a>
+        <a href="{% url 'empresas:buscar' %}" class="flex items-center gap-x-2 hover:text-primary transition">
+          <i class="fas fa-search"></i> {% trans "Buscar Empresas" %}
+        </a>
         <a href="{% url 'agenda:calendario' %}" class="flex items-center gap-x-2 hover:text-primary transition">
           <i class="fas fa-calendar-alt"></i> {% trans "Agenda" %}
         </a>

--- a/tests/empresas/test_views.py
+++ b/tests/empresas/test_views.py
@@ -7,6 +7,15 @@ from empresas.models import AvaliacaoEmpresa, Empresa, EmpresaChangeLog
 
 
 @pytest.mark.django_db
+def test_buscar_view_returns_results(client, admin_user):
+    EmpresaFactory(usuario=admin_user, organizacao=admin_user.organizacao, nome="Alpha")
+    client.force_login(admin_user)
+    resp = client.get(reverse("empresas:buscar"), {"q": "Alpha"}, HTTP_HX_REQUEST="true")
+    assert resp.status_code == 200
+    assert "Alpha" in resp.content.decode()
+
+
+@pytest.mark.django_db
 def test_list_filters_name_municipio_tags(client, admin_user, tag_factory):
     tag1 = tag_factory(nome="Tech")
     tag2 = tag_factory(nome="Food")


### PR DESCRIPTION
## Summary
- add `buscar` view and route for company search
- expose search via navigation link
- cover new view with basic test

## Testing
- `pytest tests/empresas/test_views.py::test_buscar_view_returns_results -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68a50fe46bdc8325b07392348a7c9645