### PR TITLE
feat(financeiro): render lancamentos via htmx

### DIFF
--- a/financeiro/templates/financeiro/lancamentos_list.html
+++ b/financeiro/templates/financeiro/lancamentos_list.html
@@ -6,7 +6,7 @@
 {% block content %}
 <main class="p-4 max-w-6xl mx-auto">
   <h1 class="text-2xl font-semibold mb-2">{{ _('Lançamentos') }}</h1>
-  <form id="filtros" class="mb-4 grid grid-cols-1 md:grid-cols-5 gap-4" hx-get="/api/financeiro/lancamentos/" hx-target="#lista" hx-trigger="change from:select,change from:input, submit">
+  <form id="filtros" class="mb-4 grid grid-cols-1 md:grid-cols-5 gap-4" hx-get="/api/financeiro/lancamentos/" hx-target="#lista" hx-swap="none" hx-trigger="change from:select,change from:input, submit" hx-on="htmx:afterRequest: renderLancamentos(event)">
     <legend class="sr-only">{{ _('Filtros') }}</legend>
     <div>
       <label for="filtro-status" class="block text-sm font-medium text-gray-700">{{ _('Status') }}</label>
@@ -45,7 +45,7 @@
     </div>
   </form>
   <div id="lista" aria-live="polite">
-    <table class="min-w-full divide-y divide-gray-200" hx-get="/api/financeiro/lancamentos/" hx-trigger="load" hx-target="tbody">
+    <table class="min-w-full divide-y divide-gray-200">
       <thead>
         <tr class="bg-gray-50">
           <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{{ _('ID') }}</th>
@@ -62,6 +62,43 @@
       <tbody></tbody>
     </table>
   </div>
+  <script src="{% url 'javascript-catalog' %}"></script>
+  <script>
+    const csrfToken = "{{ csrf_token }}";
+    function renderLancamentos(evt) {
+      const tbody = document.querySelector('#lista tbody');
+      tbody.innerHTML = '';
+      try {
+        const data = JSON.parse(evt.detail.xhr.response);
+        const itens = data.results || data;
+        const rows = itens
+          .map(l => `
+            <tr>
+              <td class="px-3 py-2">${l.id}</td>
+              <td class="px-3 py-2">${l.centro_custo || ''}</td>
+              <td class="px-3 py-2">${l.conta_associado || ''}</td>
+              <td class="px-3 py-2">${l.tipo}</td>
+              <td class="px-3 py-2">${l.valor}</td>
+              <td class="px-3 py-2">${l.data_lancamento}</td>
+              <td class="px-3 py-2">${l.status}</td>
+              <td class="px-3 py-2">${l.data_vencimento || ''}</td>
+              <td class="px-3 py-2 space-x-2">
+                <button hx-patch="/api/financeiro/lancamentos/${l.id}/" hx-vals='{"status":"pago"}' hx-headers='{"X-CSRFToken": "${csrfToken}"}' hx-on="htmx:afterRequest: htmx.trigger('#filtros','submit')" class="text-green-600 hover:underline">{% trans "Pagar" %}</button>
+                <button hx-patch="/api/financeiro/lancamentos/${l.id}/" hx-vals='{"status":"cancelado"}' hx-headers='{"X-CSRFToken": "${csrfToken}"}' hx-on="htmx:afterRequest: htmx.trigger('#filtros','submit')" class="text-red-600 hover:underline">{% trans "Cancelar" %}</button>
+                <button hx-post="/api/financeiro/lancamentos/${l.id}/ajustar/" hx-vals='js:{valor_corrigido: prompt(gettext("Valor corrigido?")), descricao_motivo: prompt(gettext("Motivo?"))}' hx-headers='{"X-CSRFToken": "${csrfToken}"}' hx-on="htmx:afterRequest: htmx.trigger('#filtros','submit')" class="text-blue-600 hover:underline">{% trans "Ajustar" %}</button>
+              </td>
+            </tr>
+          `)
+          .join('');
+        tbody.innerHTML = rows || `<tr><td colspan="9" class="px-3 py-2 text-center">${gettext('Nenhum lançamento')}</td></tr>`;
+      } catch (e) {
+        tbody.innerHTML = `<tr><td colspan="9" class="px-3 py-2 text-center">${gettext('Erro ao carregar')}</td></tr>`;
+      }
+    }
+    document.addEventListener('DOMContentLoaded', () => {
+      htmx.trigger('#filtros', 'submit');
+    });
+  </script>
 </main>
 
 {% endblock %}


### PR DESCRIPTION
## Summary
- render lancamentos table using HTMX afterRequest hook
- add buttons to mark as paid, cancel or adjust and refresh list

## Testing
- `pytest financeiro/tests/test_api.py::test_lancamentos_list_filtra_e_restringe -q --disable-warnings --maxfail=1` *(fails: ModuleNotFoundError: No module named 'django_redis')*


------
https://chatgpt.com/codex/tasks/task_e_68a51a2fa5588325a954eec00939edf0