### PR TITLE
Add POST requirement to connection management views

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -17,7 +17,7 @@ from django.core.files.base import ContentFile, File
 from django.core.files.storage import default_storage
 from django.db import IntegrityError, transaction
 from django.db.models import Q
-from django.http import JsonResponse
+from django.http import HttpResponseNotAllowed, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
@@ -190,6 +190,8 @@ def perfil_conexoes(request):
 
 @login_required
 def remover_conexao(request, id):
+    if request.method != "POST":
+        return HttpResponseNotAllowed(["POST"])
     try:
         other_user = User.objects.get(id=id)
         request.user.connections.remove(other_user)
@@ -201,6 +203,8 @@ def remover_conexao(request, id):
 
 @login_required
 def aceitar_conexao(request, id):
+    if request.method != "POST":
+        return HttpResponseNotAllowed(["POST"])
     try:
         other_user = User.objects.get(id=id)
     except User.DoesNotExist:
@@ -219,6 +223,8 @@ def aceitar_conexao(request, id):
 
 @login_required
 def recusar_conexao(request, id):
+    if request.method != "POST":
+        return HttpResponseNotAllowed(["POST"])
     try:
         other_user = User.objects.get(id=id)
     except User.DoesNotExist:


### PR DESCRIPTION
## Summary
- Ensure connection management views only accept POST requests

## Testing
- `pytest -m "not slow"` *(fails: SyntaxError in tests/feed/test_services.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a52f1690488325a58f1dcd7c4d555f