### PR TITLE
Consolida lógica de inscrição do evento

### DIFF
--- a/agenda/templates/agenda/detail.html
+++ b/agenda/templates/agenda/detail.html
@@ -48,33 +48,18 @@
 
   <!-- Inscrição -->
   {% if user.is_authenticated and user.user_type != 'admin' and user.user_type != 'root' %}
-
-    {% if inscricao_confirmada %}
-      {% if avaliacao_permitida %}
-      <div class="mb-10">
-        <a href="{% url 'agenda:evento_feedback' object.pk %}" class="btn-primary" aria-label="{% trans 'Avaliar evento' %}">{% trans "Avaliar evento" %}</a>
-      </div>
-      {% else %}
-      <form method="post" action="{% url 'agenda:evento_subscribe' object.pk %}" class="mb-10">
-        {% csrf_token %}
-        <button type="submit" class="btn-secondary" aria-label="{% trans 'Cancelar inscrição' %}">{% trans "Cancelar inscrição" %}</button>
-      </form>
-      {% endif %}
-    {% else %}
-      <div class="mb-10">
-        <a href="{% url 'agenda:inscricao_criar' object.pk %}" class="btn-primary" aria-label="{% trans 'Inscrever-se' %}">{% trans "Inscrever-se" %}</a>
-      </div>
-    {% endif %}
-
-
     {% with inscricao=object.inscricoes.filter(user=user, status='confirmada').first %}
       {% if inscricao %}
         <div class="mb-10 space-y-4">
           <img src="{{ inscricao.qrcode_url }}" alt="{% trans 'QR Code da inscrição' %}" class="mx-auto h-48 w-48" />
-          <form method="post" action="{% url 'agenda:evento_subscribe' object.pk %}">
-            {% csrf_token %}
-            <button type="submit" class="btn-secondary" aria-label="{% trans 'Cancelar inscrição' %}">{% trans "Cancelar inscrição" %}</button>
-          </form>
+          {% if avaliacao_permitida %}
+            <a href="{% url 'agenda:evento_feedback' object.pk %}" class="btn-primary" aria-label="{% trans 'Avaliar evento' %}">{% trans "Avaliar evento" %}</a>
+          {% else %}
+            <form method="post" action="{% url 'agenda:evento_subscribe' object.pk %}">
+              {% csrf_token %}
+              <button type="submit" class="btn-secondary" aria-label="{% trans 'Cancelar inscrição' %}">{% trans "Cancelar inscrição" %}</button>
+            </form>
+          {% endif %}
         </div>
       {% else %}
         <div class="mb-10">
@@ -82,8 +67,6 @@
         </div>
       {% endif %}
     {% endwith %}
-
-
   {% endif %}
 
   <!-- Lista de Inscritos -->


### PR DESCRIPTION
## Summary
- Unifica a lógica de inscrição/cancelamento em `detail.html`
- Exibe o QR code apenas quando a inscrição está confirmada

## Testing
- `pytest tests/agenda/test_views.py::test_evento_detail_view_sem_htmx --no-cov -q`
- `pytest tests/agenda/test_inscricoes.py::test_evento_detail_htmx --no-cov -q`


------
https://chatgpt.com/codex/tasks/task_e_68a60fdb89888325a219e29a057bccad