### PR TITLE
Add context lookup view for chat

### DIFF
--- a/chat/templates/chat/conversation_form.html
+++ b/chat/templates/chat/conversation_form.html
@@ -10,7 +10,10 @@
     {% csrf_token %}
     <div>
       <label for="{{ form.contexto_tipo.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.contexto_tipo.label }}</label>
-      {{ form.contexto_tipo|add_class:"w-full p-2 border rounded"|attr:"hx-get:/chat/contextos/"|attr:"hx-target:#id_contexto_id"|attr:"hx-trigger:change" }}
+      {% url 'chat:contextos' as contextos_url %}
+      {% with hx_get_attr='hx-get:'|add:contextos_url %}
+      {{ form.contexto_tipo|add_class:"w-full p-2 border rounded"|attr:hx_get_attr|attr:"hx-target:#id_contexto_id"|attr:"hx-trigger:change" }}
+      {% endwith %}
       {% if form.contexto_tipo.errors %}
         <p class="text-red-500 text-sm">{{ form.contexto_tipo.errors }}</p>
       {% endif %}

--- a/chat/urls.py
+++ b/chat/urls.py
@@ -7,6 +7,7 @@ app_name = "chat"
 urlpatterns = [
     path("", views.conversation_list, name="conversation_list"),
     path("nova/", views.nova_conversa, name="nova_conversa"),
+    path("contextos/", views.contextos, name="contextos"),
     path(
         "partials/message/<uuid:message_id>/",
         views.message_partial,


### PR DESCRIPTION
## Summary
- add `contextos` view to list available contexts by type
- register `contextos/` route in chat URLs
- update conversation form to fetch contexts via named URL

## Testing
- `python manage.py check`
- `pytest tests/chat/test_views.py::test_conversation_list_shows_user_conversations -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68a52f55e1688325b93c3c1ab22da68f