### PR TITLE
Add accept attributes to agenda upload fields

### DIFF
--- a/agenda/templates/agenda/create.html
+++ b/agenda/templates/agenda/create.html
@@ -8,9 +8,22 @@
 
   <form method="post" enctype="multipart/form-data" class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 space-y-6">
     {% csrf_token %}
-
-    {{ form.as_p }}
-
+    {{ form.non_field_errors }}
+    {% for field in form %}
+    <div>
+      <label for="{{ field.id_for_label }}" class="block text-sm font-medium text-neutral-700 mb-1">
+        {{ field.label }}
+      </label>
+      {% if field.name == 'avatar' or field.name == 'cover' %}
+      {{ field.as_widget(attrs={'accept': 'image/*'}) }}
+      {% else %}
+      {{ field }}
+      {% endif %}
+      {% if field.errors %}
+      <p class="text-sm text-red-600 mt-1">{{ field.errors }}</p>
+      {% endif %}
+    </div>
+    {% endfor %}
     <div class="flex justify-end gap-3 pt-4 border-t border-neutral-100">
       <a href="{% url 'agenda:calendario' %}" class="btn-secondary" aria-label="{% trans 'Cancelar' %}">{% trans "Cancelar" %}</a>
       <button type="submit" class="btn-primary" aria-label="{% trans 'Salvar' %}">{% trans "Salvar" %}</button>

--- a/agenda/templates/agenda/material_form.html
+++ b/agenda/templates/agenda/material_form.html
@@ -9,7 +9,20 @@
   </h1>
   <form method="post" enctype="multipart/form-data" class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 space-y-6">
     {% csrf_token %}
-    {{ form.as_p }}
+    {{ form.non_field_errors }}
+    {% for field in form %}
+    <div>
+      {{ field.label_tag }}
+      {% if field.name == 'arquivo' %}
+      {{ field.as_widget(attrs={'accept': '.jpg,.jpeg,.png,.pdf'}) }}
+      {% elif field.name == 'imagem_thumb' %}
+      {{ field.as_widget(attrs={'accept': '.jpg,.jpeg,.png'}) }}
+      {% else %}
+      {{ field }}
+      {% endif %}
+      {{ field.errors }}
+    </div>
+    {% endfor %}
     <div class="flex justify-end gap-3 pt-4 border-t border-neutral-100">
       <a href="{% url 'agenda:material_list' %}" class="btn-secondary" aria-label="{% trans 'Cancelar' %}">{% trans "Cancelar" %}</a>
       <button type="submit" class="btn-primary" aria-label="{% trans 'Salvar' %}">{% trans "Salvar" %}</button>

--- a/agenda/templates/agenda/parceria_form.html
+++ b/agenda/templates/agenda/parceria_form.html
@@ -8,7 +8,18 @@
   <h1 class="text-2xl font-bold text-neutral-900 mb-6">{% trans "Parceria" %}</h1>
   <form method="post" enctype="multipart/form-data" class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 space-y-6">
     {% csrf_token %}
-    {{ form.as_p }}
+    {{ form.non_field_errors }}
+    {% for field in form %}
+    <div>
+      {{ field.label_tag }}
+      {% if field.name == 'acordo' %}
+      {{ field.as_widget(attrs={'accept': '.pdf'}) }}
+      {% else %}
+      {{ field }}
+      {% endif %}
+      {{ field.errors }}
+    </div>
+    {% endfor %}
     <div class="flex justify-end gap-3 pt-4 border-t border-neutral-100">
       <a href="{% url 'agenda:parceria_list' %}" class="btn-secondary" aria-label="{% trans 'Cancelar' %}">{% trans "Cancelar" %}</a>
       <button type="submit" class="btn-primary" aria-label="{% trans 'Salvar' %}">{% trans "Salvar" %}</button>

--- a/agenda/templates/agenda/update.html
+++ b/agenda/templates/agenda/update.html
@@ -14,7 +14,11 @@
           <label for="{{ field.id_for_label }}" class="block text-sm font-medium text-neutral-700 mb-1">
             {{ field.label }}
           </label>
+          {% if field.name == 'avatar' or field.name == 'cover' %}
+          {{ field.as_widget(attrs={'accept': 'image/*'}) }}
+          {% else %}
           {{ field }}
+          {% endif %}
           {% if field.errors %}
             <p class="text-sm text-red-600 mt-1">{{ field.errors }}</p>
           {% endif %}


### PR DESCRIPTION
## Summary
- restrict material upload fields to images and PDF
- limit parceria agreement upload to PDF files
- ensure event avatar and cover inputs accept only images

## Testing
- `pytest tests/agenda/test_material.py tests/agenda/test_parceria_views.py tests/agenda/test_views.py::test_evento_create_view_post_valido -q` *(fails: TemplateSyntaxError: Could not parse the remainder: '(user.user_type' from '(user.user_type')*

------
https://chatgpt.com/codex/tasks/task_e_68a61f6f39ec83258919fb4456291441