### PR TITLE
Add centros list view and HTMX integration

### DIFF
--- a/financeiro/templates/financeiro/centros_list.html
+++ b/financeiro/templates/financeiro/centros_list.html
@@ -7,7 +7,7 @@
 <main class="p-4 max-w-5xl mx-auto">
   <header class="flex items-center justify-between mb-4">
     <h1 class="text-2xl font-semibold">{% trans "Centros de Custo" %}</h1>
-    <button class="bg-blue-600 text-white px-4 py-2 rounded" hx-get="/financeiro/centro/new/" hx-target="#modal" hx-trigger="click">
+    <button class="bg-blue-600 text-white px-4 py-2 rounded" hx-get="/api/financeiro/centros/" hx-target="#modal" hx-trigger="click">
       {% trans "Novo Centro" %}
     </button>
   </header>
@@ -32,7 +32,7 @@
           </td>
           <td class="px-3 py-2">{{ c.saldo }}</td>
           <td class="px-3 py-2 text-right space-x-2">
-            <button class="text-primary underline" hx-get="/financeiro/centro/{{ c.id }}/edit/" hx-target="#modal" hx-trigger="click">{% trans "Editar" %}</button>
+            <button class="text-primary underline" hx-get="/api/financeiro/centros/{{ c.id }}/" hx-target="#modal" hx-trigger="click">{% trans "Editar" %}</button>
             <button class="text-red-600 underline" hx-delete="/api/financeiro/centros/{{ c.id }}/" hx-target="closest tr" hx-confirm='{% trans "Tem certeza?" %}'>{% trans "Excluir" %}</button>
           </td>
         </tr>

--- a/financeiro/urls.py
+++ b/financeiro/urls.py
@@ -6,6 +6,7 @@ from .views import (
     lancamentos_list_view,
     forecast_view,
     relatorios_view,
+    centros_list_view,
     task_log_detail_view,
     task_logs_view,
 )
@@ -15,6 +16,7 @@ app_name = "financeiro"
 urlpatterns = [
     path("importar/", importar_pagamentos_view, name="importar_pagamentos"),
     path("relatorios/", relatorios_view, name="relatorios"),
+    path("centros/", centros_list_view, name="centros"),
     path("lancamentos/", lancamentos_list_view, name="lancamentos"),
     path("forecast/", forecast_view, name="forecast"),
     path("inadimplencias/", inadimplencias_view, name="inadimplencias"),

--- a/financeiro/views/__init__.py
+++ b/financeiro/views/__init__.py
@@ -413,6 +413,24 @@ def relatorios_view(request):
 
 @login_required
 @user_passes_test(_is_financeiro_or_admin)
+def centros_list_view(request):
+    limit = 20
+    offset = int(request.GET.get("offset", 0))
+    qs = CentroCusto.objects.all().select_related("organizacao", "nucleo", "evento")
+    total = qs.count()
+    centros = qs[offset : offset + limit]
+    next_offset = offset + limit if total > offset + limit else None
+    prev_offset = offset - limit if offset - limit >= 0 else None
+    context = {
+        "centros": centros,
+        "next": next_offset,
+        "prev": prev_offset,
+    }
+    return render(request, "financeiro/centros_list.html", context)
+
+
+@login_required
+@user_passes_test(_is_financeiro_or_admin)
 def lancamentos_list_view(request):
     centros = CentroCusto.objects.all()
     nucleos = {c.nucleo for c in centros if c.nucleo}


### PR DESCRIPTION
## Summary
- add centros_list_view rendering finance templates and context
- wire centros list route into financeiro urls
- use HTMX API endpoints for centros creation and edit buttons

## Testing
- `pytest financeiro/tests/test_templates_htmx.py::test_centro_criacao_htmx -q` *(fails: KeyboardInterrupt)*


------
https://chatgpt.com/codex/tasks/task_e_68a51a2e7720832587a93a41a6704fd4