### PR TITLE
Exibir variação nas métricas do dashboard

### DIFF
--- a/dashboard/templates/dashboard/partials/metric_card.html
+++ b/dashboard/templates/dashboard/partials/metric_card.html
@@ -5,4 +5,10 @@
     {% if icon %}<i class="fa-solid {{ icon }} text-primary-600" aria-label="{{ title }}"></i>{% endif %}
   </div>
   <p class="text-3xl font-bold text-neutral-900" id="{{ id }}" aria-label="{{ title }}">{{ value|localize }}</p>
+  {% if crescimento is not None %}
+    <p class="flex items-center text-sm font-medium mt-1 {% if crescimento >= 0 %}text-green-600{% else %}text-red-600{% endif %}">
+      <i class="fa-solid {% if crescimento >= 0 %}fa-arrow-up{% else %}fa-arrow-down{% endif %} mr-1"></i>
+      {{ crescimento|floatformat:2|localize }}%
+    </p>
+  {% endif %}
 </div>

--- a/dashboard/templates/dashboard/partials/metrics_list.html
+++ b/dashboard/templates/dashboard/partials/metrics_list.html
@@ -2,7 +2,7 @@
 <section class="mb-8" id="metrics">
   <div id="dashboard-cards" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4" data-save-url="{{ layout_save_url|default:'' }}">
     {% for m in metricas_iter %}
-      {% include "dashboard/partials/metric_card.html" with title=m.label value=m.data.total icon=m.icon id=m.key %}
+      {% include "dashboard/partials/metric_card.html" with title=m.label value=m.data.total icon=m.icon crescimento=m.data.crescimento id=m.key %}
     {% endfor %}
   </div>
 </section>


### PR DESCRIPTION
## Summary
- Passar `m.data.crescimento` para os cards de métricas
- Mostrar variação percentual com ícones e cores nos cards do dashboard

## Testing
- `pytest -m "not slow"` *(falhou: ModuleNotFoundError: axe_core_python, bs4, playwright, httpx, pywebpush, django_redis)*

------
https://chatgpt.com/codex/tasks/task_e_68a52f462db883258b5c60415e395c54