### PR TITLE
Add active flag management to notification templates

### DIFF
--- a/notificacoes/templates/notificacoes/template_form.html
+++ b/notificacoes/templates/notificacoes/template_form.html
@@ -40,6 +40,13 @@
       {{ form.canal|add_class:'form-select' }}
       {% if form.canal.errors %}<p class="text-sm text-red-600 mt-1">{{ form.canal.errors.0 }}</p>{% endif %}
     </div>
+    <div>
+      <label class="flex items-center gap-2">
+        {{ form.ativo|add_class:'form-checkbox' }}
+        <span class="text-sm font-medium text-neutral-700">{% trans 'Ativo' %}</span>
+      </label>
+      {% if form.ativo.errors %}<p class="text-sm text-red-600 mt-1">{{ form.ativo.errors.0 }}</p>{% endif %}
+    </div>
     <div class="flex justify-end gap-3 pt-4 border-t border-neutral-100">
       <a href="{% url 'notificacoes:templates_list' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100">{% trans 'Cancelar' %}</a>
       <button type="submit" class="text-sm px-4 py-2 rounded-xl bg-blue-600 text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500">{% trans 'Salvar' %}</button>

--- a/notificacoes/templates/notificacoes/templates_list.html
+++ b/notificacoes/templates/notificacoes/templates_list.html
@@ -27,6 +27,7 @@
           <th class="px-4 py-2 text-left font-medium text-neutral-700">{% trans 'Código' %}</th>
           <th class="px-4 py-2 text-left font-medium text-neutral-700">{% trans 'Assunto' %}</th>
           <th class="px-4 py-2 text-left font-medium text-neutral-700">{% trans 'Canal' %}</th>
+          <th class="px-4 py-2 text-left font-medium text-neutral-700">{% trans 'Ativo' %}</th>
           <th class="px-4 py-2 text-left font-medium text-neutral-700">{% trans 'Ações' %}</th>
         </tr>
       </thead>
@@ -36,8 +37,17 @@
           <td class="px-4 py-2 font-mono">{{ tpl.codigo }}</td>
           <td class="px-4 py-2">{{ tpl.assunto }}</td>
           <td class="px-4 py-2">{{ tpl.get_canal_display }}</td>
+          <td class="px-4 py-2">{{ tpl.ativo|yesno:_('Sim,Não') }}</td>
           <td class="px-4 py-2">
-            <a href="{% url 'notificacoes:template_edit' tpl.codigo %}" class="text-sm text-primary-600 hover:underline">{% trans 'Editar' %}</a>
+            <div class="flex items-center gap-2">
+              <a href="{% url 'notificacoes:template_edit' tpl.codigo %}" class="text-sm text-primary-600 hover:underline">{% trans 'Editar' %}</a>
+              {% if tpl.ativo %}
+                <a href="{% url 'notificacoes:templates_list' %}?toggle={{ tpl.codigo }}" class="text-sm text-neutral-600 hover:underline">{% trans 'Desativar' %}</a>
+              {% else %}
+                <a href="{% url 'notificacoes:templates_list' %}?toggle={{ tpl.codigo }}" class="text-sm text-neutral-600 hover:underline">{% trans 'Ativar' %}</a>
+              {% endif %}
+              <a href="{% url 'notificacoes:template_delete' tpl.codigo %}" class="text-sm text-red-600 hover:underline">{% trans 'Excluir' %}</a>
+            </div>
           </td>
         </tr>
         {% endfor %}

--- a/notificacoes/views.py
+++ b/notificacoes/views.py
@@ -28,6 +28,17 @@ logger = logging.getLogger(__name__)
 @login_required
 @permission_required("notificacoes.change_notificationtemplate", raise_exception=True)
 def list_templates(request):
+    codigo_toggle = request.GET.get("toggle")
+    if codigo_toggle:
+        template = get_object_or_404(NotificationTemplate, codigo=codigo_toggle)
+        template.ativo = not template.ativo
+        template.save(update_fields=["ativo"])
+        if template.ativo:
+            messages.success(request, _("Template ativado com sucesso."))
+        else:
+            messages.success(request, _("Template desativado com sucesso."))
+        return redirect("notificacoes:templates_list")
+
     templates = NotificationTemplate.objects.all()
     return render(request, "notificacoes/templates_list.html", {"templates": templates})
 
@@ -135,7 +146,7 @@ def historico_notificacoes(request):
 def delete_template(request, codigo: str):
     template = get_object_or_404(NotificationTemplate, codigo=codigo)
     if NotificationLog.objects.filter(template=template).exists():
-        messages.error(request, _("Template em uso; não é possível removê-lo."))
+        messages.error(request, _("Template em uso; não é possível removê-lo. Considere desativá-lo."))
 
     else:
         template.delete()


### PR DESCRIPTION
## Summary
- expose `ativo` checkbox in notification template form
- list templates with active status and actions to edit, toggle or delete
- handle activation toggling and improved deletion message in views

## Testing
- `pytest tests/notificacoes/test_models.py::test_template_str -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68a51f504d308325ae7aab4b4dbaa4bf