### PR TITLE
Remove outdated WhatsApp notice

### DIFF
--- a/configuracoes/locale/en/LC_MESSAGES/django.po
+++ b/configuracoes/locale/en/LC_MESSAGES/django.po
@@ -163,10 +163,6 @@ msgstr "Receive email notifications"
 msgid "Receber notificações por WhatsApp"
 msgstr "Receive WhatsApp notifications"
 
-#: templates/configuracoes/partials/preferencias.html:25
-msgid "Funcionalidade de WhatsApp em desenvolvimento"
-msgstr "WhatsApp feature under development"
-
 #: templates/configuracoes/partials/preferencias.html:28
 msgid "Horário diário"
 msgstr "Daily time"

--- a/configuracoes/locale/es/LC_MESSAGES/django.po
+++ b/configuracoes/locale/es/LC_MESSAGES/django.po
@@ -163,10 +163,6 @@ msgstr "Recibir notificaciones por correo electrónico"
 msgid "Receber notificações por WhatsApp"
 msgstr "Recibir notificaciones por WhatsApp"
 
-#: templates/configuracoes/partials/preferencias.html:25
-msgid "Funcionalidade de WhatsApp em desenvolvimento"
-msgstr "Funcionalidad de WhatsApp en desarrollo"
-
 #: templates/configuracoes/partials/preferencias.html:28
 msgid "Horário diário"
 msgstr "Horario diario"

--- a/configuracoes/templates/configuracoes/partials/preferencias.html
+++ b/configuracoes/templates/configuracoes/partials/preferencias.html
@@ -38,7 +38,6 @@
       {% if preferencias_form.frequencia_notificacoes_whatsapp.help_text %}
         <p class="text-xs text-gray-500">{{ preferencias_form.frequencia_notificacoes_whatsapp.help_text }}</p>
       {% endif %}
-      <p class="text-xs text-gray-500">{% trans 'Funcionalidade de WhatsApp em desenvolvimento' %}</p>
       <div class="mt-2 flex items-center gap-2">
         <button type="button" class="text-xs text-blue-600 hover:underline" hx-post="{% url 'configuracoes_api:configuracoes-testar' %}" hx-vals='{"canal": "whatsapp"}' hx-include="[name=csrfmiddlewaretoken]" hx-swap="none" hx-on:afterRequest="document.getElementById('msg-whatsapp').innerText = event.detail.xhr.responseJSON.detail">
           {% trans 'Testar WhatsApp' %}


### PR DESCRIPTION
## Summary
- remove outdated WhatsApp in-development note from notification preferences
- clean up translations

## Testing
- `pytest tests/configuracoes -q` *(fails: ModuleNotFoundError: No module named 'django_redis')*
- `pytest tests/configuracoes/test_api.py::test_update_preferences -q` *(fails: ModuleNotFoundError: No module named 'django_redis')*


------
https://chatgpt.com/codex/tasks/task_e_68a60f6143f48325bd00d9bbabea04c6