### PR TITLE
Impedir exclusão de template com logs

### DIFF
--- a/notificacoes/api.py
+++ b/notificacoes/api.py
@@ -30,6 +30,15 @@ class NotificationTemplateViewSet(viewsets.ModelViewSet):
     serializer_class = NotificationTemplateSerializer
     permission_classes = [permissions.IsAdminUser]
 
+    def destroy(self, request, *args, **kwargs):
+        obj = self.get_object()
+        if NotificationLog.objects.filter(template=obj).exists():
+            return Response(
+                {"detail": _("Template possui logs; desative-o ao invés de excluir.")},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        return super().destroy(request, *args, **kwargs)
+
 
 class NotificationLogViewSet(mixins.UpdateModelMixin, viewsets.ReadOnlyModelViewSet):
     serializer_class = NotificationLogSerializer

--- a/tests/notificacoes/test_api.py
+++ b/tests/notificacoes/test_api.py
@@ -89,3 +89,22 @@ def test_usuario_nao_marca_notificacao_de_outro(client) -> None:
         content_type="application/json",
     )
     assert resp.status_code == 404
+
+
+def test_nao_exclui_template_com_logs(client) -> None:
+    admin_user = UserFactory(is_staff=True)
+    template = NotificationTemplate.objects.create(codigo="t4", assunto="Oi", corpo="C", canal="email")
+    NotificationLog.objects.create(user=admin_user, template=template, canal="email")
+    client.force_login(admin_user)
+    resp = client.delete(f"/api/notificacoes/templates/{template.id}/")
+    assert resp.status_code == 400
+    assert NotificationTemplate.objects.filter(id=template.id).exists()
+
+
+def test_exclui_template_sem_logs(client) -> None:
+    admin_user = UserFactory(is_staff=True)
+    template = NotificationTemplate.objects.create(codigo="t5", assunto="Oi", corpo="C", canal="email")
+    client.force_login(admin_user)
+    resp = client.delete(f"/api/notificacoes/templates/{template.id}/")
+    assert resp.status_code == 204
+    assert not NotificationTemplate.objects.filter(id=template.id).exists()


### PR DESCRIPTION
## Summary
- bloqueia exclusão de templates de notificação com logs existentes
- adiciona testes para exclusão condicionada de templates

## Testing
- `pytest tests/notificacoes/test_api.py::test_nao_exclui_template_com_logs tests/notificacoes/test_api.py::test_exclui_template_sem_logs --override-ini=addopts= -q`

------
https://chatgpt.com/codex/tasks/task_e_68a51f5260208325b1462421bcb7e3bc