### PR TITLE
Enable HTMX modals for organization relations

### DIFF
--- a/organizacoes/api.py
+++ b/organizacoes/api.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+from django.contrib.auth import get_user_model
 from django.db.models import Q
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from django.core.cache import cache
-from rest_framework import viewsets
+from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.permissions import IsAuthenticated
@@ -233,12 +234,28 @@ class OrganizacaoRelatedModelViewSet(viewsets.ModelViewSet):
         return org
 
 
-class OrganizacaoUserViewSet(OrganizacaoRelatedViewSet):
+class OrganizacaoUserViewSet(OrganizacaoRelatedModelViewSet):
     serializer_class = UserSerializer
 
     def get_queryset(self):
         org = self.get_organizacao()
         return org.users.all()
+
+    def create(self, request, *args, **kwargs):  # type: ignore[override]
+        org = self.get_organizacao()
+        user_id = request.data.get("user_id")
+        user = get_object_or_404(get_user_model(), pk=user_id)
+        user.organizacao = org
+        user.save(update_fields=["organizacao"])
+        serializer = self.get_serializer(user)
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+    def destroy(self, request, pk=None, organizacao_pk=None):  # type: ignore[override]
+        org = self.get_organizacao()
+        user = get_object_or_404(get_user_model(), pk=pk, organizacao=org)
+        user.organizacao = None
+        user.save(update_fields=["organizacao"])
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
     @action(detail=False, methods=["get"], url_path="associados")
     def associados(self, request, organizacao_pk: str | None = None):
@@ -247,36 +264,96 @@ class OrganizacaoUserViewSet(OrganizacaoRelatedViewSet):
         return Response(serializer.data)
 
 
-class OrganizacaoNucleoViewSet(OrganizacaoRelatedViewSet):
+class OrganizacaoNucleoViewSet(OrganizacaoRelatedModelViewSet):
     serializer_class = NucleoSerializer
 
     def get_queryset(self):
         org = self.get_organizacao()
         return Nucleo.objects.filter(organizacao=org, deleted=False)
 
+    def create(self, request, *args, **kwargs):  # type: ignore[override]
+        org = self.get_organizacao()
+        nucleo_id = request.data.get("nucleo_id")
+        nucleo = get_object_or_404(Nucleo, pk=nucleo_id)
+        nucleo.organizacao = org
+        nucleo.save(update_fields=["organizacao"])
+        serializer = self.get_serializer(nucleo)
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
 
-class OrganizacaoEventoViewSet(OrganizacaoRelatedViewSet):
+    def destroy(self, request, pk=None, organizacao_pk=None):  # type: ignore[override]
+        org = self.get_organizacao()
+        nucleo = get_object_or_404(Nucleo, pk=pk, organizacao=org)
+        nucleo.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class OrganizacaoEventoViewSet(OrganizacaoRelatedModelViewSet):
     serializer_class = EventoSerializer
 
     def get_queryset(self):
         org = self.get_organizacao()
         return Evento.objects.filter(organizacao=org, deleted=False)
 
+    def create(self, request, *args, **kwargs):  # type: ignore[override]
+        org = self.get_organizacao()
+        evento_id = request.data.get("evento_id")
+        evento = get_object_or_404(Evento, pk=evento_id)
+        evento.organizacao = org
+        evento.save(update_fields=["organizacao"])
+        serializer = self.get_serializer(evento)
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
 
-class OrganizacaoEmpresaViewSet(OrganizacaoRelatedViewSet):
+    def destroy(self, request, pk=None, organizacao_pk=None):  # type: ignore[override]
+        org = self.get_organizacao()
+        evento = get_object_or_404(Evento, pk=pk, organizacao=org)
+        evento.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class OrganizacaoEmpresaViewSet(OrganizacaoRelatedModelViewSet):
     serializer_class = EmpresaSerializer
 
     def get_queryset(self):
         org = self.get_organizacao()
         return Empresa.objects.filter(organizacao=org, deleted=False)
 
+    def create(self, request, *args, **kwargs):  # type: ignore[override]
+        org = self.get_organizacao()
+        empresa_id = request.data.get("empresa_id")
+        empresa = get_object_or_404(Empresa, pk=empresa_id)
+        empresa.organizacao = org
+        empresa.save(update_fields=["organizacao"])
+        serializer = self.get_serializer(empresa)
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
 
