### PR TITLE
Ensure HTMX sections render on initial load

### DIFF
--- a/dashboard/templates/dashboard/cliente.html
+++ b/dashboard/templates/dashboard/cliente.html
@@ -17,11 +17,29 @@
     {% include 'dashboard/partials/metrics_list.html' %}
   </div>
 
-  <div hx-get="{% url 'dashboard:eventos-partial' %}" hx-trigger="load, every 20s" hx-target="#upcoming-events" hx-swap="innerHTML"></div>
+  <section
+    id="upcoming-events"
+    hx-get="{% url 'dashboard:eventos-partial' %}"
+    hx-trigger="load, every 20s"
+    hx-target="this"
+    hx-swap="outerHTML"
+  ></section>
 
-  <div hx-get="{% url 'dashboard:tarefas-partial' %}" hx-trigger="load, every 20s" hx-target="#tasks" hx-swap="innerHTML"></div>
+  <section
+    id="tasks"
+    hx-get="{% url 'dashboard:tarefas-partial' %}"
+    hx-trigger="load, every 20s"
+    hx-target="this"
+    hx-swap="outerHTML"
+  ></section>
 
-  <div hx-get="{% url 'dashboard:notificacoes-partial' %}" hx-trigger="load, every 20s" hx-target="#notifications" hx-swap="innerHTML"></div>
+  <section
+    id="notifications"
+    hx-get="{% url 'dashboard:notificacoes-partial' %}"
+    hx-trigger="load, every 20s"
+    hx-target="this"
+    hx-swap="outerHTML"
+  ></section>
 
   <section class="mb-8">
     <h2 class="text-xl font-semibold mb-4">{% trans "Atalhos" %}</h2>

--- a/dashboard/templates/dashboard/gerente.html
+++ b/dashboard/templates/dashboard/gerente.html
@@ -17,9 +17,21 @@
     {% include 'dashboard/partials/metrics_list.html' %}
   </div>
 
-  <div hx-get="{% url 'dashboard:tarefas-partial' %}" hx-trigger="load, every 15s" hx-target="#tasks" hx-swap="innerHTML"></div>
+  <section
+    id="tasks"
+    hx-get="{% url 'dashboard:tarefas-partial' %}"
+    hx-trigger="load, every 15s"
+    hx-target="this"
+    hx-swap="outerHTML"
+  ></section>
 
-  <div hx-get="{% url 'dashboard:notificacoes-partial' %}" hx-trigger="load, every 15s" hx-target="#notifications" hx-swap="innerHTML"></div>
+  <section
+    id="notifications"
+    hx-get="{% url 'dashboard:notificacoes-partial' %}"
+    hx-trigger="load, every 15s"
+    hx-target="this"
+    hx-swap="outerHTML"
+  ></section>
 
   <section class="mb-8">
     <h2 class="text-xl font-semibold mb-4">{% trans "Ações Rápidas" %}</h2>

--- a/dashboard/templates/dashboard/root.html
+++ b/dashboard/templates/dashboard/root.html
@@ -49,7 +49,13 @@
     </div>
   </section>
 
-  <div hx-get="{% url 'dashboard:notificacoes-partial' %}" hx-trigger="load, every 20s" hx-target="#notifications" hx-swap="innerHTML"></div>
+  <section
+    id="notifications"
+    hx-get="{% url 'dashboard:notificacoes-partial' %}"
+    hx-trigger="load, every 20s"
+    hx-target="this"
+    hx-swap="outerHTML"
+  ></section>
 
   <section class="mb-8">
     <h2 class="text-xl font-semibold mb-4">{% trans "Ações Rápidas" %}</h2>


### PR DESCRIPTION
## Summary
- Add HTMX-enabled sections for notifications, tasks and upcoming events in dashboard templates
- Ensure partial templates keep matching section IDs

## Testing
- `pytest` *(fails: could not import 'pytest_benchmark'; plus 8 other errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a52f48abd0832588ca1c9d78de3d21