### PR TITLE
Add event feedback form after event completion

### DIFF
--- a/agenda/templates/agenda/detail.html
+++ b/agenda/templates/agenda/detail.html
@@ -61,7 +61,24 @@
         <div class="mb-10 space-y-4">
           <img src="{{ inscricao.qrcode_url }}" alt="{% trans 'QR Code da inscrição' %}" class="mx-auto h-48 w-48" />
           {% if avaliacao_permitida %}
-            <a href="{% url 'agenda:evento_feedback' object.pk %}" class="btn-primary" aria-label="{% trans 'Avaliar evento' %}">{% trans "Avaliar evento" %}</a>
+            <form method="post" action="{% url 'agenda:evento_feedback' object.pk %}" class="space-y-4">
+              {% csrf_token %}
+              <div>
+                <label for="nota" class="block text-sm font-medium">{% trans "Nota" %}</label>
+                <select id="nota" name="nota" class="form-select w-full" required>
+                  {% for n in '12345' %}
+                  <option value="{{ n }}">{{ n }}</option>
+                  {% endfor %}
+                </select>
+              </div>
+              <div>
+                <label for="comentario" class="block text-sm font-medium">{% trans "Comentário" %}</label>
+                <textarea id="comentario" name="comentario" rows="4" class="form-textarea w-full" placeholder="{% trans 'Opcional' %}"></textarea>
+              </div>
+              <div class="text-right">
+                <button type="submit" class="btn-primary" aria-label="{% trans 'Enviar avaliação' %}">{% trans 'Enviar avaliação' %}</button>
+              </div>
+            </form>
           {% else %}
             <form method="post" action="{% url 'agenda:evento_subscribe' object.pk %}">
               {% csrf_token %}

--- a/agenda/views.py
+++ b/agenda/views.py
@@ -440,6 +440,22 @@ class EventoRemoveInscritoView(LoginRequiredMixin, NoSuperadminMixin, GerenteReq
 class EventoFeedbackView(LoginRequiredMixin, View):
     """Registra feedback pós-evento."""
 
+    def get(self, request, pk):
+        evento = get_object_or_404(_queryset_por_organizacao(request), pk=pk)
+        usuario = request.user
+
+        if not InscricaoEvento.objects.filter(
+            user=usuario, evento=evento, status="confirmada"
+        ).exists():
+            return HttpResponseForbidden("Apenas inscritos podem enviar feedback.")
+
+        if timezone.now() < evento.data_fim:
+            return HttpResponseForbidden(
+                "Feedback só pode ser enviado após o evento."
+            )
+
+        return render(request, "agenda/avaliacao_form.html", {"evento": evento})
+
     def post(self, request, pk):
         evento = get_object_or_404(_queryset_por_organizacao(request), pk=pk)
         usuario = request.user

--- a/tests/agenda/test_avaliacao.py
+++ b/tests/agenda/test_avaliacao.py
@@ -62,7 +62,7 @@ def test_avaliacao_permitida_pos_evento(client, usuario, organizacao):
     response = client.get(reverse("agenda:evento_detalhe", args=[evento.pk]))
     assert response.status_code == 200
     assert response.context["avaliacao_permitida"] is True
-    assert "Avaliar evento" in response.content.decode()
+    assert "Enviar avaliação" in response.content.decode()
 
 
 def test_avaliacao_negada_evento_future(client, usuario, organizacao):
@@ -82,4 +82,4 @@ def test_avaliacao_negada_evento_future(client, usuario, organizacao):
     response = client.get(reverse("agenda:evento_detalhe", args=[evento.pk]))
     assert response.status_code == 200
     assert response.context["avaliacao_permitida"] is False
-    assert "Avaliar evento" not in response.content.decode()
+    assert "Enviar avaliação" not in response.content.decode()


### PR DESCRIPTION
## Summary
- allow participants to access feedback form via GET and submit evaluations
- embed feedback form in event detail page for confirmed attendees
- adjust tests for feedback availability

## Testing
- `pytest tests/agenda/test_avaliacao.py::test_avaliacao_permitida_pos_evento` *(fails: Conflicting migrations detected; multiple leaf nodes in the migration graph: (0009_alter_apitoken_expires_at, 0009_codigoautenticacaolog in tokens))*


------
https://chatgpt.com/codex/tasks/task_e_68a654c8eccc8325b7cb2143f4c14468