### PR TITLE
Validate invite token permissions before generation

### DIFF
--- a/tokens/views.py
+++ b/tokens/views.py
@@ -17,6 +17,7 @@ from django.views import View
 
 from accounts.models import SecurityEvent
 
+from . import services
 from .forms import (
     Ativar2FAForm,
     GerarCodigoAutenticacaoForm,
@@ -25,21 +26,10 @@ from .forms import (
     ValidarCodigoAutenticacaoForm,
     ValidarTokenConviteForm,
 )
-
-from .models import TokenAcesso, TokenUsoLog, TOTPDevice
-from .services import create_invite_token
-
-from accounts.models import SecurityEvent
-
-from .models import ApiToken, ApiTokenLog, TokenAcesso, TokenUsoLog, TOTPDevice
 from .metrics import tokens_invites_revoked_total
-from . import services
-
-from .models import TokenAcesso, TOTPDevice
+from .models import ApiToken, ApiTokenLog, TokenAcesso, TokenUsoLog, TOTPDevice
 from .perms import can_issue_invite
 from .services import create_invite_token
-
-
 
 User = get_user_model()
 
@@ -167,12 +157,6 @@ class GerarTokenConviteView(LoginRequiredMixin, View):
             return JsonResponse({"error": _("Não autorizado")}, status=403)
         form = GerarTokenConviteForm(request.POST, user=request.user)
         if form.is_valid():
-
-            token, codigo = create_invite_token(
-                gerado_por=request.user,
-                tipo_destino=form.cleaned_data["tipo_destino"]
-            )
-
             target_role = form.cleaned_data["tipo_destino"]
             if not can_issue_invite(request.user, target_role):
                 if request.headers.get("HX-Request") == "true":
@@ -207,7 +191,6 @@ class GerarTokenConviteView(LoginRequiredMixin, View):
             token, codigo = create_invite_token(
                 gerado_por=request.user,
                 tipo_destino=target_role,
-
                 data_expiracao=timezone.now() + timezone.timedelta(days=30),
                 organizacao=form.cleaned_data.get("organizacao"),
                 nucleos=form.cleaned_data["nucleos"],


### PR DESCRIPTION
## Summary
- check invite permissions and daily limit before generating token
- generate invite tokens only after all validations

## Testing
- `ruff format tokens/views.py`
- `isort tokens/views.py`
- `black tokens/views.py`
- `ruff check tokens/views.py`
- `pytest -m "not slow"` *(fails: tests/configuracoes/test_accessibility.py, tests/dashboard/test_views.py, tests/e2e/test_notificacoes_e2e.py, tests/e2e/test_pwa_offline.py, tests/feed/test_services.py, tests/notificacoes/test_clients.py, tests/notificacoes/test_push_sender.py, tests/test_i18n_templates.py, tests/tokens/test_metrics.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a64a43ae6c8325b7ff58ab6dc11580