### PR TITLE
Refatora template de informações pessoais

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -117,9 +117,6 @@ class InformacoesPessoaisForm(forms.ModelForm):
             "estado",
             "cep",
         )
-        widgets = {
-            "data_nascimento": forms.DateInput(attrs={"type": "date"}),
-        }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/accounts/templates/perfil/informacoes_pessoais.html
+++ b/accounts/templates/perfil/informacoes_pessoais.html
@@ -12,61 +12,44 @@
     {% csrf_token %}
 
     <div>
-      <label for="nome_completo" class="block text-sm font-medium text-gray-700">{% trans "Nome completo" %}</label>
-      <input type="text" id="nome_completo" name="nome_completo"
-             class="mt-1 block w-full border rounded-lg p-2 text-sm"
-             value="{{ user.nome_completo }}" required>
+      {{ form.nome_completo.label_tag }}
+      {{ form.nome_completo }}
+      {{ form.nome_completo.errors }}
     </div>
 
     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
       <div>
-        <label for="username" class="block text-sm font-medium text-gray-700">{% trans "Usuário" %}</label>
-        <input type="text" id="username" name="username"
-               class="mt-1 block w-full border rounded-lg p-2 text-sm"
-               value="{{ user.username }}" required>
+        {{ form.username.label_tag }}
+        {{ form.username }}
+        {{ form.username.errors }}
       </div>
 
       <div>
-        <label for="email" class="block text-sm font-medium text-gray-700">{% trans "Email" %}</label>
-        <input type="email" id="email" name="email"
-               class="mt-1 block w-full border rounded-lg p-2 text-sm"
-               value="{{ user.email }}" required>
+        {{ form.email.label_tag }}
+        {{ form.email }}
+        {{ form.email.errors }}
       </div>
     </div>
 
     <div>
-      <label for="biografia" class="block text-sm font-medium text-gray-700">{% trans "Bio" %}</label>
-      <textarea id="biografia" name="biografia" rows="4"
-                class="mt-1 block w-full border rounded-lg p-2 text-sm">{{ user.biografia }}</textarea>
-    </div>
-
-    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-      <div>
-        <label for="data_nascimento" class="block text-sm font-medium text-gray-700">{% trans "Data de Nascimento" %}</label>
-        <input type="date" id="data_nascimento" name="data_nascimento"
-               class="mt-1 block w-full border rounded-lg p-2 text-sm"
-               value="{{ user.data_nascimento|date:'Y-m-d' }}">
-      </div>
-
-      <div>
-        <label for="genero" class="block text-sm font-medium text-gray-700">{% trans "Gênero" %}</label>
-        <select id="genero" name="genero"
-                class="mt-1 block w-full border rounded-lg p-2 text-sm">
-          <option value="">{% trans "Selecione..." %}</option>
-          <option value="M" {% if user.genero == 'M' %}selected{% endif %}>{% trans "Masculino" %}</option>
-          <option value="F" {% if user.genero == 'F' %}selected{% endif %}>{% trans "Feminino" %}</option>
-          <option value="O" {% if user.genero == 'O' %}selected{% endif %}>{% trans "Outro" %}</option>
-        </select>
-      </div>
+      {{ form.cpf.label_tag }}
+      {{ form.cpf }}
+      {{ form.cpf.errors }}
     </div>
 
     <div>
-      <label for="avatar" class="block text-sm font-medium text-gray-700">{% trans "Foto de Perfil" %}</label>
-      <input type="file" id="avatar" name="avatar"
-             class="mt-1 block w-full border rounded-lg p-2 text-sm">
-      <label for="cover" class="block text-sm font-medium text-gray-700 mt-2">{% trans "Capa" %}</label>
-      <input type="file" id="cover" name="cover"
-             class="mt-1 block w-full border rounded-lg p-2 text-sm">
+      {{ form.biografia.label_tag }}
+      {{ form.biografia }}
+      {{ form.biografia.errors }}
+    </div>
+
+    <div>
+      {{ form.avatar.label_tag }}
+      {{ form.avatar }}
+      {{ form.avatar.errors }}
+      {{ form.cover.label_tag }}
+      {{ form.cover }}
+      {{ form.cover.errors }}
     </div>
 
     <hr class="my-6">
