### PR TITLE
Ajusta fluxo de registro para 8 etapas

### DIFF
--- a/accounts/templates/register/cpf.html
+++ b/accounts/templates/register/cpf.html
@@ -8,11 +8,11 @@
   <div class="rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
     <div class="mb-8">
       <div class="mb-2 flex items-center justify-between">
-        <span class="text-sm font-medium text-primary-600">{% blocktrans with step=5 total=7 %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
-        <span class="text-sm text-neutral-500">70%</span>
+        <span class="text-sm font-medium text-primary-600">{% blocktrans with step=4 total=8 %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
+        <span class="text-sm text-neutral-500">50%</span>
       </div>
       <div class="h-2 w-full rounded-xl bg-neutral-200">
-        <div class="h-full rounded-xl bg-primary-600 w-[70%]"></div>
+        <div class="h-full rounded-xl bg-primary-600 w-[50%]"></div>
       </div>
     </div>
 
@@ -39,7 +39,7 @@
       </div>
 
       <div class="flex gap-4">
-        <a href="{% url 'accounts:email' %}" class="flex-1 rounded-xl border border-neutral-300 px-4 py-2 text-center text-neutral-700 hover:bg-neutral-100">{% trans "Voltar" %}</a>
+        <a href="{% url 'accounts:nome' %}" class="flex-1 rounded-xl border border-neutral-300 px-4 py-2 text-center text-neutral-700 hover:bg-neutral-100">{% trans "Voltar" %}</a>
         <button type="submit" id="submitButton" class="flex-1 rounded-xl bg-primary-600 px-4 py-2 text-white hover:bg-primary-700">{% trans "Continuar" %}</button>
       </div>
     </form>

--- a/accounts/templates/register/email.html
+++ b/accounts/templates/register/email.html
@@ -8,11 +8,11 @@
   <div class="rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
     <div class="mb-8">
       <div class="mb-2 flex items-center justify-between">
-        <span class="text-sm font-medium text-primary-600">{% blocktrans with step=4 total=7 %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
-        <span class="text-sm text-neutral-500">56%</span>
+        <span class="text-sm font-medium text-primary-600">{% blocktrans with step=5 total=8 %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
+        <span class="text-sm text-neutral-500">63%</span>
       </div>
       <div class="h-2 w-full rounded-xl bg-neutral-200">
-        <div class="h-full rounded-xl bg-primary-600 w-[56%]"></div>
+        <div class="h-full rounded-xl bg-primary-600 w-[63%]"></div>
       </div>
     </div>
 
@@ -39,7 +39,7 @@
       </div>
 
       <div class="flex gap-4">
-        <a href="{% url 'accounts:nome' %}" class="flex-1 rounded-xl border border-neutral-300 px-4 py-2 text-center text-neutral-700 hover:bg-neutral-100">{% trans "Voltar" %}</a>
+        <a href="{% url 'accounts:cpf' %}" class="flex-1 rounded-xl border border-neutral-300 px-4 py-2 text-center text-neutral-700 hover:bg-neutral-100">{% trans "Voltar" %}</a>
         <button type="submit" id="submitButton" class="flex-1 rounded-xl bg-primary-600 px-4 py-2 text-white hover:bg-primary-700">{% trans "Continuar" %}</button>
       </div>
     </form>

--- a/accounts/templates/register/foto.html
+++ b/accounts/templates/register/foto.html
@@ -8,11 +8,11 @@
   <div class="rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
     <div class="mb-8">
       <div class="mb-2 flex items-center justify-between">
-        <span class="text-sm font-medium text-primary-600">{% trans "Passo 6 de 7" %}</span>
-        <span class="text-sm text-neutral-500">84%</span>
+        <span class="text-sm font-medium text-primary-600">{% blocktrans with step=7 total=8 %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
+        <span class="text-sm text-neutral-500">88%</span>
       </div>
       <div class="h-2 w-full rounded-xl bg-neutral-200">
-        <div class="h-full rounded-xl bg-primary-600 w-[84%]"></div>
+        <div class="h-full rounded-xl bg-primary-600 w-[88%]"></div>
       </div>
     </div>
 

--- a/accounts/templates/register/nome.html
+++ b/accounts/templates/register/nome.html
@@ -8,11 +8,11 @@
   <div class="rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
     <div class="mb-8">
       <div class="mb-2 flex items-center justify-between">
-        <span class="text-sm font-medium text-primary-600">{% blocktrans with step=3 total=7 %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
-        <span class="text-sm text-neutral-500">42%</span>
+        <span class="text-sm font-medium text-primary-600">{% blocktrans with step=3 total=8 %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
+        <span class="text-sm text-neutral-500">38%</span>
       </div>
       <div class="h-2 w-full rounded-xl bg-neutral-200">
-        <div class="h-full rounded-xl bg-primary-600 w-[42%]"></div>
+        <div class="h-full rounded-xl bg-primary-600 w-[38%]"></div>
       </div>
     </div>
 
@@ -38,7 +38,7 @@
       </div>
 
       <div class="flex gap-4">
-        <a href="{% url 'tokens:token' %}" class="flex-1 rounded-xl border border-neutral-300 px-4 py-2 text-center text-neutral-700 hover:bg-neutral-100">{% trans "Voltar" %}</a>
+        <a href="{% url 'accounts:usuario' %}" class="flex-1 rounded-xl border border-neutral-300 px-4 py-2 text-center text-neutral-700 hover:bg-neutral-100">{% trans "Voltar" %}</a>
         <button type="submit" id="submitButton" class="flex-1 rounded-xl bg-primary-600 px-4 py-2 text-white hover:bg-primary-700">{% trans "Continuar" %}</button>
       </div>
     </form>

--- a/accounts/templates/register/senha.html
+++ b/accounts/templates/register/senha.html
@@ -8,11 +8,11 @@
   <div class="rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
     <div class="mb-8">
       <div class="mb-2 flex items-center justify-between">
-        <span class="text-sm font-medium text-primary-600">{% blocktrans with step=6 total=7 %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
-        <span class="text-sm text-neutral-500">84%</span>
+        <span class="text-sm font-medium text-primary-600">{% blocktrans with step=6 total=8 %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
+        <span class="text-sm text-neutral-500">75%</span>
       </div>
       <div class="h-2 w-full rounded-xl bg-neutral-200">
-        <div class="h-full rounded-xl bg-primary-600 w-[84%]"></div>
+        <div class="h-full rounded-xl bg-primary-600 w-[75%]"></div>
       </div>
     </div>
 
@@ -46,7 +46,7 @@
       </div>
 
       <div class="flex gap-4">
-        <a href="{% url 'accounts:cpf' %}" class="flex-1 rounded-xl border border-neutral-300 px-4 py-2 text-center text-neutral-700 hover:bg-neutral-100">{% trans "Voltar" %}</a>
+        <a href="{% url 'accounts:email' %}" class="flex-1 rounded-xl border border-neutral-300 px-4 py-2 text-center text-neutral-700 hover:bg-neutral-100">{% trans "Voltar" %}</a>
         <button type="submit" id="submitButton" class="flex-1 rounded-xl bg-primary-600 px-4 py-2 text-white hover:bg-primary-700">{% trans "Continuar" %}</button>
       </div>
     </form>

--- a/accounts/templates/register/termos.html
+++ b/accounts/templates/register/termos.html
@@ -8,11 +8,11 @@
   <div class="rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
     <div class="mb-8">
       <div class="mb-2 flex items-center justify-between">
-        <span class="text-sm font-medium text-primary-600">{% trans "Passo 7 de 7" %}</span>
+        <span class="text-sm font-medium text-primary-600">{% blocktrans with step=8 total=8 %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
         <span class="text-sm text-neutral-500">100%</span>
       </div>
       <div class="h-2 w-full rounded-xl bg-neutral-200">
-        <div class="h-full rounded-xl bg-primary-600 w-full"></div>
+        <div class="h-full rounded-xl bg-primary-600 w-[100%]"></div>
       </div>
     </div>
 

--- a/accounts/templates/register/token.html
+++ b/accounts/templates/register/token.html
@@ -8,11 +8,11 @@
   <div class="rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
     <div class="mb-8">
       <div class="mb-2 flex items-center justify-between">
-        <span class="text-sm font-medium text-primary-600">{% blocktrans with step=1 total=7 %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
-        <span class="text-sm text-neutral-500">14%</span>
+        <span class="text-sm font-medium text-primary-600">{% blocktrans with step=1 total=8 %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
+        <span class="text-sm text-neutral-500">13%</span>
       </div>
       <div class="h-2 w-full rounded-xl bg-neutral-200">
-        <div class="h-full rounded-xl bg-primary-600 w-[14%]"></div>
+        <div class="h-full rounded-xl bg-primary-600 w-[13%]"></div>
       </div>
     </div>
 

--- a/accounts/templates/register/usuario.html
+++ b/accounts/templates/register/usuario.html
@@ -8,11 +8,11 @@
   <div class="rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
     <div class="mb-8">
       <div class="mb-2 flex items-center justify-between">
-        <span class="text-sm font-medium text-primary-600">{% blocktrans with step=2 total=7 %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
-        <span class="text-sm text-neutral-500">28%</span>
+        <span class="text-sm font-medium text-primary-600">{% blocktrans with step=2 total=8 %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
+        <span class="text-sm text-neutral-500">25%</span>
       </div>
       <div class="h-2 w-full rounded-xl bg-neutral-200">
-        <div class="h-full rounded-xl bg-primary-600 w-[28%]"></div>
+        <div class="h-full rounded-xl bg-primary-600 w-[25%]"></div>
       </div>
     </div>
 
@@ -39,7 +39,7 @@
       </div>
 
       <div class="flex gap-4">
-        <a href="{% url 'accounts:email' %}" class="flex-1 rounded-xl border border-neutral-300 px-4 py-2 text-center text-neutral-700 hover:bg-neutral-100">{% trans "Voltar" %}</a>
+        <a href="{% url 'tokens:token' %}" class="flex-1 rounded-xl border border-neutral-300 px-4 py-2 text-center text-neutral-700 hover:bg-neutral-100">{% trans "Voltar" %}</a>
         <button type="submit" id="submitButton" class="flex-1 rounded-xl bg-primary-600 px-4 py-2 text-white hover:bg-primary-700">{% trans "Continuar" %}</button>
       </div>
     </form>


### PR DESCRIPTION
## Summary
- Alinha fluxo de cadastro para sequência token → usuário → nome → cpf → email → senha → foto → termos
- Atualiza cabeçalhos e barras de progresso para 8 etapas
- Corrige links de retorno entre etapas

## Testing
- `pytest` *(falha: 9 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a61c04af148325b18bf4db7b79fa82