### PR TITLE
Add budget fields form with async update

### DIFF
--- a/agenda/templates/agenda/update.html
+++ b/agenda/templates/agenda/update.html
@@ -28,6 +28,26 @@
     </div>
   </form>
 
+  <!-- Orçamento -->
+  <div class="mt-10">
+    <h2 class="text-lg font-semibold text-neutral-900 mb-4">{% trans "Orçamento" %}</h2>
+    <form id="orcamento-form" method="post" action="{% url 'agenda:evento_orcamento' object.pk %}" class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 space-y-6">
+      {% csrf_token %}
+      <div>
+        <label for="id_orcamento_estimado" class="block text-sm font-medium text-neutral-700 mb-1">{% trans "Orçamento estimado" %}</label>
+        <input type="number" step="0.01" name="orcamento_estimado" id="id_orcamento_estimado" value="{{ object.orcamento_estimado|default_if_none:'' }}" class="mt-1 block w-full rounded-xl border border-neutral-300 shadow-sm focus:ring-primary-500 focus:border-primary-500 text-sm" />
+      </div>
+      <div>
+        <label for="id_valor_gasto" class="block text-sm font-medium text-neutral-700 mb-1">{% trans "Valor gasto" %}</label>
+        <input type="number" step="0.01" name="valor_gasto" id="id_valor_gasto" value="{{ object.valor_gasto|default_if_none:'' }}" class="mt-1 block w-full rounded-xl border border-neutral-300 shadow-sm focus:ring-primary-500 focus:border-primary-500 text-sm" />
+      </div>
+      <div class="flex justify-end gap-3 pt-4 border-t border-neutral-100">
+        <button type="submit" class="btn-primary" aria-label="{% trans 'Salvar' %}">{% trans "Salvar" %}</button>
+      </div>
+    </form>
+    <p id="orcamento-feedback" class="text-sm mt-2"></p>
+  </div>
+
   <!-- Inscritos -->
   <h2 class="text-lg font-semibold text-neutral-900 mt-10 mb-4">{% trans "Inscritos" %}</h2>
   {% if object.inscricoes.all %}
@@ -53,4 +73,39 @@
     <p class="text-sm text-neutral-500">{% trans "Nenhum inscrito." %}</p>
   {% endif %}
 </section>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+  const orcamentoForm = document.getElementById('orcamento-form');
+  if (orcamentoForm) {
+    orcamentoForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const feedback = document.getElementById('orcamento-feedback');
+      const formData = new FormData(orcamentoForm);
+      try {
+        const response = await fetch(orcamentoForm.action, {
+          method: 'POST',
+          headers: {
+            'X-CSRFToken': formData.get('csrfmiddlewaretoken')
+          },
+          body: formData
+        });
+        if (response.ok) {
+          const data = await response.json();
+          document.getElementById('id_orcamento_estimado').value = data.orcamento_estimado;
+          document.getElementById('id_valor_gasto').value = data.valor_gasto;
+          feedback.textContent = '{% trans "Orçamento atualizado com sucesso." %}';
+          feedback.className = 'text-sm text-green-600';
+        } else {
+          feedback.textContent = '{% trans "Erro ao atualizar orçamento." %}';
+          feedback.className = 'text-sm text-red-600';
+        }
+      } catch (err) {
+        feedback.textContent = '{% trans "Erro ao atualizar orçamento." %}';
+        feedback.className = 'text-sm text-red-600';
+      }
+    });
+  }
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- allow editing `orcamento_estimado` and `valor_gasto` directly in the event page
- update budget values asynchronously through `evento_orcamento` endpoint with success/error feedback

## Testing
- `pytest tests/agenda/test_views.py::test_evento_detail_view_htmx -q` *(fails: ModuleNotFoundError: No module named 'django_redis')*


------
https://chatgpt.com/codex/tasks/task_e_68a60fde4d048325a3b13177fd19270d