### PR TITLE
Add deadline and reason fields for briefing actions

### DIFF
--- a/agenda/templates/agenda/briefing_list.html
+++ b/agenda/templates/agenda/briefing_list.html
@@ -75,9 +75,15 @@
                 <form
                   method="post"
                   action="{% url 'agenda:briefing_status' briefing.pk 'orcamentado' %}"
-                  class="inline"
+                  class="inline space-x-1"
                 >
                   {% csrf_token %}
+                  <input
+                    type="datetime-local"
+                    name="prazo_limite_resposta"
+                    required
+                    class="rounded-md border-gray-300 px-2 py-1 text-xs"
+                  />
                   <button type="submit" class="text-green-600 hover:underline">
                     {% trans "Orçar" %}
                   </button>
@@ -95,9 +101,16 @@
                 <form
                   method="post"
                   action="{% url 'agenda:briefing_status' briefing.pk 'recusado' %}"
-                  class="inline"
+                  class="inline space-x-1"
                 >
                   {% csrf_token %}
+                  <input
+                    type="text"
+                    name="motivo_recusa"
+                    placeholder="{% trans 'Motivo' %}"
+                    required
+                    class="rounded-md border-gray-300 px-2 py-1 text-xs"
+                  />
                   <button type="submit" class="text-red-600 hover:underline">
                     {% trans "Recusar" %}
                   </button>

--- a/agenda/views.py
+++ b/agenda/views.py
@@ -24,6 +24,7 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.template.response import TemplateResponse
 from django.urls import reverse_lazy
 from django.utils import timezone
+from django.utils.dateparse import parse_datetime
 from django.utils.translation import gettext_lazy as _
 from django.views import View
 from django.views.decorators.csrf import csrf_exempt
@@ -779,9 +780,19 @@ class BriefingEventoStatusView(LoginRequiredMixin, View):
         briefing.avaliado_em = now
         detalhes = {}
         if status == "orcamentado":
+            prazo_str = request.POST.get("prazo_limite_resposta")
+            if not prazo_str:
+                messages.error(request, _("Informe o prazo limite de resposta."))
+                return redirect("agenda:briefing_list")
+            prazo = parse_datetime(prazo_str)
+            if prazo is None:
+                messages.error(request, _("Prazo limite inválido."))
+                return redirect("agenda:briefing_list")
+            if timezone.is_naive(prazo):
+                prazo = timezone.make_aware(prazo)
             briefing.status = "orcamentado"
             briefing.orcamento_enviado_em = now
-            briefing.prazo_limite_resposta = request.POST.get("prazo_limite_resposta") or briefing.prazo_limite_resposta
+            briefing.prazo_limite_resposta = prazo
             update_fields.extend(["orcamento_enviado_em", "prazo_limite_resposta"])
         elif status == "aprovado":
             briefing.status = "aprovado"
@@ -789,12 +800,16 @@ class BriefingEventoStatusView(LoginRequiredMixin, View):
             briefing.coordenadora_aprovou = True
             update_fields.extend(["aprovado_em", "coordenadora_aprovou"])
         elif status == "recusado":
+            motivo = request.POST.get("motivo_recusa", "").strip()
+            if not motivo:
+                messages.error(request, _("Informe o motivo da recusa."))
+                return redirect("agenda:briefing_list")
             briefing.status = "recusado"
             briefing.recusado_em = now
             briefing.recusado_por = request.user
-            briefing.motivo_recusa = request.POST.get("motivo_recusa", "")
+            briefing.motivo_recusa = motivo
             update_fields.extend(["recusado_em", "motivo_recusa", "recusado_por"])
-            detalhes["motivo_recusa"] = briefing.motivo_recusa
+            detalhes["motivo_recusa"] = motivo
         else:
             return HttpResponseBadRequest()
         briefing.save(update_fields=update_fields)

