### PR TITLE
Add mensalidade field to Núcleo forms and serializer

### DIFF
--- a/nucleos/forms.py
+++ b/nucleos/forms.py
@@ -13,11 +13,25 @@ User = get_user_model()
 class NucleoForm(forms.ModelForm):
     class Meta:
         model = Nucleo
-        fields = ["nome", "slug", "descricao", "avatar", "cover", "ativo"]
+        fields = [
+            "nome",
+            "slug",
+            "descricao",
+            "avatar",
+            "cover",
+            "mensalidade",
+            "ativo",
+        ]
 
     def clean_descricao(self):
         descricao = self.cleaned_data.get("descricao", "")
         return bleach.clean(descricao)
+
+    def clean_mensalidade(self):
+        valor = self.cleaned_data.get("mensalidade")
+        if valor is not None and valor < 0:
+            raise forms.ValidationError(_("Valor inválido"))
+        return valor
 
 
 class NucleoSearchForm(forms.Form):

--- a/nucleos/serializers.py
+++ b/nucleos/serializers.py
@@ -67,6 +67,7 @@ class NucleoSerializer(serializers.ModelSerializer):
             "descricao",
             "avatar",
             "cover",
+            "mensalidade",
             "ativo",
             "created_at",
             "deleted",
@@ -74,6 +75,11 @@ class NucleoSerializer(serializers.ModelSerializer):
             "suplentes",
         ]
         read_only_fields = ["deleted", "deleted_at", "created_at"]
+
+    def validate_mensalidade(self, valor):
+        if valor < 0:
+            raise serializers.ValidationError("Valor inválido")
+        return valor
 
 
 class ConviteNucleoSerializer(serializers.ModelSerializer):

--- a/nucleos/templates/nucleos/create.html
+++ b/nucleos/templates/nucleos/create.html
@@ -7,7 +7,13 @@
 <section class="max-w-2xl mx-auto py-8">
   <form method="post" enctype="multipart/form-data" class="space-y-4">
     {% csrf_token %}
-    {{ form.as_p }}
+    <p>{{ form.nome.label_tag }} {{ form.nome }} {{ form.nome.errors }}</p>
+    <p>{{ form.slug.label_tag }} {{ form.slug }} {{ form.slug.errors }}</p>
+    <p>{{ form.descricao.label_tag }} {{ form.descricao }} {{ form.descricao.errors }}</p>
+    <p>{{ form.avatar.label_tag }} {{ form.avatar }} {{ form.avatar.errors }}</p>
+    <p>{{ form.cover.label_tag }} {{ form.cover }} {{ form.cover.errors }}</p>
+    <p>{{ form.mensalidade.label_tag }} {{ form.mensalidade }} {{ form.mensalidade.errors }}</p>
+    <p>{{ form.ativo.label_tag }} {{ form.ativo }} {{ form.ativo.errors }}</p>
     <div class="flex justify-end gap-2">
       <a href="{% url 'nucleos:list' %}" class="px-4 py-2 border rounded">{% trans 'Cancelar' %}</a>
       <button type="submit" class="px-4 py-2 bg-green-600 text-white rounded">{% trans 'Salvar' %}</button>

--- a/nucleos/templates/nucleos/update.html
+++ b/nucleos/templates/nucleos/update.html
@@ -7,7 +7,13 @@
 <section class="max-w-2xl mx-auto py-8">
   <form method="post" enctype="multipart/form-data" class="space-y-4">
     {% csrf_token %}
-    {{ form.as_p }}
+    <p>{{ form.nome.label_tag }} {{ form.nome }} {{ form.nome.errors }}</p>
+    <p>{{ form.slug.label_tag }} {{ form.slug }} {{ form.slug.errors }}</p>
+    <p>{{ form.descricao.label_tag }} {{ form.descricao }} {{ form.descricao.errors }}</p>
+    <p>{{ form.avatar.label_tag }} {{ form.avatar }} {{ form.avatar.errors }}</p>
+    <p>{{ form.cover.label_tag }} {{ form.cover }} {{ form.cover.errors }}</p>
+    <p>{{ form.mensalidade.label_tag }} {{ form.mensalidade }} {{ form.mensalidade.errors }}</p>
+    <p>{{ form.ativo.label_tag }} {{ form.ativo }} {{ form.ativo.errors }}</p>
     <div class="flex justify-end gap-2">
       <a href="{% url 'nucleos:detail' object.pk %}" class="px-4 py-2 border rounded">{% trans 'Cancelar' %}</a>
       <button type="submit" class="px-4 py-2 bg-green-600 text-white rounded">{% trans 'Salvar' %}</button>

--- a/tests/nucleos/test_forms.py
+++ b/tests/nucleos/test_forms.py
@@ -7,13 +7,27 @@ pytestmark = pytest.mark.django_db
 
 def test_nucleo_form_fields():
     form = NucleoForm()
-    assert list(form.fields) == ["nome", "slug", "descricao", "avatar", "cover", "ativo"]
+    assert list(form.fields) == [
+        "nome",
+        "slug",
+        "descricao",
+        "avatar",
+        "cover",
+        "mensalidade",
+        "ativo",
+    ]
 
 
 def test_form_validation_errors():
     form = NucleoForm(data={"nome": "", "slug": ""})
     assert not form.is_valid()
     assert "nome" in form.errors
+
+
+def test_mensalidade_negative_value():
+    form = NucleoForm(data={"nome": "N", "slug": "n", "mensalidade": -1})
+    assert not form.is_valid()
+    assert "mensalidade" in form.errors
 
 
 def test_search_form_contains_field():

--- a/tests/nucleos/test_serializers.py
+++ b/tests/nucleos/test_serializers.py
@@ -1,0 +1,24 @@
+import pytest
+from decimal import Decimal
+
+from nucleos.models import Nucleo
+from nucleos.serializers import NucleoSerializer
+from organizacoes.models import Organizacao
+
+pytestmark = pytest.mark.django_db
+
+
+def test_nucleo_serializer_contains_mensalidade():
+    org = Organizacao.objects.create(nome="Org", cnpj="00.000.000/0001-00", slug="org")
+    nucleo = Nucleo.objects.create(nome="N", slug="n", organizacao=org, mensalidade=Decimal("10"))
+    data = NucleoSerializer(nucleo).data
+    assert str(data["mensalidade"]) == "10.00"
+
+
+def test_nucleo_serializer_validate_mensalidade():
+    org = Organizacao.objects.create(nome="Org2", cnpj="00.000.000/0002-00", slug="org2")
+    serializer = NucleoSerializer(
+        data={"organizacao": org.pk, "nome": "N", "slug": "n", "mensalidade": -5}
+    )
+    assert not serializer.is_valid()
+    assert "mensalidade" in serializer.errors


### PR DESCRIPTION
## Summary
- include `mensalidade` field in `NucleoForm` with validation
- expose and validate `mensalidade` in `NucleoSerializer`
- render mensalidade field on create/update templates and test coverage

## Testing
- `pytest tests/nucleos/test_forms.py tests/nucleos/test_serializers.py --no-cov -q`


------
https://chatgpt.com/codex/tasks/task_e_68a524ebb0588325af13ae17d5025c64