### PR TITLE
Add label to export format dropdown

### DIFF
--- a/dashboard/templates/dashboard/partials/filters_form.html
+++ b/dashboard/templates/dashboard/partials/filters_form.html
@@ -63,14 +63,15 @@
     </div>
   </fieldset>
   <div class="flex gap-2 mt-4">
-    <button type="submit" class="px-4 py-2 bg-primary-600 text-white rounded focus:outline-none focus:ring" aria-label="{% trans 'Aplicar filtros' %}">{% trans 'Filtrar' %}</button>
-    {% if can_export %}
-    <select name="formato" class="border-gray-300 rounded" aria-label="{% trans 'Formato de exportação' %}">
-      <option value="csv">{% trans 'CSV' %}</option>
-      <option value="pdf">{% trans 'PDF' %}</option>
-      <option value="xlsx">{% trans 'Excel' %}</option>
-      <option value="png">{% trans 'PNG' %}</option>
-    </select>
+      <button type="submit" class="px-4 py-2 bg-primary-600 text-white rounded focus:outline-none focus:ring" aria-label="{% trans 'Aplicar filtros' %}">{% trans 'Filtrar' %}</button>
+      {% if can_export %}
+      <label for="formato" class="sr-only">{% trans 'Formato de exportação' %}</label>
+      <select id="formato" name="formato" class="border-gray-300 rounded" aria-label="{% trans 'Formato de exportação' %}">
+        <option value="csv">{% trans 'CSV' %}</option>
+        <option value="pdf">{% trans 'PDF' %}</option>
+        <option value="xlsx">{% trans 'Excel' %}</option>
+        <option value="png">{% trans 'PNG' %}</option>
+      </select>
     <button type="submit" formaction="{% url 'dashboard:export' %}" class="px-4 py-2 bg-neutral-200 text-neutral-800 rounded focus:outline-none focus:ring" aria-label="{% trans 'Exportar métricas' %}">{% trans 'Exportar' %}</button>
     {% endif %}
     <a href="{% url 'dashboard:filter-create' %}?{{ request.GET.urlencode }}" class="px-4 py-2 bg-neutral-200 text-neutral-800 rounded focus:outline-none focus:ring" aria-label="{% trans 'Salvar filtro rápido' %}">{% trans 'Salvar filtro' %}</a>


### PR DESCRIPTION
## Summary
- Add hidden label and id to export format select for dashboard filters

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'playwright', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a60fb2ce88832581c79a1eab15ca13