### PR TITLE
Add confirmation page for Nucleo deletion

### DIFF
--- a/nucleos/templates/nucleos/list.html
+++ b/nucleos/templates/nucleos/list.html
@@ -35,9 +35,7 @@
       <div class="mt-2">
         <a href="{% url 'nucleos:detail' nucleo.pk %}" class="text-blue-600" aria-label="{% blocktrans with nome=nucleo.nome %}Ver detalhes do núcleo {{ nome }}{% endblocktrans %}">{% trans 'Detalhes' %}</a>
         {% if request.user.user_type in ('admin', 'root') %}
-        <form method="post" action="{% url 'nucleos:delete' nucleo.pk %}" class="inline">{% csrf_token %}
-          <button class="text-red-600 ml-2" aria-label="{% blocktrans with nome=nucleo.nome %}Excluir núcleo {{ nome }}{% endblocktrans %}">{% trans 'Excluir' %}</button>
-        </form>
+        <a href="{% url 'nucleos:delete' nucleo.pk %}" class="text-red-600 ml-2" aria-label="{% blocktrans with nome=nucleo.nome %}Excluir núcleo {{ nome }}{% endblocktrans %}">{% trans 'Excluir' %}</a>
         {% endif %}
       </div>
     </li>

--- a/nucleos/views.py
+++ b/nucleos/views.py
@@ -116,6 +116,15 @@ class NucleoUpdateView(GerenteRequiredMixin, LoginRequiredMixin, UpdateView):
 
 
 class NucleoDeleteView(AdminRequiredMixin, LoginRequiredMixin, View):
+    def get(self, request, pk):
+        nucleo = get_object_or_404(Nucleo, pk=pk, deleted=False)
+        if (
+            request.user.user_type == UserType.ADMIN
+            and nucleo.organizacao != request.user.organizacao
+        ):
+            return redirect("nucleos:list")
+        return render(request, "nucleos/delete.html", {"object": nucleo})
+
     def post(self, request, pk):
         nucleo = get_object_or_404(Nucleo, pk=pk, deleted=False)
         if request.user.user_type == UserType.ADMIN and nucleo.organizacao != request.user.organizacao:

--- a/tests/nucleos/test_views.py
+++ b/tests/nucleos/test_views.py
@@ -62,11 +62,19 @@ def test_nucleo_create_and_soft_delete(client, admin_user, organizacao):
     client.force_login(admin_user)
     resp = client.post(
         reverse("nucleos:create"),
-        data={"nome": "N1", "slug": "n1", "descricao": "d", "ativo": True},
+        data={
+            "nome": "N1",
+            "slug": "n1",
+            "descricao": "d",
+            "ativo": True,
+            "mensalidade": "30.00",
+        },
     )
     assert resp.status_code == 302
     nucleo = Nucleo.objects.get(nome="N1")
     assert not nucleo.deleted
+    resp = client.get(reverse("nucleos:delete", args=[nucleo.pk]))
+    assert resp.status_code == 200
     resp = client.post(reverse("nucleos:delete", args=[nucleo.pk]))
     nucleo.refresh_from_db()
     assert nucleo.deleted is True


### PR DESCRIPTION
## Summary
- render delete confirmation page on GET
- navigate to confirmation page before deleting
- test deletion flow with confirmation step

## Testing
- `pytest tests/nucleos/test_views.py::test_nucleo_create_and_soft_delete --no-cov -q`

------
https://chatgpt.com/codex/tasks/task_e_68a642e74dd083258ca3d4d52501047e