### PR TITLE
Refactor briefing form template

### DIFF
--- a/agenda/templates/agenda/briefing_form.html
+++ b/agenda/templates/agenda/briefing_form.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load i18n %}
+{% load i18n widget_tweaks %}
 {% block title %}{% if object %}{% trans "Editar Briefing" %}{% else %}{% trans "Novo Briefing" %}{% endif %} | Hubx{% endblock %}
 
 {% block content %}
@@ -9,7 +9,22 @@
   </h1>
   <form method="post" class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 space-y-6">
     {% csrf_token %}
-    {{ form.as_p }}
+    {{ form.non_field_errors }}
+    {% for field in form %}
+    <div>
+      <label for="{{ field.id_for_label }}" class="block text-sm font-medium text-neutral-700 mb-1">
+        {{ field.label }}
+      </label>
+      {% if field.name == 'evento' %}
+        {{ field|add_class:'form-select' }}
+      {% else %}
+        {{ field|add_class:'form-textarea' }}
+      {% endif %}
+      {% if field.errors %}
+        <p class="text-sm text-red-600 mt-1">{{ field.errors }}</p>
+      {% endif %}
+    </div>
+    {% endfor %}
     <div class="flex justify-end gap-3 pt-4 border-t border-neutral-100">
       <a href="{% url 'agenda:briefing_list' %}" class="btn-secondary" aria-label="{% trans 'Cancelar' %}">{% trans 'Cancelar' %}</a>
       <button type="submit" class="btn-primary" aria-label="{% trans 'Salvar' %}">{% trans 'Salvar' %}</button>


### PR DESCRIPTION
## Summary
- replace `form.as_p` with explicit field blocks
- add Tailwind utility classes to briefing form inputs and labels

## Testing
- `pytest tests/agenda/test_briefing.py tests/agenda/test_briefing_status.py -q` *(fails: Conflicting migrations detected; multiple leaf nodes in migration graph)*

------
https://chatgpt.com/codex/tasks/task_e_68a654cf15fc8325b5d624310f0366a7