### PR TITLE
Remove duplicate field loop in event create template

### DIFF
--- a/agenda/templates/agenda/create.html
+++ b/agenda/templates/agenda/create.html
@@ -11,28 +11,16 @@
 
     {{ form.non_field_errors }}
     {% for field in form %}
-    <div>
-      <label for="{{ field.id_for_label }}" class="block text-sm font-medium text-neutral-700 mb-1">
-        {{ field.label }}
-      </label>
-      {% if field.name == 'avatar' or field.name == 'cover' %}
-      {{ field.as_widget(attrs={'accept': 'image/*'}) }}
-      {% else %}
-      {{ field }}
-      {% endif %}
-      {% if field.errors %}
-      <p class="text-sm text-red-600 mt-1">{{ field.errors }}</p>
-      {% endif %}
-    </div>
-    {% endfor %}
-
-    {% for field in form %}
       {% if field.name not in ('participantes_maximo','espera_habilitada') %}
         <div>
           <label for="{{ field.id_for_label }}" class="block text-sm font-medium text-neutral-700 mb-1">
             {{ field.label }}
           </label>
-          {{ field }}
+          {% if field.name == 'avatar' or field.name == 'cover' %}
+            {{ field.as_widget(attrs={'accept': 'image/*'}) }}
+          {% else %}
+            {{ field }}
+          {% endif %}
           {% if field.errors %}
             <p class="text-sm text-red-600 mt-1">{{ field.errors }}</p>
           {% endif %}


### PR DESCRIPTION
## Summary
- avoid rendering duplicated fields on event creation page
- keep participant limit and wait list fields rendered only once after main fields

## Testing
- `pytest -m "not slow"` *(fails: SyntaxError: invalid syntax in tests/feed/test_services.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a654c3bf34832594d01ebc717d1411