### PR TITLE
Render forecast API data in table and chart

### DIFF
--- a/financeiro/templates/financeiro/forecast.html
+++ b/financeiro/templates/financeiro/forecast.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 <div class="container mx-auto p-4" hx-boost="true">
-  <form id="filters" class="space-y-4" hx-get="{% url 'financeiro_api:forecast-list' %}" hx-target="#forecast-result" hx-trigger="change,submit">
+  <form id="filters" class="space-y-4" hx-get="{% url 'financeiro_api:forecast-list' %}" hx-trigger="change,submit" hx-swap="none" hx-on:afterRequest="renderForecast(event.detail.xhr)">
     <div>
       <label for="escopo" class="block text-sm font-medium">{% trans "Escopo" %}</label>
       <select name="escopo" id="escopo" class="mt-1 w-full border p-2 rounded">
@@ -38,10 +38,62 @@
     <a href="#" onclick="exportData('xlsx');return false;" class="bg-gray-200 px-3 py-1 rounded">{% trans "Exportar XLSX" %}</a>
   </div>
 </div>
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script>
+let lastParams = null;
+
+function renderForecast(xhr){
+  if(xhr.status !== 200) return;
+  let data;
+  try { data = JSON.parse(xhr.responseText); } catch(e){ return; }
+  lastParams = data.parametros;
+  const container = document.getElementById('forecast-result');
+  container.innerHTML = '';
+  const rows = data.historico.concat(data.previsao);
+  if(rows.length){
+    const table = document.createElement('table');
+    table.className = 'min-w-full border';
+    table.innerHTML = `<thead><tr>
+      <th class="border px-2">{% trans "Mês" %}</th>
+      <th class="border px-2">{% trans "Receita" %}</th>
+      <th class="border px-2">{% trans "Despesa" %}</th>
+      <th class="border px-2">{% trans "Saldo" %}</th>
+    </tr></thead>`;
+    const tbody = document.createElement('tbody');
+    rows.forEach(r => {
+      const tr = document.createElement('tr');
+      tr.innerHTML = `<td class="border px-2">${r.mes}</td>
+        <td class="border px-2">${r.receita.toFixed(2)}</td>
+        <td class="border px-2">${r.despesa.toFixed(2)}</td>
+        <td class="border px-2">${r.saldo.toFixed(2)}</td>`;
+      tbody.appendChild(tr);
+    });
+    table.appendChild(tbody);
+    container.appendChild(table);
+
+    if(window.Chart){
+      const canvas = document.createElement('canvas');
+      canvas.id = 'forecastChart';
+      canvas.className = 'mt-4';
+      container.appendChild(canvas);
+      const ctx = canvas.getContext('2d');
+      new Chart(ctx, {
+        type: 'line',
+        data: {
+          labels: rows.map(r => r.mes),
+          datasets: [
+            {label: '{% trans "Receita" %}', data: rows.map(r => r.receita), borderColor: '#16a34a', backgroundColor: 'rgba(22,163,74,0.2)'},
+            {label: '{% trans "Despesa" %}', data: rows.map(r => r.despesa), borderColor: '#dc2626', backgroundColor: 'rgba(220,38,38,0.2)'}
+          ]
+        },
+        options: {responsive: true}
+      });
+    }
+  }
+}
+
 function exportData(fmt){
-  const form = document.getElementById('filters');
-  const params = new URLSearchParams(new FormData(form));
+  const params = lastParams ? new URLSearchParams(lastParams) : new URLSearchParams(new FormData(document.getElementById('filters')));
   window.location = '{% url 'financeiro_api:forecast-list' %}?'+params.toString()+'&format='+fmt;
 }
 </script>


### PR DESCRIPTION
## Summary
- Render forecast API JSON into an HTML table and Chart.js line chart
- Export uses parameters from last fetched forecast

## Testing
- `pytest financeiro/tests/test_forecast.py -q` *(fails: Required test coverage of 90% not reached. Total coverage: 23.63%)*

------
https://chatgpt.com/codex/tasks/task_e_68a51a32e260832596d76238cc2b1725