### PR TITLE
Handle infected file uploads in chat

### DIFF
--- a/chat/static/chat/js/chat_socket.js
+++ b/chat/static/chat/js/chat_socket.js
@@ -610,6 +610,10 @@
             fetch(uploadUrl,{method:'POST',body:formData,headers:{'X-CSRFToken':csrfToken}})
                 .then(r=>{ if(!r.ok) throw new Error(); return r.json(); })
                 .then(async data=>{
+                    if(data.infected){
+                        alert(t('fileInfected','Arquivo infectado'));
+                        return;
+                    }
 
                     if(isE2EE){
                         const {cipher, alg, keyVersion} = await encryptMessage(data.url);


### PR DESCRIPTION
## Summary
- prevent sending infected file attachments

## Testing
- `pytest` *(fails: could not import 'pytest_benchmark', 9 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a72e00bcf88325995370a089dcf5b9