### PR TITLE
Support filtering topics by multiple tags

### DIFF
--- a/discussao/views.py
+++ b/discussao/views.py
@@ -198,9 +198,9 @@ class TopicoListView(LoginRequiredMixin, ListView):
                 score_total=Coalesce(Sum("interacoes__valor"), 0),
             )
         )
-        tags_param = self.request.GET.get("tags")
+        tags_param = self.request.GET.getlist("tags")
         if tags_param:
-            names = [t.strip() for t in tags_param.split(",") if t.strip()]
+            names = [t.strip() for t in tags_param if t.strip()]
             for name in names:
                 qs = qs.filter(tags__nome=name)
         query = self.request.GET.get("q")
@@ -236,8 +236,8 @@ class TopicoListView(LoginRequiredMixin, ListView):
         context["categoria"] = self.categoria
         context["ordenacao"] = self.request.GET.get("ordenacao", "recentes")
         context["q"] = self.request.GET.get("q", "")
-        tags_param = self.request.GET.get("tags", "")
-        context["selected_tags"] = [t for t in tags_param.split(",") if t]
+        tags_param = self.request.GET.getlist("tags")
+        context["selected_tags"] = [t for t in tags_param if t]
         context["tags"] = Tag.objects.all()
         context["content_type_id"] = ContentType.objects.get_for_model(TopicoDiscussao).id
         return context


### PR DESCRIPTION
## Summary
- use `getlist` to read multiple `tags` values in discussion topic list
- track selected tag list in context and update test

## Testing
- `pytest tests/discussao/test_views.py::test_topico_list_view_filters_by_multiple_tags -q -o addopts='' -p no:cov`


------
https://chatgpt.com/codex/tasks/task_e_68a52f314524832592da6db16ee1be8e