### PR TITLE
Enable post-event evaluations in event detail view

### DIFF
--- a/agenda/templates/agenda/detail.html
+++ b/agenda/templates/agenda/detail.html
@@ -18,17 +18,23 @@
 
   <!-- Informações -->
   <div class="space-y-2 text-sm text-neutral-800 mb-6">
-    <p><strong>{% trans "Início" %}:</strong> {{ object.data_inicio|date:SHORT_DATETIME_FORMAT }}</p>
-    <p><strong>{% trans "Fim" %}:</strong> {{ object.data_fim|date:SHORT_DATETIME_FORMAT }}</p>
+    <p><strong>{% trans "Início" %}:</strong> {{ object.data_inicio|date:"SHORT_DATETIME_FORMAT" }}</p>
+    <p><strong>{% trans "Fim" %}:</strong> {{ object.data_fim|date:"SHORT_DATETIME_FORMAT" }}</p>
   </div>
 
   <!-- Inscrição -->
-  {% if user.is_authenticated and user.user_type not in ('admin','root') %}
-    {% if object.inscricoes.filter(user=user, status='confirmada').exists %}
+  {% if user.is_authenticated and user.user_type != 'admin' and user.user_type != 'root' %}
+    {% if inscricao_confirmada %}
+      {% if avaliacao_permitida %}
+      <div class="mb-10">
+        <a href="{% url 'agenda:evento_feedback' object.pk %}" class="btn-primary" aria-label="{% trans 'Avaliar evento' %}">{% trans "Avaliar evento" %}</a>
+      </div>
+      {% else %}
       <form method="post" action="{% url 'agenda:evento_subscribe' object.pk %}" class="mb-10">
         {% csrf_token %}
         <button type="submit" class="btn-secondary" aria-label="{% trans 'Cancelar inscrição' %}">{% trans "Cancelar inscrição" %}</button>
       </form>
+      {% endif %}
     {% else %}
       <div class="mb-10">
         <a href="{% url 'agenda:inscricao_criar' object.pk %}" class="btn-primary" aria-label="{% trans 'Inscrever-se' %}">{% trans "Inscrever-se" %}</a>

--- a/agenda/views.py
+++ b/agenda/views.py
@@ -251,6 +251,17 @@ class EventoDetailView(LoginRequiredMixin, NoSuperadminMixin, GerenteRequiredMix
             .prefetch_related("inscricoes", "feedbacks")
         )
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        user = self.request.user
+        evento: Evento = self.object
+        confirmada = evento.inscricoes.filter(
+            user=user, status="confirmada"
+        ).exists()
+        context["inscricao_confirmada"] = confirmada
+        context["avaliacao_permitida"] = confirmada and timezone.now() > evento.data_fim
+        return context
+
 
 class TarefaDetailView(LoginRequiredMixin, NoSuperadminMixin, GerenteRequiredMixin, DetailView):
     model = Tarefa

--- a/tests/agenda/test_avaliacao.py
+++ b/tests/agenda/test_avaliacao.py
@@ -1,0 +1,85 @@
+from datetime import timedelta
+
+import pytest
+from django.urls import reverse
+from django.utils import timezone
+
+from accounts.models import User, UserType
+from agenda.models import Evento, InscricaoEvento
+from organizacoes.models import Organizacao
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def organizacao():
+    return Organizacao.objects.create(nome="Org Teste", cnpj="00000000000191")
+
+
+@pytest.fixture
+def usuario(client, organizacao):
+    user = User.objects.create_user(
+        username="coord",
+        email="coord@example.com",
+        password="12345",
+        user_type=UserType.COORDENADOR,
+        organizacao=organizacao,
+    )
+    client.force_login(user)
+    return user
+
+
+def criar_evento(organizacao, usuario, inicio, fim):
+    return Evento.objects.create(
+        organizacao=organizacao,
+        titulo="Evento",
+        descricao="Desc",
+        data_inicio=inicio,
+        data_fim=fim,
+        briefing="",
+        coordenador=usuario,
+        status=0,
+        publico_alvo=1,
+        numero_convidados=50,
+        numero_presentes=30,
+    )
+
+
+def test_avaliacao_permitida_pos_evento(client, usuario, organizacao):
+    evento = criar_evento(
+        organizacao,
+        usuario,
+        timezone.now() - timedelta(days=1),
+        timezone.now() - timedelta(hours=1),
+    )
+    InscricaoEvento.objects.create(
+        evento=evento,
+        user=usuario,
+        status="confirmada",
+        data_confirmacao=timezone.now(),
+        presente=False,
+    )
+    response = client.get(reverse("agenda:evento_detalhe", args=[evento.pk]))
+    assert response.status_code == 200
+    assert response.context["avaliacao_permitida"] is True
+    assert "Avaliar evento" in response.content.decode()
+
+
+def test_avaliacao_negada_evento_future(client, usuario, organizacao):
+    evento = criar_evento(
+        organizacao,
+        usuario,
+        timezone.now() + timedelta(hours=1),
+        timezone.now() + timedelta(days=1),
+    )
+    InscricaoEvento.objects.create(
+        evento=evento,
+        user=usuario,
+        status="confirmada",
+        data_confirmacao=timezone.now(),
+        presente=False,
+    )
+    response = client.get(reverse("agenda:evento_detalhe", args=[evento.pk]))
+    assert response.status_code == 200
+    assert response.context["avaliacao_permitida"] is False
+    assert "Avaliar evento" not in response.content.decode()

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -3,6 +3,7 @@ from django.views.i18n import JavaScriptCatalog
 
 urlpatterns = [
     path("", include(("accounts.urls", "accounts"), namespace="accounts")),
+    path("core/", include(("core.urls", "core"), namespace="core")),
     path("api/notificacoes/", include("notificacoes.api_urls")),
     path("financeiro/", include(("financeiro.urls", "financeiro"), namespace="financeiro")),
     path("accounts/", include(("accounts.urls", "accounts"), namespace="accounts")),


### PR DESCRIPTION
## Summary
- Allow EventoDetailView to expose evaluation availability
- Show "Avaliar evento" button after event completion for confirmed users
- Test evaluation button visibility for past and future events

## Testing
- `pytest tests/agenda/test_avaliacao.py --cov=agenda --cov-report=term --cov-fail-under=0 -q`


------
https://chatgpt.com/codex/tasks/task_e_68a52f707cfc83259437784432cc6c03