### PR TITLE
Add valor_pago field and upload validation

### DIFF
--- a/agenda/forms.py
+++ b/agenda/forms.py
@@ -69,10 +69,32 @@ class InscricaoEventoForm(forms.ModelForm):
     class Meta:
         model = InscricaoEvento
         fields = [
+            "valor_pago",
             "metodo_pagamento",
             "comprovante_pagamento",
             "observacao",
         ]
+
+    def clean_valor_pago(self):
+        valor = self.cleaned_data.get("valor_pago")
+        if valor is not None and valor <= 0:
+            raise forms.ValidationError(_("O valor pago deve ser positivo."))
+        return valor
+
+    def clean_comprovante_pagamento(self):
+        arquivo = self.cleaned_data.get("comprovante_pagamento")
+        if not arquivo:
+            return arquivo
+        ext = os.path.splitext(arquivo.name)[1].lower()
+        if ext in {".jpg", ".jpeg", ".png"}:
+            max_size = 10 * 1024 * 1024
+        elif ext == ".pdf":
+            max_size = 20 * 1024 * 1024
+        else:
+            raise forms.ValidationError(_("Formato de arquivo não permitido."))
+        if arquivo.size > max_size:
+            raise forms.ValidationError(_("Arquivo excede o tamanho máximo permitido."))
+        return arquivo
 
 
 class FeedbackForm(forms.ModelForm):

--- a/agenda/templates/agenda/inscricao_form.html
+++ b/agenda/templates/agenda/inscricao_form.html
@@ -13,8 +13,12 @@
       {{ form.metodo_pagamento }}
     </div>
     <div>
+      {{ form.valor_pago.label_tag }}
+      {{ form.valor_pago }}
+    </div>
+    <div>
       {{ form.comprovante_pagamento.label_tag }}
-      {{ form.comprovante_pagamento }}
+      {{ form.comprovante_pagamento.as_widget(attrs={'accept': '.jpg,.jpeg,.png,.pdf'}) }}
     </div>
     <div>
       {{ form.observacao.label_tag }}


### PR DESCRIPTION
## Summary
- include `valor_pago` in event registration form
- validate paid value and receipt file uploads
- show new field and restrict upload types in registration template

## Testing
- `python -m flake8 agenda/forms.py agenda/templates/agenda/inscricao_form.html` *(fails: No module named flake8)*
- `pytest tests/agenda -q` *(fails: No module named 'django_redis')*
- `pytest tests/agenda/test_inscricoes.py::test_usuario_pode_inscrever_e_cancelar -q --disable-warnings --no-cov` *(fails: NoReverseMatch: 'core' is not a registered namespace)*

------
https://chatgpt.com/codex/tasks/task_e_68a52f6c5bc48325bd4bffd89c481adf