### PR TITLE
Deactivate invalid OneSignal push subscriptions

### DIFF
--- a/notificacoes/services/push_client.py
+++ b/notificacoes/services/push_client.py
@@ -1,17 +1,50 @@
 import logging
 from django.conf import settings
 
+from ..models import PushSubscription
+
+try:  # pragma: no cover - lib externa
+    from onesignal_sdk.error import OneSignalHTTPError  # type: ignore
+except Exception:  # pragma: no cover - fallback quando lib não instalada
+    class OneSignalHTTPError(Exception):  # type: ignore
+        status_code = None
+        http_response = None
+
+
 logger = logging.getLogger(__name__)
+
 
 def send_push(user, message: str) -> None:
     """Enviar push usando OneSignal."""
     try:
         from onesignal_sdk.client import Client as OneSignalClient  # type: ignore
         client = OneSignalClient(app_id=settings.ONESIGNAL_APP_ID, rest_api_key=settings.ONESIGNAL_API_KEY)
-        client.send_notification({
-            "contents": {"en": message},
-            "include_external_user_ids": [str(user.id)],
-        })
+        client.send_notification(
+            {
+                "contents": {"en": message},
+                "include_external_user_ids": [str(user.id)],
+            }
+        )
+    except OneSignalHTTPError as exc:  # pragma: no cover - lib externa
+        status = getattr(exc, "status_code", None)
+        if status in {404, 410}:
+            errors: list[str] = []
+            try:
+                errors = exc.http_response.json().get("errors", [])
+            except Exception:  # pragma: no cover - resposta inesperada
+                errors = []
+            subs = PushSubscription.objects.filter(user=user, ativo=True)
+            for sub in subs:
+                if any(str(sub.device_id) in str(err) for err in errors):
+                    sub.ativo = False
+                    sub.save(update_fields=["ativo"])
+                    logger.info(
+                        "push_inscricao_inativa",
+                        extra={"user": getattr(user, "id", None), "device_id": sub.device_id},
+                    )
+        else:
+            logger.exception("erro_push", extra={"user": getattr(user, "id", None)})
+            raise
     except Exception as exc:  # pragma: no cover - falha de integração
         logger.exception(
             "erro_push",

--- a/tests/notificacoes/test_clients.py
+++ b/tests/notificacoes/test_clients.py
@@ -2,9 +2,12 @@ import logging
 import sys
 import types
 
+import httpx
 import pytest
+from onesignal_sdk.error import OneSignalHTTPError
 
 from accounts.factories import UserFactory
+from notificacoes.models import PushSubscription
 from notificacoes.services.email_client import send_email
 from notificacoes.services.push_client import send_push
 from notificacoes.services.whatsapp_client import send_whatsapp
@@ -77,3 +80,32 @@ def test_send_push_success(monkeypatch, settings, caplog):
     with caplog.at_level(logging.INFO):
         send_push(user, "msg")
     assert "push_enviado" in caplog.text
+
+
+def test_send_push_invalida_inscricao(monkeypatch, settings, caplog):
+    user = UserFactory()
+    settings.ONESIGNAL_APP_ID = "app"
+    settings.ONESIGNAL_API_KEY = "key"
+    sub = PushSubscription.objects.create(
+        user=user,
+        device_id="d1",
+        endpoint="https://example.com",
+        p256dh="p",
+        auth="a",
+    )
+
+    class FakeClient:
+        def __init__(self, app_id, rest_api_key):
+            pass
+
+        def send_notification(self, data):
+            response = httpx.Response(410, json={"errors": ["d1"]})
+            raise OneSignalHTTPError(response)
+
+    module = types.SimpleNamespace(Client=FakeClient)
+    monkeypatch.setitem(sys.modules, "onesignal_sdk.client", module)
+    with caplog.at_level(logging.INFO):
+        send_push(user, "msg")
+    sub.refresh_from_db()
+    assert sub.ativo is False
+    assert "push_inscricao_inativa" in caplog.text


### PR DESCRIPTION
## Summary
- handle OneSignal 404/410 errors by deactivating matching push subscriptions and logging
- test OneSignal push failure marks subscription inactive

## Testing
- `pytest tests/notificacoes/test_clients.py -q -o addopts=""`
- `pytest tests/notificacoes/test_push_sender.py -q -o addopts=""`


------
https://chatgpt.com/codex/tasks/task_e_68a51f55dc888325a49f7dfde5247bb0