### PR TITLE
Renomeia parâmetros de busca e ordenação na listagem de organizações

### DIFF
--- a/organizacoes/templates/organizacoes/list.html
+++ b/organizacoes/templates/organizacoes/list.html
@@ -22,7 +22,7 @@
   </div>
 
   <form hx-get="{% url 'organizacoes:list' %}" hx-target="#org-list" hx-push-url="true" class="mb-6 grid md:grid-cols-6 gap-2">
-    <input type="text" name="q" value="{{ request.GET.q }}" placeholder="{% trans 'Buscar por nome ou slug' %}" class="w-full p-2 border rounded-lg" />
+    <input type="text" name="search" value="{{ request.GET.search }}" placeholder="{% trans 'Buscar por nome ou slug' %}" class="w-full p-2 border rounded-lg" />
     <select name="tipo" class="w-full p-2 border rounded-lg">
       <option value="">{% trans 'Tipo' %}</option>
       {% for value, label in tipos %}
@@ -46,11 +46,11 @@
       <option value="false" {% if inativa == 'false' %}selected{% endif %}>{% trans 'Ativas' %}</option>
       <option value="true" {% if inativa == 'true' %}selected{% endif %}>{% trans 'Inativas' %}</option>
     </select>
-    <select name="order" class="w-full p-2 border rounded-lg">
-      <option value="nome" {% if request.GET.order == 'nome' or not request.GET.order %}selected{% endif %}>{% trans 'Nome' %}</option>
-      <option value="tipo" {% if request.GET.order == 'tipo' %}selected{% endif %}>{% trans 'Tipo' %}</option>
-      <option value="cidade" {% if request.GET.order == 'cidade' %}selected{% endif %}>{% trans 'Localização' %}</option>
-      <option value="created_at" {% if request.GET.order == 'created_at' %}selected{% endif %}>{% trans 'Data' %}</option>
+    <select name="ordering" class="w-full p-2 border rounded-lg">
+      <option value="nome" {% if request.GET.ordering == 'nome' or not request.GET.ordering %}selected{% endif %}>{% trans 'Nome' %}</option>
+      <option value="tipo" {% if request.GET.ordering == 'tipo' %}selected{% endif %}>{% trans 'Tipo' %}</option>
+      <option value="cidade" {% if request.GET.ordering == 'cidade' %}selected{% endif %}>{% trans 'Localização' %}</option>
+      <option value="created_at" {% if request.GET.ordering == 'created_at' %}selected{% endif %}>{% trans 'Data' %}</option>
     </select>
     <div class="md:col-span-6 flex justify-end">
       <button type="submit" class="px-4 py-2 bg-primary-600 text-white rounded-lg">{% trans 'Filtrar' %}</button>
@@ -116,11 +116,11 @@
     </div>
     <div class="mt-6 flex justify-center gap-2">
       {% if page_obj.has_previous %}
-        <a hx-get="?page={{ page_obj.previous_page_number }}{% if request.GET.q %}&q={{ request.GET.q }}{% endif %}{% if request.GET.tipo %}&tipo={{ request.GET.tipo }}{% endif %}{% if request.GET.cidade %}&cidade={{ request.GET.cidade }}{% endif %}{% if request.GET.estado %}&estado={{ request.GET.estado }}{% endif %}{% if request.GET.order %}&order={{ request.GET.order }}{% endif %}{% if inativa %}&inativa={{ inativa }}{% endif %}" hx-target="#org-list" hx-push-url="true" class="px-3 py-1 border rounded" aria-label="{% trans 'Anterior' %}">{% trans 'Anterior' %}</a>
+        <a hx-get="?page={{ page_obj.previous_page_number }}{% if request.GET.search %}&search={{ request.GET.search }}{% endif %}{% if request.GET.tipo %}&tipo={{ request.GET.tipo }}{% endif %}{% if request.GET.cidade %}&cidade={{ request.GET.cidade }}{% endif %}{% if request.GET.estado %}&estado={{ request.GET.estado }}{% endif %}{% if request.GET.ordering %}&ordering={{ request.GET.ordering }}{% endif %}{% if inativa %}&inativa={{ inativa }}{% endif %}" hx-target="#org-list" hx-push-url="true" class="px-3 py-1 border rounded" aria-label="{% trans 'Anterior' %}">{% trans 'Anterior' %}</a>
       {% endif %}
       <span class="px-3 py-1">{{ page_obj.number }} / {{ page_obj.paginator.num_pages }}</span>
       {% if page_obj.has_next %}
