### PR TITLE
Exibe número de visualizações nos tópicos de discussão

### DIFF
--- a/discussao/templates/discussao/topico_detail.html
+++ b/discussao/templates/discussao/topico_detail.html
@@ -18,7 +18,7 @@
       <span class="ml-2 px-2 py-1 text-xs font-semibold bg-green-100 text-green-800 rounded">{% trans "Resolvido" %}</span>
       {% endif %}
     </h1>
-    <p class="text-sm text-neutral-600">{% trans "Por" %} {{ topico.autor.get_full_name|default:topico.autor.username }} · {{ topico.created_at|date:SHORT_DATETIME_FORMAT }}</p>
+    <p class="text-sm text-neutral-600">{% trans "Por" %} {{ topico.autor.get_full_name|default:topico.autor.username }} · {{ topico.created_at|date:SHORT_DATETIME_FORMAT }} · {{ topico.numero_visualizacoes }} {% trans "visualizações" %}</p>
     {% if pode_editar_topico %}
       <a href="{% url 'discussao:topico_editar' topico.categoria.slug topico.slug %}" class="text-sm text-blue-600">{% trans "Editar" %}</a>
     {% endif %}

--- a/discussao/templates/discussao/topicos_list.html
+++ b/discussao/templates/discussao/topicos_list.html
@@ -28,6 +28,7 @@
       </div>
     </td>
     <td class="px-4 py-2 text-center">{{ topico.num_comentarios }}</td>
+    <td class="px-4 py-2 text-center">{{ topico.numero_visualizacoes }}</td>
     <td class="px-4 py-2">{{ topico.last_activity|date:SHORT_DATETIME_FORMAT }}</td>
   </tr>
   {% endfor %}
@@ -61,6 +62,7 @@
           <th class="px-4 py-2 text-left font-medium text-neutral-700">{% trans "Criado em" %}</th>
           <th class="px-4 py-2 text-center font-medium text-neutral-700">{% trans "Votos" %}</th>
           <th class="px-4 py-2 text-center font-medium text-neutral-700">{% trans "Coment\u00e1rios" %}</th>
+          <th class="px-4 py-2 text-center font-medium text-neutral-700">{% trans "Visualizações" %}</th>
           <th class="px-4 py-2 text-left font-medium text-neutral-700">{% trans "\u00daltima atividade" %}</th>
         </tr>
       </thead>


### PR DESCRIPTION
## Summary
- adiciona coluna de visualizações na listagem de tópicos
- exibe número de visualizações no detalhe do tópico

## Testing
- `pytest` *(falhou: ModuleNotFoundError: No module named 'django_redis')*

------
https://chatgpt.com/codex/tasks/task_e_68a6361dc1988325a296c60f8719a340