### PR TITLE
Use created_at in discussao templates

### DIFF
--- a/discussao/templates/discussao/comentario_item.html
+++ b/discussao/templates/discussao/comentario_item.html
@@ -2,7 +2,7 @@
 <article class="p-4 border-b border-neutral-200 {% if melhor %}bg-green-50{% endif %}" id="coment-{{ comentario.id }}">
   <header class="mb-2 flex items-center justify-between">
     <div class="text-sm text-neutral-700">
-      {{ comentario.autor.get_full_name|default:comentario.autor.username }} - {{ comentario.created|date:"SHORT_DATETIME_FORMAT" }}
+      {{ comentario.autor.get_full_name|default:comentario.autor.username }} - {{ comentario.created_at|date:"SHORT_DATETIME_FORMAT" }}
     </div>
     <div class="flex items-center gap-2">
     {% if comentario.pode_editar %}

--- a/discussao/templates/discussao/topico_detail.html
+++ b/discussao/templates/discussao/topico_detail.html
@@ -18,7 +18,7 @@
       <span class="ml-2 px-2 py-1 text-xs font-semibold bg-green-100 text-green-800 rounded">{% trans "Resolvido" %}</span>
       {% endif %}
     </h1>
-    <p class="text-sm text-neutral-600">{% trans "Por" %} {{ topico.autor.get_full_name|default:topico.autor.username }} · {{ topico.created|date:SHORT_DATETIME_FORMAT }}</p>
+    <p class="text-sm text-neutral-600">{% trans "Por" %} {{ topico.autor.get_full_name|default:topico.autor.username }} · {{ topico.created_at|date:SHORT_DATETIME_FORMAT }}</p>
     {% if pode_editar_topico %}
       <a href="{% url 'discussao:topico_editar' topico.categoria.slug topico.slug %}" class="text-sm text-blue-600">{% trans "Editar" %}</a>
     {% endif %}

--- a/discussao/templates/discussao/topicos_list.html
+++ b/discussao/templates/discussao/topicos_list.html
@@ -10,7 +10,7 @@
       </div>
     </td>
     <td class="px-4 py-2">{{ topico.autor.get_full_name|default:topico.autor.username }}</td>
-    <td class="px-4 py-2">{{ topico.created|date:SHORT_DATE_FORMAT }}</td>
+    <td class="px-4 py-2">{{ topico.created_at|date:SHORT_DATE_FORMAT }}</td>
     <td class="px-4 py-2 text-center">
       <div class="flex items-center justify-center space-x-1">
         <button


### PR DESCRIPTION
## Summary
- use `created_at` field in discussao templates

## Testing
- `pytest tests/discussao/test_views.py::test_topico_list_view -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68a60fa034fc8325981deda227c4b5d2