### PR TITLE
Add blank option to dashboard filter selects

### DIFF
--- a/dashboard/templates/dashboard/partials/filters_form.html
+++ b/dashboard/templates/dashboard/partials/filters_form.html
@@ -22,6 +22,7 @@
   <div>
     <label for="organizacao_id" class="block text-sm font-medium text-neutral-700">{% trans 'Organização' %}</label>
     <select id="organizacao_id" name="organizacao_id" class="mt-1 block border-gray-300 rounded" aria-label="{% trans 'Selecionar organização' %}">
+      <option value="" {% if not filtros.organizacao_id|default:'' %}selected{% endif %}>—</option>
       {% for org in organizacoes_permitidas %}
       <option value="{{ org.id }}" {% if filtros.organizacao_id|default:'' == org.id|stringformat:'s' %}selected{% endif %}>{{ org.nome }}</option>
       {% endfor %}
@@ -30,6 +31,7 @@
   <div>
     <label for="nucleo_id" class="block text-sm font-medium text-neutral-700">{% trans 'Núcleo' %}</label>
     <select id="nucleo_id" name="nucleo_id" class="mt-1 block border-gray-300 rounded" aria-label="{% trans 'Selecionar núcleo' %}">
+      <option value="" {% if not filtros.nucleo_id|default:'' %}selected{% endif %}>—</option>
       {% for nucleo in nucleos_permitidos %}
       <option value="{{ nucleo.id }}" {% if filtros.nucleo_id|default:'' == nucleo.id|stringformat:'s' %}selected{% endif %}>{{ nucleo.nome }}</option>
       {% endfor %}
@@ -38,6 +40,7 @@
   <div>
     <label for="evento_id" class="block text-sm font-medium text-neutral-700">{% trans 'Evento' %}</label>
     <select id="evento_id" name="evento_id" class="mt-1 block border-gray-300 rounded" aria-label="{% trans 'Selecionar evento' %}">
+      <option value="" {% if not filtros.evento_id|default:'' %}selected{% endif %}>—</option>
       {% for evento in eventos_permitidos %}
       <option value="{{ evento.id }}" {% if filtros.evento_id|default:'' == evento.id|stringformat:'s' %}selected{% endif %}>{{ evento.titulo }}</option>
       {% endfor %}


### PR DESCRIPTION
## Summary
- add empty selection option to organization, nucleus, and event filters

## Testing
- `make test` *(fails: SyntaxError in tests/feed/test_services.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a60fb210348325bc4b2b6f023a313d