### PR TITLE
Ajuste da exclusão de contas e purga periódica

### DIFF
--- a/accounts/api.py
+++ b/accounts/api.py
@@ -165,8 +165,7 @@ class AccountViewSet(viewsets.GenericViewSet):
         user = request.user
         user.delete()
         user.is_active = False
-        user.exclusao_confirmada = True
-        user.save(update_fields=["is_active", "exclusao_confirmada"])
+        user.save(update_fields=["is_active"])
         SecurityEvent.objects.create(
             usuario=user,
             evento="conta_excluida",

--- a/accounts/management/commands/purge_deleted_accounts.py
+++ b/accounts/management/commands/purge_deleted_accounts.py
@@ -12,7 +12,7 @@ class Command(BaseCommand):
         User = get_user_model()
         limite = timezone.now() - timezone.timedelta(days=30)
         qs = (
-            User.objects.filter(deleted=True, deleted_at__lt=limite, exclusao_confirmada=True)
+            User.objects.filter(deleted=True, deleted_at__lt=limite)
             .prefetch_related("medias")
         )
         count = 0

--- a/accounts/tasks.py
+++ b/accounts/tasks.py
@@ -42,7 +42,7 @@ def send_confirmation_email(token_id: int) -> None:
 
 @shared_task
 def purge_soft_deleted(batch_size: int = 500) -> None:
-    """Remove definitivamente usuários soft-deleted há mais de 30 dias."""
+    """Remove definitivamente usuários marcados como excluídos há mais de 30 dias."""
     limit = timezone.now() - timezone.timedelta(days=30)
     total_purged = 0
     try:
@@ -51,7 +51,6 @@ def purge_soft_deleted(batch_size: int = 500) -> None:
                 User.all_objects.filter(
                     deleted=True,
                     deleted_at__lte=limit,
-                    exclusao_confirmada=True,
                 )
                 .order_by("pk")
                 .values_list("pk", flat=True)[:batch_size]

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -327,10 +327,9 @@ def excluir_conta(request):
             return redirect("accounts:excluir_conta")
         with transaction.atomic():
             user = request.user
-            user.delete()
-            user.exclusao_confirmada = True
+            user.delete()  # marca deleted/deleted_at
             user.is_active = False
-            user.save(update_fields=["exclusao_confirmada", "is_active"])
+            user.save(update_fields=["is_active"])
             SecurityEvent.objects.create(
                 usuario=user,
                 evento="conta_excluida",
@@ -338,7 +337,7 @@ def excluir_conta(request):
             )
         logout(request)
         messages.success(request, _("Sua conta foi excluída com sucesso."))
-        return redirect("core:home")
+        return redirect("/")
 def password_reset(request):
     """Solicita redefinição de senha."""
     if request.method == "POST":

--- a/tests/accounts/test_delete_account_api.py
+++ b/tests/accounts/test_delete_account_api.py
@@ -15,6 +15,8 @@ def test_delete_me_sets_user_inactive():
     assert resp.status_code == 204
     user.refresh_from_db()
     assert not user.is_active
+    assert user.deleted and user.deleted_at is not None
+    assert not user.exclusao_confirmada
 
 
 @pytest.mark.django_db
@@ -24,8 +26,9 @@ def test_cancel_delete_reactivates_user():
     client.force_authenticate(user=user)
     client.delete(reverse("accounts_api:account-delete-me"))
     user.refresh_from_db()
-    assert not user.is_active
+    assert not user.is_active and user.deleted
     resp = client.post(reverse("accounts_api:account-cancel-delete"))
     assert resp.status_code == 200
     user.refresh_from_db()
     assert user.is_active
+    assert not user.deleted and user.deleted_at is None

--- a/tests/accounts/test_delete_account_view.py
+++ b/tests/accounts/test_delete_account_view.py
@@ -17,6 +17,6 @@ def test_delete_account_view(client):
     assert resp.status_code == 302
     user.refresh_from_db()
     assert user.deleted is True and user.deleted_at is not None
-    assert user.exclusao_confirmada
+    assert not user.exclusao_confirmada
     assert not user.is_active
     assert SecurityEvent.objects.filter(usuario=user, evento="conta_excluida").exists()

--- a/tests/accounts/test_purge_soft_deleted.py
+++ b/tests/accounts/test_purge_soft_deleted.py
@@ -17,7 +17,6 @@ def _create_deleted_user(**kwargs) -> User:
         password="x",
         deleted=True,
         deleted_at=timezone.now() - timezone.timedelta(days=31),
-        exclusao_confirmada=True,
         **kwargs,
     )
 
@@ -37,7 +36,6 @@ def test_purge_keeps_recent_users():
         password="x",
         deleted=True,
         deleted_at=timezone.now() - timezone.timedelta(days=10),
-        exclusao_confirmada=True,
     )
     purge_soft_deleted()
     assert User.all_objects.filter(pk=user.pk).exists()


### PR DESCRIPTION
## Summary
- Marque contas como pendentes de exclusão ao usuário solicitar remoção
- Purge definitivo de contas marcadas há mais de 30 dias

## Testing
- `pytest tests/accounts/test_delete_account_view.py tests/accounts/test_delete_account_api.py tests/accounts/test_purge_soft_deleted.py -q --override-ini="addopts="`


------
https://chatgpt.com/codex/tasks/task_e_68a52f122f1083258c85a316952896a3