### PR TITLE
feat(chat): add read indicators

### DIFF
--- a/chat/static/chat/js/chat_socket.js
+++ b/chat/static/chat/js/chat_socket.js
@@ -60,12 +60,31 @@
                         fetch(`/api/chat/channels/${destinatarioId}/messages/${msgId}/mark-read/`,{
                             method:'POST',
                             headers:{'X-CSRFToken':csrfToken}
+                        }).then(r=>{
+                            if(r.ok){ addReaderIndicator(entry.target); }
                         });
                     }
                     markReadObserver.unobserve(entry.target);
                 }
             });
         },{root: messages});
+
+        function addReaderIndicator(article){
+            const indicator = article.querySelector('.read-status');
+            if(!indicator) return;
+            const list = indicator.querySelector('.reader-icons');
+            const countEl = indicator.querySelector('.reader-count');
+            if(list && countEl && !list.querySelector(`[data-username="${currentUser}"]`)){
+                const li = document.createElement('li');
+                li.className = 'w-4 h-4 rounded-full bg-gray-300 text-[0.5rem] flex items-center justify-center';
+                li.dataset.username = currentUser;
+                li.textContent = currentUser.charAt(0).toUpperCase();
+                list.appendChild(li);
+                const count = parseInt(countEl.textContent || '0') + 1;
+                countEl.textContent = count;
+            }
+            indicator.classList.remove('hidden');
+        }
 
         if(editCancel){
             editCancel.addEventListener('click', ()=> editModal.close());
@@ -467,7 +486,7 @@
 
             div.innerHTML = `${replyHtml}<div class="msg-body"><strong>${remetente}</strong>: ${content}</div><ul class="reactions flex gap-2 ml-2"></ul><div class="reaction-container relative"><button type="button" class="reaction-btn" aria-haspopup="true" aria-expanded="false" aria-label="${t('addReaction','Adicionar reação')}">🙂</button><ul class="reaction-menu hidden absolute bg-white border rounded p-1 flex gap-1" role="menu"><li><button type="button" class="react-option" data-emoji="🙂" aria-label="${t('reactWith','Reagir com')} 🙂">🙂</button></li><li><button type="button" class="react-option" data-emoji="❤️" aria-label="${t('reactWith','Reagir com')} ❤️">❤️</button></li><li><button type="button" class="react-option" data-emoji="👍" aria-label="${t('reactWith','Reagir com')} 👍">👍</button></li><li><button type="button" class="react-option" data-emoji="😂" aria-label="${t('reactWith','Reagir com')} 😂">😂</button></li><li><button type="button" class="react-option" data-emoji="🎉" aria-label="${t('reactWith','Reagir com')} 🎉">🎉</button></li><li><button type="button" class="react-option" data-emoji="😢" aria-label="${t('reactWith','Reagir com')} 😢">😢</button></li><li><button type="button" class="react-option" data-emoji="😡" aria-label="${t('reactWith','Reagir com')} 😡">😡</button></li></ul></div><div class="action-container relative"><button type="button" class="action-btn" aria-haspopup="true" aria-expanded="false" aria-label="${t('openMenu','Abrir menu')}">⋮</button><ul class="action-menu hidden absolute bg-white border rounded p-1 flex flex-col" role="menu"><li><button type="button" class="reply-btn" aria-label="${t('reply','Responder')}">${t('reply','Responder')}</button></li><li><button type="button" class="create-item" aria-label="${t('createItem','Criar evento/tarefa')}">${t('createItem','Criar evento/tarefa')}</button></li></ul></div>`;
 
-            div.innerHTML = `<div><strong>${remetente}</strong>: ${content}</div><ul class="reactions flex gap-2 ml-2"></ul><div class="reaction-container relative"><button type="button" class="reaction-btn" aria-haspopup="true" aria-expanded="false" aria-label="${t('addReaction','Adicionar reação')}">🙂</button><ul class="reaction-menu hidden absolute bg-white border rounded p-1 flex gap-1" role="menu"><li><button type="button" class="react-option" data-emoji="🙂" aria-label="${t('reactWith','Reagir com')} 🙂">🙂</button></li><li><button type="button" class="react-option" data-emoji="❤️" aria-label="${t('reactWith','Reagir com')} ❤️">❤️</button></li><li><button type="button" class="react-option" data-emoji="👍" aria-label="${t('reactWith','Reagir com')} 👍">👍</button></li><li><button type="button" class="react-option" data-emoji="😂" aria-label="${t('reactWith','Reagir com')} 😂">😂</button></li><li><button type="button" class="react-option" data-emoji="🎉" aria-label="${t('reactWith','Reagir com')} 🎉">🎉</button></li><li><button type="button" class="react-option" data-emoji="😢" aria-label="${t('reactWith','Reagir com')} 😢">😢</button></li><li><button type="button" class="react-option" data-emoji="😡" aria-label="${t('reactWith','Reagir com')} 😡">😡</button></li></ul></div><div class="action-container relative"><button type="button" class="action-btn" aria-haspopup="true" aria-expanded="false" aria-label="${t('openMenu','Abrir menu')}">⋮</button><ul class="action-menu hidden absolute bg-white border rounded p-1 flex flex-col" role="menu"><li><button type="button" class="create-item" aria-label="${t('createItem','Criar evento/tarefa')}">${t('createItem','Criar evento/tarefa')}</button></li></ul></div><button type="button" class="favorite-btn" aria-label="${t('favorite','Favoritar mensagem')}">⭐</button>`;
+            div.innerHTML = `<div><strong>${remetente}</strong>: ${content}</div><ul class="reactions flex gap-2 ml-2"></ul><div class="reaction-container relative"><button type="button" class="reaction-btn" aria-haspopup="true" aria-expanded="false" aria-label="${t('addReaction','Adicionar reação')}">🙂</button><ul class="reaction-menu hidden absolute bg-white border rounded p-1 flex gap-1" role="menu"><li><button type="button" class="react-option" data-emoji="🙂" aria-label="${t('reactWith','Reagir com')} 🙂">🙂</button></li><li><button type="button" class="react-option" data-emoji="❤️" aria-label="${t('reactWith','Reagir com')} ❤️">❤️</button></li><li><button type="button" class="react-option" data-emoji="👍" aria-label="${t('reactWith','Reagir com')} 👍">👍</button></li><li><button type="button" class="react-option" data-emoji="😂" aria-label="${t('reactWith','Reagir com')} 😂">😂</button></li><li><button type="button" class="react-option" data-emoji="🎉" aria-label="${t('reactWith','Reagir com')} 🎉">🎉</button></li><li><button type="button" class="react-option" data-emoji="😢" aria-label="${t('reactWith','Reagir com')} 😢">😢</button></li><li><button type="button" class="react-option" data-emoji="😡" aria-label="${t('reactWith','Reagir com')} 😡">😡</button></li></ul></div><div class="action-container relative"><button type="button" class="action-btn" aria-haspopup="true" aria-expanded="false" aria-label="${t('openMenu','Abrir menu')}">⋮</button><ul class="action-menu hidden absolute bg-white border rounded p-1 flex flex-col" role="menu"><li><button type="button" class="create-item" aria-label="${t('createItem','Criar evento/tarefa')}">${t('createItem','Criar evento/tarefa')}</button></li></ul></div><button type="button" class="favorite-btn" aria-label="${t('favorite','Favoritar mensagem')}">⭐</button><div class="read-status hidden text-xs text-gray-500 flex items-center gap-1"><ul class="reader-icons flex -space-x-1"></ul><span class="reader-count">0</span></div>`;
 
 
             if(id){ div.dataset.id = id; div.dataset.messageId = id; }

--- a/chat/templates/chat/partials/message.html
+++ b/chat/templates/chat/partials/message.html
@@ -142,5 +142,22 @@
         {% endfor %}
       </ul>
     </div>
+    <div class="read-status mt-1 text-xs text-gray-500 flex items-center gap-1 {% if m.lido_por.count == 0 %}hidden{% endif %}">
+      <ul class="reader-icons flex -space-x-1">
+        {% for user in m.lido_por.all %}
+          <li
+            class="w-4 h-4 rounded-full bg-gray-300 text-[0.5rem] flex items-center justify-center"
+            data-username="{{ user.username }}"
+          >
+            {% if user.profile.avatar %}
+              <img src="{{ user.profile.avatar.url }}" alt="{{ user.username }}" class="w-4 h-4 rounded-full" />
+            {% else %}
+              {{ user.username|first|upper }}
+            {% endif %}
+          </li>
+        {% endfor %}
+      </ul>
+      <span class="reader-count">{{ m.lido_por.count }}</span>
+    </div>
   </div>
 </article>


### PR DESCRIPTION
## Summary
- show readers of messages in chat
- update DOM after messages marked as read

## Testing
- `pytest` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68a60fc982788325b6284c1be8087d6f