### PR TITLE
Exibe status do membro em detalhes do núcleo

### DIFF
--- a/nucleos/templates/nucleos/detail.html
+++ b/nucleos/templates/nucleos/detail.html
@@ -19,6 +19,8 @@
     <a href="{% url 'nucleos:metrics' object.pk %}" class="text-blue-600">{% trans 'Ver métricas' %}</a>
   </div>
 
+  <div id="membro-status" class="mt-2 text-sm text-gray-700"></div>
+
   <h2 class="mt-6 font-semibold">{% trans 'Membros' %}</h2>
   <ul>
     {% for part in membros_ativos %}
@@ -138,3 +140,27 @@
     <div id="modal"></div>
   </section>
   {% endblock %}
+
+{% block extra_js %}
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+  const statusEl = document.getElementById('membro-status');
+  if (!statusEl) return;
+  const url = "{% url 'nucleos_api:nucleo-membro-status' object.pk %}";
+  function updateStatus() {
+    fetch(url)
+      .then(resp => resp.ok ? resp.json() : null)
+      .then(data => {
+        if (!data) return;
+        let papel = data.papel === 'coordenador' ? 'Coordenador' : 'Membro';
+        let status = data.ativo ? 'Ativo' : 'Inativo';
+        if (data.suspenso) status += ' (Suspenso)';
+        statusEl.textContent = papel + ' - ' + status;
+      })
+      .catch(() => {});
+  }
+  updateStatus();
+  document.body.addEventListener('htmx:afterRequest', updateStatus);
+});
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Adiciona elemento na página de núcleo para mostrar papel e status do membro
- Consome `nucleos_api:nucleo-membro-status` via JavaScript e atualiza papel/estado dinamicamente

## Testing
- `pytest --no-cov tests/nucleos/test_suspensao.py::test_membro_status_endpoint -q`


------
https://chatgpt.com/codex/tasks/task_e_68a642eaacf08325ac84059bbc2d834b