### PR TITLE
Add rate limit multiplier to organization form

### DIFF
--- a/organizacoes/forms.py
+++ b/organizacoes/forms.py
@@ -1,5 +1,6 @@
 from django import forms
 from django.utils.text import slugify
+from django.utils.translation import gettext_lazy as _
 
 from .models import Organizacao
 from .utils import validate_cnpj
@@ -22,7 +23,11 @@ class OrganizacaoForm(forms.ModelForm):
             "contato_telefone",
             "avatar",
             "cover",
+            "rate_limit_multiplier",
         ]
+        labels = {
+            "rate_limit_multiplier": _("Multiplicador de limite de taxa"),
+        }
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
@@ -31,6 +36,12 @@ class OrganizacaoForm(forms.ModelForm):
             existing = field.widget.attrs.get("class", "")
             field.widget.attrs["class"] = f"{existing} {base_cls}".strip()
         self.fields["slug"].required = False
+
+    def clean_rate_limit_multiplier(self):
+        mult = self.cleaned_data.get("rate_limit_multiplier")
+        if mult is not None and mult <= 0:
+            raise forms.ValidationError(_("Deve ser maior que zero."))
+        return mult
 
     def clean_cnpj(self):
         cnpj = validate_cnpj(self.cleaned_data.get("cnpj"))

--- a/organizacoes/templates/organizacoes/create.html
+++ b/organizacoes/templates/organizacoes/create.html
@@ -112,6 +112,14 @@
     </div>
 
     <div>
+      <label for="{{ form.rate_limit_multiplier.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.rate_limit_multiplier.label }}</label>
+      {{ form.rate_limit_multiplier }}
+      {% if form.rate_limit_multiplier.errors %}
+        <p class="text-red-500 text-xs mt-1">{{ form.rate_limit_multiplier.errors }}</p>
+      {% endif %}
+    </div>
+
+    <div>
       <label for="{{ form.avatar.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.avatar.label }}</label>
       {{ form.avatar }}
       {% if form.avatar.errors %}

--- a/organizacoes/templates/organizacoes/update.html
+++ b/organizacoes/templates/organizacoes/update.html
@@ -116,6 +116,14 @@
     </div>
 
     <div>
+      <label for="{{ form.rate_limit_multiplier.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.rate_limit_multiplier.label }}</label>
+      {{ form.rate_limit_multiplier }}
+      {% if form.rate_limit_multiplier.errors %}
+        <p class="text-red-500 text-xs mt-1">{{ form.rate_limit_multiplier.errors }}</p>
+      {% endif %}
+    </div>
+
+    <div>
       <label for="{{ form.avatar.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.avatar.label }}</label>
       {{ form.avatar }}
       {% if form.avatar.errors %}


### PR DESCRIPTION
## Summary
- include `rate_limit_multiplier` in `OrganizacaoForm` with validation
- show rate limit multiplier field in create/update organization templates

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'django_redis')*
- `pytest tests/organizacoes/test_api.py -q` *(fails: ModuleNotFoundError: No module named 'django_redis')*

------
https://chatgpt.com/codex/tasks/task_e_68a5251c7fa88325ae14334bb73d8ed7