### PR TITLE
Add check-in form view and link

### DIFF
--- a/agenda/templates/agenda/inscricao_list.html
+++ b/agenda/templates/agenda/inscricao_list.html
@@ -78,6 +78,13 @@
                 >
                   {% trans "Ver" %}
                 </a>
+                |
+                <a
+                  href="{% url 'agenda:inscricao_checkin_form' inscricao.pk %}"
+                  class="text-blue-600 hover:underline"
+                >
+                  {% trans "Check-in" %}
+                </a>
               </td>
             </tr>
           {% empty %}

--- a/agenda/urls.py
+++ b/agenda/urls.py
@@ -59,6 +59,7 @@ urlpatterns = [
         EventoFeedbackView.as_view(),
         name="evento_feedback",
     ),
+    path("checkin/<int:pk>/", views.checkin_form, name="inscricao_checkin_form"),
     path(
         "api/inscricoes/<int:pk>/checkin/",
         views.checkin_inscricao,

--- a/agenda/views.py
+++ b/agenda/views.py
@@ -545,6 +545,12 @@ def avaliar_parceria(request, pk: int):
     return render(request, "agenda/parceria_avaliar.html", {"parceria": parceria})
 
 
+@login_required
+def checkin_form(request, pk: int):
+    inscricao = get_object_or_404(InscricaoEvento, pk=pk)
+    return render(request, "agenda/checkin_form.html", {"inscricao": inscricao})
+
+
 def checkin_inscricao(request, pk: int):
     """Valida o QRCode enviado e registra o check-in."""
     if request.method != "POST":


### PR DESCRIPTION
## Summary
- add `checkin_form` view to render check-in page for inscriptions
- expose `checkin/<int:pk>/` route and link from inscription list

## Testing
- ⚠️ `pytest tests/agenda/test_inscricoes.py::test_qrcode_and_checkin -q --no-cov` (database connection issues)
- ✅ `python -m py_compile agenda/views.py agenda/urls.py`


------
https://chatgpt.com/codex/tasks/task_e_68a61f7353808325bdc2f8d7912d4094