### PR TITLE
Fix Nucleo export buttons for file downloads

### DIFF
--- a/nucleos/templates/nucleos/detail.html
+++ b/nucleos/templates/nucleos/detail.html
@@ -102,8 +102,18 @@
 
   <div class="mt-6 space-x-2">
     <div class="inline-block relative">
-      <button class="text-blue-600" hx-get="{% url 'nucleos:exportar_membros' object.pk %}?formato=csv" hx-trigger="click" hx-swap="none">{% trans 'Exportar CSV' %}</button>
-      <button class="text-blue-600" hx-get="{% url 'nucleos:exportar_membros' object.pk %}?formato=xls" hx-trigger="click" hx-swap="none">{% trans 'Exportar XLS' %}</button>
+      <a
+        href="{% url 'nucleos:exportar_membros' object.pk %}?formato=csv"
+        class="text-blue-600"
+        hx-boost="false"
+        download="nucleo-{{ object.pk }}-membros.csv"
+      >{% trans 'Exportar CSV' %}</a>
+      <a
+        href="{% url 'nucleos:exportar_membros' object.pk %}?formato=xls"
+        class="text-blue-600"
+        hx-boost="false"
+        download="nucleo-{{ object.pk }}-membros.xlsx"
+      >{% trans 'Exportar XLS' %}</a>
     </div>
     {% if request.user.user_type in ('admin','coordenador','root') %}
     <form method="post" action="{% url 'nucleos:toggle_active' object.pk %}" class="inline">{% csrf_token %}


### PR DESCRIPTION
## Summary
- replace htmx export buttons with direct links for CSV and XLS downloads

## Testing
- `pytest tests/nucleos/test_views.py::test_exportar_membros_csv tests/nucleos/test_api.py::test_exportar_membros --no-cov -q`


------
https://chatgpt.com/codex/tasks/task_e_68a524f7895c8325a4a1f8a8f0292152