### PR TITLE
Add tag filtering support to feed

### DIFF
--- a/feed/static/feed/js/feed.js
+++ b/feed/static/feed/js/feed.js
@@ -77,4 +77,15 @@ document.addEventListener("DOMContentLoaded", () => {
       this.style.height = Math.min(this.scrollHeight, 300) + "px"
     })
   }
+
+  // Atualiza campo oculto com tags selecionadas para o filtro
+  const tagsSelect = document.getElementById("tags-select")
+  const tagsHidden = document.getElementById("filtro-tags")
+
+  if (tagsSelect && tagsHidden) {
+    tagsSelect.addEventListener("change", () => {
+      const values = Array.from(tagsSelect.selectedOptions).map(o => o.value).join(",")
+      tagsHidden.value = values
+    })
+  }
 })

--- a/feed/templates/feed/feed.html
+++ b/feed/templates/feed/feed.html
@@ -28,7 +28,7 @@
             hx-get="{% url 'feed:listar' %}"
             hx-target="#feed-grid"
             hx-indicator="#feed-loading"
-            hx-include="#feed-search,#filtro-nucleo"
+            hx-include="#feed-search,#filtro-nucleo,#filtro-tags"
             class="rounded border-gray-300 focus:outline-none focus:ring-2 focus:ring-indigo-500">
       <option value="">{% trans "Global" %}</option>
       {% for n in nucleos_do_usuario %}
@@ -37,12 +37,26 @@
     </select>
   </div>
 
+  <div class="flex items-center gap-4 mb-4">
+    <label class="font-semibold">{% trans "Tags" %}:</label>
+    <select id="tags-select" multiple class="rounded border-gray-300 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            hx-get="{% url 'feed:listar' %}"
+            hx-target="#feed-grid"
+            hx-indicator="#feed-loading"
+            hx-include="#feed-search,#filtro-nucleo,#filtro-tags">
+      {% for tag in tags_disponiveis %}
+        <option value="{{ tag.nome }}">{{ tag.nome }}</option>
+      {% endfor %}
+    </select>
+    <input type="hidden" id="filtro-tags" name="tags">
+  </div>
+
   <input type="search" name="q" id="feed-search"
          placeholder="{% trans 'Buscar postagens…' %}"
          hx-get="{% url 'feed:listar' %}"
          hx-trigger="keyup changed delay:500ms"
          hx-target="#feed-grid"
-         hx-include="#filtro-nucleo"
+         hx-include="#filtro-nucleo,#filtro-tags"
          class="w-full rounded border-gray-300 mb-6 focus:outline-none focus:ring-2 focus:ring-indigo-500">
 
   <div id="feed-loading" class="htmx-indicator">{% trans "Carregando…" %}</div>
@@ -50,4 +64,5 @@
   {% include "feed/_grid.html" %}
 
 </section>
+<script src="{% static 'feed/js/feed.js' %}"></script>
 {% endblock %}

--- a/feed/templates/feed/nova_postagem.html
+++ b/feed/templates/feed/nova_postagem.html
@@ -59,6 +59,10 @@
         <label for="id_evento" class="font-semibold mb-1 block">{% trans "Evento" %}</label>
       {{ form.evento|as_widget }}
     </div>
+    <div class="mb-4">
+        <label for="{{ form.tags.id_for_label }}" class="font-semibold mb-1 block">{% trans "Tags" %}</label>
+      {{ form.tags|as_widget }}
+    </div>
 
     <!-- Arquivo -->
     <div>

--- a/feed/templates/feed/post_update.html
+++ b/feed/templates/feed/post_update.html
@@ -30,6 +30,11 @@
     </div>
 
     <div>
+      <label for="{{ form.tags.id_for_label }}" class="block text-sm font-medium text-neutral-700">{% trans "Tags" %}</label>
+      {{ form.tags|as_widget }}
+    </div>
+
+    <div>
       <label for="id_file" class="block text-sm font-medium text-neutral-700">{% trans "Arquivo (imagem ou PDF)" %}</label>
       <input type="file" id="id_file" name="arquivo" accept="image/*,.pdf" class="mt-2 block w-full text-sm text-neutral-600 file:mr-4 file:py-2 file:px-4 file:rounded-xl file:border-0 file:text-sm file:font-semibold file:bg-neutral-100 file:text-neutral-700 hover:file:bg-neutral-200">
       {% if form.image.errors or form.pdf.errors %}

--- a/feed/views.py
+++ b/feed/views.py
@@ -18,7 +18,7 @@ from accounts.models import UserType
 from nucleos.models import Nucleo
 
 from .forms import CommentForm, LikeForm, PostForm
-from .models import Like, ModeracaoPost, Post
+from .models import Like, ModeracaoPost, Post, Tag
 
 
 @login_required
@@ -149,6 +149,7 @@ class FeedListView(LoginRequiredMixin, ListView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["nucleos_do_usuario"] = Nucleo.objects.filter(participacoes__user=self.request.user)
+        context["tags_disponiveis"] = Tag.objects.all()
         return context
 
     def render_to_response(self, context, **response_kwargs):


### PR DESCRIPTION
## Summary
- add tag selection fields to new and edit post forms
- enable tag filtering on feed with multi-select and HTMX integration
- update JS to send selected tags in requests

## Testing
- `pytest` *(fails: 8 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a514acc37c83258523e81d09e64b03