### PR TITLE
Check inactive user status before granting access

### DIFF
--- a/Hubx/settings.py
+++ b/Hubx/settings.py
@@ -105,6 +105,7 @@ MIDDLEWARE = [
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "accounts.middleware.ActiveUserRequiredMiddleware",
     "configuracoes.middleware.RequestInfoMiddleware",
     "configuracoes.middleware.UserLocaleMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
@@ -298,9 +299,7 @@ CELERY_BEAT_SCHEDULE = {
     },
     "executar_feed_plugins": {  # executa plugins do feed periodicamente
         "task": "feed.tasks.executar_plugins",
-        "schedule": crontab(
-            minute="*" if FEED_PLUGINS_INTERVAL_MINUTES == 1 else f"*/{FEED_PLUGINS_INTERVAL_MINUTES}"
-        ),
+        "schedule": crontab(minute="*" if FEED_PLUGINS_INTERVAL_MINUTES == 1 else f"*/{FEED_PLUGINS_INTERVAL_MINUTES}"),
     },
 }
 

--- a/accounts/middleware.py
+++ b/accounts/middleware.py
@@ -1,0 +1,17 @@
+from django.shortcuts import redirect
+from django.urls import reverse
+
+
+class ActiveUserRequiredMiddleware:
+    """Redirects authenticated but inactive users to a warning page."""
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        if request.user.is_authenticated and not request.user.is_active:
+            inactive_url = reverse("accounts:inactive")
+            allowed = {inactive_url}
+            if request.path not in allowed:
+                return redirect("accounts:inactive")
+        return self.get_response(request)

--- a/accounts/templates/account_inactive.html
+++ b/accounts/templates/account_inactive.html
@@ -1,13 +1,13 @@
 {% extends "base.html" %}
 {% load i18n %}
 
-{% block title %}{% trans "Registro Concluído" %} | Hubx{% endblock %}
+{% block title %}{% trans "Conta inativa" %} | Hubx{% endblock %}
 
 {% block content %}
 <section class="max-w-md mx-auto px-4 py-12 text-center">
   <div class="rounded-2xl border border-neutral-200 bg-white p-8 shadow-sm">
-    <h1 class="mb-4 text-3xl font-bold text-neutral-900">{% trans "Bem-vindo ao HubX!" %}</h1>
-    <p class="mb-6 text-neutral-600">{% trans "Seu cadastro foi concluído. Verifique seu e-mail para ativar sua conta." %}</p>
+    <h1 class="mb-4 text-3xl font-bold text-neutral-900">{% trans "Conta inativa" %}</h1>
+    <p class="mb-6 text-neutral-600">{% trans "Sua conta ainda não foi ativada. Verifique seu e-mail para continuar." %}</p>
     <a
       href="{% url 'accounts:login' %}"
       class="rounded-xl bg-primary-600 px-4 py-2 text-white hover:bg-primary-700"
@@ -15,3 +15,4 @@
   </div>
 </section>
 {% endblock %}
+

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -26,6 +26,7 @@ urlpatterns = [
     path("foto/", views.foto, name="foto"),
     path("termos/", views.termos, name="termos"),
     path("registro_sucesso/", views.registro_sucesso, name="registro_sucesso"),
+    path("conta-inativa/", views.conta_inativa, name="inactive"),
     # Perfil
     path("perfil/", views.perfil_home, name="perfil"),
     path("perfil/informacoes/", views.perfil_informacoes, name="informacoes_pessoais"),


### PR DESCRIPTION
## Summary
- Prevent login for inactive accounts and show feedback
- Add middleware and warning template for inactive users
- Avoid auto login after terms acceptance

## Testing
- `ruff format accounts/views.py accounts/middleware.py accounts/urls.py Hubx/settings.py`
- `isort accounts/views.py accounts/middleware.py accounts/urls.py Hubx/settings.py`
- `black accounts/views.py accounts/middleware.py accounts/urls.py Hubx/settings.py`
- `ruff check accounts/views.py accounts/middleware.py accounts/urls.py Hubx/settings.py`
- `bandit -r accounts/views.py accounts/middleware.py Hubx/settings.py accounts/urls.py`
- `pytest tests/accounts/test_user_registration.py::test_user_creation_creates_inactive_and_token -q --no-cov` *(failed: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68a52f0c78e883259876379fa9c5a877