### PR TITLE
Permitir reenvio de confirmação sem autenticação

### DIFF
--- a/accounts/api.py
+++ b/accounts/api.py
@@ -23,7 +23,7 @@ class AccountViewSet(viewsets.GenericViewSet):
     serializer_class = UserSerializer
 
     def get_permissions(self):
-        if self.action in {"delete_me", "cancel_delete", "enable_2fa", "disable_2fa", "resend_confirmation"}:
+        if self.action in {"delete_me", "cancel_delete", "enable_2fa", "disable_2fa"}:
             return [IsAuthenticated()]
         return [AllowAny()]
 
@@ -49,7 +49,13 @@ class AccountViewSet(viewsets.GenericViewSet):
 
     @action(detail=False, methods=["post"], url_path="resend-confirmation")
     def resend_confirmation(self, request):
-        user = request.user
+        email = request.data.get("email")
+        if not email:
+            return Response({"detail": _("Email ausente.")}, status=400)
+        try:
+            user = User.objects.get(email__iexact=email)
+        except User.DoesNotExist:
+            return Response(status=204)
         if user.is_active:
             return Response({"detail": _("Conta já ativada.")}, status=400)
         token = AccountToken.objects.create(

--- a/docs/accounts/registro_multietapas.md
+++ b/docs/accounts/registro_multietapas.md
@@ -40,3 +40,15 @@ dos elementos segue fluxo lógico para navegação assistida.
 Após concluir o cadastro, o usuário pode solicitar novo e‑mail de confirmação.
 Tokens antigos são marcados como usados e não podem ser reutilizados.
 
+**Endpoint**: `POST /api/accounts/resend-confirmation/`
+
+```json
+{
+  "email": "usuario@example.com"
+}
+```
+
+O endpoint não exige autenticação e retorna `204 No Content` mesmo quando o e‑mail
+não existir. Caso a conta já esteja ativa, é retornado `400` com a mensagem
+`"Conta já ativada."`.
+

--- a/tests/accounts/test_email_confirmation.py
+++ b/tests/accounts/test_email_confirmation.py
@@ -15,9 +15,8 @@ def test_resend_and_confirm_email(settings, mailoutbox):
     settings.CELERY_TASK_ALWAYS_EAGER = True
     user = User.objects.create_user(email="a@example.com", username="a", is_active=False)
     client = APIClient()
-    client.force_authenticate(user=user)
     url = reverse("accounts_api:account-resend-confirmation")
-    resp = client.post(url)
+    resp = client.post(url, {"email": user.email})
     assert resp.status_code == 204
     token = AccountToken.objects.filter(usuario=user, tipo=AccountToken.Tipo.EMAIL_CONFIRMATION).latest("created_at")
     assert token.expires_at > timezone.now()

--- a/tests/accounts/test_security_events.py
+++ b/tests/accounts/test_security_events.py
@@ -68,8 +68,7 @@ def test_reset_password_logs_security_event():
 def test_resend_confirmation_logs_security_event():
     user = User.objects.create_user(email="inactive@example.com", username="i", is_active=False)
     client = APIClient()
-    client.force_authenticate(user=user)
-    resp = client.post(reverse("accounts_api:account-resend-confirmation"))
+    resp = client.post(reverse("accounts_api:account-resend-confirmation"), {"email": user.email})
     assert resp.status_code == 204
     assert SecurityEvent.objects.filter(usuario=user, evento="resend_confirmation").exists()
 


### PR DESCRIPTION
## Summary
- Allow unauthenticated users to resend email confirmation tokens by email
- Document new resend-confirmation endpoint and update tests

## Testing
- `pytest tests/accounts/test_email_confirmation.py tests/accounts/test_security_events.py -q --nomigrations --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68a6523a79088325856fa674ab761d2c