--- a/tests/agenda/test_briefing_status.py
+++ b/tests/agenda/test_briefing_status.py
@@ -1,0 +1,85 @@
+import pytest
+from unittest.mock import patch
+from django.urls import reverse
+from django.utils import timezone
+
+from accounts.factories import UserFactory
+from accounts.models import UserType
+from organizacoes.factories import OrganizacaoFactory
+from agenda.factories import EventoFactory
+from agenda.models import BriefingEvento, EventoLog
+
+
+@pytest.mark.django_db
+def test_aprovar_briefing(client):
+    org = OrganizacaoFactory()
+    user = UserFactory(user_type=UserType.ADMIN, organizacao=org)
+    client.force_login(user)
+    evento = EventoFactory(organizacao=org, coordenador=user)
+    briefing = BriefingEvento.objects.create(
+        evento=evento,
+        objetivos="obj",
+        publico_alvo="pub",
+        requisitos_tecnicos="req",
+    )
+    url = reverse("agenda:briefing_status", args=[briefing.pk, "aprovado"])
+    with patch("agenda.views.notificar_briefing_status.delay") as mock_delay:
+        response = client.post(url)
+    assert response.status_code == 302
+    briefing.refresh_from_db()
+    assert briefing.status == "aprovado"
+    assert briefing.avaliado_por == user
+    assert briefing.aprovado_em is not None
+    assert EventoLog.objects.filter(evento=evento, acao="briefing_aprovado").exists()
+    mock_delay.assert_called_once_with(briefing.pk, "aprovado")
+
+
+@pytest.mark.django_db
+def test_orcamentar_briefing(client):
+    org = OrganizacaoFactory()
+    user = UserFactory(user_type=UserType.ADMIN, organizacao=org)
+    client.force_login(user)
+    evento = EventoFactory(organizacao=org, coordenador=user)
+    briefing = BriefingEvento.objects.create(
+        evento=evento,
+        objetivos="obj",
+        publico_alvo="pub",
+        requisitos_tecnicos="req",
+    )
+    url = reverse("agenda:briefing_status", args=[briefing.pk, "orcamentado"])
+    prazo = (timezone.now() + timezone.timedelta(days=5)).isoformat()
+    with patch("agenda.views.notificar_briefing_status.delay") as mock_delay:
+        response = client.post(url, {"prazo_limite_resposta": prazo})
+    assert response.status_code == 302
+    briefing.refresh_from_db()
+    assert briefing.status == "orcamentado"
+    assert briefing.prazo_limite_resposta.isoformat() == prazo
+    assert briefing.orcamento_enviado_em is not None
+    assert EventoLog.objects.filter(evento=evento, acao="briefing_orcamentado").exists()
+    mock_delay.assert_called_once_with(briefing.pk, "orcamentado")
+
+
+@pytest.mark.django_db
+def test_recusar_briefing_com_motivo(client):
+    org = OrganizacaoFactory()
+    user = UserFactory(user_type=UserType.ADMIN, organizacao=org)
+    client.force_login(user)
+    evento = EventoFactory(organizacao=org, coordenador=user)
+    briefing = BriefingEvento.objects.create(
+        evento=evento,
+        objetivos="obj",
+        publico_alvo="pub",
+        requisitos_tecnicos="req",
+    )
+    url = reverse("agenda:briefing_status", args=[briefing.pk, "recusado"])
+    motivo = "Sem orçamento"
+    with patch("agenda.views.notificar_briefing_status.delay") as mock_delay:
+        response = client.post(url, {"motivo_recusa": motivo})
+    assert response.status_code == 302
+    briefing.refresh_from_db()
+    assert briefing.status == "recusado"
+    assert briefing.motivo_recusa == motivo
+    assert briefing.recusado_por == user
+    assert briefing.recusado_em is not None
+    assert EventoLog.objects.filter(evento=evento, acao="briefing_recusado").exists()
+    mock_delay.assert_called_once_with(briefing.pk, "recusado")


### PR DESCRIPTION
## Summary
- add deadline and rejection reason inputs to briefing list actions
- validate `prazo_limite_resposta` and `motivo_recusa` in briefing status view
- cover approval, budgeting, and rejection scenarios in tests

## Testing
- `pytest --no-cov tests/agenda/test_briefing_status.py -q | tail -n 2`


------
https://chatgpt.com/codex/tasks/task_e_68a52f6df9c883259e2732d091c997b8