### PR TITLE
feat: adicionar filtros avançados no feed

### DIFF
--- a/feed/templates/feed/feed.html
+++ b/feed/templates/feed/feed.html
@@ -22,27 +22,91 @@
     </div>
   </div>
 
-  <div class="flex items-center gap-4 mb-4">
-    <label class="font-semibold">{% trans "Núcleo" %}:</label>
-    <select id="filtro-nucleo" name="nucleo"
-            hx-get="{% url 'feed:listar' %}"
-            hx-target="#feed-grid"
-            hx-indicator="#feed-loading"
-            hx-include="#feed-search,#filtro-nucleo"
-            class="rounded border-gray-300 focus:outline-none focus:ring-2 focus:ring-indigo-500">
-      <option value="">{% trans "Global" %}</option>
-      {% for n in nucleos_do_usuario %}
-        <option value="{{ n.id }}">{{ n.nome }}</option>
-      {% endfor %}
-    </select>
-  </div>
+  <form id="feed-filters" class="flex flex-wrap items-center gap-4 mb-4">
+    <div>
+      <label class="font-semibold" for="tipo-feed">{% trans "Tipo" %}:</label>
+      <select id="tipo-feed" name="tipo_feed"
+              hx-get="{% url 'feed:listar' %}"
+              hx-target="#feed-grid"
+              hx-trigger="change"
+              hx-indicator="#feed-loading"
+              hx-include="#feed-filters,#feed-search"
+              class="rounded border-gray-300 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+        <option value="global">{% trans "Global" %}</option>
+        <option value="usuario">{% trans "Usuário" %}</option>
+        <option value="nucleo">{% trans "Núcleo" %}</option>
+        <option value="evento">{% trans "Evento" %}</option>
+      </select>
+    </div>
+    <div>
+      <label class="font-semibold" for="filtro-nucleo">{% trans "Núcleo" %}:</label>
+      <select id="filtro-nucleo" name="nucleo"
+              hx-get="{% url 'feed:listar' %}"
+              hx-target="#feed-grid"
+              hx-trigger="change"
+              hx-indicator="#feed-loading"
+              hx-include="#feed-filters,#feed-search"
+              class="rounded border-gray-300 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+        <option value="">{% trans "Global" %}</option>
+        {% for n in nucleos_do_usuario %}
+          <option value="{{ n.id }}">{{ n.nome }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div>
+      <label class="font-semibold" for="filtro-evento">{% trans "Evento" %}:</label>
+      <select id="filtro-evento" name="evento"
+              hx-get="{% url 'feed:listar' %}"
+              hx-target="#feed-grid"
+              hx-trigger="change"
+              hx-indicator="#feed-loading"
+              hx-include="#feed-filters,#feed-search"
+              class="rounded border-gray-300 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+        <option value="">{% trans "Selecione" %}</option>
+        {% for e in eventos_do_usuario %}
+          <option value="{{ e.id }}">{{ e.titulo }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div>
+      <label class="font-semibold" for="date-from">{% trans "De" %}:</label>
+      <input type="date" id="date-from" name="date_from"
+             hx-get="{% url 'feed:listar' %}"
+             hx-target="#feed-grid"
+             hx-trigger="change"
+             hx-indicator="#feed-loading"
+             hx-include="#feed-filters,#feed-search"
+             class="rounded border-gray-300 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+    </div>
+    <div>
+      <label class="font-semibold" for="date-to">{% trans "Até" %}:</label>
+      <input type="date" id="date-to" name="date_to"
+             hx-get="{% url 'feed:listar' %}"
+             hx-target="#feed-grid"
+             hx-trigger="change"
+             hx-indicator="#feed-loading"
+             hx-include="#feed-filters,#feed-search"
+             class="rounded border-gray-300 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+    </div>
+    <div>
+      <label class="font-semibold" for="filtro-tags">{% trans "Tags" %}:</label>
+      <input type="text" id="filtro-tags" name="tags"
+             placeholder="{% trans 'Ex: educação,tecnologia' %}"
+             hx-get="{% url 'feed:listar' %}"
+             hx-target="#feed-grid"
+             hx-trigger="keyup changed delay:500ms"
+             hx-indicator="#feed-loading"
+             hx-include="#feed-filters,#feed-search"
+             class="rounded border-gray-300 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+    </div>
+  </form>
 
   <input type="search" name="q" id="feed-search"
          placeholder="{% trans 'Buscar postagens…' %}"
          hx-get="{% url 'feed:listar' %}"
          hx-trigger="keyup changed delay:500ms"
          hx-target="#feed-grid"
-         hx-include="#filtro-nucleo"
+         hx-include="#feed-filters"
          class="w-full rounded border-gray-300 mb-6 focus:outline-none focus:ring-2 focus:ring-indigo-500">
 
   <div id="feed-loading" class="htmx-indicator">{% trans "Carregando…" %}</div>

--- a/feed/tests/test_filters.py
+++ b/feed/tests/test_filters.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from datetime import timedelta
+
+from django.test import RequestFactory, TestCase
+from django.utils import timezone
+
+from accounts.factories import UserFactory
+from feed.factories import PostFactory
+from feed.views import FeedListView
+from organizacoes.factories import OrganizacaoFactory
+
+
+class FeedFilterViewTest(TestCase):
+    def setUp(self) -> None:
+        org = OrganizacaoFactory()
+        self.user = UserFactory(organizacao=org)
+        self.client.force_login(self.user)
+
+    def test_date_range_filters(self) -> None:
+        older = PostFactory(autor=self.user, created_at=timezone.now() - timedelta(days=5))
+        newer = PostFactory(autor=self.user, created_at=timezone.now() - timedelta(days=1))
+        rf = RequestFactory()
+        date_from = (timezone.now() - timedelta(days=2)).date().isoformat()
+        request = rf.get("/feed/", {"date_from": date_from})
+        request.user = self.user
+        view = FeedListView()
+        view.request = request
+        qs = view.get_queryset()
+        self.assertIn(newer, qs)
+        self.assertNotIn(older, qs)


### PR DESCRIPTION
## Summary
- adicionar filtros de tipo de feed, evento, intervalo de datas e tags
- incluir novos campos nas requisições HTMX
- permitir filtragem por datas e eventos em `FeedListView`

## Testing
- `pytest feed/tests/test_filters.py -q --no-cov` (fails: KeyboardInterrupt)


------
https://chatgpt.com/codex/tasks/task_e_68a514a659288325970a30c7794d68ab