### PR TITLE
Enable nested replies in feed comments

### DIFF
--- a/feed/templates/feed/_comment.html
+++ b/feed/templates/feed/_comment.html
@@ -3,4 +3,10 @@
   <p class="text-sm font-medium">{{ comment.user.get_full_name|default:comment.user.username }}</p>
   <p class="text-xs text-neutral-500">{{ comment.created|date:"SHORT_DATETIME_FORMAT" }}</p>
   <p class="text-sm text-neutral-800">{{ comment.texto }}</p>
+  <button type="button" class="text-primary-600 text-xs" hx-on:click="setReplyTo('{{ comment.id }}')">{% trans "Responder" %}</button>
+  <ul class="mt-2 space-y-2 ml-4" id="replies-{{ comment.id }}">
+    {% for reply in comment.replies.all %}
+      {% include 'feed/_comment.html' with comment=reply %}
+    {% endfor %}
+  </ul>
 </li>

--- a/feed/templates/feed/post_detail.html
+++ b/feed/templates/feed/post_detail.html
@@ -58,8 +58,9 @@
 
     <div class="mt-6">
       <h3 class="text-lg font-medium">{% trans "Comentários" %}</h3>
-      <form method="post" action="{% url 'feed:create_comment' post.id %}" hx-post="{% url 'feed:create_comment' post.id %}" hx-target="#comments" hx-swap="afterbegin" class="space-y-2">
+      <form id="comment-form" method="post" action="{% url 'feed:create_comment' post.id %}" hx-post="{% url 'feed:create_comment' post.id %}" hx-target="#comments" hx-swap="afterbegin" class="space-y-2" hx-on:afterRequest="this.reset(); setReplyTo(null)">
         {% csrf_token %}
+        {{ comment_form.reply_to.as_hidden }}
         {{ comment_form.texto }}
         {% if comment_form.texto.errors %}
           <p class="text-red-500 text-xs">{{ comment_form.texto.errors }}</p>
@@ -95,5 +96,18 @@
       keepalive: true
     });
   });
+
+  function setReplyTo(commentId) {
+    const replyInput = document.getElementById('id_reply_to');
+    const form = document.getElementById('comment-form');
+    if (commentId) {
+      replyInput.value = commentId;
+      form.setAttribute('hx-target', `#replies-${commentId}`);
+    } else {
+      replyInput.value = '';
+      form.setAttribute('hx-target', '#comments');
+    }
+    document.getElementById('id_texto').focus();
+  }
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- render hidden `reply_to` in post detail comment form
- add reply button on comments to set `reply_to` and handle nested insertion
- display nested comment structure recursively

## Testing
- `pip install django-redis`
- `pytest tests/feed/test_views.py::test_create_comment -q -p no:cov --override-ini="addopts="` *(fails: 'core' is not a registered namespace)*

------
https://chatgpt.com/codex/tasks/task_e_68a514a7490c8325906d04d2026e1409