### PR TITLE
Remove duplicated imports in tokens modules

### DIFF
--- a/tokens/services.py
+++ b/tokens/services.py
@@ -3,28 +3,28 @@ from __future__ import annotations
 import hashlib
 import secrets
 import uuid
-from datetime import timedelta, datetime
-from typing import Callable, Iterable, Tuple
+from datetime import datetime, timedelta
+from typing import Iterable, Tuple
 
 from django.contrib.auth import get_user_model
 from django.utils import timezone
 
-
-from .models import ApiToken
 from .metrics import (
     tokens_api_tokens_created_total,
     tokens_api_tokens_revoked_total,
 )
-
 from .models import ApiToken, TokenAcesso
-
 
 User = get_user_model()
 
 
 # Callbacks para webhooks, sobrescritos em ``apps.py``
-token_created: Callable[[ApiToken, str], None] = lambda token, raw: None
-token_revoked: Callable[[ApiToken], None] = lambda token: None
+def token_created(token: ApiToken, raw: str) -> None:
+    pass
+
+
+def token_revoked(token: ApiToken) -> None:
+    pass
 
 
 def generate_token(
@@ -76,15 +76,6 @@ def list_tokens(user: User) -> Iterable[ApiToken]:
         qs = qs.filter(user=user)
     return qs
 
-
-
-from datetime import datetime
-from typing import Tuple
-
-from .models import TokenAcesso
-
-
-
 def create_invite_token(
     *,
     gerado_por: User,
@@ -107,7 +98,6 @@ def create_invite_token(
     if nucleos:
         token.nucleos.set(nucleos)
     return token, codigo
-
 
 def find_token_by_code(codigo: str) -> TokenAcesso:
     """Retorna o ``TokenAcesso`` correspondente ao ``codigo``.

--- a/tokens/views.py
+++ b/tokens/views.py
@@ -25,21 +25,10 @@ from .forms import (
     ValidarCodigoAutenticacaoForm,
     ValidarTokenConviteForm,
 )
-
-from .models import TokenAcesso, TokenUsoLog, TOTPDevice
-from .services import create_invite_token
-
-from accounts.models import SecurityEvent
-
-from .models import ApiToken, ApiTokenLog, TokenAcesso, TokenUsoLog, TOTPDevice
 from .metrics import tokens_invites_revoked_total
-from . import services
-
-from .models import TokenAcesso, TOTPDevice
+from .models import ApiToken, ApiTokenLog, TokenAcesso, TokenUsoLog, TOTPDevice
 from .perms import can_issue_invite
-from .services import create_invite_token
-
-
+from .services import create_invite_token, list_tokens, revoke_token
 
 User = get_user_model()
 
@@ -137,7 +126,7 @@ def revogar_convite(request, token_id: int):
 
 @login_required
 def listar_api_tokens(request):
-    tokens = services.list_tokens(request.user)
+    tokens = list_tokens(request.user)
     return render(request, "tokens/api_tokens.html", {"tokens": tokens})
 
 
@@ -147,7 +136,7 @@ def revogar_api_token(request, token_id: str):
     if token.revoked_at:
         messages.info(request, _("Token já revogado."))
     else:
-        services.revoke_token(token.id, revogado_por=request.user)
+        revoke_token(token.id, revogado_por=request.user)
         ApiTokenLog.objects.create(
             token=token,
             usuario=request.user,


### PR DESCRIPTION
## Summary
- deduplicate imports in token views and services modules
- replace lambda callbacks with defs in token services
- drop redundant service references in token views

## Testing
- `ruff check tokens/views.py tokens/services.py`
- `flake8 tokens/views.py tokens/services.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a64a4889f48325aa7cbfde925f4671