### PR TITLE
Add company deletion confirmation template

### DIFF
--- a/empresas/templates/empresas/confirmar_remocao.html
+++ b/empresas/templates/empresas/confirmar_remocao.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+{% load i18n %}
+{% block title %}{% trans 'Remover Empresa' %}{% endblock %}
+{% block content %}
+<section class="max-w-md mx-auto py-16">
+  <div class="bg-red-50 text-red-800 p-6 rounded-md text-center space-y-4">
+    <h2 class="text-xl font-semibold">{% trans 'Confirmar remoção' %}</h2>
+    <p class="text-sm">{% blocktrans %}Tem certeza que deseja remover <strong>{{ object.nome }}</strong>?{% endblocktrans %}</p>
+    <form method="post" class="flex justify-center gap-3">
+      {% csrf_token %}
+      <a href="{% url 'empresas:lista' %}" class="px-4 py-2 border rounded text-sm">{% trans 'Cancelar' %}</a>
+      <button type="submit" class="px-4 py-2 bg-red-600 text-white rounded text-sm hover:bg-red-700">{% trans 'Remover' %}</button>
+    </form>
+  </div>
+</section>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add template for company removal confirmation with POST form and cancel link

## Testing
- `pytest empresas/tests -q` *(fails: KeyboardInterrupt)*
- `pytest empresas/tests/test_forms.py::test_tags_are_sanitized -q` *(fails: KeyboardInterrupt)*
- `python - <<'PY' ...` to render template for direct and HTMX requests


------
https://chatgpt.com/codex/tasks/task_e_68a60537ad248325a723e7cf7246a4b7