### PR TITLE
Restrict organization history to root users

### DIFF
--- a/organizacoes/views.py
+++ b/organizacoes/views.py
@@ -26,7 +26,7 @@ from feed.models import Post
 from nucleos.models import Nucleo
 
 from .forms import OrganizacaoForm
-from .models import Organizacao, OrganizacaoChangeLog
+from .models import Organizacao, OrganizacaoChangeLog, OrganizacaoAtividadeLog
 from .services import registrar_log, serialize_organizacao
 from .tasks import organizacao_alterada
 
@@ -272,13 +272,6 @@ class OrganizacaoHistoryView(LoginRequiredMixin, View):
             user.is_superuser
             or getattr(user, "user_type", None) == UserType.ROOT.value
             or user.get_tipo_usuario == UserType.ROOT.value
-            or (
-                (
-                    user.get_tipo_usuario == UserType.ADMIN.value
-                    or getattr(user, "user_type", None) == UserType.ADMIN.value
-                )
-                and getattr(user, "organizacao_id", None) == org.id
-            )
         ):
             return HttpResponseForbidden()
         if request.GET.get("export") == "csv":

--- a/tests/organizacoes/test_views.py
+++ b/tests/organizacoes/test_views.py
@@ -247,7 +247,7 @@ def test_toggle_denied_for_admin(admin_user, organizacao):
 def test_logs_view_permission(superadmin_user, admin_user, organizacao):
     url = reverse("organizacoes:historico", args=[organizacao.pk])
     assert superadmin_user.get(url).status_code == 200
-    assert admin_user.get(url).status_code == 200
+    assert admin_user.get(url).status_code == 403
 
 
 def test_signal_emitted_on_create(monkeypatch, superadmin_user, faker_ptbr):


### PR DESCRIPTION
## Summary
- Only root/superuser may access organization history
- Cover admin vs root access in integration tests

## Testing
- `pytest -p no:cov --override-ini=addopts='' tests/organizacoes/test_views.py::test_logs_view_permission -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6470368c0832591d6d165d39b5c62