-class OrganizacaoPostViewSet(OrganizacaoRelatedViewSet):
+    def destroy(self, request, pk=None, organizacao_pk=None):  # type: ignore[override]
+        org = self.get_organizacao()
+        empresa = get_object_or_404(Empresa, pk=pk, organizacao=org)
+        empresa.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class OrganizacaoPostViewSet(OrganizacaoRelatedModelViewSet):
     serializer_class = PostSerializer
 
     def get_queryset(self):
         org = self.get_organizacao()
         return Post.objects.filter(organizacao=org, deleted=False)
+
+    def create(self, request, *args, **kwargs):  # type: ignore[override]
+        org = self.get_organizacao()
+        post_id = request.data.get("post_id")
+        post = get_object_or_404(Post, pk=post_id)
+        post.organizacao = org
+        post.save(update_fields=["organizacao"])
+        serializer = self.get_serializer(post)
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+    def destroy(self, request, pk=None, organizacao_pk=None):  # type: ignore[override]
+        org = self.get_organizacao()
+        post = get_object_or_404(Post, pk=pk, organizacao=org)
+        post.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
 
 class OrganizacaoCentroCustoViewSet(OrganizacaoRelatedModelViewSet):

--- a/organizacoes/templates/organizacoes/detail.html
+++ b/organizacoes/templates/organizacoes/detail.html
@@ -55,74 +55,24 @@
     </dl>
   </section>
 
-  <section>
-    <h2 class="text-xl font-semibold text-neutral-900 mb-2">{% trans 'Membros' %} ({{ usuarios|length }})</h2>
-    <ul class="list-disc pl-6 text-neutral-700">
-      {% for user in usuarios %}
-        <li>{{ user.get_full_name|default:user.username }}</li>
-      {% empty %}
-        <li class="list-none text-neutral-500">{% trans 'Nenhum usuário associado.' %}</li>
-      {% endfor %}
-    </ul>
-    {% if request.user.user_type == 'root' or request.user.user_type == 'admin' %}
-    <a href="#" class="mt-2 inline-block text-sm text-primary-600 hover:underline" hx-get="#" hx-target="#modal">{% trans 'Adicionar/Remover' %}</a>
-    {% endif %}
+  <section id="usuarios-section">
+    {% include 'organizacoes/partials/usuarios_list.html' %}
   </section>
 
-  <section>
-    <h2 class="text-xl font-semibold text-neutral-900 mb-2">{% trans 'Núcleos' %} ({{ nucleos|length }})</h2>
-    <ul class="list-disc pl-6 text-neutral-700">
-      {% for nucleo in nucleos %}
-        <li>{{ nucleo.nome }}</li>
-      {% empty %}
-        <li class="list-none text-neutral-500">{% trans 'Nenhum núcleo associado.' %}</li>
-      {% endfor %}
-    </ul>
-    {% if request.user.user_type == 'root' or request.user.user_type == 'admin' %}
-    <a href="#" class="mt-2 inline-block text-sm text-primary-600 hover:underline" hx-get="#" hx-target="#modal">{% trans 'Adicionar/Remover' %}</a>
-    {% endif %}
+  <section id="nucleos-section">
+    {% include 'organizacoes/partials/nucleos_list.html' %}
   </section>
 
-  <section>
-    <h2 class="text-xl font-semibold text-neutral-900 mb-2">{% trans 'Eventos' %} ({{ eventos|length }})</h2>
-    <ul class="list-disc pl-6 text-neutral-700">
-      {% for evento in eventos %}
-        <li>{{ evento.titulo }}</li>
-      {% empty %}
-        <li class="list-none text-neutral-500">{% trans 'Nenhum evento associado.' %}</li>
-      {% endfor %}
-    </ul>
-    {% if request.user.user_type == 'root' or request.user.user_type == 'admin' %}
-    <a href="#" class="mt-2 inline-block text-sm text-primary-600 hover:underline" hx-get="#" hx-target="#modal">{% trans 'Adicionar/Remover' %}</a>
-    {% endif %}
+  <section id="eventos-section">
+    {% include 'organizacoes/partials/eventos_list.html' %}
   </section>
 
