### PR TITLE
refactor: enforce csrf on check-in

### DIFF
--- a/agenda/views.py
+++ b/agenda/views.py
@@ -27,7 +27,6 @@ from django.utils import timezone
 from django.utils.dateparse import parse_datetime
 from django.utils.translation import gettext_lazy as _
 from django.views import View
-from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import (
     CreateView,
     DeleteView,
@@ -541,7 +540,6 @@ def avaliar_parceria(request, pk: int):
     return render(request, "agenda/parceria_avaliar.html", {"parceria": parceria})
 
 
-@csrf_exempt
 def checkin_inscricao(request, pk: int):
     """Valida o QRCode enviado e registra o check-in."""
     if request.method != "POST":


### PR DESCRIPTION
## Summary
- remove `@csrf_exempt` from `checkin_inscricao`
- rely on existing CSRF token in check-in form

## Testing
- `pytest agenda/tests/test_qrcode.py -q` *(fails: KeyboardInterrupt during migrations)*

------
https://chatgpt.com/codex/tasks/task_e_68a60fdefc708325a8b5b6eb12ddfe91