### PR TITLE
feat(chat): add message flagging

### DIFF
--- a/chat/static/chat/js/chat_socket.js
+++ b/chat/static/chat/js/chat_socket.js
@@ -245,11 +245,27 @@
                 btn.setAttribute('aria-expanded', hidden ? 'false' : 'true');
             });
             menu.addEventListener('click', e=>{
-                const opt = e.target.closest('.create-item');
-                if(opt){
+                const createOpt = e.target.closest('.create-item');
+                const flagOpt = e.target.closest('.flag-message');
+                if(createOpt){
                     menu.classList.add('hidden');
                     btn.setAttribute('aria-expanded','false');
                     openItemModal(id);
+                } else if(flagOpt){
+                    menu.classList.add('hidden');
+                    btn.setAttribute('aria-expanded','false');
+                    if(confirm(t('confirmFlag','Tem certeza que deseja denunciar?'))){
+                        fetch(`/api/chat/channels/${destinatarioId}/messages/${id}/flag/`,{
+                            method:'POST',
+                            headers:{'X-CSRFToken':csrfToken}
+                        }).then(r=>{
+                            if(r.ok){
+                                alert(t('flagged','Denúncia enviada'));
+                            }else{
+                                alert(t('flagError','Erro ao denunciar'));
+                            }
+                        });
+                    }
                 }
             });
         }

--- a/chat/templates/chat/partials/message.html
+++ b/chat/templates/chat/partials/message.html
@@ -86,6 +86,11 @@
               {% trans 'Criar evento/tarefa' %}
             </button>
           </li>
+          <li>
+            <button type="button" class="flag-message" aria-label="{% trans 'Denunciar mensagem' %}">
+              {% trans 'Denunciar' %}
+            </button>
+          </li>
         </ul>
       </div>
 


### PR DESCRIPTION
## Summary
- add report action to chat message menu
- send POST to flag messages with confirmation and user feedback

## Testing
- `pytest` *(fails: tests/configuracoes/test_accessibility.py, tests/dashboard/test_views.py, tests/e2e/test_notificacoes_e2e.py, tests/e2e/test_pwa_offline.py, tests/feed/test_services.py, tests/notificacoes/test_clients.py, tests/notificacoes/test_push_sender.py, tests/test_i18n_templates.py, tests/tokens/test_metrics.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a52f588608832581847188154ae760