-  <section>
-    <h2 class="text-xl font-semibold text-neutral-900 mb-2">{% trans 'Empresas' %} ({{ empresas|length }})</h2>
-    <ul class="list-disc pl-6 text-neutral-700">
-      {% for empresa in empresas %}
-        <li>{{ empresa.nome }}</li>
-      {% empty %}
-        <li class="list-none text-neutral-500">{% trans 'Nenhuma empresa associada.' %}</li>
-      {% endfor %}
-    </ul>
-    {% if request.user.user_type == 'root' or request.user.user_type == 'admin' %}
-    <a href="#" class="mt-2 inline-block text-sm text-primary-600 hover:underline" hx-get="#" hx-target="#modal">{% trans 'Adicionar/Remover' %}</a>
-    {% endif %}
+  <section id="empresas-section">
+    {% include 'organizacoes/partials/empresas_list.html' %}
   </section>
 
-  <section>
-    <h2 class="text-xl font-semibold text-neutral-900 mb-2">{% trans 'Posts' %} ({{ posts|length }})</h2>
-    <ul class="list-disc pl-6 text-neutral-700">
-      {% for post in posts %}
-        <li>{{ post.conteudo|truncatewords:10 }}</li>
-      {% empty %}
-        <li class="list-none text-neutral-500">{% trans 'Nenhum post associado.' %}</li>
-      {% endfor %}
-    </ul>
-    {% if request.user.user_type == 'root' or request.user.user_type == 'admin' %}
-    <a href="#" class="mt-2 inline-block text-sm text-primary-600 hover:underline" hx-get="#" hx-target="#modal">{% trans 'Adicionar/Remover' %}</a>
-    {% endif %}
+  <section id="posts-section">
+    {% include 'organizacoes/partials/posts_list.html' %}
   </section>
 
   <div class="flex justify-end gap-3">
@@ -143,5 +93,6 @@
     {% endif %}
     <a href="{% url 'organizacoes:list' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100">{% trans 'Voltar' %}</a>
   </div>
+  <div id="modal"></div>
 </section>
 {% endblock %}

--- a/organizacoes/templates/organizacoes/empresas_modal.html
+++ b/organizacoes/templates/organizacoes/empresas_modal.html
@@ -1,0 +1,20 @@
+{% load i18n %}
+<div class="bg-white p-4 rounded shadow" hx-target="this">
+  <h3 class="text-lg font-semibold mb-2">{% trans 'Gerenciar empresas' %}</h3>
+  <form hx-post="/api/organizacoes/{{ organizacao.id }}/empresas/" hx-on="htmx:afterRequest: htmx.ajax('GET', '{{ refresh_url }}', '#empresas-section'); this.closest('#modal').innerHTML='';" class="space-y-2">
+    {% csrf_token %}
+    <label class="block text-sm" for="empresa_id">{% trans 'ID da empresa' %}</label>
+    <input type="text" name="empresa_id" class="w-full border px-2 py-1 rounded">
+    <button type="submit" class="mt-2 px-3 py-1 bg-blue-600 text-white rounded">{% trans 'Adicionar' %}</button>
+  </form>
+  <ul class="mt-4 space-y-1">
+    {% for empresa in empresas %}
+      <li class="flex justify-between items-center">
+        {{ empresa.nome }}
+        <button hx-delete="/api/organizacoes/{{ organizacao.id }}/empresas/{{ empresa.id }}/" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}' hx-on="htmx:afterRequest: htmx.ajax('GET', '{{ refresh_url }}', '#empresas-section');" class="text-red-600 text-sm">{% trans 'Remover' %}</button>
+      </li>
+    {% empty %}
+      <li class="text-neutral-500 text-sm">{% trans 'Nenhuma empresa associada.' %}</li>
+    {% endfor %}
+  </ul>
+</div>

--- a/organizacoes/templates/organizacoes/eventos_modal.html
+++ b/organizacoes/templates/organizacoes/eventos_modal.html
@@ -1,0 +1,20 @@
+{% load i18n %}
+<div class="bg-white p-4 rounded shadow" hx-target="this">
+  <h3 class="text-lg font-semibold mb-2">{% trans 'Gerenciar eventos' %}</h3>
+  <form hx-post="/api/organizacoes/{{ organizacao.id }}/eventos/" hx-on="htmx:afterRequest: htmx.ajax('GET', '{{ refresh_url }}', '#eventos-section'); this.closest('#modal').innerHTML='';" class="space-y-2">
+    {% csrf_token %}
+    <label class="block text-sm" for="evento_id">{% trans 'ID do evento' %}</label>
+    <input type="text" name="evento_id" class="w-full border px-2 py-1 rounded">
+    <button type="submit" class="mt-2 px-3 py-1 bg-blue-600 text-white rounded">{% trans 'Adicionar' %}</button>
+  </form>
+  <ul class="mt-4 space-y-1">
+    {% for evento in eventos %}
+      <li class="flex justify-between items-center">
+        {{ evento.titulo }}
+        <button hx-delete="/api/organizacoes/{{ organizacao.id }}/eventos/{{ evento.id }}/" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}' hx-on="htmx:afterRequest: htmx.ajax('GET', '{{ refresh_url }}', '#eventos-section');" class="text-red-600 text-sm">{% trans 'Remover' %}</button>
+      </li>
+    {% empty %}
+      <li class="text-neutral-500 text-sm">{% trans 'Nenhum evento associado.' %}</li>
+    {% endfor %}
+  </ul>
+</div>

