### PR TITLE
Add task views with logging and templates

### DIFF
--- a/agenda/forms.py
+++ b/agenda/forms.py
@@ -10,7 +10,26 @@ from .models import (
     InscricaoEvento,
     MaterialDivulgacaoEvento,
     ParceriaEvento,
+    Tarefa,
 )
+
+
+class TarefaForm(forms.ModelForm):
+    class Meta:
+        model = Tarefa
+        fields = [
+            "titulo",
+            "descricao",
+            "data_inicio",
+            "data_fim",
+            "responsavel",
+            "status",
+        ]
+        widgets = {
+            "data_inicio": forms.DateTimeInput(attrs={"type": "datetime-local"}),
+            "data_fim": forms.DateTimeInput(attrs={"type": "datetime-local"}),
+            "descricao": forms.Textarea(attrs={"rows": 3}),
+        }
 
 
 class EventoForm(forms.ModelForm):

--- a/agenda/templates/agenda/tarefa_form.html
+++ b/agenda/templates/agenda/tarefa_form.html
@@ -1,0 +1,49 @@
+{% extends 'base.html' %}
+{% load i18n %}
+{% block title %}{% if object %}{% trans "Editar Tarefa" %}{% else %}{% trans "Nova Tarefa" %}{% endif %} | Hubx{% endblock %}
+
+{% block content %}
+<section class="max-w-screen-xl mx-auto pt-8 px-6 lg:px-8">
+  <h1 class="text-2xl font-bold text-neutral-900 mb-6">
+    {% if object %}{% trans "Editar Tarefa" %}{% else %}{% trans "Cadastrar Tarefa" %}{% endif %}
+  </h1>
+  <form method="post" class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 space-y-6">
+    {% csrf_token %}
+    {{ form.non_field_errors }}
+    <div>
+      {{ form.titulo.label_tag }}
+      {{ form.titulo }}
+      {{ form.titulo.errors }}
+    </div>
+    <div>
+      {{ form.descricao.label_tag }}
+      {{ form.descricao }}
+      {{ form.descricao.errors }}
+    </div>
+    <div>
+      {{ form.data_inicio.label_tag }}
+      {{ form.data_inicio }}
+      {{ form.data_inicio.errors }}
+    </div>
+    <div>
+      {{ form.data_fim.label_tag }}
+      {{ form.data_fim }}
+      {{ form.data_fim.errors }}
+    </div>
+    <div>
+      {{ form.responsavel.label_tag }}
+      {{ form.responsavel }}
+      {{ form.responsavel.errors }}
+    </div>
+    <div>
+      {{ form.status.label_tag }}
+      {{ form.status }}
+      {{ form.status.errors }}
+    </div>
+    <div class="flex justify-end gap-3 pt-4 border-t border-neutral-100">
+      <a href="{% url 'agenda:tarefa_list' %}" class="btn-secondary" aria-label="{% trans 'Cancelar' %}">{% trans "Cancelar" %}</a>
+      <button type="submit" class="btn-primary" aria-label="{% trans 'Salvar' %}">{% trans "Salvar" %}</button>
+    </div>
+  </form>
+</section>
+{% endblock %}

--- a/agenda/templates/agenda/tarefa_list.html
+++ b/agenda/templates/agenda/tarefa_list.html
@@ -1,0 +1,19 @@
+{% extends 'base.html' %}
+{% load i18n %}
+{% block title %}{% trans "Tarefas" %} | Hubx{% endblock %}
+
+{% block content %}
+<section class="max-w-screen-xl mx-auto pt-8 px-6 lg:px-8">
+  <h1 class="text-2xl font-bold text-neutral-900 mb-6">{% trans "Tarefas" %}</h1>
+  <ul class="space-y-2">
+    {% for tarefa in tarefas %}
+      <li class="p-4 bg-white border border-neutral-200 rounded-2xl shadow-sm">
+        <a href="{% url 'agenda:tarefa_detalhe' tarefa.pk %}" class="font-semibold">{{ tarefa.titulo }}</a>
+        <div class="text-sm text-neutral-600">{{ tarefa.responsavel }} - {{ tarefa.status }}</div>
+      </li>
+    {% empty %}
+      <li>{% trans "Nenhuma tarefa encontrada." %}</li>
+    {% endfor %}
+  </ul>
+</section>
+{% endblock %}

