### PR TITLE
feat(financeiro): add integracao config viewset and templates

### DIFF
--- a/financeiro/api_urls.py
+++ b/financeiro/api_urls.py
@@ -10,6 +10,7 @@ from .viewsets import (
     FinanceiroForecastViewSet,
     ImportacaoPagamentosViewSet,
     LancamentoFinanceiroViewSet,
+    IntegracaoConfigViewSet,
 )
 
 router = routers.DefaultRouter()
@@ -19,6 +20,7 @@ router.register("importacoes", ImportacaoPagamentosViewSet, basename="importacao
 router.register("logs", FinanceiroLogViewSet, basename="log")
 router.register("task-logs", FinanceiroTaskLogViewSet, basename="task-log")
 router.register("forecast", FinanceiroForecastViewSet, basename="forecast")
+router.register("integracoes", IntegracaoConfigViewSet, basename="integracao")
 router.register("", FinanceiroViewSet, basename="financeiro")
 
 urlpatterns = router.urls

--- a/financeiro/serializers/__init__.py
+++ b/financeiro/serializers/__init__.py
@@ -14,6 +14,7 @@ from ..models import (
     FinanceiroTaskLog,
     LancamentoFinanceiro,
     ImportacaoPagamentos,
+    IntegracaoConfig,
 )
 from ..services.distribuicao import repassar_receita_ingresso
 from ..services.notificacoes import enviar_aporte
@@ -224,6 +225,25 @@ class ImportacaoPagamentosSerializer(serializers.ModelSerializer):
             "status",
         ]
         read_only_fields = fields
+
+
+class IntegracaoConfigSerializer(serializers.ModelSerializer):
+    """Serializador para ``IntegracaoConfig``."""
+
+    credenciais = serializers.CharField(source="credenciais_encrypted", allow_blank=True, required=False)
+
+    class Meta:
+        model = IntegracaoConfig
+        fields = [
+            "id",
+            "nome",
+            "tipo",
+            "base_url",
+            "credenciais",
+            "created_at",
+            "updated_at",
+        ]
+        read_only_fields = ["created_at", "updated_at"]
 
 
 class FinanceiroLogSerializer(serializers.ModelSerializer):

--- a/financeiro/templates/financeiro/integracao_form.html
+++ b/financeiro/templates/financeiro/integracao_form.html
@@ -1,0 +1,37 @@
+{% load i18n %}
+<form id="integracao-form"
+      {% if integracao %}
+        hx-put="/api/financeiro/integracoes/{{ integracao.id }}/"
+      {% else %}
+        hx-post="/api/financeiro/integracoes/"
+      {% endif %}
+      hx-target="#integracoes-list"
+      hx-on="htmx:afterRequest: htmx.ajax('GET', '/financeiro/integracoes/', '#integracoes-list'); document.getElementById('modal').innerHTML='';"
+      class="p-4 bg-white rounded shadow max-w-md space-y-4" aria-live="assertive">
+  {% csrf_token %}
+  <div>
+    <label for="id_nome" class="block text-sm font-medium">{{ _('Nome') }}</label>
+    <input id="id_nome" name="nome" type="text" class="border p-2 w-full" required {% if integracao %}value="{{ integracao.nome }}"{% endif %} {% if form and form.nome.errors %}aria-invalid="true"{% endif %} />
+    {% if form and form.nome.errors %}<p class="text-red-600 text-sm" aria-live="polite">{{ form.nome.errors }}</p>{% endif %}
+  </div>
+  <div>
+    <label for="id_tipo" class="block text-sm font-medium">{{ _('Tipo') }}</label>
+    <select id="id_tipo" name="tipo" class="border p-2 w-full" required {% if form and form.tipo.errors %}aria-invalid="true"{% endif %}>
+      <option value="erp"{% if integracao and integracao.tipo == 'erp' %} selected{% endif %}>{{ _('ERP') }}</option>
+      <option value="contabilidade"{% if integracao and integracao.tipo == 'contabilidade' %} selected{% endif %}>{{ _('Contabilidade') }}</option>
+      <option value="gateway"{% if integracao and integracao.tipo == 'gateway' %} selected{% endif %}>{{ _('Gateway de Pagamento') }}</option>
+    </select>
+    {% if form and form.tipo.errors %}<p class="text-red-600 text-sm" aria-live="polite">{{ form.tipo.errors }}</p>{% endif %}
+  </div>
+  <div>
+    <label for="id_base_url" class="block text-sm font-medium">{{ _('Base URL') }}</label>
+    <input id="id_base_url" name="base_url" type="url" class="border p-2 w-full" required {% if integracao %}value="{{ integracao.base_url }}"{% endif %} {% if form and form.base_url.errors %}aria-invalid="true"{% endif %} />
+    {% if form and form.base_url.errors %}<p class="text-red-600 text-sm" aria-live="polite">{{ form.base_url.errors }}</p>{% endif %}
+  </div>
+  <div>
+    <label for="id_credenciais" class="block text-sm font-medium">{{ _('Credenciais') }}</label>
+    <textarea id="id_credenciais" name="credenciais" class="border p-2 w-full" rows="3" {% if form and form.credenciais.errors %}aria-invalid="true"{% endif %}>{% if integracao %}{{ integracao.credenciais_encrypted }}{% endif %}</textarea>
+    {% if form and form.credenciais.errors %}<p class="text-red-600 text-sm" aria-live="polite">{{ form.credenciais.errors }}</p>{% endif %}
+  </div>
+  <button type="submit" class="bg-green-600 text-white px-4 py-2 rounded">{{ _('Salvar') }}</button>
+</form>

