### PR TITLE
Log contextual push notification changes

### DIFF
--- a/configuracoes/signals.py
+++ b/configuracoes/signals.py
@@ -31,6 +31,8 @@ CONTA_FIELDS = [
 CONTEXT_FIELDS = [
     "frequencia_notificacoes_email",
     "frequencia_notificacoes_whatsapp",
+    "receber_notificacoes_push",
+    "frequencia_notificacoes_push",
     "idioma",
     "tema",
 ]


### PR DESCRIPTION
## Summary
- include push notification fields in contextual configuration logging
- test logging for push notification contextual preference changes

## Testing
- `pytest tests/configuracoes/test_contextual.py::test_logs_created_for_push_fields -q --no-cov`

------
https://chatgpt.com/codex/tasks/task_e_68a60f5f4b888325a2cff9bc1ff73645