--- a/agenda/urls.py
+++ b/agenda/urls.py
@@ -23,6 +23,9 @@ from .views import (
     ParceriaEventoListView,
     ParceriaEventoUpdateView,
     TarefaDetailView,
+    TarefaCreateView,
+    TarefaListView,
+    TarefaUpdateView,
 )
 
 app_name = "agenda"
@@ -93,5 +96,8 @@ urlpatterns = [
         BriefingEventoStatusView.as_view(),
         name="briefing_status",
     ),
+    path("tarefas/", TarefaListView.as_view(), name="tarefa_list"),
+    path("tarefa/nova/", TarefaCreateView.as_view(), name="tarefa_criar"),
+    path("tarefa/<uuid:pk>/editar/", TarefaUpdateView.as_view(), name="tarefa_editar"),
     path("tarefa/<uuid:pk>/", TarefaDetailView.as_view(), name="tarefa_detalhe"),
 ]

--- a/tests/agenda/test_tarefas.py
+++ b/tests/agenda/test_tarefas.py
@@ -1,0 +1,83 @@
+import pytest
+from datetime import timedelta
+from django.urls import reverse
+from django.utils import timezone
+
+from accounts.models import UserType
+from agenda.models import Tarefa, TarefaLog
+from organizacoes.models import Organizacao
+
+pytestmark = pytest.mark.urls("Hubx.urls")
+
+
+@pytest.fixture
+def organizacao():
+    return Organizacao.objects.create(
+        nome="Org", cnpj="00.000.000/0001-00", slug="org"
+    )
+
+
+@pytest.fixture
+def admin_user(django_user_model, organizacao):
+    return django_user_model.objects.create_user(
+        username="admin",
+        email="admin@example.com",
+        password="password",
+        organizacao=organizacao,
+        user_type=UserType.ADMIN,
+    )
+
+
+@pytest.mark.django_db
+def test_criar_tarefa_log(client, admin_user):
+    client.force_login(admin_user)
+    inicio = timezone.now()
+    fim = inicio + timedelta(hours=1)
+    resp = client.post(
+        reverse("agenda:tarefa_criar"),
+        {
+            "titulo": "Teste",
+            "descricao": "Desc",
+            "data_inicio": inicio.strftime("%Y-%m-%dT%H:%M"),
+            "data_fim": fim.strftime("%Y-%m-%dT%H:%M"),
+            "responsavel": admin_user.pk,
+            "status": "pendente",
+        },
+    )
+    assert resp.status_code == 302
+    tarefa = Tarefa.objects.get(titulo="Teste")
+    assert TarefaLog.objects.filter(
+        tarefa=tarefa, acao="tarefa_criada", usuario=admin_user
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_atualizar_tarefa_log(client, admin_user):
+    inicio = timezone.now()
+    fim = inicio + timedelta(hours=1)
+    tarefa = Tarefa.objects.create(
+        titulo="Old",
+        descricao="Desc",
+        data_inicio=inicio,
+        data_fim=fim,
+        responsavel=admin_user,
+        organizacao=admin_user.organizacao,
+    )
+    client.force_login(admin_user)
+    resp = client.post(
+        reverse("agenda:tarefa_editar", args=[tarefa.pk]),
+        {
+            "titulo": "New",
+            "descricao": "Desc",
+            "data_inicio": inicio.strftime("%Y-%m-%dT%H:%M"),
+            "data_fim": fim.strftime("%Y-%m-%dT%H:%M"),
+            "responsavel": admin_user.pk,
+            "status": "pendente",
+        },
+    )
+    assert resp.status_code == 302
+    tarefa.refresh_from_db()
+    assert tarefa.titulo == "New"
+    assert TarefaLog.objects.filter(
+        tarefa=tarefa, acao="tarefa_atualizada", usuario=admin_user
+    ).exists()


### PR DESCRIPTION
## Summary
- add TarefaForm and views for listing, creating and updating tasks
- record TarefaLog entries on task creation and updates
- include task templates and tests

## Testing
- `pytest tests/agenda/test_tarefas.py -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68a52f6fd8a48325b48c63e179850afb