### PR TITLE
Update date fields in feed templates

### DIFF
--- a/feed/templates/feed/_comment.html
+++ b/feed/templates/feed/_comment.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 <li class="border border-neutral-200 bg-white rounded-xl shadow-sm p-4" id="comment-{{ comment.id }}">
   <p class="text-sm font-medium">{{ comment.user.get_full_name|default:comment.user.username }}</p>
-  <p class="text-xs text-neutral-500">{{ comment.created|date:"SHORT_DATETIME_FORMAT" }}</p>
+  <p class="text-xs text-neutral-500">{{ comment.created_at|date:"SHORT_DATETIME_FORMAT" }}</p>
   <p class="text-sm text-neutral-800">{{ comment.texto }}</p>
 </li>

--- a/feed/templates/feed/_grid.html
+++ b/feed/templates/feed/_grid.html
@@ -25,7 +25,7 @@
         </a>
         <div>
           <p class="text-sm font-medium text-neutral-800">{{ post.autor.get_full_name|default:post.autor.username }}</p>
-          <p class="text-xs text-neutral-500">{{ post.criado_em|date:SHORT_DATETIME_FORMAT }}</p>
+          <p class="text-xs text-neutral-500">{{ post.created_at|date:SHORT_DATETIME_FORMAT }}</p>
         </div>
       </div>
       <div class="text-sm text-neutral-800 whitespace-pre-line">

--- a/feed/templates/feed/_post_list.html
+++ b/feed/templates/feed/_post_list.html
@@ -14,7 +14,7 @@
             {{ post.autor.get_full_name|default:post.autor.username }}
           </p>
           <p class="text-xs text-neutral-500">
-            {{ post.criado_em|date:SHORT_DATETIME_FORMAT }}
+            {{ post.created_at|date:SHORT_DATETIME_FORMAT }}
           </p>
         </div>
       </div>

--- a/feed/templates/feed/post_detail.html
+++ b/feed/templates/feed/post_detail.html
@@ -19,7 +19,7 @@
       {% endif %}
       <div>
         <p class="text-sm font-medium text-neutral-800">{{ post.autor.get_full_name|default:post.autor.username }}</p>
-        <p class="text-xs text-neutral-500">{{ post.criado_em|date:SHORT_DATETIME_FORMAT }}</p>
+        <p class="text-xs text-neutral-500">{{ post.created_at|date:SHORT_DATETIME_FORMAT }}</p>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- use `post.created_at` instead of `post.criado_em` in feed templates
- use `comment.created_at` instead of `comment.created`

## Testing
- `pytest feed/tests -q` *(fails: ModuleNotFoundError: No module named 'django_redis')*

------
https://chatgpt.com/codex/tasks/task_e_68a5148539c8832591c676559acd0245