### PR TITLE
Restrict organization admin actions to root users

### DIFF
--- a/organizacoes/templates/organizacoes/detail.html
+++ b/organizacoes/templates/organizacoes/detail.html
@@ -82,7 +82,7 @@
     {% if perms.organizacoes.delete_organizacao %}
       <a href="{% url 'organizacoes:delete' object.id %}" class="text-sm px-4 py-2 rounded-xl bg-red-100 text-red-700 hover:bg-red-200">{% trans 'Excluir' %}</a>
     {% endif %}
-    {% if request.user.user_type == 'root' or request.user.user_type == 'admin' and request.user.organizacao_id == object.id %}
+    {% if request.user.user_type == 'root' %}
       <form method="post" action="{% url 'organizacoes:toggle' object.id %}">
         {% csrf_token %}
         <button type="submit" class="text-sm px-4 py-2 rounded-xl bg-neutral-100 text-neutral-700 hover:bg-neutral-200">

--- a/organizacoes/templates/organizacoes/partials/empresas_list.html
+++ b/organizacoes/templates/organizacoes/partials/empresas_list.html
@@ -7,6 +7,6 @@
     <li class="list-none text-neutral-500">{% trans 'Nenhuma empresa associada.' %}</li>
   {% endfor %}
 </ul>
-{% if request.user.user_type == 'root' or request.user.user_type == 'admin' %}
+{% if request.user.user_type == 'root' %}
 <a href="#" class="mt-2 inline-block text-sm text-primary-600 hover:underline" hx-get="{% url 'organizacoes:empresas_modal' object.id %}" hx-target="#modal">{% trans 'Adicionar/Remover' %}</a>
 {% endif %}

--- a/organizacoes/templates/organizacoes/partials/eventos_list.html
+++ b/organizacoes/templates/organizacoes/partials/eventos_list.html
@@ -7,6 +7,6 @@
     <li class="list-none text-neutral-500">{% trans 'Nenhum evento associado.' %}</li>
   {% endfor %}
 </ul>
-{% if request.user.user_type == 'root' or request.user.user_type == 'admin' %}
+{% if request.user.user_type == 'root' %}
 <a href="#" class="mt-2 inline-block text-sm text-primary-600 hover:underline" hx-get="{% url 'organizacoes:eventos_modal' object.id %}" hx-target="#modal">{% trans 'Adicionar/Remover' %}</a>
 {% endif %}

--- a/organizacoes/templates/organizacoes/partials/nucleos_list.html
+++ b/organizacoes/templates/organizacoes/partials/nucleos_list.html
@@ -7,6 +7,6 @@
     <li class="list-none text-neutral-500">{% trans 'Nenhum núcleo associado.' %}</li>
   {% endfor %}
 </ul>
-{% if request.user.user_type == 'root' or request.user.user_type == 'admin' %}
+{% if request.user.user_type == 'root' %}
 <a href="#" class="mt-2 inline-block text-sm text-primary-600 hover:underline" hx-get="{% url 'organizacoes:nucleos_modal' object.id %}" hx-target="#modal">{% trans 'Adicionar/Remover' %}</a>
 {% endif %}

--- a/organizacoes/templates/organizacoes/partials/posts_list.html
+++ b/organizacoes/templates/organizacoes/partials/posts_list.html
@@ -7,6 +7,6 @@
     <li class="list-none text-neutral-500">{% trans 'Nenhum post associado.' %}</li>
   {% endfor %}
 </ul>
-{% if request.user.user_type == 'root' or request.user.user_type == 'admin' %}
+{% if request.user.user_type == 'root' %}
 <a href="#" class="mt-2 inline-block text-sm text-primary-600 hover:underline" hx-get="{% url 'organizacoes:posts_modal' object.id %}" hx-target="#modal">{% trans 'Adicionar/Remover' %}</a>
 {% endif %}

--- a/organizacoes/templates/organizacoes/partials/usuarios_list.html
+++ b/organizacoes/templates/organizacoes/partials/usuarios_list.html
@@ -7,6 +7,6 @@
     <li class="list-none text-neutral-500">{% trans 'Nenhum usuário associado.' %}</li>
   {% endfor %}
 </ul>
-{% if request.user.user_type == 'root' or request.user.user_type == 'admin' %}
+{% if request.user.user_type == 'root' %}
 <a href="#" class="mt-2 inline-block text-sm text-primary-600 hover:underline" hx-get="{% url 'organizacoes:usuarios_modal' object.id %}" hx-target="#modal">{% trans 'Adicionar/Remover' %}</a>
 {% endif %}


### PR DESCRIPTION
## Summary
- show organization inactivation and history options only for root users
- limit add/remove links in organization lists to root users

## Testing
- `pytest` *(fails: tests/configuracoes/test_accessibility.py, tests/dashboard/test_views.py, tests/e2e/test_notificacoes_e2e.py, tests/e2e/test_pwa_offline.py, tests/feed/test_services.py, tests/notificacoes/test_clients.py, tests/notificacoes/test_push_sender.py, tests/test_i18n_templates.py, tests/tokens/test_metrics.py)*


------
https://chatgpt.com/codex/tasks/task_e_68a64702825883259eec52b3174e2455