### PR TITLE
Use translated escopo tipo in contextual list

### DIFF
--- a/configuracoes/templates/configuracoes/contextual_list.html
+++ b/configuracoes/templates/configuracoes/contextual_list.html
@@ -19,7 +19,7 @@
 
       <li class="p-4 bg-white rounded-lg shadow space-y-2">
         <div class="flex items-center justify-between">
-          <span>{{ cfg.escopo_tipo }} {{ cfg.escopo_id }} - {{ cfg.tema }}</span>
+          <span>{{ cfg.get_escopo_tipo_display }} {{ cfg.escopo_id }} - {{ cfg.tema }}</span>
           <span class="space-x-2">
             <a
               href="{% url 'configuracoes-contextual-update' cfg.id %}"


### PR DESCRIPTION
## Summary
- use translated escopo tipo display in contextual list

## Testing
- `pytest tests/configuracoes/test_contextual.py` *(fails: Conflicting 'comentario' models in application 'discussao')*
- `pytest tests/test_i18n_templates.py` *(fails: Conflicting 'comentario' models in application 'discussao')*

------
https://chatgpt.com/codex/tasks/task_e_68a72fca38588325a71fef23d9185e10