### PR TITLE
Fix dashboard quick action links

### DIFF
--- a/dashboard/templates/dashboard/admin.html
+++ b/dashboard/templates/dashboard/admin.html
@@ -102,19 +102,15 @@
         <i class="fa-solid fa-trophy mb-2"></i>
         <span class="block">{% trans "Conquistas" %}</span>
       </a>
-      <a href="#" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50">
+      <a href="{% url 'admin:accounts_user_changelist' %}" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50">
         <i class="fa-solid fa-user-gear mb-2"></i>
         <span class="block">{% trans "Administrar Usuários" %}</span>
       </a>
-      <a href="#" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50">
-        <i class="fa-solid fa-calendar-check mb-2"></i>
-        <span class="block">{% trans "Aprovar Eventos" %}</span>
-      </a>
-      <a href="#" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50">
+      <a href="{% url 'financeiro:relatorios' %}" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50">
         <i class="fa-solid fa-file-invoice-dollar mb-2"></i>
         <span class="block">{% trans "Relatórios Financeiros" %}</span>
       </a>
-      <a href="#" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50">
+      <a href="{% url 'notificacoes:logs_list' %}" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50">
         <i class="fa-solid fa-bell mb-2"></i>
         <span class="block">{% trans "Logs de Notificações" %}</span>
       </a>

--- a/dashboard/templates/dashboard/cliente.html
+++ b/dashboard/templates/dashboard/cliente.html
@@ -44,11 +44,11 @@
   <section class="mb-8">
     <h2 class="text-xl font-semibold mb-4">{% trans "Atalhos" %}</h2>
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-      <a href="#" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50">
+      <a href="{% url 'agenda:calendario' %}" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50">
         <i class="fa-solid fa-calendar-plus mb-2"></i>
         <span class="block">{% trans "Inscrever-se em Eventos" %}</span>
       </a>
-      <a href="#" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50">
+      <a href="{% url 'feed:listar' %}" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50">
         <i class="fa-solid fa-rss mb-2"></i>
         <span class="block">{% trans "Ver Feed" %}</span>
       </a>

--- a/dashboard/templates/dashboard/gerente.html
+++ b/dashboard/templates/dashboard/gerente.html
@@ -36,14 +36,6 @@
   <section class="mb-8">
     <h2 class="text-xl font-semibold mb-4">{% trans "Ações Rápidas" %}</h2>
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-      <a href="#" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50">
-        <i class="fa-solid fa-clipboard-check mb-2"></i>
-        <span class="block">{% trans "Aprovar Tarefas" %}</span>
-      </a>
-      <a href="#" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50">
-        <i class="fa-solid fa-calendar mb-2"></i>
-        <span class="block">{% trans "Gerenciar Eventos" %}</span>
-      </a>
       <a href="{% url 'dashboard:achievements' %}" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50">
         <i class="fa-solid fa-trophy mb-2"></i>
         <span class="block">{% trans "Conquistas" %}</span>


### PR DESCRIPTION
## Summary
- Remove quick actions without implementations
- Replace placeholder hrefs with real URLs in dashboards

## Testing
- `pytest dashboard` *(fails: Required test coverage of 90% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_68a632cb67548325b368f7df8d911e6c