### PR TITLE
Add alt text to Núcleos template images for accessibility

### DIFF
--- a/nucleos/templates/nucleos/detail.html
+++ b/nucleos/templates/nucleos/detail.html
@@ -6,10 +6,10 @@
 {% block content %}
 <section class="max-w-3xl mx-auto py-8">
   {% if object.cover %}
-  <img src="{{ object.cover.url }}" class="w-full h-48 object-cover rounded" />
+  <img src="{{ object.cover.url }}" class="w-full h-48 object-cover rounded" alt="Capa de {{ object.nome }}" />
   {% endif %}
   <div class="flex items-center gap-4 mt-4">
-    {% if object.avatar %}<img src="{{ object.avatar.url }}" class="w-16 h-16 rounded-full" />{% endif %}
+    {% if object.avatar %}<img src="{{ object.avatar.url }}" class="w-16 h-16 rounded-full" alt="{{ object.nome }}" />{% endif %}
     <div>
       <h1 class="text-2xl font-bold">{{ object.nome }}</h1>
       <p class="text-sm text-gray-500">{{ object.slug }}</p>

--- a/nucleos/templates/nucleos/list.html
+++ b/nucleos/templates/nucleos/list.html
@@ -25,7 +25,7 @@
     {% for nucleo in object_list %}
     <li role="listitem" class="border rounded p-4">
       <div class="flex items-center gap-3">
-        {% if nucleo.avatar %}<img src="{{ nucleo.avatar.url }}" class="w-12 h-12 rounded-full" />{% endif %}
+        {% if nucleo.avatar %}<img src="{{ nucleo.avatar.url }}" class="w-12 h-12 rounded-full" alt="{{ nucleo.nome }}" />{% endif %}
         <div>
           <h2 class="font-semibold">{{ nucleo.nome }}</h2>
           <p class="text-sm text-gray-500">{{ nucleo.slug }}</p>


### PR DESCRIPTION
## Summary
- add descriptive alt text to Núcleos list and detail images for better accessibility

## Testing
- `pytest tests/nucleos -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68a642e3365c8325804b93d96b2ca97f