### PR TITLE
style(financeiro): improve task log templates

### DIFF
--- a/financeiro/templates/financeiro/task_log_detail.html
+++ b/financeiro/templates/financeiro/task_log_detail.html
@@ -4,13 +4,16 @@
 {% block title %}{{ _('Detalhes da Tarefa Financeira') }}{% endblock %}
 
 {% block content %}
-<section class="max-w-3xl mx-auto p-4 space-y-4">
-  <h1 class="text-2xl font-semibold mb-2">{{ log.nome_tarefa }}</h1>
-  <p><strong>{{ _('Executada em') }}:</strong> {{ log.executada_em|date:SHORT_DATETIME_FORMAT }}</p>
-  <p><strong>{{ _('Status') }}:</strong> {{ log.status }}</p>
+<section class="max-w-screen-xl mx-auto pt-8 px-6 lg:px-8 space-y-6">
+  <a href="{% url 'financeiro:task_logs' %}" class="text-sm text-primary hover:underline">&larr; {% trans 'Voltar para tarefas' %}</a>
+  <h1 class="text-2xl font-bold text-neutral-900">{{ log.nome_tarefa }}</h1>
+  <div class="text-sm text-neutral-600 space-y-1">
+    <p><span class="font-medium">{{ _('Executada em') }}:</span> {{ log.executada_em|date:SHORT_DATETIME_FORMAT }}</p>
+    <p><span class="font-medium">{{ _('Status') }}:</span> {{ log.status }}</p>
+  </div>
   <div>
-    <h2 class="text-xl font-semibold">{{ _('Detalhes') }}</h2>
-    <pre class="whitespace-pre-wrap bg-gray-100 p-2 rounded">{{ log.detalhes|default:_('Sem detalhes') }}</pre>
+    <h2 class="text-xl font-semibold mb-2">{{ _('Detalhes') }}</h2>
+    <pre class="whitespace-pre-wrap bg-neutral-100 border border-neutral-200 rounded-2xl p-4 text-sm">{{ log.detalhes|default:_('Sem detalhes') }}</pre>
   </div>
 </section>
 {% endblock %}

--- a/financeiro/templates/financeiro/task_logs.html
+++ b/financeiro/templates/financeiro/task_logs.html
@@ -4,32 +4,34 @@
 {% block title %}{{ _('Histórico de Tarefas Financeiras') }}{% endblock %}
 
 {% block content %}
-<section class="max-w-5xl mx-auto p-4 space-y-4">
-  <h1 class="text-2xl font-semibold mb-2">{{ _('Histórico de Tarefas Financeiras') }}</h1>
-  <table class="min-w-full border">
-    <thead>
-      <tr>
-        <th class="px-4 py-2 text-left">{{ _('Tarefa') }}</th>
-        <th class="px-4 py-2 text-left">{{ _('Data') }}</th>
-        <th class="px-4 py-2 text-left">{{ _('Status') }}</th>
-        <th class="px-4 py-2 text-left">{{ _('Detalhes') }}</th>
-      </tr>
-    </thead>
-    <tbody>
-      {% for log in logs %}
-      <tr>
-        <td class="border px-4 py-2">{{ log.nome_tarefa }}</td>
-        <td class="border px-4 py-2">{{ log.executada_em|date:SHORT_DATETIME_FORMAT }}</td>
-        <td class="border px-4 py-2">{{ log.status }}</td>
-        <td class="border px-4 py-2"><a class="text-primary underline" href="{% url 'financeiro:task_log_detail' log.id %}">{{ _('Ver') }}</a></td>
-      </tr>
-      {% empty %}
-      <tr>
-        <td colspan="4" class="border px-4 py-2 text-center">{{ _('Nenhum registro encontrado') }}</td>
-      </tr>
-      {% endfor %}
-    </tbody>
-  </table>
+<section class="max-w-screen-xl mx-auto pt-8 px-6 lg:px-8">
+  <h1 class="text-2xl font-bold text-neutral-900 mb-6">{{ _('Histórico de Tarefas Financeiras') }}</h1>
+  <div class="overflow-x-auto bg-white border border-neutral-200 rounded-2xl shadow-sm">
+    <table class="min-w-full divide-y divide-neutral-200 text-sm">
+      <thead class="bg-neutral-50">
+        <tr>
+          <th class="px-4 py-2 text-left font-medium text-neutral-700">{{ _('Tarefa') }}</th>
+          <th class="px-4 py-2 text-left font-medium text-neutral-700">{{ _('Data') }}</th>
+          <th class="px-4 py-2 text-left font-medium text-neutral-700">{{ _('Status') }}</th>
+          <th class="px-4 py-2 text-left font-medium text-neutral-700">{{ _('Detalhes') }}</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-neutral-200">
+        {% for log in logs %}
+        <tr>
+          <td class="px-4 py-2">{{ log.nome_tarefa }}</td>
+          <td class="px-4 py-2">{{ log.executada_em|date:SHORT_DATETIME_FORMAT }}</td>
+          <td class="px-4 py-2">{{ log.status }}</td>
+          <td class="px-4 py-2"><a class="text-primary underline" href="{% url 'financeiro:task_log_detail' log.id %}">{{ _('Ver') }}</a></td>
+        </tr>
+        {% empty %}
+        <tr>
+          <td colspan="4" class="px-4 py-2 text-center text-neutral-600">{{ _('Nenhum registro encontrado') }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
 </section>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- wrap finance task log pages in responsive sections
- style headings, metadata, and tables with Tailwind
- add back link to task list

## Testing
- `pytest financeiro/tests/test_logs_api.py` *(fails: Conflicting migrations, coverage < 90%)*

------
https://chatgpt.com/codex/tasks/task_e_68a654d1cf3883258cf160fa40885c68