-        <a hx-get="?page={{ page_obj.next_page_number }}{% if request.GET.q %}&q={{ request.GET.q }}{% endif %}{% if request.GET.tipo %}&tipo={{ request.GET.tipo }}{% endif %}{% if request.GET.cidade %}&cidade={{ request.GET.cidade }}{% endif %}{% if request.GET.estado %}&estado={{ request.GET.estado }}{% endif %}{% if request.GET.order %}&order={{ request.GET.order }}{% endif %}{% if inativa %}&inativa={{ inativa }}{% endif %}" hx-target="#org-list" hx-push-url="true" class="px-3 py-1 border rounded" aria-label="{% trans 'Próxima' %}">{% trans 'Próxima' %}</a>
+        <a hx-get="?page={{ page_obj.next_page_number }}{% if request.GET.search %}&search={{ request.GET.search }}{% endif %}{% if request.GET.tipo %}&tipo={{ request.GET.tipo }}{% endif %}{% if request.GET.cidade %}&cidade={{ request.GET.cidade }}{% endif %}{% if request.GET.estado %}&estado={{ request.GET.estado }}{% endif %}{% if request.GET.ordering %}&ordering={{ request.GET.ordering }}{% endif %}{% if inativa %}&inativa={{ inativa }}{% endif %}" hx-target="#org-list" hx-push-url="true" class="px-3 py-1 border rounded" aria-label="{% trans 'Próxima' %}">{% trans 'Próxima' %}</a>
       {% endif %}
     </div>
   {% else %}

--- a/organizacoes/views.py
+++ b/organizacoes/views.py
@@ -45,11 +45,11 @@ class OrganizacaoListView(AdminRequiredMixin, LoginRequiredMixin, ListView):
             .select_related("created_by")
             .prefetch_related("evento_set", "nucleos", "users")
         )
-        query = self.request.GET.get("q")
+        search = self.request.GET.get("search")
         tipo = self.request.GET.get("tipo")
         cidade = self.request.GET.get("cidade")
         estado = self.request.GET.get("estado")
-        order = self.request.GET.get("order", "nome")
+        ordering = self.request.GET.get("ordering", "nome")
         inativa = self.request.GET.get("inativa")
 
         if inativa is not None and inativa != "":
@@ -57,8 +57,8 @@ class OrganizacaoListView(AdminRequiredMixin, LoginRequiredMixin, ListView):
         else:
             qs = qs.filter(inativa=False)
 
-        if query:
-            qs = qs.filter(Q(nome__icontains=query) | Q(slug__icontains=query))
+        if search:
+            qs = qs.filter(Q(nome__icontains=search) | Q(slug__icontains=search))
         if tipo:
             qs = qs.filter(tipo=tipo)
         if cidade:
@@ -67,9 +67,9 @@ class OrganizacaoListView(AdminRequiredMixin, LoginRequiredMixin, ListView):
             qs = qs.filter(estado=estado)
 
         allowed_order = {"nome", "tipo", "cidade", "estado", "created_at"}
-        if order not in allowed_order:
-            order = "nome"
-        return qs.order_by(order)
+        if ordering not in allowed_order:
+            ordering = "nome"
+        return qs.order_by(ordering)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)


### PR DESCRIPTION
## Summary
- renomeia parâmetros de busca e ordenação no template de organizações
- atualiza `OrganizacaoListView` para usar `search` e `ordering`

## Testing
- `pytest tests/organizacoes/test_views.py::test_list_view_superadmin -q` *(interrompido por KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68a64702a2d08325beac67293015b858