### PR TITLE
Exibir detalhes e logs da tarefa

### DIFF
--- a/agenda/templates/agenda/tarefa_detail.html
+++ b/agenda/templates/agenda/tarefa_detail.html
@@ -4,4 +4,17 @@
 {% block content %}
 <h1>{{ object.titulo }}</h1>
 <p>{{ object.descricao }}</p>
+<p><strong>{% trans "Data de início" %}:</strong> {{ object.data_inicio }}</p>
+<p><strong>{% trans "Data de fim" %}:</strong> {{ object.data_fim }}</p>
+<p><strong>{% trans "Responsável" %}:</strong> {{ object.responsavel }}</p>
+<p><strong>{% trans "Status" %}:</strong> {{ object.get_status_display }}</p>
+
+<h2>{% trans "Logs" %}</h2>
+<ul>
+  {% for log in logs %}
+    <li>{{ log.created_at }} - {{ log.usuario }} - {{ log.acao }}</li>
+  {% empty %}
+    <li>{% trans "Nenhum log disponível." %}</li>
+  {% endfor %}
+</ul>
 {% endblock %}

--- a/agenda/views.py
+++ b/agenda/views.py
@@ -302,6 +302,11 @@ class TarefaDetailView(LoginRequiredMixin, NoSuperadminMixin, GerenteRequiredMix
             filtro |= Q(nucleo__in=nucleo_ids)
         return qs.filter(filtro)
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["logs"] = self.object.logs.select_related("usuario").all()
+        return context
+
 
 class TarefaListView(LoginRequiredMixin, NoSuperadminMixin, GerenteRequiredMixin, ListView):
     model = Tarefa


### PR DESCRIPTION
## Summary
- mostrar datas, responsável e status no detalhe da tarefa
- listar logs da tarefa no detalhe

## Testing
- `pytest agenda/tests -q` *(fails: Coverage failure: total of 13 is less than fail-under=90)*

------
https://chatgpt.com/codex/tasks/task_e_68a60fdcca7083258eaaa94f79d332b7