### PR TITLE
feat: add 'Meus Núcleos' listing

### DIFF
--- a/nucleos/README.md
+++ b/nucleos/README.md
@@ -3,6 +3,7 @@
 Views principais:
 
 - `nucleos:list` – lista núcleos ativos com busca por nome ou *slug*.
+- `nucleos:meus` – exibe apenas os núcleos dos quais o usuário participa.
 - `nucleos:create` – criação de núcleo vinculado à organização do usuário.
 - `nucleos:update` – edição de dados básicos do núcleo.
 - `nucleos:toggle_active` – inativa ou reativa um núcleo.

--- a/nucleos/templates/nucleos/meus_list.html
+++ b/nucleos/templates/nucleos/meus_list.html
@@ -1,19 +1,19 @@
 {% extends 'base.html' %}
 {% load i18n %}
 
-{% block title %}{% trans "Núcleos" %}{% endblock %}
+{% block title %}{% trans "Meus Núcleos" %}{% endblock %}
 
 {% block content %}
 <section class="max-w-5xl mx-auto py-8">
-  <h1 class="text-2xl font-bold mb-4">{% trans "Núcleos" %}</h1>
+  <div class="flex items-center justify-between mb-4">
+    <h1 class="text-2xl font-bold">{% trans "Meus Núcleos" %}</h1>
+    <a href="{% url 'nucleos:list' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100" aria-label="{% trans 'Ver todos os núcleos' %}">{% trans "Todos os Núcleos" %}</a>
+  </div>
   <form method="get" class="mb-4 flex gap-2">
     <input type="text" name="q" value="{{ form.q.value }}" placeholder="{% trans 'Buscar...' %}" class="border rounded px-2 py-1 flex-1" />
     <button class="px-3 py-1 bg-blue-600 text-white rounded" aria-label="{% trans 'Buscar núcleos' %}">{% trans 'Buscar' %}</button>
   </form>
-  <div class="mb-4">
-    <a href="{% url 'nucleos:meus' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100" aria-label="{% trans 'Ver meus núcleos' %}">{% trans 'Meus Núcleos' %}</a>
-  </div>
-  {% if request.user.user_type in ('admin', 'root') %}
+    {% if request.user.user_type == 'admin' or request.user.user_type == 'root' %}
   <div class="mb-4">
     <a href="{% url 'nucleos:create' %}" class="px-3 py-2 bg-green-600 text-white rounded" aria-label="{% trans 'Criar novo núcleo' %}">{% trans 'Novo' %}</a>
   </div>
@@ -37,7 +37,7 @@
       <p class="text-sm mt-2">{% trans "Membros" %}: {{ nucleo.membros_count }}</p>
       <div class="mt-2">
         <a href="{% url 'nucleos:detail' nucleo.pk %}" class="text-blue-600" aria-label="{% blocktrans with nome=nucleo.nome %}Ver detalhes do núcleo {{ nome }}{% endblocktrans %}">{% trans 'Detalhes' %}</a>
-        {% if request.user.user_type in ('admin', 'root') %}
+          {% if request.user.user_type == 'admin' or request.user.user_type == 'root' %}
         <form method="post" action="{% url 'nucleos:delete' nucleo.pk %}" class="inline">{% csrf_token %}
           <button class="text-red-600 ml-2" aria-label="{% blocktrans with nome=nucleo.nome %}Excluir núcleo {{ nome }}{% endblocktrans %}">{% trans 'Excluir' %}</button>
         </form>

--- a/nucleos/urls.py
+++ b/nucleos/urls.py
@@ -6,6 +6,7 @@ app_name = "nucleos"
 
 urlpatterns = [
     path("", views.NucleoListView.as_view(), name="list"),
+    path("meus/", views.NucleoMeusView.as_view(), name="meus"),
     path("novo/", views.NucleoCreateView.as_view(), name="create"),
     path("<int:pk>/", views.NucleoDetailView.as_view(), name="detail"),
     path("<int:pk>/metrics/", views.NucleoMetricsView.as_view(), name="metrics"),

--- a/templates/base.html
+++ b/templates/base.html
@@ -115,6 +115,9 @@
         <a href="{% url 'nucleos:list' %}" class="flex items-center gap-x-2 hover:text-primary transition">
           <i class="fas fa-users"></i> {% trans "Núcleos" %}
         </a>
+        <a href="{% url 'nucleos:meus' %}" class="flex items-center gap-x-2 hover:text-primary transition">
+          <i class="fas fa-user-group"></i> {% trans "Meus Núcleos" %}
+        </a>
         {% if user.is_authenticated %}
         {% if user.user_type == 'financeiro' or user.user_type == 'admin' %}
         <a href="{% url 'financeiro:repasses' %}" class="flex items-center gap-x-2 hover:text-primary transition">

--- a/tests/nucleos/test_views.py
+++ b/tests/nucleos/test_views.py
@@ -214,3 +214,14 @@ def test_suplente_create_success(client, admin_user, membro_user, organizacao):
     assert CoordenadorSuplente.objects.filter(
         nucleo=nucleo, usuario=membro_user
     ).exists()
+
+
+def test_meus_nucleos_view(client, membro_user, organizacao):
+    nucleo1 = Nucleo.objects.create(nome="N1", slug="n1", organizacao=organizacao)
+    nucleo2 = Nucleo.objects.create(nome="N2", slug="n2", organizacao=organizacao)
+    ParticipacaoNucleo.objects.create(nucleo=nucleo1, user=membro_user, status="ativo")
+    ParticipacaoNucleo.objects.create(nucleo=nucleo2, user=membro_user, status="inativo")
+    client.force_login(membro_user)
+    resp = client.get(reverse("nucleos:meus"))
+    assert resp.status_code == 200
+    assert list(resp.context["object_list"]) == [nucleo1]


### PR DESCRIPTION
## Summary
- implement NucleoMeusView to list nuclei for the current user
- add templates and navigation link for "Meus Núcleos"
- document and test the new view

## Testing
- `pytest tests/nucleos/test_views.py::test_meus_nucleos_view --no-cov -q`


------
https://chatgpt.com/codex/tasks/task_e_68a642ee72048325bc00f7a0d99219fd