### PR TITLE
Valida núcleo em conversas privadas

### DIFF
--- a/chat/forms.py
+++ b/chat/forms.py
@@ -3,6 +3,8 @@ from django.contrib.auth import get_user_model
 from django.utils.translation import gettext_lazy as _
 from django_select2 import forms as s2forms
 
+from services.nucleos import user_belongs_to_nucleo
+
 from .models import ChatChannel, ChatMessage
 
 User = get_user_model()
@@ -13,7 +15,7 @@ class NovaConversaForm(forms.ModelForm):
         choices=ChatChannel.CONTEXT_CHOICES,
         label=_("Tipo de contexto"),
     )
-    contexto_id = forms.UUIDField(
+    contexto_id = forms.CharField(
         required=False,
         label=_("Contexto"),
         widget=s2forms.Select2Widget,
@@ -43,9 +45,30 @@ class NovaConversaForm(forms.ModelForm):
 
     def __init__(self, *args, user=None, **kwargs):
         super().__init__(*args, **kwargs)
+        self.user = user
         qs = User.objects.exclude(id=user.id) if user else User.objects.all()
         self.fields["participants"].queryset = qs
         self.fields["titulo"].label = _("Nome da conversa")
+
+    def clean(self):
+        cleaned = super().clean()
+        contexto_tipo = cleaned.get("contexto_tipo")
+        contexto_id = cleaned.get("contexto_id")
+        participants = cleaned.get("participants") or []
+        if contexto_tipo == "privado":
+            if not contexto_id:
+                self.add_error("contexto_id", _("Informe o núcleo"))
+            else:
+                nucleo_id = int(contexto_id)
+                cleaned["contexto_id"] = nucleo_id
+                users = [self.user] + list(participants)
+                for u in users:
+                    participa, info, suspenso = user_belongs_to_nucleo(u, nucleo_id)
+                    if not (participa and info.endswith("ativo") and not suspenso):
+                        raise forms.ValidationError(
+                            _("Usuário não pertence ao núcleo informado")
+                        )
+        return cleaned
 
 
 class NovaMensagemForm(forms.ModelForm):

--- a/chat/services.py
+++ b/chat/services.py
@@ -46,11 +46,10 @@ def criar_canal(
     ``contexto_tipo`` define o escopo da conversa. Validações
     adicionais de permissão serão implementadas futuramente.
     """
-    if contexto_tipo != "privado":
-        users = [criador] + list(participantes)
-        for u in users:
-            if not _usuario_no_contexto(u, contexto_tipo, contexto_id):
-                raise PermissionError("Usuário não pertence ao contexto informado")
+    users = [criador] + list(participantes)
+    for u in users:
+        if not _usuario_no_contexto(u, contexto_tipo, contexto_id):
+            raise PermissionError("Usuário não pertence ao contexto informado")
     canal = ChatChannel.objects.create(
         contexto_tipo=contexto_tipo,
         contexto_id=contexto_id,
@@ -70,7 +69,9 @@ def _usuario_no_contexto(user: User, contexto_tipo: str, contexto_id: Optional[s
     """Retorna ``True`` se o ``user`` pertence ao contexto especificado."""
     if contexto_tipo == "organizacao":
         return str(user.organizacao_id) == str(contexto_id)
-    if contexto_tipo == "nucleo":
+    if contexto_tipo in {"nucleo", "privado"}:
+        if not contexto_id:
+            return True
         participa, info, suspenso = user_belongs_to_nucleo(user, contexto_id)
         return participa and info.endswith("ativo") and not suspenso
     if contexto_tipo == "evento":

--- a/tests/chat/test_forms.py
+++ b/tests/chat/test_forms.py
@@ -1,6 +1,7 @@
 from django.core.files.uploadedfile import SimpleUploadedFile
 
-from chat.forms import NovaMensagemForm
+from chat.forms import NovaMensagemForm, NovaConversaForm
+from nucleos.models import ParticipacaoNucleo
 
 
 def test_nova_mensagem_form_requires_content_or_file():
@@ -14,3 +15,30 @@ def test_nova_mensagem_form_accepts_file_only():
         files={"arquivo": SimpleUploadedFile("f.txt", b"data")},
     )
     assert form.is_valid()
+
+
+def test_nova_conversa_form_privado_valida_nucleo(admin_user, coordenador_user, nucleo):
+    ParticipacaoNucleo.objects.create(user=admin_user, nucleo=nucleo, status="ativo")
+    ParticipacaoNucleo.objects.create(
+        user=coordenador_user, nucleo=nucleo, status="ativo"
+    )
+    data = {
+        "contexto_tipo": "privado",
+        "contexto_id": str(nucleo.id),
+        "participants": [str(coordenador_user.id)],
+    }
+    form = NovaConversaForm(data=data, user=admin_user)
+    assert form.is_valid()
+
+
+def test_nova_conversa_form_privado_requer_pertencimento(
+    admin_user, coordenador_user, associado_user, nucleo
+):
+    ParticipacaoNucleo.objects.create(user=admin_user, nucleo=nucleo, status="ativo")
+    data = {
+        "contexto_tipo": "privado",
+        "contexto_id": str(nucleo.id),
+        "participants": [str(associado_user.id)],
+    }
+    form = NovaConversaForm(data=data, user=admin_user)
+    assert not form.is_valid()

--- a/tests/chat/test_services.py
+++ b/tests/chat/test_services.py
@@ -65,6 +65,42 @@ def test_criar_canal_valida_contexto_nucleo(
         )
 
 
+def test_criar_canal_privado_valida_nucleo(
+    admin_user, coordenador_user, associado_user, nucleo
+):
+    ParticipacaoNucleo.objects.create(user=admin_user, nucleo=nucleo, status="ativo")
+    ParticipacaoNucleo.objects.create(
+        user=coordenador_user, nucleo=nucleo, status="ativo"
+    )
+    canal = criar_canal(
+        criador=admin_user,
+        contexto_tipo="privado",
+        contexto_id=nucleo.id,
+        titulo="",
+        descricao="",
+        participantes=[coordenador_user],
+    )
+    assert canal.contexto_id == nucleo.id
+    with pytest.raises(PermissionError):
+        criar_canal(
+            criador=admin_user,
+            contexto_tipo="privado",
+            contexto_id=nucleo.id,
+            titulo="",
+            descricao="",
+            participantes=[associado_user],
+        )
+    with pytest.raises(PermissionError):
+        criar_canal(
+            criador=associado_user,
+            contexto_tipo="privado",
+            contexto_id=nucleo.id,
+            titulo="",
+            descricao="",
+            participantes=[coordenador_user],
+        )
+
+
 def test_enviar_mensagem_valida_participacao(admin_user, coordenador_user, associado_user):
     canal = criar_canal(
         criador=admin_user,


### PR DESCRIPTION
## Summary
- exigir validação de pertencimento mesmo em conversas privadas
- solicitar núcleo em `NovaConversaForm` e verificar membros
- cobrir criação de canal privado com núcleo em testes

## Testing
- `pytest tests/chat/test_services.py::test_criar_canal_privado_valida_nucleo tests/chat/test_forms.py::test_nova_conversa_form_privado_valida_nucleo tests/chat/test_forms.py::test_nova_conversa_form_privado_requer_pertencimento -q --no-cov`

------
https://chatgpt.com/codex/tasks/task_e_68a60fc79458832583b0a58762c25703