### PR TITLE
Mostrar indicador de edição em comentários

### DIFF
--- a/discussao/templates/discussao/comentario_item.html
+++ b/discussao/templates/discussao/comentario_item.html
@@ -3,6 +3,9 @@
   <header class="mb-2 flex items-center justify-between">
     <div class="text-sm text-neutral-700">
       {{ comentario.autor.get_full_name|default:comentario.autor.username }} - {{ comentario.created|date:"SHORT_DATETIME_FORMAT" }}
+      {% if comentario.editado %}
+        ({% blocktrans with data=comentario.editado_em|date:"SHORT_DATETIME_FORMAT" %}editado em {{ data }}{% endblocktrans %})
+      {% endif %}
     </div>
     <div class="flex items-center gap-2">
     {% if comentario.pode_editar %}


### PR DESCRIPTION
## Resumo
- exibe mensagem de edição nos comentários com data formatada

## Testes
- `pytest -m "not slow"` *(falhou: 9 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a60fa1ee90832585dec7bb3a214d8d