### PR TITLE
Use dynamic WebSocket scheme in topic view

### DIFF
--- a/discussao/templates/discussao/topico_detail.html
+++ b/discussao/templates/discussao/topico_detail.html
@@ -107,7 +107,8 @@
 {% endblock %}
 {% block extra_js %}
 <script>
-  const socket = new WebSocket(`ws://${window.location.host}/ws/discussao/{{ topico.id }}/`);
+  const scheme = window.location.protocol === 'https:' ? 'wss' : 'ws';
+  const socket = new WebSocket(`${scheme}://${window.location.host}/ws/discussao/{{ topico.id }}/`);
   socket.onmessage = function(e) {
     const data = JSON.parse(e.data);
     if (data.evento === 'nova_resposta') {


### PR DESCRIPTION
## Summary
- dynamically select ws or wss in topic detail WebSocket setup

## Testing
- `node -e "['http:','https:'].forEach(p=>{const scheme=p==='https:'?'wss':'ws';console.log(p,'=>',scheme);});"`
- `pytest tests/discussao/test_views.py::test_topico_list_view --override-ini="addopts="` *(fails: Conflicting migrations detected)*

------
https://chatgpt.com/codex/tasks/task_e_68a735b202a88325b74ec030b9de7bad