### PR TITLE
Adicionar listagem de favoritos no feed

### DIFF
--- a/feed/templates/feed/bookmarks.html
+++ b/feed/templates/feed/bookmarks.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+{% load i18n %}
+{% block title %}{% trans "Meus Favoritos" %} | Hubx{% endblock %}
+
+{% block content %}
+<section class="max-w-6xl mx-auto px-4 py-10">
+  <div class="flex items-center justify-between mb-6">
+    <h1 class="text-2xl font-bold text-neutral-900">{% trans "Meus Favoritos" %}</h1>
+    <div class="flex gap-2">
+      <a href="{% url 'feed:listar' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100 focus:outline-none focus:ring-2 focus:ring-indigo-500" aria-label="{% trans 'Voltar ao feed' %}">{% trans "Voltar ao feed" %}</a>
+    </div>
+  </div>
+  {% include "feed/_grid.html" with posts=posts %}
+</section>
+{% endblock %}

--- a/feed/templates/feed/feed.html
+++ b/feed/templates/feed/feed.html
@@ -11,6 +11,7 @@
     <h1 class="text-2xl font-bold text-neutral-900">{% trans "Feed de Postagens" %}</h1>
     <div class="flex gap-2">
       <a href="{% url 'feed:meu_mural' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100 focus:outline-none focus:ring-2 focus:ring-indigo-500" aria-label="{% trans 'Mural' %}">{% trans "Mural" %}</a>
+      <a href="{% url 'feed:bookmarks' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100 focus:outline-none focus:ring-2 focus:ring-indigo-500" aria-label="{% trans 'Favoritos' %}">{% trans "Favoritos" %}</a>
       {% if request.user.user_type != 'root' %}
         <a href="{% url 'feed:nova_postagem' %}" target="_blank" class="inline-flex items-center gap-2 rounded bg-emerald-600 px-4 py-2 text-white hover:bg-emerald-700 focus:outline-none focus:ring-2 focus:ring-emerald-500" aria-label="{% trans 'Nova postagem' %}">
           <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/feed/templates/feed/mural.html
+++ b/feed/templates/feed/mural.html
@@ -10,6 +10,7 @@
     <h1 class="text-2xl font-bold text-neutral-900">{% trans "Meu Mural" %}</h1>
     <div class="flex gap-2">
       <a href="{% url 'feed:listar' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100 focus:outline-none focus:ring-2 focus:ring-indigo-500" aria-label="{% trans 'Ver Feed Global' %}">{% trans "Ver Feed Global" %}</a>
+      <a href="{% url 'feed:bookmarks' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100 focus:outline-none focus:ring-2 focus:ring-indigo-500" aria-label="{% trans 'Favoritos' %}">{% trans "Favoritos" %}</a>
       {% if request.user.user_type != 'root' %}
       <a href="{% url 'feed:nova_postagem' %}" target="_blank" class="inline-flex items-center gap-2 px-4 py-2 rounded-md bg-blue-500 hover:bg-blue-600 text-white text-sm font-medium shadow-sm transition focus:outline-none focus:ring-2 focus:ring-blue-500" aria-label="{% trans 'Nova postagem' %}">
         <i class="fa-solid fa-circle-plus"></i>

--- a/feed/urls.py
+++ b/feed/urls.py
@@ -7,6 +7,7 @@ app_name = "feed"
 urlpatterns = [
     path("", views.FeedListView.as_view(), name="listar"),
     path("mural/", views.meu_mural, name="meu_mural"),
+    path("favoritos/", views.bookmark_list, name="bookmarks"),
     path("novo/", views.NovaPostagemView.as_view(), name="nova_postagem"),
     path("<uuid:pk>/", views.PostDetailView.as_view(), name="post_detail"),
     path("<uuid:pk>/comentar/", views.create_comment, name="create_comment"),

--- a/feed/views.py
+++ b/feed/views.py
@@ -22,7 +22,7 @@ from nucleos.models import Nucleo
 from agenda.models import Evento
 
 from .forms import CommentForm, LikeForm, PostForm
-from .models import Like, ModeracaoPost, Post, Tag
+from .models import Bookmark, Like, ModeracaoPost, Post, Tag
 
 
 @login_required
@@ -53,6 +53,29 @@ def meu_mural(request):
         "nucleos_do_usuario": Nucleo.objects.filter(participacoes__user=request.user),
     }
     return render(request, "feed/mural.html", context)
+
+
+@login_required
+def bookmark_list(request):
+    bookmarks = (
+        Bookmark.objects.filter(user=request.user)
+        .select_related(
+            "post__autor",
+            "post__organizacao",
+            "post__nucleo",
+            "post__evento",
+        )
+        .prefetch_related(
+            "post__likes",
+            "post__comments",
+            "post__bookmarks",
+            "post__flags",
+            "post__reacoes",
+        )
+        .order_by("-created_at")
+    )
+    posts = [bookmark.post for bookmark in bookmarks]
+    return render(request, "feed/bookmarks.html", {"posts": posts})
 
 
 class FeedListView(LoginRequiredMixin, ListView):


### PR DESCRIPTION
## Summary
- adicionar rota e view para listar favoritos do usuário
- criar template para exibir posts favoritos
- incluir links para favoritos no feed e mural

## Testing
- `pre-commit run --files feed/views.py feed/urls.py feed/templates/feed/bookmarks.html feed/templates/feed/feed.html feed/templates/feed/mural.html feed/tests/test_bookmarks_view.py` *(fails: InvalidConfigError: .pre-commit-config.yaml is not a file)*
- `pytest feed/tests/test_bookmark_api.py --no-cov -q` *(fails: 404 Not Found for bookmark endpoints)*

------
https://chatgpt.com/codex/tasks/task_e_68a6058a2f388325b487f6ea97d55aed