--- a/organizacoes/templates/organizacoes/nucleos_modal.html
+++ b/organizacoes/templates/organizacoes/nucleos_modal.html
@@ -1,0 +1,20 @@
+{% load i18n %}
+<div class="bg-white p-4 rounded shadow" hx-target="this">
+  <h3 class="text-lg font-semibold mb-2">{% trans 'Gerenciar núcleos' %}</h3>
+  <form hx-post="/api/organizacoes/{{ organizacao.id }}/nucleos/" hx-on="htmx:afterRequest: htmx.ajax('GET', '{{ refresh_url }}', '#nucleos-section'); this.closest('#modal').innerHTML='';" class="space-y-2">
+    {% csrf_token %}
+    <label class="block text-sm" for="nucleo_id">{% trans 'ID do núcleo' %}</label>
+    <input type="text" name="nucleo_id" class="w-full border px-2 py-1 rounded">
+    <button type="submit" class="mt-2 px-3 py-1 bg-blue-600 text-white rounded">{% trans 'Adicionar' %}</button>
+  </form>
+  <ul class="mt-4 space-y-1">
+    {% for nucleo in nucleos %}
+      <li class="flex justify-between items-center">
+        {{ nucleo.nome }}
+        <button hx-delete="/api/organizacoes/{{ organizacao.id }}/nucleos/{{ nucleo.id }}/" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}' hx-on="htmx:afterRequest: htmx.ajax('GET', '{{ refresh_url }}', '#nucleos-section');" class="text-red-600 text-sm">{% trans 'Remover' %}</button>
+      </li>
+    {% empty %}
+      <li class="text-neutral-500 text-sm">{% trans 'Nenhum núcleo associado.' %}</li>
+    {% endfor %}
+  </ul>
+</div>

--- a/organizacoes/templates/organizacoes/partials/empresas_list.html
+++ b/organizacoes/templates/organizacoes/partials/empresas_list.html
@@ -1,0 +1,12 @@
+{% load i18n %}
+<h2 class="text-xl font-semibold text-neutral-900 mb-2">{% trans 'Empresas' %} ({{ empresas|length }})</h2>
+<ul class="list-disc pl-6 text-neutral-700">
+  {% for empresa in empresas %}
+    <li>{{ empresa.nome }}</li>
+  {% empty %}
+    <li class="list-none text-neutral-500">{% trans 'Nenhuma empresa associada.' %}</li>
+  {% endfor %}
+</ul>
+{% if request.user.user_type == 'root' or request.user.user_type == 'admin' %}
+<a href="#" class="mt-2 inline-block text-sm text-primary-600 hover:underline" hx-get="{% url 'organizacoes:empresas_modal' object.id %}" hx-target="#modal">{% trans 'Adicionar/Remover' %}</a>
+{% endif %}

--- a/organizacoes/templates/organizacoes/partials/eventos_list.html
+++ b/organizacoes/templates/organizacoes/partials/eventos_list.html
@@ -1,0 +1,12 @@
+{% load i18n %}
+<h2 class="text-xl font-semibold text-neutral-900 mb-2">{% trans 'Eventos' %} ({{ eventos|length }})</h2>
+<ul class="list-disc pl-6 text-neutral-700">
+  {% for evento in eventos %}
+    <li>{{ evento.titulo }}</li>
+  {% empty %}
+    <li class="list-none text-neutral-500">{% trans 'Nenhum evento associado.' %}</li>
+  {% endfor %}
+</ul>
+{% if request.user.user_type == 'root' or request.user.user_type == 'admin' %}
+<a href="#" class="mt-2 inline-block text-sm text-primary-600 hover:underline" hx-get="{% url 'organizacoes:eventos_modal' object.id %}" hx-target="#modal">{% trans 'Adicionar/Remover' %}</a>
+{% endif %}

