### PR TITLE
Fix aria-checked attribute in notification preferences template

### DIFF
--- a/configuracoes/templates/configuracoes/partials/preferencias.html
+++ b/configuracoes/templates/configuracoes/partials/preferencias.html
@@ -8,7 +8,9 @@
     <div>
       <label class="flex items-center gap-2">
         {% with email_checked=preferencias_form.receber_notificacoes_email.value|yesno:"true,false" %}
-          {{ preferencias_form.receber_notificacoes_email|add_class:'form-checkbox'|attr:'role:switch'|attr:'tabindex:0'|attr:'aria-label:Receber notificações por e-mail'|attr:'aria-checked:'|add:email_checked }}
+          {% with email_attr='aria-checked:'|add:email_checked %}
+            {{ preferencias_form.receber_notificacoes_email|add_class:'form-checkbox'|attr:'role:switch'|attr:'tabindex:0'|attr:'aria-label:Receber notificações por e-mail'|attr:email_attr }}
+          {% endwith %}
         {% endwith %}
         <span class="text-sm font-medium">{% trans 'Receber notificações por e-mail' %}</span>
       </label>
@@ -32,7 +34,9 @@
     <div>
       <label class="flex items-center gap-2">
         {% with whats_checked=preferencias_form.receber_notificacoes_whatsapp.value|yesno:"true,false" %}
-          {{ preferencias_form.receber_notificacoes_whatsapp|add_class:'form-checkbox'|attr:'role:switch'|attr:'tabindex:0'|attr:'aria-label:Receber notificações por WhatsApp'|attr:'aria-checked:'|add:whats_checked }}
+          {% with whats_attr='aria-checked:'|add:whats_checked %}
+            {{ preferencias_form.receber_notificacoes_whatsapp|add_class:'form-checkbox'|attr:'role:switch'|attr:'tabindex:0'|attr:'aria-label:Receber notificações por WhatsApp'|attr:whats_attr }}
+          {% endwith %}
         {% endwith %}
         <span class="text-sm font-medium">{% trans 'Receber notificações por WhatsApp' %}</span>
       </label>
@@ -57,7 +61,9 @@
     <div>
       <label class="flex items-center gap-2">
         {% with push_checked=preferencias_form.receber_notificacoes_push.value|yesno:"true,false" %}
-          {{ preferencias_form.receber_notificacoes_push|add_class:'form-checkbox'|attr:'role:switch'|attr:'tabindex:0'|attr:'aria-label:Receber notificações push'|attr:'aria-checked:'|add:push_checked }}
+          {% with push_attr='aria-checked:'|add:push_checked %}
+            {{ preferencias_form.receber_notificacoes_push|add_class:'form-checkbox'|attr:'role:switch'|attr:'tabindex:0'|attr:'aria-label:Receber notificações push'|attr:push_attr }}
+          {% endwith %}
         {% endwith %}
         <span class="text-sm font-medium">{% trans 'Receber notificações push' %}</span>
       </label>


### PR DESCRIPTION
## Summary
- ensure notification preference checkboxes render valid aria-checked attributes

## Testing
- `python manage.py shell <<'PY'
from configuracoes.forms import ConfiguracaoContaForm
from configuracoes.models import ConfiguracaoConta
from django.template.loader import render_to_string
form = ConfiguracaoContaForm(instance=ConfiguracaoConta(
    receber_notificacoes_email=True,
    receber_notificacoes_whatsapp=False,
    receber_notificacoes_push=True,
))
html = render_to_string('configuracoes/partials/preferencias.html', {'preferencias_form': form})
import re
for name in ['receber_notificacoes_email','receber_notificacoes_whatsapp','receber_notificacoes_push']:
    m = re.search(r'%s[^>]*>' % name, html)
    print(m.group(0))
PY`
- `pytest -m "not slow"` *(fails: ModuleNotFoundError: No module named 'onesignal_sdk')*

------
https://chatgpt.com/codex/tasks/task_e_68a72fc2fe7c8325b1d18041f9e6bc9c