### PR TITLE
Exibe valores legíveis de canal e frequência

### DIFF
--- a/notificacoes/templates/notificacoes/historico_rows.html
+++ b/notificacoes/templates/notificacoes/historico_rows.html
@@ -3,8 +3,8 @@
 <tr>
   <td class="px-4 py-2 whitespace-nowrap">{{ item.enviado_em|date:'Y-m-d H:i' }}</td>
   <td class="px-4 py-2 whitespace-nowrap">{{ item.data_referencia|date:'Y-m-d' }}</td>
-  <td class="px-4 py-2">{{ item.canal }}</td>
-  <td class="px-4 py-2">{{ item.frequencia }}</td>
+  <td class="px-4 py-2">{{ item.get_canal_display }}</td>
+  <td class="px-4 py-2">{{ item.get_frequencia_display }}</td>
   <td class="px-4 py-2">{{ item.conteudo|join:", " }}</td>
 </tr>
 {% empty %}


### PR DESCRIPTION
## Summary
- troca `item.canal` e `item.frequencia` por `get_canal_display`/`get_frequencia_display`

## Testing
- `pytest` *(fails: could not import 'pytest_benchmark'; several collection errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a51f550c6883258c541ed1db412861