### PR TITLE
Fix topic list template context

### DIFF
--- a/discussao/templates/discussao/comentario_item.html
+++ b/discussao/templates/discussao/comentario_item.html
@@ -18,7 +18,7 @@
         <button type="submit" class="text-red-600 text-xs">{% trans "Remover" %}</button>
       </form>
     {% endif %}
-    {% if (user == topico.autor or user.get_tipo_usuario in ['admin','root']) and not topico.melhor_resposta %}
+    {% if not topico.melhor_resposta and (user == topico.autor or user.get_tipo_usuario in ['admin','root']) %}
       <form method="post" hx-post="{% url 'discussao:topico_resolver' topico.categoria.slug topico.slug %}" hx-target="#topico-container" hx-swap="outerHTML">
         {% csrf_token %}
         <input type="hidden" name="melhor_resposta" value="{{ comentario.id }}" />

--- a/discussao/templates/discussao/topicos_list.html
+++ b/discussao/templates/discussao/topicos_list.html
@@ -65,7 +65,7 @@
         </tr>
       </thead>
       <tbody id="lista-topicos" class="divide-y divide-neutral-200">
-        {% include 'discussao/topicos_list.html' with partial=True only %}
+        {% include 'discussao/topicos_list.html' with partial=True topicos=topicos categoria=categoria content_type_id=content_type_id only %}
       </tbody>
     </table>
   </div>

--- a/templates/base.html
+++ b/templates/base.html
@@ -94,7 +94,7 @@
           </div>
         </div>
         {% endif %}
-        <a href="{% url 'dashboard:dashboard' %}" class="flex items-center gap-x-2 hover:text-primary transition">
+        <a href="/" class="flex items-center gap-x-2 hover:text-primary transition">
           <i class="fas fa-tachometer-alt"></i> {% trans "Dashboard" %}
         </a>
         <a href="{% url 'empresas:lista' %}" class="flex items-center gap-x-2 hover:text-primary transition">
@@ -115,10 +115,12 @@
         <a href="{% url 'nucleos:list' %}" class="flex items-center gap-x-2 hover:text-primary transition">
           <i class="fas fa-users"></i> {% trans "Núcleos" %}
         </a>
-        {% if user.is_authenticated and (user.user_type == 'financeiro' or user.user_type == 'admin') %}
+        {% if user.is_authenticated %}
+        {% if user.user_type == 'financeiro' or user.user_type == 'admin' %}
         <a href="{% url 'financeiro:repasses' %}" class="flex items-center gap-x-2 hover:text-primary transition">
           <i class="fas fa-hand-holding-usd"></i> {% trans "Financeiro" %}
         </a>
+        {% endif %}
         {% endif %}
         {% if user.is_authenticated and user.user_type == 'root' %}
         <a href="{% url 'organizacoes:list' %}" class="flex items-center gap-x-2 hover:text-primary transition">


### PR DESCRIPTION
## Summary
- ensure topic list partial receives required context variables
- avoid invalid IF expressions and missing link targets in base templates

## Testing
- `pytest tests/discussao/test_views.py::test_topico_list_view -q` *(fails: NoReverseMatch: 'empresas' is not a registered namespace)*
- `pytest tests/discussao/test_views.py::test_topico_list_includes_num_votos -q` *(fails: Required test coverage of 90% not reached. Total coverage: 13.54%)*

------
https://chatgpt.com/codex/tasks/task_e_68a636014b7c83258ca4e162425f8078