### PR TITLE
feat: improve dashboard layout creation

### DIFF
--- a/dashboard/static/dashboard/layout.js
+++ b/dashboard/static/dashboard/layout.js
@@ -4,12 +4,21 @@ document.addEventListener('DOMContentLoaded', () => {
   const container = document.getElementById('dashboard-cards');
   if (!container) return;
   const url = container.dataset.saveUrl;
+  const input = document.getElementById('layout_json');
+  const saveOrder = (order) => {
+    if (input) input.value = JSON.stringify(order);
+    if (url && url !== '#') {
+      htmx.ajax('POST', url, {values: {layout_json: JSON.stringify(order)}});
+    }
+  };
+  const initial = Array.from(container.children).map(el => el.id);
+  saveOrder(initial);
   Sortable.create(container, {
     animation: 150,
     handle: '.card-handle',
     onEnd() {
       const order = Array.from(container.children).map(el => el.id);
-      htmx.ajax('POST', url, {values: {layout_json: JSON.stringify(order)}});
+      saveOrder(order);
     }
   });
   container.addEventListener('keydown', (e) => {
@@ -18,7 +27,11 @@ document.addEventListener('DOMContentLoaded', () => {
     if (['ArrowLeft','ArrowUp'].includes(e.key)) {
       e.preventDefault();
       const prev = item.previousElementSibling;
-      if (prev) container.insertBefore(item, prev);
+      if (prev) {
+        container.insertBefore(item, prev);
+        const order = Array.from(container.children).map(el => el.id);
+        saveOrder(order);
+      }
     }
     if (['ArrowRight','ArrowDown'].includes(e.key)) {
       e.preventDefault();
@@ -26,7 +39,7 @@ document.addEventListener('DOMContentLoaded', () => {
       if (next) {
         next.parentNode.insertBefore(next, item);
         const order = Array.from(container.children).map(el => el.id);
-        htmx.ajax('POST', url, {values: {layout_json: JSON.stringify(order)}});
+        saveOrder(order);
       }
     }
   });

--- a/dashboard/templates/dashboard/layout_form.html
+++ b/dashboard/templates/dashboard/layout_form.html
@@ -17,14 +17,10 @@
     <input type="hidden" name="layout_json" id="layout_json" value="{{ object.layout_json|default:'{}' }}">
     <button type="submit" class="btn btn-primary">{% trans "Salvar" %}</button>
   </form>
-  {% if layout_save_url %}
-    {% include 'dashboard/partials/metrics_list.html' %}
-  {% endif %}
+  {% include 'dashboard/partials/metrics_list.html' %}
 </main>
 {% endblock %}
 
 {% block extra_js %}
-  {% if layout_save_url %}
-    <script src="{% static 'dashboard/layout.js' %}"></script>
-  {% endif %}
+  <script src="{% static 'dashboard/layout.js' %}"></script>
 {% endblock %}

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -832,8 +832,26 @@ class DashboardLayoutCreateView(LoginRequiredMixin, CreateView):
     template_name = "dashboard/layout_form.html"
     success_url = "/dashboard/layouts/"
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["layout_save_url"] = "#"
+        metricas = list(METRICAS_INFO.keys())
+        metrics = DashboardMetricsService.get_metrics(self.request.user, metricas=metricas)
+        context["metricas_iter"] = [
+            {
+                "key": m,
+                "data": metrics[m],
+                "label": METRICAS_INFO[m]["label"],
+                "icon": METRICAS_INFO[m]["icon"],
+            }
+            for m in metricas
+            if m in metrics
+        ]
+        context["metricas_selecionadas"] = metricas
+        return context
+
     def form_valid(self, form):
-        layout_data = self.request.POST.get("layout_json", "{}")
+        layout_data = self.request.POST.get("layout_json", "[]")
         self.object = form.save(self.request.user, layout_data)
         log_layout_action(
             user=self.request.user,


### PR DESCRIPTION
## Summary
- add default metrics and temp save url for new dashboard layouts
- always render metrics list on layout form
- persist initial layout order via JavaScript

## Testing
- `pytest --no-cov tests/dashboard/test_layouts.py` *(fails: TemplateSyntaxError: Could not parse the remainder: '(user.user_type' from '(user.user_type'))*


------
https://chatgpt.com/codex/tasks/task_e_68a632c6b52083259945b5272ba98f40