### PR TITLE
Use named URLs for material approval actions

### DIFF
--- a/agenda/templates/agenda/material_list.html
+++ b/agenda/templates/agenda/material_list.html
@@ -67,7 +67,7 @@
                   </a>
                   {% if user.user_type in ('admin','coordenador','root') %}
                   <form
-                    hx-post="/api/agenda/materiais/{{ material.pk }}/aprovar/"
+                    hx-post="{% url 'agenda_api:material-aprovar' material.pk %}"
                     hx-on="htmx:afterRequest: location.reload()"
                     hx-swap="none"
                     class="inline"
@@ -76,7 +76,7 @@
                     <button type="submit" class="text-green-600 hover:underline">{% trans "Aprovar" %}</button>
                   </form>
                   <form
-                    hx-post="/api/agenda/materiais/{{ material.pk }}/devolver/"
+                    hx-post="{% url 'agenda_api:material-devolver' material.pk %}"
                     hx-on="htmx:afterRequest: location.reload()"
                     hx-swap="none"
                     class="inline-flex items-center gap-1"


### PR DESCRIPTION
## Summary
- replace hardcoded approve/devolver endpoints with named URL routes in material list template
- confirm material approval and return actions are available via DRF router

## Testing
- `python manage.py shell -c 'from django.urls import reverse; print(reverse("agenda_api:material-aprovar", args=[1]))'`
- `python manage.py shell -c 'from django.urls import reverse; print(reverse("agenda_api:material-devolver", args=[1]))'`
- `pytest tests/agenda/test_material_api.py::test_aprovar_material -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68a61f7349ac83259f96e13082415eab