@@ -75,48 +58,38 @@
 
     <div class="grid md:grid-cols-2 gap-4">
       <div>
-        <label for="fone" class="block text-sm font-medium text-gray-700">{% trans "Telefone" %}</label>
-        <input type="tel" id="fone" name="fone"
-               class="mt-1 block w-full border rounded-lg p-2 text-sm"
-               value="{{ user.fone }}" placeholder="{% trans '(00) 00000-0000' %}">
+        {{ form.fone.label_tag }}
+        {{ form.fone }}
+        {{ form.fone.errors }}
       </div>
       <div>
-        <label for="whatsapp" class="block text-sm font-medium text-gray-700">{% trans "WhatsApp" %}</label>
-        <input type="tel" id="whatsapp" name="whatsapp"
-               class="mt-1 block w-full border rounded-lg p-2 text-sm"
-               value="{{ user.whatsapp }}" placeholder="{% trans '(00) 00000-0000' %}">
+        {{ form.whatsapp.label_tag }}
+        {{ form.whatsapp }}
+        {{ form.whatsapp.errors }}
       </div>
     </div>
 
     <div>
-      <label for="endereco" class="block text-sm font-medium text-gray-700">{% trans "Endereço" %}</label>
-      <input type="text" id="endereco" name="endereco"
-             class="mt-1 block w-full border rounded-lg p-2 text-sm"
-             value="{{ user.endereco }}" placeholder="{% trans 'Rua, número, complemento' %}">
+      {{ form.endereco.label_tag }}
+      {{ form.endereco }}
+      {{ form.endereco.errors }}
     </div>
 
     <div class="grid md:grid-cols-3 gap-4">
       <div>
-        <label for="cidade" class="block text-sm font-medium text-gray-700">{% trans "Cidade" %}</label>
-        <input type="text" id="cidade" name="cidade"
-               class="mt-1 block w-full border rounded-lg p-2 text-sm"
-               value="{{ user.cidade }}">
+        {{ form.cidade.label_tag }}
+        {{ form.cidade }}
+        {{ form.cidade.errors }}
       </div>
       <div>
-        <label for="estado" class="block text-sm font-medium text-gray-700">{% trans "Estado" %}</label>
-        <select id="estado" name="estado"
-                class="mt-1 block w-full border rounded-lg p-2 text-sm">
-          <option value="">{% trans "Selecione..." %}</option>
-          {% for uf, sigla in estados %}
-            <option value="{{ sigla }}" {% if user.estado == sigla %}selected{% endif %}>{{ uf }}</option>
-          {% endfor %}
-        </select>
+        {{ form.estado.label_tag }}
+        {{ form.estado }}
+        {{ form.estado.errors }}
       </div>
       <div>
-        <label for="cep" class="block text-sm font-medium text-gray-700">{% trans "CEP" %}</label>
-        <input type="text" id="cep" name="cep"
-               class="mt-1 block w-full border rounded-lg p-2 text-sm"
-               value="{{ user.cep }}" placeholder="{% trans '00000-000' %}">
+        {{ form.cep.label_tag }}
+        {{ form.cep }}
+        {{ form.cep.errors }}
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- Substitui inputs manuais por campos do formulário e exibição de erros
- Adiciona campo de CPF e remove referências a gênero e data de nascimento
- Remove widget obsoleto para campo inexistente em `InformacoesPessoaisForm`

## Testing
- `pytest tests/accounts/test_email_change_requires_confirmation.py -q` *(falha: ModuleNotFoundError: No module named 'django_redis')*

------
https://chatgpt.com/codex/tasks/task_e_68a52f0d5a608325a293cf6eed331e85