--- a/organizacoes/templates/organizacoes/partials/nucleos_list.html
+++ b/organizacoes/templates/organizacoes/partials/nucleos_list.html
@@ -1,0 +1,12 @@
+{% load i18n %}
+<h2 class="text-xl font-semibold text-neutral-900 mb-2">{% trans 'Núcleos' %} ({{ nucleos|length }})</h2>
+<ul class="list-disc pl-6 text-neutral-700">
+  {% for nucleo in nucleos %}
+    <li>{{ nucleo.nome }}</li>
+  {% empty %}
+    <li class="list-none text-neutral-500">{% trans 'Nenhum núcleo associado.' %}</li>
+  {% endfor %}
+</ul>
+{% if request.user.user_type == 'root' or request.user.user_type == 'admin' %}
+<a href="#" class="mt-2 inline-block text-sm text-primary-600 hover:underline" hx-get="{% url 'organizacoes:nucleos_modal' object.id %}" hx-target="#modal">{% trans 'Adicionar/Remover' %}</a>
+{% endif %}

--- a/organizacoes/templates/organizacoes/partials/posts_list.html
+++ b/organizacoes/templates/organizacoes/partials/posts_list.html
@@ -1,0 +1,12 @@
+{% load i18n %}
+<h2 class="text-xl font-semibold text-neutral-900 mb-2">{% trans 'Posts' %} ({{ posts|length }})</h2>
+<ul class="list-disc pl-6 text-neutral-700">
+  {% for post in posts %}
+    <li>{{ post.conteudo|truncatewords:10 }}</li>
+  {% empty %}
+    <li class="list-none text-neutral-500">{% trans 'Nenhum post associado.' %}</li>
+  {% endfor %}
+</ul>
+{% if request.user.user_type == 'root' or request.user.user_type == 'admin' %}
+<a href="#" class="mt-2 inline-block text-sm text-primary-600 hover:underline" hx-get="{% url 'organizacoes:posts_modal' object.id %}" hx-target="#modal">{% trans 'Adicionar/Remover' %}</a>
+{% endif %}

--- a/organizacoes/templates/organizacoes/partials/usuarios_list.html
+++ b/organizacoes/templates/organizacoes/partials/usuarios_list.html
@@ -1,0 +1,12 @@
+{% load i18n %}
+<h2 class="text-xl font-semibold text-neutral-900 mb-2">{% trans 'Membros' %} ({{ usuarios|length }})</h2>
+<ul class="list-disc pl-6 text-neutral-700">
+  {% for user in usuarios %}
+    <li>{{ user.get_full_name|default:user.username }}</li>
+  {% empty %}
+    <li class="list-none text-neutral-500">{% trans 'Nenhum usuário associado.' %}</li>
+  {% endfor %}
+</ul>
+{% if request.user.user_type == 'root' or request.user.user_type == 'admin' %}
+<a href="#" class="mt-2 inline-block text-sm text-primary-600 hover:underline" hx-get="{% url 'organizacoes:usuarios_modal' object.id %}" hx-target="#modal">{% trans 'Adicionar/Remover' %}</a>
+{% endif %}

--- a/organizacoes/templates/organizacoes/posts_modal.html
+++ b/organizacoes/templates/organizacoes/posts_modal.html
@@ -1,0 +1,20 @@
+{% load i18n %}
+<div class="bg-white p-4 rounded shadow" hx-target="this">
+  <h3 class="text-lg font-semibold mb-2">{% trans 'Gerenciar posts' %}</h3>
+  <form hx-post="/api/organizacoes/{{ organizacao.id }}/posts/" hx-on="htmx:afterRequest: htmx.ajax('GET', '{{ refresh_url }}', '#posts-section'); this.closest('#modal').innerHTML='';" class="space-y-2">
+    {% csrf_token %}
+    <label class="block text-sm" for="post_id">{% trans 'ID do post' %}</label>
+    <input type="text" name="post_id" class="w-full border px-2 py-1 rounded">
+    <button type="submit" class="mt-2 px-3 py-1 bg-blue-600 text-white rounded">{% trans 'Adicionar' %}</button>
+  </form>
+  <ul class="mt-4 space-y-1">
+    {% for post in posts %}
+      <li class="flex justify-between items-center">
+        {{ post.conteudo|truncatewords:10 }}
+        <button hx-delete="/api/organizacoes/{{ organizacao.id }}/posts/{{ post.id }}/" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}' hx-on="htmx:afterRequest: htmx.ajax('GET', '{{ refresh_url }}', '#posts-section');" class="text-red-600 text-sm">{% trans 'Remover' %}</button>
+      </li>
+    {% empty %}
+      <li class="text-neutral-500 text-sm">{% trans 'Nenhum post associado.' %}</li>
+    {% endfor %}
+  </ul>
+</div>

