### PR TITLE
Use HTTP 429 for daily invite limit

### DIFF
--- a/tokens/views.py
+++ b/tokens/views.py
@@ -199,10 +199,10 @@ class GerarTokenConviteView(LoginRequiredMixin, View):
                         request,
                         "tokens/_resultado.html",
                         {"error": _("Limite diário atingido.")},
-                        status=409,
+                        status=429,
                     )
                 messages.error(request, _("Limite diário atingido."))
-                return JsonResponse({"error": _("Limite diário atingido.")}, status=409)
+                return JsonResponse({"error": _("Limite diário atingido.")}, status=429)
 
             token, codigo = create_invite_token(
                 gerado_por=request.user,


### PR DESCRIPTION
## Summary
- return HTTP 429 when invite limit reached for htmx and API responses

## Testing
- `pytest` *(fails: 9 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a64a450ae8832588d3b590eed2af14