### PR TITLE
Use 'Salvar configuração' in dashboard config form

### DIFF
--- a/dashboard/locale/en/LC_MESSAGES/django.po
+++ b/dashboard/locale/en/LC_MESSAGES/django.po
@@ -118,11 +118,6 @@ msgstr ""
 msgid "Ver Feed"
 msgstr ""
 
-#: templates/dashboard/config_form.html:3
-#: templates/dashboard/config_form.html:6
-msgid "Salvar filtros"
-msgstr ""
-
 #: templates/dashboard/config_form.html:7
 msgid "Formulário de configuração do dashboard"
 msgstr ""
@@ -138,6 +133,8 @@ msgstr ""
 msgid "Público"
 msgstr ""
 
+#: templates/dashboard/config_form.html:3
+#: templates/dashboard/config_form.html:6
 #: templates/dashboard/config_form.html:17
 #: templates/dashboard/partials/filters_form.html:64
 msgid "Salvar configuração"

--- a/dashboard/locale/pt_BR/LC_MESSAGES/django.po
+++ b/dashboard/locale/pt_BR/LC_MESSAGES/django.po
@@ -118,11 +118,6 @@ msgstr ""
 msgid "Ver Feed"
 msgstr ""
 
-#: templates/dashboard/config_form.html:3
-#: templates/dashboard/config_form.html:6
-msgid "Salvar filtros"
-msgstr ""
-
 #: templates/dashboard/config_form.html:7
 msgid "Formulário de configuração do dashboard"
 msgstr ""
@@ -138,6 +133,8 @@ msgstr ""
 msgid "Público"
 msgstr ""
 
+#: templates/dashboard/config_form.html:3
+#: templates/dashboard/config_form.html:6
 #: templates/dashboard/config_form.html:17
 #: templates/dashboard/partials/filters_form.html:64
 msgid "Salvar configuração"

--- a/dashboard/templates/dashboard/config_form.html
+++ b/dashboard/templates/dashboard/config_form.html
@@ -1,9 +1,9 @@
 {% extends 'base.html' %}
 {% load i18n %}
-{% block title %}{% trans 'Salvar filtros' %}{% endblock %}
+{% block title %}{% trans 'Salvar configuração' %}{% endblock %}
 {% block content %}
 <main class="max-w-md mx-auto p-4" role="main">
-  <h1 class="text-2xl font-semibold mb-4">{% trans 'Salvar filtros' %}</h1>
+  <h1 class="text-2xl font-semibold mb-4">{% trans 'Salvar configuração' %}</h1>
   <form method="post" class="space-y-4" aria-label="{% trans 'Formulário de configuração do dashboard' %}">
     {% csrf_token %}
     <div>


### PR DESCRIPTION
## Summary
- Update dashboard config form title and heading to "Salvar configuração"
- Sync dashboard translation files with new text

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_68a60fb115188325abf3345861afc24d