--- a/organizacoes/templates/organizacoes/usuarios_modal.html
+++ b/organizacoes/templates/organizacoes/usuarios_modal.html
@@ -1,0 +1,20 @@
+{% load i18n %}
+<div class="bg-white p-4 rounded shadow" hx-target="this">
+  <h3 class="text-lg font-semibold mb-2">{% trans 'Gerenciar usuários' %}</h3>
+  <form hx-post="/api/organizacoes/{{ organizacao.id }}/usuarios/" hx-on="htmx:afterRequest: htmx.ajax('GET', '{{ refresh_url }}', '#usuarios-section'); this.closest('#modal').innerHTML='';" class="space-y-2">
+    {% csrf_token %}
+    <label class="block text-sm" for="user_id">{% trans 'ID do usuário' %}</label>
+    <input type="text" name="user_id" class="w-full border px-2 py-1 rounded">
+    <button type="submit" class="mt-2 px-3 py-1 bg-blue-600 text-white rounded">{% trans 'Adicionar' %}</button>
+  </form>
+  <ul class="mt-4 space-y-1">
+    {% for user in usuarios %}
+      <li class="flex justify-between items-center">
+        {{ user.get_full_name|default:user.username }}
+        <button hx-delete="/api/organizacoes/{{ organizacao.id }}/usuarios/{{ user.id }}/" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}' hx-on="htmx:afterRequest: htmx.ajax('GET', '{{ refresh_url }}', '#usuarios-section');" class="text-red-600 text-sm">{% trans 'Remover' %}</button>
+      </li>
+    {% empty %}
+      <li class="text-neutral-500 text-sm">{% trans 'Nenhum usuário associado.' %}</li>
+    {% endfor %}
+  </ul>
+</div>

--- a/organizacoes/urls.py
+++ b/organizacoes/urls.py
@@ -8,6 +8,31 @@ urlpatterns = [
     path("", views.OrganizacaoListView.as_view(), name="list"),
     path("nova/", views.OrganizacaoCreateView.as_view(), name="create"),
     path("<uuid:pk>/", views.OrganizacaoDetailView.as_view(), name="detail"),
+    path(
+        "<uuid:pk>/usuarios/modal/",
+        views.OrganizacaoUsuariosModalView.as_view(),
+        name="usuarios_modal",
+    ),
+    path(
+        "<uuid:pk>/nucleos/modal/",
+        views.OrganizacaoNucleosModalView.as_view(),
+        name="nucleos_modal",
+    ),
+    path(
+        "<uuid:pk>/eventos/modal/",
+        views.OrganizacaoEventosModalView.as_view(),
+        name="eventos_modal",
+    ),
+    path(
+        "<uuid:pk>/empresas/modal/",
+        views.OrganizacaoEmpresasModalView.as_view(),
+        name="empresas_modal",
+    ),
+    path(
+        "<uuid:pk>/posts/modal/",
+        views.OrganizacaoPostsModalView.as_view(),
+        name="posts_modal",
+    ),
     path("<uuid:pk>/editar/", views.OrganizacaoUpdateView.as_view(), name="update"),
     path("<uuid:pk>/remover/", views.OrganizacaoDeleteView.as_view(), name="delete"),
     path(


### PR DESCRIPTION
## Summary
- replace placeholder links in organization detail with HTMX modals
- add API and view support for adding/removing related users, nuclei, events, companies, and posts
- refresh organization sections via HTMX after operations

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'axe_core_python', ModuleNotFoundError: No module named 'bs4', ModuleNotFoundError: No module named 'playwright', ModuleNotFoundError: No module named 'httpx', ModuleNotFoundError: No module named 'pywebpush', ModuleNotFoundError: No module named 'django_redis')*

------
https://chatgpt.com/codex/tasks/task_e_68a525204ddc83258c6a1c7c2dd0196a