### PR TITLE
Validate material return reason

### DIFF
--- a/agenda/api.py
+++ b/agenda/api.py
@@ -177,10 +177,16 @@ class MaterialDivulgacaoEventoViewSet(OrganizacaoFilterMixin, viewsets.ModelView
     @action(detail=True, methods=["post"])
     def devolver(self, request, pk=None):
         material = self.get_object()
+        motivo = request.data.get("motivo_devolucao", "").strip()
+        if not motivo:
+            return Response(
+                {"detail": "Motivo de devolução é obrigatório."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         material.status = "devolvido"
         material.avaliado_por = request.user
         material.avaliado_em = timezone.now()
-        material.motivo_devolucao = request.data.get("motivo_devolucao", "")
+        material.motivo_devolucao = motivo
         material.save(
             update_fields=[
                 "status",

--- a/agenda/templates/agenda/material_list.html
+++ b/agenda/templates/agenda/material_list.html
@@ -87,6 +87,7 @@
                       name="motivo_devolucao"
                       placeholder="{% trans 'Motivo' %}"
                       class="border rounded px-1 py-0.5 text-xs"
+                      required
                     />
                     <button type="submit" class="text-red-600 hover:underline">{% trans "Devolver" %}</button>
                   </form>


### PR DESCRIPTION
## Summary
- require reason when returning dissemination material
- validate input and handle missing reason in API
- test returning material with and without reason

## Testing
- `pytest tests/agenda/test_material_api.py -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68a60fdd83dc8325b2975101f544e851