--- a/financeiro/templates/financeiro/integracoes_list.html
+++ b/financeiro/templates/financeiro/integracoes_list.html
@@ -1,0 +1,63 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Integrações" %}{% endblock %}
+
+{% block content %}
+<main class="p-4 max-w-5xl mx-auto">
+  <header class="flex items-center justify-between mb-4">
+    <h1 class="text-2xl font-semibold">{% trans "Integrações" %}</h1>
+    <button class="bg-blue-600 text-white px-4 py-2 rounded"
+            hx-get="/api/financeiro/integracoes/"
+            hx-target="#modal" hx-trigger="click">
+      {% trans "Nova Configuração" %}
+    </button>
+  </header>
+  <section id="integracoes-list" class="overflow-x-auto" aria-live="polite">
+    <table class="min-w-full divide-y divide-gray-200">
+      <thead class="bg-gray-50">
+        <tr>
+          <th scope="col" class="px-3 py-2 text-left text-xs font-medium text-gray-500">{% trans "Nome" %}</th>
+          <th scope="col" class="px-3 py-2 text-left text-xs font-medium text-gray-500">{% trans "Tipo" %}</th>
+          <th scope="col" class="px-3 py-2 text-left text-xs font-medium text-gray-500">{% trans "Base URL" %}</th>
+          <th scope="col" class="px-3 py-2 text-right text-xs font-medium text-gray-500">{% trans "Ações" %}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for i in integracoes %}
+        <tr class="divide-x divide-gray-200">
+          <td class="px-3 py-2">{{ i.nome }}</td>
+          <td class="px-3 py-2">{{ i.get_tipo_display }}</td>
+          <td class="px-3 py-2">{{ i.base_url }}</td>
+          <td class="px-3 py-2 text-right space-x-2">
+            <button class="text-primary underline"
+                    hx-get="/api/financeiro/integracoes/{{ i.id }}/"
+                    hx-target="#modal" hx-trigger="click">{% trans "Editar" %}</button>
+            <button class="text-red-600 underline"
+                    hx-delete="/api/financeiro/integracoes/{{ i.id }}/"
+                    hx-target="closest tr" hx-confirm='{% trans "Tem certeza?" %}'>{% trans "Excluir" %}</button>
+          </td>
+        </tr>
+        {% empty %}
+        <tr>
+          <td colspan="4" class="px-3 py-2 text-center text-sm text-gray-500">{% trans "Nenhuma integração encontrada." %}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    <div class="mt-4 flex justify-between">
+      {% if prev %}
+        <button class="px-3 py-1 text-sm bg-gray-200 rounded"
+                hx-get="?offset={{ prev }}" hx-target="#integracoes-list"
+                hx-trigger="click" hx-swap="outerHTML">{% trans "Anterior" %}</button>
+      {% endif %}
+      {% if next %}
+        <button class="px-3 py-1 text-sm bg-gray-200 rounded ml-auto"
+                hx-get="?offset={{ next }}" hx-target="#integracoes-list"
+                hx-trigger="click" hx-swap="outerHTML">{% trans "Próximo" %}</button>
+      {% endif %}
+    </div>
+  </section>
+  <div id="modal" class="mt-4" aria-live="assertive"></div>
+</main>
+{% endblock %}

