### PR TITLE
Ensure sequential registration steps render messages

### DIFF
--- a/accounts/templates/register/cpf.html
+++ b/accounts/templates/register/cpf.html
@@ -21,6 +21,14 @@
       <p class="text-neutral-600">{% trans "Precisamos para validar sua identidade e segurança" %}</p>
     </div>
 
+    {% if messages %}
+    <div class="mb-4 space-y-2">
+      {% for message in messages %}
+        <p class="rounded-xl px-4 py-2 text-sm {{ message.tags == 'success'|yesno:'bg-green-100 text-green-700,bg-red-100 text-red-700' }}">{{ message }}</p>
+      {% endfor %}
+    </div>
+    {% endif %}
+
     <form id="cpfForm" method="post" action="{% url 'accounts:cpf' %}" class="space-y-6">
       {% csrf_token %}
       <div>
@@ -31,7 +39,7 @@
       </div>
 
       <div class="flex gap-4">
-        <a href="{% url 'accounts:nome' %}" class="flex-1 rounded-xl border border-neutral-300 px-4 py-2 text-center text-neutral-700 hover:bg-neutral-100">{% trans "Voltar" %}</a>
+        <a href="{% url 'accounts:email' %}" class="flex-1 rounded-xl border border-neutral-300 px-4 py-2 text-center text-neutral-700 hover:bg-neutral-100">{% trans "Voltar" %}</a>
         <button type="submit" id="submitButton" class="flex-1 rounded-xl bg-primary-600 px-4 py-2 text-white hover:bg-primary-700">{% trans "Continuar" %}</button>
       </div>
     </form>

--- a/accounts/templates/register/email.html
+++ b/accounts/templates/register/email.html
@@ -21,6 +21,14 @@
       <p class="text-neutral-600">{% trans "Usaremos para comunicação e recuperação de conta" %}</p>
     </div>
 
+    {% if messages %}
+    <div class="mb-4 space-y-2">
+      {% for message in messages %}
+        <p class="rounded-xl px-4 py-2 text-sm {{ message.tags == 'success'|yesno:'bg-green-100 text-green-700,bg-red-100 text-red-700' }}">{{ message }}</p>
+      {% endfor %}
+    </div>
+    {% endif %}
+
     <form id="emailForm" method="post" action="{% url 'accounts:email' %}" class="space-y-6">
       {% csrf_token %}
       <div>

--- a/accounts/templates/register/foto.html
+++ b/accounts/templates/register/foto.html
@@ -21,6 +21,14 @@
       <p class="text-neutral-600">{% trans "Personalize sua presença na comunidade" %}</p>
     </div>
 
+    {% if messages %}
+    <div class="mb-4 space-y-2">
+      {% for message in messages %}
+        <p class="rounded-xl px-4 py-2 text-sm {{ message.tags == 'success'|yesno:'bg-green-100 text-green-700,bg-red-100 text-red-700' }}">{{ message }}</p>
+      {% endfor %}
+    </div>
+    {% endif %}
+
     <form id="fotoForm" method="post" action="{% url 'accounts:foto' %}" enctype="multipart/form-data" class="space-y-6">
       {% csrf_token %}
       <div>

--- a/accounts/templates/register/nome.html
+++ b/accounts/templates/register/nome.html
@@ -21,6 +21,14 @@
       <p class="text-neutral-600">{% trans "Digite seu nome completo" %}</p>
     </div>
 
+    {% if messages %}
+    <div class="mb-4 space-y-2">
+      {% for message in messages %}
+        <p class="rounded-xl px-4 py-2 text-sm {{ message.tags == 'success'|yesno:'bg-green-100 text-green-700,bg-red-100 text-red-700' }}">{{ message }}</p>
+      {% endfor %}
+    </div>
+    {% endif %}
+
     <form id="nomeForm" method="post" action="{% url 'accounts:nome' %}" class="space-y-6">
       {% csrf_token %}
       <div>

--- a/accounts/templates/register/onboarding.html
+++ b/accounts/templates/register/onboarding.html
@@ -23,6 +23,14 @@
             </p>
         </div>
 
+        {% if messages %}
+        <div class="mb-4 space-y-2">
+            {% for message in messages %}
+            <p class="rounded-xl px-4 py-2 text-sm {{ message.tags == 'success'|yesno:'bg-green-100 text-green-700,bg-red-100 text-red-700' }}">{{ message }}</p>
+            {% endfor %}
+        </div>
+        {% endif %}
+
         <div class="grid md:grid-cols-3 gap-6 mb-8">
             <div class="text-center">
                 <div class="w-15 h-15 bg-success-100 rounded-full flex items-center justify-center mx-auto mb-3">

--- a/accounts/templates/register/registro_sucesso.html
+++ b/accounts/templates/register/registro_sucesso.html
@@ -6,6 +6,13 @@
 {% block content %}
 <section class="max-w-md mx-auto px-4 py-12 text-center">
   <div class="rounded-2xl border border-neutral-200 bg-white p-8 shadow-sm">
+    {% if messages %}
+    <div class="mb-4 space-y-2">
+      {% for message in messages %}
+        <p class="rounded-xl px-4 py-2 text-sm {{ message.tags == 'success'|yesno:'bg-green-100 text-green-700,bg-red-100 text-red-700' }}">{{ message }}</p>
+      {% endfor %}
+    </div>
+    {% endif %}
     <h1 class="mb-4 text-3xl font-bold text-neutral-900">{% trans "Bem-vindo ao HubX!" %}</h1>
     <p class="mb-6 text-neutral-600">{% trans "Seu cadastro foi concluído com sucesso." %}</p>
     <a href="{% url 'accounts:perfil' %}" class="rounded-xl bg-primary-600 px-4 py-2 text-white hover:bg-primary-700">{% trans "Ir para meu Perfil →" %}</a>

