### PR TITLE
Use select2 widget for empresa tags

### DIFF
--- a/docs/empresas.md
+++ b/docs/empresas.md
@@ -1,0 +1,7 @@
+# Empresas
+
+## Seleção de tags
+
+Os formulários de criação e edição de empresas utilizam um campo de seleção múltipla com autocomplete para associar *tags* existentes.
+Digite parte do nome para buscar e escolha as opções desejadas.
+Novas tags devem ser cadastradas na tela de gestão de produtos e serviços.

--- a/empresas/templates/empresas/nova.html
+++ b/empresas/templates/empresas/nova.html
@@ -1,7 +1,12 @@
 {% extends "base.html" %}
-{% load custom_filters i18n %}
+{% load custom_filters i18n static %}
 
 {% block title %}{% if form.instance.pk %}{% translate 'Editar Empresa' %}{% else %}{% translate 'Nova Empresa' %}{% endif %}{% endblock %}
+
+{% block extra_css %}
+{{ block.super }}
+<link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
+{% endblock %}
 
 {% block content %}
 <section class="max-w-3xl mx-auto px-4 py-10 space-y-6">
@@ -44,9 +49,9 @@
         {{ form.tipo.errors }}
       </div>
       <div>
-        <label for="{{ form.tags_field.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.tags_field.label }}</label>
-        {{ form.tags_field|add_class:'w-full p-2 border rounded' }}
-        {{ form.tags_field.errors }}
+        <label for="{{ form.tags.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.tags.label }}</label>
+        {{ form.tags|add_class:'w-full p-2 border rounded' }}
+        {{ form.tags.errors }}
       </div>
     </div>
     <div>
@@ -88,4 +93,11 @@
     </div>
   </form>
 </section>
+{% endblock %}
+
+{% block extra_js %}
+{{ block.super }}
+<script src="https://cdn.jsdelivr.net/npm/jquery@3.7.1/dist/jquery.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
+<script src="{% static 'django_select2/django_select2.js' %}"></script>
 {% endblock %}

--- a/empresas/tests/test_forms.py
+++ b/empresas/tests/test_forms.py
@@ -6,13 +6,14 @@ from empresas.models import Tag
 
 
 @pytest.mark.django_db
-def test_tags_are_sanitized():
+def test_tags_are_assigned_from_ids():
+    tag1 = Tag.objects.create(nome="Alpha")
+    tag2 = Tag.objects.create(nome="Beta")
     empresa = EmpresaFactory()
     form = EmpresaForm(instance=empresa)
-    data = form.initial
-    data["tags_field"] = "Tag<script>, outro!@#"
+    data = dict(form.initial)
+    data["tags"] = [tag1.id, tag2.id]
     form = EmpresaForm(data, instance=empresa)
     assert form.is_valid()
     form.save()
-    assert Tag.objects.filter(nome="Tagscript").exists()
-    assert Tag.objects.filter(nome="outro").exists()
+    assert set(empresa.tags.all()) == {tag1, tag2}

--- a/tests/empresas/test_forms.py
+++ b/tests/empresas/test_forms.py
@@ -16,7 +16,7 @@ def test_clean_cnpj_formats_and_unique(nucleado_user):
             "estado": "SC",
             "descricao": "",
             "palavras_chave": "",
-            "tags_field": "",
+            "tags": [],
         },
         initial={"usuario": nucleado_user, "organizacao": nucleado_user.organizacao},
     )
@@ -35,7 +35,7 @@ def test_clean_cnpj_formats_and_unique(nucleado_user):
             "estado": "SC",
             "descricao": "",
             "palavras_chave": "",
-            "tags_field": "",
+            "tags": [],
         },
         initial={"usuario": nucleado_user, "organizacao": nucleado_user.organizacao},
     )
@@ -54,7 +54,7 @@ def test_clean_cnpj_invalid(nucleado_user):
             "estado": "SC",
             "descricao": "",
             "palavras_chave": "",
-            "tags_field": "",
+            "tags": [],
         },
         initial={"usuario": nucleado_user, "organizacao": nucleado_user.organizacao},
     )

--- a/tests/empresas/test_views.py
+++ b/tests/empresas/test_views.py
@@ -42,7 +42,7 @@ def test_create_empresa_sets_user_and_org(client, nucleado_user):
         "estado": "SP",
         "descricao": "",
         "palavras_chave": "",
-        "tags_field": "",
+        "tags": [],
     }
     resp = client.post(reverse("empresas:empresa_criar"), data)
     assert resp.status_code in (302, 200)
@@ -66,7 +66,7 @@ def test_duplicate_cnpj_returns_error(client, nucleado_user):
         "estado": "SP",
         "descricao": "",
         "palavras_chave": "",
-        "tags_field": "",
+        "tags": [],
     }
     resp = client.post(reverse("empresas:empresa_criar"), data)
     assert resp.status_code == 200

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -56,7 +56,6 @@ urlpatterns = [
         include(("dashboard.api_urls", "dashboard_api"), namespace="dashboard_api"),
     ),
 
-
     path("jsi18n/", JavaScriptCatalog.as_view(), name="javascript-catalog"),
-
+    path("select2/", include("django_select2.urls")),
 ]


### PR DESCRIPTION
## Summary
- replace tag text field with select2 multi-select in EmpresaForm
- render select2 widget and assets in empresa form template
- document new tag selection and update related tests

## Testing
- `pytest tests/empresas/test_forms.py tests/empresas/test_views.py empresas/tests/test_forms.py --no-cov -q`

------
https://chatgpt.com/codex/tasks/task_e_68a60539554c83259e3f15d25a197fcc