--- a/financeiro/urls.py
+++ b/financeiro/urls.py
@@ -8,6 +8,7 @@ from .views import (
     lancamentos_list_view,
     relatorios_view,
     centros_list_view,
+    integracoes_list_view,
     task_log_detail_view,
     task_logs_view,
 )
@@ -19,6 +20,7 @@ urlpatterns = [
     path("aportes/", aportes_form_view, name="aportes_form"),
     path("relatorios/", relatorios_view, name="relatorios"),
     path("centros/", centros_list_view, name="centros"),
+    path("integracoes/", integracoes_list_view, name="integracoes"),
     path("lancamentos/", lancamentos_list_view, name="lancamentos"),
     path("forecast/", forecast_view, name="forecast"),
     path("inadimplencias/", inadimplencias_view, name="inadimplencias"),

--- a/financeiro/views/__init__.py
+++ b/financeiro/views/__init__.py
@@ -27,6 +27,7 @@ from ..models import (
     FinanceiroTaskLog,
     ImportacaoPagamentos,
     LancamentoFinanceiro,
+    IntegracaoConfig,
 )
 from ..permissions import (
     IsAssociadoReadOnly,
@@ -432,6 +433,24 @@ def centros_list_view(request):
         "prev": prev_offset,
     }
     return render(request, "financeiro/centros_list.html", context)
+
+
+@login_required
+@user_passes_test(_is_financeiro_or_admin)
+def integracoes_list_view(request):
+    limit = 20
+    offset = int(request.GET.get("offset", 0))
+    qs = IntegracaoConfig.objects.all()
+    total = qs.count()
+    integracoes = qs[offset : offset + limit]
+    next_offset = offset + limit if total > offset + limit else None
+    prev_offset = offset - limit if offset - limit >= 0 else None
+    context = {
+        "integracoes": integracoes,
+        "next": next_offset,
+        "prev": prev_offset,
+    }
+    return render(request, "financeiro/integracoes_list.html", context)
 
 
 @login_required

--- a/financeiro/viewsets.py
+++ b/financeiro/viewsets.py
@@ -26,6 +26,7 @@ from .models import (
     FinanceiroTaskLog,
     ImportacaoPagamentos,
     LancamentoFinanceiro,
+    IntegracaoConfig,
 )
 from .permissions import IsAssociadoReadOnly, IsCoordenador, IsFinanceiroOrAdmin, IsNotRoot
 from .serializers import (
@@ -33,6 +34,7 @@ from .serializers import (
     FinanceiroTaskLogSerializer,
     ImportacaoPagamentosSerializer,
     LancamentoFinanceiroSerializer,
+    IntegracaoConfigSerializer,
 )
 from .services.distribuicao import repassar_receita_ingresso
 from .services.auditoria import log_financeiro
@@ -302,6 +304,14 @@ class FinanceiroTaskLogViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin,
         return qs
 
 
+class IntegracaoConfigViewSet(viewsets.ModelViewSet):
+    """CRUD das configurações de integrações externas."""
+
+    queryset = IntegracaoConfig.objects.all()
+    serializer_class = IntegracaoConfigSerializer
+    permission_classes = [IsAuthenticated, IsNotRoot, IsFinanceiroOrAdmin]
+
+
 __all__ = [
     "CentroCustoViewSet",
     "FinanceiroViewSet",
@@ -310,5 +320,6 @@ __all__ = [
     "FinanceiroLogViewSet",
     "FinanceiroForecastViewSet",
     "FinanceiroTaskLogViewSet",
+    "IntegracaoConfigViewSet",
 ]
 


### PR DESCRIPTION
## Summary
- add IntegracaoConfigViewSet with IsFinanceiroOrAdmin guard
- expose IntegracaoConfigSerializer and routes
- create integracoes listing page with modal form

## Testing
- `pytest financeiro/tests/test_models.py::test_lancamento_atualiza_saldos -q` *(fails: Coverage failure: total of 12 is less than fail-under=90)*

------
https://chatgpt.com/codex/tasks/task_e_68a605b233848325a8fca6a698037ec5