### PR TITLE
Add achievements link to dashboard pages

### DIFF
--- a/dashboard/templates/dashboard/admin.html
+++ b/dashboard/templates/dashboard/admin.html
@@ -98,6 +98,10 @@
         <i class="fa-solid fa-chart-line mb-2"></i>
         <span class="block">{% trans "Métricas Personalizadas" %}</span>
       </a>
+      <a href="{% url 'dashboard:achievements' %}" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50">
+        <i class="fa-solid fa-trophy mb-2"></i>
+        <span class="block">{% trans "Conquistas" %}</span>
+      </a>
       <a href="#" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50">
         <i class="fa-solid fa-user-gear mb-2"></i>
         <span class="block">{% trans "Administrar Usuários" %}</span>

--- a/dashboard/templates/dashboard/cliente.html
+++ b/dashboard/templates/dashboard/cliente.html
@@ -34,6 +34,10 @@
         <i class="fa-solid fa-rss mb-2"></i>
         <span class="block">{% trans "Ver Feed" %}</span>
       </a>
+      <a href="{% url 'dashboard:achievements' %}" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50">
+        <i class="fa-solid fa-trophy mb-2"></i>
+        <span class="block">{% trans "Conquistas" %}</span>
+      </a>
     </div>
   </section>
 

--- a/dashboard/templates/dashboard/gerente.html
+++ b/dashboard/templates/dashboard/gerente.html
@@ -32,6 +32,10 @@
         <i class="fa-solid fa-calendar mb-2"></i>
         <span class="block">{% trans "Gerenciar Eventos" %}</span>
       </a>
+      <a href="{% url 'dashboard:achievements' %}" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50">
+        <i class="fa-solid fa-trophy mb-2"></i>
+        <span class="block">{% trans "Conquistas" %}</span>
+      </a>
     </div>
   </section>
 

--- a/dashboard/templates/dashboard/partials/achievements_badges.html
+++ b/dashboard/templates/dashboard/partials/achievements_badges.html
@@ -9,3 +9,6 @@
   <p class="text-sm text-neutral-600">{% trans 'Nenhuma conquista ainda.' %}</p>
 {% endfor %}
 </div>
+{% if has_pending_achievements %}
+<a href="{% url 'dashboard:achievements' %}" class="text-sm text-blue-600 hover:underline">{% trans 'Ver conquistas' %}</a>
+{% endif %}

--- a/dashboard/templates/dashboard/root.html
+++ b/dashboard/templates/dashboard/root.html
@@ -62,6 +62,10 @@
         <i class="fa-solid fa-chart-line mb-2"></i>
         <span class="block">{% trans "Métricas Personalizadas" %}</span>
       </a>
+      <a href="{% url 'dashboard:achievements' %}" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50">
+        <i class="fa-solid fa-trophy mb-2"></i>
+        <span class="block">{% trans "Conquistas" %}</span>
+      </a>
     </div>
   </section>
 

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -206,6 +206,8 @@ class DashboardBaseView(LoginRequiredMixin, TemplateView):
             for m in metricas
             if m in metrics
         ]
+        obtidas = UserAchievement.objects.filter(user=self.request.user).count()
+        context["has_pending_achievements"] = Achievement.objects.count() > obtidas
         user = self.request.user
         if user.user_type in {UserType.ROOT, UserType.ADMIN}:
             orgs = Organizacao.objects.all()


### PR DESCRIPTION
## Summary
- Add achievements quick-access link to all dashboard views
- Show achievements link when there are pending achievements
- Track pending achievements in dashboard context

## Testing
- `pytest` *(fails: could not import pytest_benchmark; errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a52f4a1d24832586055ee34ce887b1