### PR TITLE
Organiza respostas hierarquicas com destaque de comentario pai

### DIFF
--- a/discussao/templates/discussao/comentario_item.html
+++ b/discussao/templates/discussao/comentario_item.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-<article class="p-4 border-b border-neutral-200 {% if melhor %}bg-green-50{% endif %}" id="coment-{{ comentario.id }}">
+<article class="p-4 border-b border-neutral-200 reply-parent {% if melhor %}bg-green-50{% endif %}" id="coment-{{ comentario.id }}">
   <header class="mb-2 flex items-center justify-between">
     <div class="text-sm text-neutral-700">
       {{ comentario.autor.get_full_name|default:comentario.autor.username }} - {{ comentario.created|date:"SHORT_DATETIME_FORMAT" }}
@@ -26,7 +26,11 @@
 
 
     {% if not topico.fechado %}
-      <button type="button" class="text-primary-600 text-xs" hx-on:click="document.getElementById('reply_to').value='{{ comentario.id }}'; document.getElementById('id_conteudo').focus();">
+      <button
+        type="button"
+        class="text-primary-600 text-xs"
+        hx-on:click="document.getElementById('reply_to').value='{{ comentario.id }}'; document.getElementById('id_conteudo').focus(); document.querySelectorAll('.reply-parent').forEach(e=>e.classList.remove('ring-2','ring-primary-600')); document.getElementById('coment-{{ comentario.id }}').classList.add('ring-2','ring-primary-600');"
+      >
         {% trans "Responder" %}
       </button>
     {% endif %}
@@ -53,3 +57,10 @@
     <button type="submit" class="mt-1 bg-red-600 text-white px-3 py-1 text-xs rounded">{% trans "Enviar" %}</button>
   </form>
 </article>
+{% if comentario.respostas_filhas %}
+  <div class="ml-6 border-l border-neutral-200">
+    {% for resposta in comentario.respostas_filhas %}
+      {% include 'discussao/comentario_item.html' with comentario=resposta user=user topico=topico resposta_content_type_id=resposta_content_type_id %}
+    {% endfor %}
+  </div>
+{% endif %}

--- a/discussao/templates/discussao/topico_detail.html
+++ b/discussao/templates/discussao/topico_detail.html
@@ -1,7 +1,7 @@
 {% if partial %}
   {% for comentario in comentarios %}
 
-    {% include 'discussao/comentario_item.html' with comentario=comentario user=user topico=topico content_type_id=content_type_id %}
+    {% include 'discussao/comentario_item.html' with comentario=comentario user=user topico=topico resposta_content_type_id=resposta_content_type_id %}
 
 
   {% endfor %}
@@ -62,10 +62,10 @@
     <h2 id="comentarios" class="text-xl font-semibold">{% trans "Coment\u00e1rios" %}</h2>
     {% if melhor_resposta %}
 
-      {% include 'discussao/comentario_item.html' with comentario=melhor_resposta user=user topico=topico melhor=True content_type_id=resposta_content_type_id %}
+      {% include 'discussao/comentario_item.html' with comentario=melhor_resposta user=user topico=topico melhor=True resposta_content_type_id=resposta_content_type_id %}
     {% endif %}
     <div id="lista-comentarios">
-      {% include 'discussao/topico_detail.html' with partial=True topico=topico user=user content_type_id=resposta_content_type_id only %}
+      {% include 'discussao/topico_detail.html' with partial=True topico=topico user=user resposta_content_type_id=resposta_content_type_id only %}
 
     </div>
     {% if comentarios.has_previous or comentarios.has_next %}

--- a/discussao/views.py
+++ b/discussao/views.py
@@ -279,22 +279,43 @@ class TopicoDetailView(LoginRequiredMixin, DetailView):
                     "partial": True,
                     "user": request.user,
                     "topico": self.object,
-                    "content_type_id": context["resposta_content_type_id"],
+                    "resposta_content_type_id": context["resposta_content_type_id"],
                 },
             )
         return self.render_to_response(context)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        comentarios_qs = self.object.respostas.select_related("autor")
+        respostas_qs = self.object.respostas.select_related("autor")
+        todas_respostas = list(respostas_qs)
+
+        class RespostaNode:
+            def __init__(self, obj):
+                self._obj = obj
+                self.respostas_filhas: list["RespostaNode"] = []
+
+            def __getattr__(self, attr):
+                return getattr(self._obj, attr)
+
+        nodes = {r.pk: RespostaNode(r) for r in todas_respostas}
+        raiz: list[RespostaNode] = []
+        for r in todas_respostas:
+            node = nodes[r.pk]
+            if r.reply_to_id and r.reply_to_id in nodes:
+                nodes[r.reply_to_id].respostas_filhas.append(node)
+            else:
+                raiz.append(node)
+
         melhor = self.object.melhor_resposta
-        if melhor:
-            comentarios_qs = comentarios_qs.exclude(pk=melhor.pk)
-        paginator = Paginator(comentarios_qs, self.paginate_by)
+        melhor_node = nodes.get(melhor.pk) if melhor else None
+        if melhor_node and melhor_node in raiz:
+            raiz.remove(melhor_node)
+
+        paginator = Paginator(raiz, self.paginate_by)
         page = self.request.GET.get("page")
         comentarios = paginator.get_page(page)
         context["comentarios"] = comentarios
-        context["melhor_resposta"] = melhor
+        context["melhor_resposta"] = melhor_node
         context["content_type_id"] = ContentType.objects.get_for_model(TopicoDiscussao).id
 
         context["resposta_content_type_id"] = ContentType.objects.get_for_model(


### PR DESCRIPTION
## Summary
- Estrutura respostas em arvore na visualização de tópico
- Renderiza respostas filhas recursivamente com indentação
- Destaca comentário pai ao acionar botão de resposta

## Testing
- `pytest tests/discussao -q` *(falhou: TemplateSyntaxError)*

------
https://chatgpt.com/codex/tasks/task_e_68a60fa2985c8325963a1d7c5db98cc9