### PR TITLE
Move partnership evaluation route outside API and align templates

### DIFF
--- a/agenda/templates/agenda/parceria_avaliar.html
+++ b/agenda/templates/agenda/parceria_avaliar.html
@@ -5,11 +5,17 @@
 {% block content %}
 <main class="max-w-md mx-auto py-8 px-4">
   <h1 class="text-xl font-semibold mb-4">{% trans "Avaliar parceria" %}</h1>
-  <form id="avaliacao-form" method="post" action="{% url 'agenda:parceria_avaliar' parceria.pk %}" class="space-y-4">
+  <form
+    id="avaliacao-form"
+    method="post"
+    action="#"
+    data-api-url="{% url 'agenda_api:parceria-avaliar' parceria.pk %}"
+    class="space-y-4"
+  >
     {% csrf_token %}
     <div>
-      <label for="nota" class="block text-sm font-medium">{% trans "Nota" %}</label>
-      <select id="nota" name="nota" class="form-select w-full" required>
+      <label for="avaliacao" class="block text-sm font-medium">{% trans "Nota" %}</label>
+      <select id="avaliacao" name="avaliacao" class="form-select w-full" required>
         {% for n in '12345' %}
         <option value="{{ n }}">{{ n }}</option>
         {% endfor %}
@@ -29,7 +35,7 @@
 const form = document.getElementById('avaliacao-form');
 form.addEventListener('submit', async function(e) {
   e.preventDefault();
-  const response = await fetch(form.action, {
+  const response = await fetch(form.dataset.apiUrl, {
     method: 'POST',
     headers: {
       'X-Requested-With': 'XMLHttpRequest',

--- a/agenda/templates/agenda/parceria_list.html
+++ b/agenda/templates/agenda/parceria_list.html
@@ -28,10 +28,22 @@
               <td class="px-4 py-2">{{ parceria.get_tipo_parceria_display }}</td>
               <td class="px-4 py-2 space-x-2">
                 {% if parceria.avaliacao is None %}
-                  <a href="{% url 'agenda:parceria_avaliar' parceria.pk %}" class="text-green-600 hover:underline">{% trans "Avaliar" %}</a>
+                  <a
+                    href="{% url 'agenda:parceria_avaliar' parceria.pk %}"
+                    class="text-green-600 hover:underline"
+                    >{% trans "Avaliar" %}</a
+                  >
                 {% endif %}
-                <a href="{% url 'agenda:parceria_editar' parceria.pk %}" class="text-blue-600 hover:underline">{% trans "Editar" %}</a>
-                <a href="{% url 'agenda:parceria_excluir' parceria.pk %}" class="text-red-600 hover:underline">{% trans "Excluir" %}</a>
+                <a
+                  href="{% url 'agenda:parceria_editar' parceria.pk %}"
+                  class="text-blue-600 hover:underline"
+                  >{% trans "Editar" %}</a
+                >
+                <a
+                  href="{% url 'agenda:parceria_excluir' parceria.pk %}"
+                  class="text-red-600 hover:underline"
+                  >{% trans "Excluir" %}</a
+                >
               </td>
             </tr>
           {% empty %}

--- a/agenda/urls.py
+++ b/agenda/urls.py
@@ -66,7 +66,7 @@ urlpatterns = [
     ),
     path("api/eventos/<uuid:pk>/orcamento/", views.evento_orcamento, name="evento_orcamento"),
     path("api/eventos/<uuid:pk>/espera/", views.fila_espera, name="fila_espera"),
-    path("api/parcerias/<int:pk>/avaliar/", views.avaliar_parceria, name="parceria_avaliar"),
+    path("parceria/<int:pk>/avaliar/", views.avaliar_parceria, name="parceria_avaliar"),
     path("eventos_por_dia/", views.eventos_por_dia, name="eventos_por_dia"),
     path("inscricoes/", InscricaoEventoListView.as_view(), name="inscricao_list"),
     path("materiais/", MaterialDivulgacaoEventoListView.as_view(), name="material_list"),


### PR DESCRIPTION
## Summary
- move avaliar_parceria view to non-API route `parceria/<pk>/avaliar/`
- adjust templates to point to new URL and submit evaluations through REST action

## Testing
- `pytest tests/agenda/test_audit.py::test_parceria_avaliar_gera_log -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68a61f7469ec8325a94b455c84c236fe