### PR TITLE
Handle GET requests in delete account view

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -321,24 +321,31 @@ def logout_view(request):
 @login_required
 def excluir_conta(request):
     """Permite que o usuário exclua sua própria conta."""
-    if request.method == "POST":
-        if request.POST.get("confirm") != "EXCLUIR":
-            messages.error(request, _("Confirme digitando EXCLUIR."))
-            return redirect("accounts:excluir_conta")
-        with transaction.atomic():
-            user = request.user
-            user.delete()
-            user.exclusao_confirmada = True
-            user.is_active = False
-            user.save(update_fields=["exclusao_confirmada", "is_active"])
-            SecurityEvent.objects.create(
-                usuario=user,
-                evento="conta_excluida",
-                ip=request.META.get("REMOTE_ADDR"),
-            )
-        logout(request)
-        messages.success(request, _("Sua conta foi excluída com sucesso."))
-        return redirect("core:home")
+    if request.method == "GET":
+        return render(request, "accounts/delete_account_confirm.html")
+
+    if request.method != "POST":
+        return redirect("accounts:excluir_conta")
+
+    if request.POST.get("confirm") != "EXCLUIR":
+        messages.error(request, _("Confirme digitando EXCLUIR."))
+        return redirect("accounts:excluir_conta")
+
+    with transaction.atomic():
+        user = request.user
+        user.delete()
+        user.exclusao_confirmada = True
+        user.is_active = False
+        user.save(update_fields=["exclusao_confirmada", "is_active"])
+        SecurityEvent.objects.create(
+            usuario=user,
+            evento="conta_excluida",
+            ip=request.META.get("REMOTE_ADDR"),
+        )
+
+    logout(request)
+    messages.success(request, _("Sua conta foi excluída com sucesso."))
+    return redirect("core:home")
 def password_reset(request):
     """Solicita redefinição de senha."""
     if request.method == "POST":


### PR DESCRIPTION
## Summary
- Render delete account confirmation page on GET requests
- Ensure deletion only occurs for POST requests with confirmation

## Testing
- `pytest tests/accounts/test_delete_account_view.py -q --cov-fail-under=0` *(fails: django.urls.exceptions.NoReverseMatch: 'core' is not a registered namespace)*

------
https://chatgpt.com/codex/tasks/task_e_68a52f0fe00483259a8507c8d2eae9dd