### PR TITLE
Use sanitized Markdown for discussion content

### DIFF
--- a/discussao/templates/discussao/comentario_item.html
+++ b/discussao/templates/discussao/comentario_item.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n markdown_extras %}
 <article class="p-4 border-b border-neutral-200 reply-parent {% if melhor %}bg-green-50{% endif %}" id="coment-{{ comentario.id }}">
   <header class="mb-2 flex items-center justify-between">
     <div class="text-sm text-neutral-700">
@@ -49,7 +49,7 @@
 
     </div>
   </header>
-  <div class="prose max-w-none text-sm">{{ comentario.conteudo|linebreaks }}</div>
+  <div class="prose max-w-none text-sm">{{ comentario.conteudo|markdown }}</div>
   {% if topico.melhor_resposta_id == comentario.id %}
     <div class="text-xs text-green-700 font-semibold mt-2">{% trans "Melhor resposta" %}</div>
   {% endif %}

--- a/discussao/templates/discussao/topico_detail.html
+++ b/discussao/templates/discussao/topico_detail.html
@@ -7,7 +7,7 @@
   {% endfor %}
 {% else %}
 {% extends 'base.html' %}
-{% load i18n %}
+{% load i18n markdown_extras %}
 {% block title %}{{ topico.titulo }} | HubX{% endblock %}
 {% block content %}
 <article id="topico-container" class="max-w-3xl mx-auto px-4 py-10">
@@ -57,7 +57,7 @@
       </form>
     </div>
   </header>
-  <div class="prose max-w-none mb-10">{{ topico.conteudo|linebreaks }}</div>
+  <div class="prose max-w-none mb-10">{{ topico.conteudo|markdown }}</div>
   <section aria-labelledby="comentarios" class="space-y-4">
     <h2 id="comentarios" class="text-xl font-semibold">{% trans "Coment\u00e1rios" %}</h2>
     {% if melhor_resposta %}

--- a/discussao/templatetags/markdown_extras.py
+++ b/discussao/templatetags/markdown_extras.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import markdown as md
+import bleach
+from django import template
+from django.utils.safestring import mark_safe
+
+ALLOWED_TAGS = [
+    "p",
+    "pre",
+    "span",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "ul",
+    "ol",
+    "li",
+    "blockquote",
+    "code",
+    "em",
+    "strong",
+    "a",
+    "img",
+    "hr",
+    "br",
+]
+ALLOWED_ATTRIBUTES = {
+    "a": ["href", "title", "rel"],
+    "img": ["src", "alt", "title"],
+}
+
+register = template.Library()
+
+
+@register.filter(name="markdown")
+def markdown_filter(text: str | None) -> str:
+    if not text:
+        return ""
+    html = md.markdown(text)
+    cleaned = bleach.clean(
+        html, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRIBUTES, strip=True
+    )
+    return mark_safe(cleaned)

--- a/requirements.txt
+++ b/requirements.txt
@@ -75,6 +75,7 @@ jsonschema==4.24.0
 jsonschema-specifications==2025.4.1
 kiwisolver==1.4.8
 kombu==5.5.4
+Markdown==3.6
 markdown-it-py==3.0.0
 matplotlib==3.10.5
 mdurl==0.1.2

--- a/tests/discussao/test_markdown_filter.py
+++ b/tests/discussao/test_markdown_filter.py
@@ -1,0 +1,19 @@
+from django.template import Context, Template
+
+
+def render(template_string: str, context: dict | None = None) -> str:
+    tpl = Template(template_string)
+    return tpl.render(Context(context or {}))
+
+
+def test_markdown_renders_basic_markdown():
+    tpl = "{% load markdown_extras %}{{ text|markdown }}"
+    rendered = render(tpl, {"text": "*oi*"})
+    assert "<em>oi</em>" in rendered
+
+
+def test_markdown_sanitizes_html():
+    tpl = "{% load markdown_extras %}{{ text|markdown }}"
+    rendered = render(tpl, {"text": "script <script>alert('x')</script>"})
+    assert "<script>" not in rendered
+    assert "alert('x')" in rendered


### PR DESCRIPTION
## Summary
- add Markdown dependency
- create `markdown` template filter with bleach sanitization
- render discussion topics and comments with safe Markdown
- add tests for Markdown rendering and sanitization

## Testing
- `pytest tests/discussao/test_markdown_filter.py tests/discussao/test_views.py` *(fails: CommandError: Conflicting migrations)*

------
https://chatgpt.com/codex/tasks/task_e_68a735aed6c88325b638446fd7345945