### PR TITLE
Remover votação duplicada em comentários

### DIFF
--- a/discussao/templates/discussao/comentario_item.html
+++ b/discussao/templates/discussao/comentario_item.html
@@ -41,20 +41,6 @@
 
     </div>
   </header>
-  <div class="flex items-center space-x-1 mb-2">
-    <button
-      hx-post="{% url 'discussao:interacao' content_type_id comentario.id 'up' %}"
-      hx-swap="none"
-      hx-on:afterRequest="const r=event.detail.xhr.responseJSON;document.getElementById('comment-score-{{comentario.id}}').innerText=r.score;document.getElementById('comment-votes-{{comentario.id}}').innerText=r.num_votos"
-    >&#9650;</button>
-    <span id="comment-score-{{ comentario.id }}">{{ comentario.score }}</span>
-    (<span id="comment-votes-{{ comentario.id }}">{{ comentario.num_votos }}</span>)
-    <button
-      hx-post="{% url 'discussao:interacao' content_type_id comentario.id 'down' %}"
-      hx-swap="none"
-      hx-on:afterRequest="const r=event.detail.xhr.responseJSON;document.getElementById('comment-score-{{comentario.id}}').innerText=r.score;document.getElementById('comment-votes-{{comentario.id}}').innerText=r.num_votos"
-    >&#9660;</button>
-  </div>
   <div class="prose max-w-none text-sm">{{ comentario.conteudo|linebreaks }}</div>
   {% if topico.melhor_resposta_id == comentario.id %}
     <div class="text-xs text-green-700 font-semibold mt-2">{% trans "Melhor resposta" %}</div>


### PR DESCRIPTION
## Summary
- remover bloco de votação que usava `content_type_id` no template de comentários

## Testing
- `pytest` *(falhou: 9 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a52f327c38832586e7c5155ed9b548