--- a/accounts/templates/register/senha.html
+++ b/accounts/templates/register/senha.html
@@ -8,11 +8,11 @@
   <div class="rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
     <div class="mb-8">
       <div class="mb-2 flex items-center justify-between">
-        <span class="text-sm font-medium text-primary-600">{% blocktrans with step=5 total=7 %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
-        <span class="text-sm text-neutral-500">70%</span>
+        <span class="text-sm font-medium text-primary-600">{% blocktrans with step=6 total=7 %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
+        <span class="text-sm text-neutral-500">84%</span>
       </div>
       <div class="h-2 w-full rounded-xl bg-neutral-200">
-        <div class="h-full rounded-xl bg-primary-600 w-[70%]"></div>
+        <div class="h-full rounded-xl bg-primary-600 w-[84%]"></div>
       </div>
     </div>
 
@@ -20,6 +20,14 @@
       <h1 class="mb-2 text-3xl font-bold text-neutral-900">{% trans "Crie uma senha segura" %}</h1>
       <p class="text-neutral-600">{% trans "Proteja sua conta com uma senha forte" %}</p>
     </div>
+
+    {% if messages %}
+    <div class="mb-4 space-y-2">
+      {% for message in messages %}
+        <p class="rounded-xl px-4 py-2 text-sm {{ message.tags == 'success'|yesno:'bg-green-100 text-green-700,bg-red-100 text-red-700' }}">{{ message }}</p>
+      {% endfor %}
+    </div>
+    {% endif %}
 
     <form id="senhaForm" method="post" action="{% url 'accounts:senha' %}" class="space-y-6">
       {% csrf_token %}
@@ -38,7 +46,7 @@
       </div>
 
       <div class="flex gap-4">
-        <a href="{% url 'accounts:email' %}" class="flex-1 rounded-xl border border-neutral-300 px-4 py-2 text-center text-neutral-700 hover:bg-neutral-100">{% trans "Voltar" %}</a>
+        <a href="{% url 'accounts:cpf' %}" class="flex-1 rounded-xl border border-neutral-300 px-4 py-2 text-center text-neutral-700 hover:bg-neutral-100">{% trans "Voltar" %}</a>
         <button type="submit" id="submitButton" class="flex-1 rounded-xl bg-primary-600 px-4 py-2 text-white hover:bg-primary-700">{% trans "Continuar" %}</button>
       </div>
     </form>

--- a/accounts/templates/register/termos.html
+++ b/accounts/templates/register/termos.html
@@ -21,6 +21,14 @@
       <p class="text-neutral-600">{% trans "Revise e aceite os termos para finalizar" %}</p>
     </div>
 
+    {% if messages %}
+    <div class="mb-4 space-y-2">
+      {% for message in messages %}
+        <p class="rounded-xl px-4 py-2 text-sm {{ message.tags == 'success'|yesno:'bg-green-100 text-green-700,bg-red-100 text-red-700' }}">{{ message }}</p>
+      {% endfor %}
+    </div>
+    {% endif %}
+
     <form id="termosForm" method="post" action="{% url 'accounts:termos' %}" class="space-y-6">
       {% csrf_token %}
       <div class="space-y-4 max-h-64 overflow-y-auto p-4 border border-neutral-200 rounded-lg">

--- a/accounts/templates/register/token.html
+++ b/accounts/templates/register/token.html
@@ -28,6 +28,14 @@
       <p class="text-neutral-600">{% trans "Digite seu token de convite para começar o cadastro" %}</p>
     </div>
 
+    {% if messages %}
+    <div class="mb-4 space-y-2">
+      {% for message in messages %}
+        <p class="rounded-xl px-4 py-2 text-sm {{ message.tags == 'success'|yesno:'bg-green-100 text-green-700,bg-red-100 text-red-700' }}">{{ message }}</p>
+      {% endfor %}
+    </div>
+    {% endif %}
+
     <form method="post" action="{% url 'tokens:token' %}" class="space-y-6">
       {% csrf_token %}
       <div>

--- a/accounts/templates/register/usuario.html
+++ b/accounts/templates/register/usuario.html
@@ -21,6 +21,14 @@
       <p class="text-neutral-600">{% trans "Como você será identificado na plataforma" %}</p>
     </div>
 
+    {% if messages %}
+    <div class="mb-4 space-y-2">
+      {% for message in messages %}
+        <p class="rounded-xl px-4 py-2 text-sm {{ message.tags == 'success'|yesno:'bg-green-100 text-green-700,bg-red-100 text-red-700' }}">{{ message }}</p>
+      {% endfor %}
+    </div>
+    {% endif %}
+
     <form id="usuarioForm" method="post" action="{% url 'accounts:usuario' %}" class="space-y-6">
       {% csrf_token %}
       <div>


### PR DESCRIPTION
## Summary
- Display validation messages across all registration steps
- Move CPF to step 5 and password to step 6 in onboarding flow

## Testing
- `pytest tests/accounts -q` *(fails: ModuleNotFoundError: No module named 'django_redis')*
- `pytest tests/accounts/test_connections.py::test_aceitar_conexao --maxfail=1 -q --disable-warnings` *(fails: ModuleNotFoundError: No module named 'django_redis')*

------
https://chatgpt.com/codex/tasks/task_e_68a52f0b26648325bba78525d92e1b57