### PR TITLE
Add modal chat views for user list and rooms

### DIFF
--- a/chat/urls.py
+++ b/chat/urls.py
@@ -8,6 +8,8 @@ urlpatterns = [
     path("", views.conversation_list, name="conversation_list"),
     path("nova/", views.nova_conversa, name="nova_conversa"),
     path("contextos/", views.contextos, name="contextos"),
+    path("modal/users/", views.modal_users, name="modal_users"),
+    path("modal/room/<uuid:user_id>/", views.modal_room, name="modal_room"),
     path(
         "partials/message/<uuid:message_id>/",
         views.message_partial,

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -5,6 +5,7 @@ urlpatterns = [
     path("", include(("accounts.urls", "accounts"), namespace="accounts")),
     path("core/", include(("core.urls", "core"), namespace="core")),
     path("api/notificacoes/", include("notificacoes.api_urls")),
+    path("chat/", include(("chat.urls", "chat"), namespace="chat")),
     path("financeiro/", include(("financeiro.urls", "financeiro"), namespace="financeiro")),
     path("accounts/", include(("accounts.urls", "accounts"), namespace="accounts")),
     path("dashboard/", include(("dashboard.urls", "dashboard"), namespace="dashboard")),


### PR DESCRIPTION
## Summary
- add authenticated modal endpoints for user list and private chat rooms
- wire modal routes into chat URLs and project test URLs
- cover new views with tests

## Testing
- `pip install django-redis -q`
- `python -m pytest tests/chat/test_views.py::test_modal_users_requires_login tests/chat/test_views.py::test_modal_users_lists_other_users tests/chat/test_views.py::test_modal_room_loads_messages -q -p no:cov -o addopts=""`


------
https://chatgpt.com/codex/tasks/task_e_68a62ae394e08325b7ce6706d775e9d9