### PR TITLE
Fix contextual settings link semantics

### DIFF
--- a/configuracoes/templates/configuracoes/configuracoes.html
+++ b/configuracoes/templates/configuracoes/configuracoes.html
@@ -13,13 +13,15 @@
       {% endfor %}
     </div>
   {% endif %}
-    <nav class="flex flex-wrap gap-4 border-b mb-4 text-sm" aria-label="{% trans 'Seções de Configuração' %}" role="tablist">
-      <button role="tab" aria-selected="{% if tab == 'informacoes' %}true{% else %}false{% endif %}" aria-controls="content" hx-get="{% url 'configuracoes' %}?tab=informacoes" hx-target="#content" tabindex="0" class="py-2 px-3 rounded-t-md {% if tab == 'informacoes' %}bg-white border border-b-0{% else %}bg-gray-100{% endif %}">{% trans 'Informações Pessoais' %}</button>
-      <button role="tab" aria-selected="{% if tab == 'seguranca' %}true{% else %}false{% endif %}" aria-controls="content" hx-get="{% url 'configuracoes' %}?tab=seguranca" hx-target="#content" tabindex="0" class="py-2 px-3 rounded-t-md {% if tab == 'seguranca' %}bg-white border border-b-0{% else %}bg-gray-100{% endif %}">{% trans 'Segurança' %}</button>
-      <button role="tab" aria-selected="{% if tab == 'redes' %}true{% else %}false{% endif %}" aria-controls="content" hx-get="{% url 'configuracoes' %}?tab=redes" hx-target="#content" tabindex="0" class="py-2 px-3 rounded-t-md {% if tab == 'redes' %}bg-white border border-b-0{% else %}bg-gray-100{% endif %}">{% trans 'Conexões Sociais' %}</button>
-      <button role="tab" aria-selected="{% if tab == 'preferencias' %}true{% else %}false{% endif %}" aria-controls="content" hx-get="{% url 'configuracoes' %}?tab=preferencias" hx-target="#content" tabindex="0" class="py-2 px-3 rounded-t-md {% if tab == 'preferencias' %}bg-white border border-b-0{% else %}bg-gray-100{% endif %}">{% trans 'Preferências' %}</button>
-      <a role="tab" aria-selected="false" aria-controls="content" href="{% url 'configuracoes-contextual-list' %}" class="py-2 px-3 rounded-t-md bg-gray-100">{% trans 'Configurações Contextuais' %}</a>
-    </nav>
+    <div class="flex flex-wrap gap-4 border-b mb-4 text-sm">
+      <nav aria-label="{% trans 'Seções de Configuração' %}" role="tablist" class="flex flex-wrap gap-4">
+        <button role="tab" aria-selected="{% if tab == 'informacoes' %}true{% else %}false{% endif %}" aria-controls="content" hx-get="{% url 'configuracoes' %}?tab=informacoes" hx-target="#content" tabindex="0" class="py-2 px-3 rounded-t-md {% if tab == 'informacoes' %}bg-white border border-b-0{% else %}bg-gray-100{% endif %}">{% trans 'Informações Pessoais' %}</button>
+        <button role="tab" aria-selected="{% if tab == 'seguranca' %}true{% else %}false{% endif %}" aria-controls="content" hx-get="{% url 'configuracoes' %}?tab=seguranca" hx-target="#content" tabindex="0" class="py-2 px-3 rounded-t-md {% if tab == 'seguranca' %}bg-white border border-b-0{% else %}bg-gray-100{% endif %}">{% trans 'Segurança' %}</button>
+        <button role="tab" aria-selected="{% if tab == 'redes' %}true{% else %}false{% endif %}" aria-controls="content" hx-get="{% url 'configuracoes' %}?tab=redes" hx-target="#content" tabindex="0" class="py-2 px-3 rounded-t-md {% if tab == 'redes' %}bg-white border border-b-0{% else %}bg-gray-100{% endif %}">{% trans 'Conexões Sociais' %}</button>
+        <button role="tab" aria-selected="{% if tab == 'preferencias' %}true{% else %}false{% endif %}" aria-controls="content" hx-get="{% url 'configuracoes' %}?tab=preferencias" hx-target="#content" tabindex="0" class="py-2 px-3 rounded-t-md {% if tab == 'preferencias' %}bg-white border border-b-0{% else %}bg-gray-100{% endif %}">{% trans 'Preferências' %}</button>
+      </nav>
+      <a href="{% url 'configuracoes-contextual-list' %}" class="py-2 px-3 rounded-t-md bg-gray-100">{% trans 'Configurações Contextuais' %}</a>
+    </div>
     <div id="content" role="tabpanel" class="bg-white p-6 rounded-b-md shadow" hx-get="{% url 'configuracoes' %}?tab={{ tab }}" hx-trigger="load">
       {% include 'configuracoes/partials/'|add:tab|add:'.html' %}
     </div>


### PR DESCRIPTION
## Summary
- keep contextual settings link visually as a tab but outside the tablist

## Testing
- `pytest -q` (fails: ModuleNotFoundError: No module named 'axe_core_python')

------
https://chatgpt.com/codex/tasks/task_e_68a72fcbad488325bbdf3c88c56087c6