### PR TITLE
feat(chat): configurable WebSocket host

### DIFF
--- a/chat/README.md
+++ b/chat/README.md
@@ -79,6 +79,11 @@ Após conectar, envie objetos JSON com `tipo` e `conteudo` para publicar
 mensagens. O servidor transmite eventos de novos participantes,
 reações, pins e moderação para todos os conectados.
 
+O script `static/chat/js/chat_socket.js` utiliza `window.location.host` para
+montar a URL padrão de conexão. Em cenários com proxy reverso, é possível
+sobrescrever o host definindo a variável global `CHAT_WS_URL` ou atribuindo um
+valor ao atributo `data-ws-url` no container do chat.
+
 ## Permissões e papéis
 
 - **Participante** – pode ler e enviar mensagens.

--- a/chat/static/chat/js/chat_socket.js
+++ b/chat/static/chat/js/chat_socket.js
@@ -24,8 +24,13 @@
         const uploadUrl = container.dataset.uploadUrl || '';
         const historyUrl = container.dataset.historyUrl || '';
         const scheme = window.location.protocol === 'https:' ? 'wss://' : 'ws://';
-        const hostname = window.location.hostname;
-        const url = scheme + hostname + ':8001/ws/chat/' + destinatarioId + '/';
+        let baseWs = container.dataset.wsUrl || window.CHAT_WS_URL;
+        if (!baseWs) {
+            baseWs = scheme + window.location.host;
+        } else if (!/^wss?:\/\//.test(baseWs)) {
+            baseWs = scheme + baseWs;
+        }
+        const url = baseWs.replace(/\/$/, '') + '/ws/chat/' + destinatarioId + '/';
 
         if(container._chatCleanup){ container._chatCleanup(); }
         const closeSocket = createSocket(container, url);


### PR DESCRIPTION
## Summary
- allow `chat_socket.js` to resolve WebSocket host via `window.location.host`, `CHAT_WS_URL` env or `data-ws-url`
- document WebSocket host override in chat README

## Testing
- `pytest chat -q` *(fails: Coverage failure: total of 9 is less than fail-under=90)*

------
https://chatgpt.com/codex/tasks/task_e_68a60fca305483259b51ca9f020a5a0d