### PR TITLE
Add event identifier to notification messages

### DIFF
--- a/notificacoes/static/notificacoes/js/push_socket.js
+++ b/notificacoes/static/notificacoes/js/push_socket.js
@@ -1,27 +1,30 @@
-(function(){
-    if(window.HubxPushInit) return;
-    window.HubxPushInit = true;
+(function () {
+  if (window.HubxPushInit) return;
+  window.HubxPushInit = true;
 
-    function init(){
-        if(document.body.dataset.isAuthenticated !== 'true') return;
-        const scheme = window.location.protocol === 'https:' ? 'wss://' : 'ws://';
-        const socket = new WebSocket(scheme + window.location.host + '/ws/notificacoes/');
-        const countEl = document.getElementById('notif-count');
-        socket.onmessage = function(e){
-            const data = JSON.parse(e.data);
-            if(countEl){
-                const current = parseInt(countEl.textContent || '0', 10);
-                countEl.textContent = current + 1;
-            }
-            const container = document.getElementById('messages');
-            const div = document.createElement('div');
-            div.className = 'px-4 py-2 rounded shadow bg-blue-500 text-white';
-            div.setAttribute('role','alert');
-            div.setAttribute('aria-live','assertive');
-            div.textContent = (data.titulo ? data.titulo + ': ' : '') + data.mensagem;
-            (container || document.body).appendChild(div);
-            setTimeout(()=>div.remove(),4000);
-        };
-    }
-    document.addEventListener('DOMContentLoaded', init);
+  function init() {
+    if (document.body.dataset.isAuthenticated !== "true") return;
+    const scheme = window.location.protocol === "https:" ? "wss://" : "ws://";
+    const socket = new WebSocket(
+      scheme + window.location.host + "/ws/notificacoes/",
+    );
+    const countEl = document.getElementById("notif-count");
+    socket.onmessage = function (e) {
+      const data = JSON.parse(e.data);
+      if (data.event !== "notification_message") return;
+      if (countEl) {
+        const current = parseInt(countEl.textContent || "0", 10);
+        countEl.textContent = current + 1;
+      }
+      const container = document.getElementById("messages");
+      const div = document.createElement("div");
+      div.className = "px-4 py-2 rounded shadow bg-blue-500 text-white";
+      div.setAttribute("role", "alert");
+      div.setAttribute("aria-live", "assertive");
+      div.textContent = (data.titulo ? data.titulo + ": " : "") + data.mensagem;
+      (container || document.body).appendChild(div);
+      setTimeout(() => div.remove(), 4000);
+    };
+  }
+  document.addEventListener("DOMContentLoaded", init);
 })();

--- a/notificacoes/tasks.py
+++ b/notificacoes/tasks.py
@@ -49,6 +49,7 @@ def enviar_notificacao_async(self, subject: str, body: str, log_id: str) -> None
                 f"notificacoes_{user.id}",
                 {
                     "type": "notification.message",
+                    "event": "notification_message",
                     "titulo": subject,
                     "mensagem": body,
                     "canal": canal,
@@ -132,6 +133,7 @@ def _enviar_resumo(config: ConfiguracaoConta, canais: list[str], agora, tipo: st
                 f"notificacoes_{config.user.id}",
                 {
                     "type": "notification.message",
+                    "event": "notification_message",
                     "titulo": subject,
                     "mensagem": body,
                     "canal": canal,


### PR DESCRIPTION
## Summary
- attach `event: notification_message` when broadcasting notifications
- handle notification_message event in push_socket.js

## Testing
- `pytest -q` *(fails: SyntaxError in tests/feed/test_services.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a51f5371448325bc8339316f6cdd76