### PR TITLE
Add favorite button and mark-read observer

### DIFF
--- a/chat/static/chat/js/chat_socket.js
+++ b/chat/static/chat/js/chat_socket.js
@@ -50,6 +50,21 @@
         let historyEnd = false;
         let historyLoading = false;
 
+        const markReadObserver = new IntersectionObserver((entries)=>{
+            entries.forEach(entry=>{
+                if(entry.isIntersecting){
+                    const msgId = entry.target.dataset.messageId;
+                    if(msgId){
+                        fetch(`/api/chat/channels/${destinatarioId}/messages/${msgId}/mark-read/`,{
+                            method:'POST',
+                            headers:{'X-CSRFToken':csrfToken}
+                        });
+                    }
+                    markReadObserver.unobserve(entry.target);
+                }
+            });
+        },{root: messages});
+
         if(editCancel){
             editCancel.addEventListener('click', ()=> editModal.close());
         }
@@ -356,7 +371,7 @@
 
             }
 
-            div.innerHTML = `<div><strong>${remetente}</strong>: ${content}</div><ul class="reactions flex gap-2 ml-2"></ul><div class="reaction-container relative"><button type="button" class="reaction-btn" aria-haspopup="true" aria-expanded="false" aria-label="${t('addReaction','Adicionar reação')}">🙂</button><ul class="reaction-menu hidden absolute bg-white border rounded p-1 flex gap-1" role="menu"><li><button type="button" class="react-option" data-emoji="🙂" aria-label="${t('reactWith','Reagir com')} 🙂">🙂</button></li><li><button type="button" class="react-option" data-emoji="❤️" aria-label="${t('reactWith','Reagir com')} ❤️">❤️</button></li><li><button type="button" class="react-option" data-emoji="👍" aria-label="${t('reactWith','Reagir com')} 👍">👍</button></li><li><button type="button" class="react-option" data-emoji="😂" aria-label="${t('reactWith','Reagir com')} 😂">😂</button></li><li><button type="button" class="react-option" data-emoji="🎉" aria-label="${t('reactWith','Reagir com')} 🎉">🎉</button></li><li><button type="button" class="react-option" data-emoji="😢" aria-label="${t('reactWith','Reagir com')} 😢">😢</button></li><li><button type="button" class="react-option" data-emoji="😡" aria-label="${t('reactWith','Reagir com')} 😡">😡</button></li></ul></div><div class="action-container relative"><button type="button" class="action-btn" aria-haspopup="true" aria-expanded="false" aria-label="${t('openMenu','Abrir menu')}">⋮</button><ul class="action-menu hidden absolute bg-white border rounded p-1 flex flex-col" role="menu"><li><button type="button" class="create-item" aria-label="${t('createItem','Criar evento/tarefa')}">${t('createItem','Criar evento/tarefa')}</button></li></ul></div>`;
+            div.innerHTML = `<div><strong>${remetente}</strong>: ${content}</div><ul class="reactions flex gap-2 ml-2"></ul><div class="reaction-container relative"><button type="button" class="reaction-btn" aria-haspopup="true" aria-expanded="false" aria-label="${t('addReaction','Adicionar reação')}">🙂</button><ul class="reaction-menu hidden absolute bg-white border rounded p-1 flex gap-1" role="menu"><li><button type="button" class="react-option" data-emoji="🙂" aria-label="${t('reactWith','Reagir com')} 🙂">🙂</button></li><li><button type="button" class="react-option" data-emoji="❤️" aria-label="${t('reactWith','Reagir com')} ❤️">❤️</button></li><li><button type="button" class="react-option" data-emoji="👍" aria-label="${t('reactWith','Reagir com')} 👍">👍</button></li><li><button type="button" class="react-option" data-emoji="😂" aria-label="${t('reactWith','Reagir com')} 😂">😂</button></li><li><button type="button" class="react-option" data-emoji="🎉" aria-label="${t('reactWith','Reagir com')} 🎉">🎉</button></li><li><button type="button" class="react-option" data-emoji="😢" aria-label="${t('reactWith','Reagir com')} 😢">😢</button></li><li><button type="button" class="react-option" data-emoji="😡" aria-label="${t('reactWith','Reagir com')} 😡">😡</button></li></ul></div><div class="action-container relative"><button type="button" class="action-btn" aria-haspopup="true" aria-expanded="false" aria-label="${t('openMenu','Abrir menu')}">⋮</button><ul class="action-menu hidden absolute bg-white border rounded p-1 flex flex-col" role="menu"><li><button type="button" class="create-item" aria-label="${t('createItem','Criar evento/tarefa')}">${t('createItem','Criar evento/tarefa')}</button></li></ul></div><button type="button" class="favorite-btn" aria-label="${t('favorite','Favoritar mensagem')}">⭐</button>`;
 
             if(id){ div.dataset.id = id; div.dataset.messageId = id; }
             if(isAdmin && id){
@@ -391,10 +406,7 @@
             setupItemMenu(div,id);
 
             if(id && remetente !== currentUser){
-                fetch(`/api/chat/channels/${destinatarioId}/messages/${id}/mark-read/`,{
-                    method:'POST',
-                    headers:{'X-CSRFToken':csrfToken}
-                });
+                markReadObserver.observe(div);
             }
             return div;
         }

--- a/chat/templates/chat/partials/message.html
+++ b/chat/templates/chat/partials/message.html
@@ -89,6 +89,12 @@
         </ul>
       </div>
 
+      <button
+        type="button"
+        class="favorite-btn"
+        aria-label="{% trans 'Favoritar mensagem' %}"
+      >⭐</button>
+
       {% if is_admin %}
         <button
           hx-post="/api/chat/channels/{{ m.channel_id }}/messages/{{ m.id }}/pin/"


### PR DESCRIPTION
## Summary
- add favorite button to message actions
- track message visibility to mark as read via IntersectionObserver

## Testing
- `pytest -m "not slow"` *(fails: could not import pytest_benchmark and other modules)*

------
https://chatgpt.com/codex/tasks/task_e_68a52f56a608832593c55ba25e0a29be