### PR TITLE
Refatora geração de convites

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -130,7 +130,7 @@
           <i class="fas fa-sitemap"></i> {% trans "Organizações" %}
         </a>
         {% endif %}
-        <a href="{% url 'tokens:gerar_token' %}" class="flex items-center gap-x-2 hover:text-primary transition">
+        <a href="{% url 'tokens:gerar_convite' %}" class="flex items-center gap-x-2 hover:text-primary transition">
           <i class="fas fa-key"></i> {% trans "Token" %}
         </a>
         {% if user.is_authenticated %}

--- a/tests/tokens/test_views.py
+++ b/tests/tokens/test_views.py
@@ -16,14 +16,18 @@ def _login(client, user):
     client.force_login(user)
 
 
-def test_gerar_token_view_creates_token(client):
-    user = UserFactory(is_staff=True)
+def test_gerar_convite_form_fields(client):
+    user = UserFactory(is_staff=True, user_type=UserType.ADMIN.value)
+    org = OrganizacaoFactory()
+    org.users.add(user)
+    NucleoFactory(organizacao=org)
     _login(client, user)
-    resp = client.post(reverse("tokens:gerar_token"), {"tipo_destino": TokenAcesso.TipoUsuario.ADMIN})
+    resp = client.get(reverse("tokens:gerar_convite"))
     assert resp.status_code == 200
-    token = TokenAcesso.objects.get(gerado_por=user)
-    assert token.tipo_destino == TokenAcesso.TipoUsuario.ADMIN
-    assert token.gerado_por == user
+    content = resp.content.decode()
+    assert "name=\"tipo_destino\"" in content
+    assert "name=\"organizacao\"" in content
+    assert "name=\"nucleos\"" in content
 
 
 def test_gerar_token_convite_view(client):

--- a/tokens/templates/tokens/gerar_token.html
+++ b/tokens/templates/tokens/gerar_token.html
@@ -9,8 +9,8 @@
     <p class="text-sm text-neutral-600 mt-2">{% trans "Use este token para convidar novos membros ou recuperar o acesso." %}</p>
   </header>
 
-  <form method="post" action="{% url 'tokens:gerar_token' %}"
-        hx-post="{% url 'tokens:gerar_token' %}"
+  <form method="post" action="{% url 'tokens:gerar_convite' %}"
+        hx-post="{% url 'tokens:gerar_convite' %}"
         hx-target="#resultado" hx-swap="innerHTML"
         class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 space-y-6">
     {% csrf_token %}

--- a/tokens/urls.py
+++ b/tokens/urls.py
@@ -6,7 +6,6 @@ app_name = "tokens"
 
 urlpatterns = [
     path("", views.token, name="token"),
-    path("gerar-token/", views.criar_token, name="gerar_token"),
     path("convites/", views.listar_convites, name="listar_convites"),
     path("convites/<int:token_id>/revogar/", views.revogar_convite, name="revogar_convite"),
     path("api-tokens/", views.listar_api_tokens, name="listar_api_tokens"),


### PR DESCRIPTION
## Summary
- encaminha formulário de geração de convites para nova URL
- move exibição do formulário para `GerarTokenConviteView`
- atualiza rotas, templates e testes

## Testing
- `pytest tests/tokens/test_views.py::test_gerar_convite_form_fields -q -x` *(fails: SyntaxError in organizacoes/views.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a64a437ba48325bd2c555fe25fb04b