### PR TITLE
Exibir QR code após inscrição confirmada

### DIFF
--- a/agenda/templates/agenda/detail.html
+++ b/agenda/templates/agenda/detail.html
@@ -23,17 +23,22 @@
   </div>
 
   <!-- Inscrição -->
-  {% if user.is_authenticated and user.user_type not in ('admin','root') %}
-    {% if object.inscricoes.filter(user=user, status='confirmada').exists %}
-      <form method="post" action="{% url 'agenda:evento_subscribe' object.pk %}" class="mb-10">
-        {% csrf_token %}
-        <button type="submit" class="btn-secondary" aria-label="{% trans 'Cancelar inscrição' %}">{% trans "Cancelar inscrição" %}</button>
-      </form>
-    {% else %}
-      <div class="mb-10">
-        <a href="{% url 'agenda:inscricao_criar' object.pk %}" class="btn-primary" aria-label="{% trans 'Inscrever-se' %}">{% trans "Inscrever-se" %}</a>
-      </div>
-    {% endif %}
+  {% if user.is_authenticated and user.user_type != 'admin' and user.user_type != 'root' %}
+    {% with inscricao=object.inscricoes.filter(user=user, status='confirmada').first %}
+      {% if inscricao %}
+        <div class="mb-10 space-y-4">
+          <img src="{{ inscricao.qrcode_url }}" alt="{% trans 'QR Code da inscrição' %}" class="mx-auto h-48 w-48" />
+          <form method="post" action="{% url 'agenda:evento_subscribe' object.pk %}">
+            {% csrf_token %}
+            <button type="submit" class="btn-secondary" aria-label="{% trans 'Cancelar inscrição' %}">{% trans "Cancelar inscrição" %}</button>
+          </form>
+        </div>
+      {% else %}
+        <div class="mb-10">
+          <a href="{% url 'agenda:inscricao_criar' object.pk %}" class="btn-primary" aria-label="{% trans 'Inscrever-se' %}">{% trans "Inscrever-se" %}</a>
+        </div>
+      {% endif %}
+    {% endwith %}
   {% endif %}
 
   <!-- Lista de Inscritos -->

--- a/agenda/tests/test_qrcode.py
+++ b/agenda/tests/test_qrcode.py
@@ -1,0 +1,65 @@
+import pytest
+from datetime import datetime, timedelta
+from django.urls import reverse, path, include
+from django.utils.timezone import make_aware
+from django.test import override_settings
+
+from accounts.models import User, UserType
+from agenda.models import Evento, InscricaoEvento
+from organizacoes.models import Organizacao
+
+
+urlpatterns = [
+    path("", include(("core.urls", "core"), namespace="core")),
+    path("agenda/", include(("agenda.urls", "agenda"), namespace="agenda")),
+]
+
+pytestmark = pytest.mark.django_db
+
+
+@override_settings(ROOT_URLCONF="agenda.tests.test_qrcode")
+def test_usuario_ve_qrcode_apos_inscricao(client, monkeypatch):
+    monkeypatch.setattr("agenda.views.check_achievements", lambda user: None)
+    monkeypatch.setattr(
+        InscricaoEvento,
+        "gerar_qrcode",
+        lambda self: setattr(self, "qrcode_url", "/fake-qrcode.png"),
+    )
+    organizacao = Organizacao.objects.create(
+        nome="Org Teste", cnpj="00000000000191"
+    )
+    usuario = User.objects.create_user(
+        username="usuario",
+        email="u@example.com",
+        password="12345",
+        organizacao=organizacao,
+        user_type=UserType.NUCLEADO,
+    )
+    client.force_login(usuario)
+
+    evento = Evento.objects.create(
+        titulo="Evento",
+        descricao="Desc",
+        data_inicio=make_aware(datetime.now() + timedelta(days=1)),
+        data_fim=make_aware(datetime.now() + timedelta(days=2)),
+        local="Rua 1",
+        cidade="Cidade",
+        estado="ST",
+        cep="12345-678",
+        coordenador=usuario,
+        organizacao=organizacao,
+        status=0,
+        publico_alvo=0,
+        numero_convidados=10,
+        numero_presentes=0,
+    )
+
+    url = reverse("agenda:evento_subscribe", args=[evento.pk])
+    response = client.post(url, follow=True)
+
+    assert response.status_code == 200
+    inscricao = InscricaoEvento.objects.get(user=usuario, evento=evento)
+    assert inscricao.status == "confirmada"
+    assert inscricao.qrcode_url
+    assert inscricao.qrcode_url in response.content.decode()
+

--- a/agenda/views.py
+++ b/agenda/views.py
@@ -269,7 +269,7 @@ class TarefaDetailView(LoginRequiredMixin, NoSuperadminMixin, GerenteRequiredMix
 
 
 class EventoSubscribeView(LoginRequiredMixin, NoSuperadminMixin, View):
-    """Cancela a inscrição do usuário no evento."""
+    """Inscreve ou cancela a inscrição do usuário no evento."""
 
     def post(self, request, pk):  # pragma: no cover
         evento = get_object_or_404(_queryset_por_organizacao(request), pk=pk)
@@ -278,15 +278,23 @@ class EventoSubscribeView(LoginRequiredMixin, NoSuperadminMixin, View):
                 request, _("Administradores não podem se inscrever em eventos.")
             )  # pragma: no cover
             return redirect("agenda:evento_detalhe", pk=pk)
-        inscricao = get_object_or_404(
-            InscricaoEvento, user=request.user, evento=evento
+
+        inscricao, created = InscricaoEvento.objects.get_or_create(
+            user=request.user, evento=evento
         )
-        try:
-            inscricao.cancelar_inscricao()
-        except ValueError as exc:
-            messages.error(request, str(exc))
+        if inscricao.status == "confirmada":
+            try:
+                inscricao.cancelar_inscricao()
+                messages.success(request, _("Inscrição cancelada."))  # pragma: no cover
+            except ValueError as exc:
+                messages.error(request, str(exc))
         else:
-            messages.success(request, _("Inscrição cancelada."))  # pragma: no cover
+            inscricao.confirmar_inscricao()
+            check_achievements(request.user)
+            if inscricao.status == "confirmada":
+                messages.success(request, _("Inscrição realizada."))  # pragma: no cover
+            else:
+                messages.success(request, _("Você está na lista de espera."))  # pragma: no cover
         return redirect("agenda:evento_detalhe", pk=pk)
 
 


### PR DESCRIPTION
## Summary
- exibe QR code da inscrição confirmada na página de evento
- ajusta fluxo de inscrição para redirecionar à página do evento
- adiciona teste funcional para QR code de inscrições

## Testing
- `pytest agenda/tests/test_qrcode.py -q` *(fails: KeyboardInterrupt after 60s)*

------
https://chatgpt.com/codex/tasks/task_e_68a52f6d14a08325a0849f388b1d2b99