### PR TITLE
Gera recibo de aporte com envio por e-mail

### DIFF
--- a/financeiro/templates/financeiro/aportes_form.html
+++ b/financeiro/templates/financeiro/aportes_form.html
@@ -2,7 +2,7 @@
 <form
   hx-post="/api/financeiro/aportes/"
   hx-target="#aportes-messages"
-  hx-on="htmx:afterRequest: if(event.detail.successful){this.reset();document.getElementById('aportes-messages').textContent='{{ _('Aporte registrado com sucesso') }}';}else{document.getElementById('aportes-messages').textContent='{{ _('Erro ao registrar aporte') }}';}"
+  hx-on="htmx:afterRequest: if(event.detail.successful){this.reset();var resp=JSON.parse(event.detail.xhr.response);var msg='{{ _('Aporte registrado com sucesso') }}';if(resp.recibo_url){msg+=' <a href=\"'+resp.recibo_url+'\" target=\"_blank\">{{ _('Baixar recibo') }}</a>'; }document.getElementById('aportes-messages').innerHTML=msg;}else{document.getElementById('aportes-messages').textContent='{{ _('Erro ao registrar aporte') }}';}"
   class="p-4 bg-white rounded shadow max-w-md"
   aria-live="assertive"
 >
@@ -31,4 +31,3 @@
   <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">{{ _('Registrar') }}</button>
   <div id="aportes-messages" class="mt-2 text-sm" aria-live="polite"></div>
 </form>
-

--- a/financeiro/templates/financeiro/recibo_aporte.html
+++ b/financeiro/templates/financeiro/recibo_aporte.html
@@ -1,0 +1,15 @@
+{% load i18n %}
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>{% trans 'Recibo de Aporte' %}</title>
+  </head>
+  <body>
+    <h1>{% trans 'Recibo de Aporte' %}</h1>
+    <p><strong>ID:</strong> {{ lancamento.id }}</p>
+    <p><strong>{% trans 'Data' %}:</strong> {{ lancamento.data_lancamento }}</p>
+    <p><strong>{% trans 'Valor' %}:</strong> {{ lancamento.valor }}</p>
+    <p><strong>{% trans 'Descrição' %}:</strong> {{ lancamento.descricao }}</p>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- cria recibo HTML para aportes e envia por e-mail
- inclui link de download do recibo no retorno da API e no formulário
- adiciona teste para geração de recibo

## Testing
- `ruff format financeiro/views/__init__.py financeiro/tests/test_aportes.py`
- `black financeiro/views/__init__.py financeiro/tests/test_aportes.py`
- `ruff check financeiro/views/__init__.py financeiro/tests/test_aportes.py`
- `pytest financeiro/tests/test_aportes.py` *(falhou: Required test coverage of 90% not reached)*
- `bandit -r . --exclude .venv,migrations,static`

------
https://chatgpt.com/codex/tasks/task_e_68a605b487e48325b7a13a1ed3aa6db8