### PR TITLE
Restrict nucleus actions to admins and handle 403

### DIFF
--- a/nucleos/templates/nucleos/detail.html
+++ b/nucleos/templates/nucleos/detail.html
@@ -91,7 +91,7 @@
   </div>
   {% endif %}
 
-  {% if request.user.user_type in ('admin','coordenador') %}
+  {% if request.user.user_type == 'admin' %}
   <div class="mt-4">
     <button type="button" class="px-4 py-2 bg-purple-600 text-white rounded" hx-get="{% url 'nucleos:convites_modal' object.pk %}" hx-target="#modal">
       {% trans 'Gerenciar convites' %} ({{ convites_pendentes }})

--- a/nucleos/templates/nucleos/list.html
+++ b/nucleos/templates/nucleos/list.html
@@ -10,7 +10,7 @@
     <input type="text" name="q" value="{{ form.q.value }}" placeholder="{% trans 'Buscar...' %}" class="border rounded px-2 py-1 flex-1" />
     <button class="px-3 py-1 bg-blue-600 text-white rounded" aria-label="{% trans 'Buscar núcleos' %}">{% trans 'Buscar' %}</button>
   </form>
-  {% if request.user.user_type == 'admin' or request.user.user_type == 'coordenador' %}
+  {% if request.user.user_type in ('admin', 'root') %}
   <div class="mb-4">
     <a href="{% url 'nucleos:create' %}" class="px-3 py-2 bg-green-600 text-white rounded" aria-label="{% trans 'Criar novo núcleo' %}">{% trans 'Novo' %}</a>
   </div>
@@ -28,7 +28,7 @@
       <p class="text-sm mt-2">{% trans "Membros" %}: {{ nucleo.membros.count }}</p>
       <div class="mt-2">
         <a href="{% url 'nucleos:detail' nucleo.pk %}" class="text-blue-600" aria-label="{% blocktrans with nome=nucleo.nome %}Ver detalhes do núcleo {{ nome }}{% endblocktrans %}">{% trans 'Detalhes' %}</a>
-        {% if request.user.user_type == 'admin' or request.user.user_type == 'coordenador' or request.user.user_type == 'root' %}
+        {% if request.user.user_type in ('admin', 'root') %}
         <form method="post" action="{% url 'nucleos:delete' nucleo.pk %}" class="inline">{% csrf_token %}
           <button class="text-red-600 ml-2" aria-label="{% blocktrans with nome=nucleo.nome %}Excluir núcleo {{ nome }}{% endblocktrans %}">{% trans 'Excluir' %}</button>
         </form>

--- a/templates/base.html
+++ b/templates/base.html
@@ -159,6 +159,13 @@
   <script src="https://unpkg.com/htmx.org@{{ HTMX_VERSION }}"></script>
   <script src="{% static 'js/dashboard.js' %}"></script>
   <script>
+    document.body.addEventListener('htmx:responseError', function (evt) {
+      if (evt.detail.xhr.status === 403) {
+        alert(gettext('Você não tem permissão para realizar esta ação.'));
+      }
+    });
+  </script>
+  <script>
     (function () {
       const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
 


### PR DESCRIPTION
## Summary
- Limit "Novo" and "Excluir" buttons in nucleus list to admin/root users
- Show "Gerenciar convites" in nucleus detail only to admins
- Add global HTMX handler to alert when an API returns 403

## Testing
- ⚠️ `pytest tests/test_accounts_auth.py::AuthTests::test_email_login_success -q` (interrupted: KeyboardInterrupt)


------
https://chatgpt.com/codex/tasks/task_e_68a524eedfd083259c17a147e8305f4f