### PR TITLE
Adicionar confirmação e CSRF ao botão Revogar

### DIFF
--- a/nucleos/locale/en/LC_MESSAGES/django.po
+++ b/nucleos/locale/en/LC_MESSAGES/django.po
@@ -242,3 +242,7 @@ msgstr ""
 #: templates/nucleos/solicitar_modal.html:10
 msgid "Confirmar"
 msgstr ""
+
+#: templates/nucleos/convites_modal.html:23
+msgid "Confirmar revogação?"
+msgstr "Confirm revocation?"

--- a/nucleos/locale/pt_BR/LC_MESSAGES/django.po
+++ b/nucleos/locale/pt_BR/LC_MESSAGES/django.po
@@ -242,3 +242,7 @@ msgstr ""
 #: templates/nucleos/solicitar_modal.html:10
 msgid "Confirmar"
 msgstr ""
+
+#: templates/nucleos/convites_modal.html:23
+msgid "Confirmar revogação?"
+msgstr "Confirmar revogação?"

--- a/nucleos/templates/nucleos/convites_modal.html
+++ b/nucleos/templates/nucleos/convites_modal.html
@@ -18,7 +18,12 @@
     {% for c in convites %}
     <li id="convite-{{ c.id }}" class="flex justify-between items-center">
       <span>{{ c.email }} - {{ c.papel }}</span>
-      <button class="text-red-600" hx-delete="{% url 'nucleos_api:nucleo-revogar-convite' nucleo.pk c.id %}" hx-target="#convite-{{ c.id }}" hx-swap="outerHTML">{% trans 'Revogar' %}</button>
+      <form hx-delete="{% url 'nucleos_api:nucleo-revogar-convite' nucleo.pk c.id %}"
+            hx-target="#convite-{{ c.id }}" hx-swap="outerHTML"
+            hx-confirm="{% trans 'Confirmar revogação?' %}">
+        {% csrf_token %}
+        <button type="submit" class="text-red-600">{% trans 'Revogar' %}</button>
+      </form>
     </li>
     {% empty %}
     <li class="text-sm text-gray-500">{% trans 'Nenhum convite pendente.' %}</li>

--- a/tokens/locale/en/LC_MESSAGES/django.po
+++ b/tokens/locale/en/LC_MESSAGES/django.po
@@ -122,3 +122,7 @@ msgstr ""
 #: templates/tokens/validar_token.html:26
 msgid "Validar Token"
 msgstr ""
+
+#: templates/tokens/api_tokens.html:27 templates/tokens/listar_convites.html:25
+msgid "Confirmar revogação?"
+msgstr "Confirm revocation?"

--- a/tokens/locale/pt_BR/LC_MESSAGES/django.po
+++ b/tokens/locale/pt_BR/LC_MESSAGES/django.po
@@ -122,3 +122,7 @@ msgstr ""
 #: templates/tokens/validar_token.html:26
 msgid "Validar Token"
 msgstr ""
+
+#: templates/tokens/api_tokens.html:27 templates/tokens/listar_convites.html:25
+msgid "Confirmar revogação?"
+msgstr "Confirmar revogação?"

--- a/tokens/templates/tokens/api_tokens.html
+++ b/tokens/templates/tokens/api_tokens.html
@@ -24,7 +24,7 @@
             {% if token.revoked_at %}
               <span class="text-neutral-400">{% trans "Revogado" %}</span>
             {% else %}
-            <form method="post" action="{% url 'tokens:revogar_api_token' token.id %}">
+            <form method="post" action="{% url 'tokens:revogar_api_token' token.id %}" hx-confirm="{% trans 'Confirmar revogação?' %}">
               {% csrf_token %}
               <button type="submit" class="text-red-600 hover:underline">{% trans "Revogar" %}</button>
             </form>

--- a/tokens/templates/tokens/listar_convites.html
+++ b/tokens/templates/tokens/listar_convites.html
@@ -22,7 +22,7 @@
           <td class="px-4 py-2 text-sm text-neutral-900">{{ token.get_estado_display }}</td>
           <td class="px-4 py-2 text-sm">
             {% if token.estado != 'revogado' %}
-            <form method="post" action="{% url 'tokens:revogar_convite' token.id %}">
+            <form method="post" action="{% url 'tokens:revogar_convite' token.id %}" hx-confirm="{% trans 'Confirmar revogação?' %}">
               {% csrf_token %}
               <button type="submit" class="text-red-600 hover:underline">{% trans "Revogar" %}</button>
             </form>


### PR DESCRIPTION
## Resumo
- pedir confirmação antes de revogar convites e tokens
- garantir envio do token CSRF nas ações de revogação

## Testes
- `pytest -m "not slow"` *(falhou: 9 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a642e88d3083259d512374ec0e9c68