### PR TITLE
Listar e gerenciar contatos no detalhe da empresa

### DIFF
--- a/empresas/templates/empresas/detail.htm
+++ b/empresas/templates/empresas/detail.htm
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load i18n %}
+{% load i18n l10n %}
 {% block title %}{{ empresa.nome }} | Hubx{% endblock %}
 
 {% block content %}
@@ -32,14 +32,41 @@
       {% endif %}
     </p>
     <p><strong>{% trans "Localização" %}:</strong> {{ empresa.municipio }}, {{ empresa.estado }}</p>
-    {% with empresa.get_contato_principal as contato %}
-      {% if contato %}
-        <p><strong>{% trans "Contato" %}:</strong> {{ contato.nome }}</p>
-      {% else %}
-        <p><strong>{% trans "Contato" %}:</strong> {% trans "Nenhum contato cadastrado" %}</p>
-      {% endif %}
-    {% endwith %}
+    {% if pode_visualizar_contatos %}
+      {% with empresa.get_contato_principal as contato %}
+        {% if contato %}
+          <p><strong>{% trans "Contato" %}:</strong> {{ contato.nome }}</p>
+        {% else %}
+          <p><strong>{% trans "Contato" %}:</strong> {% trans "Nenhum contato cadastrado" %}</p>
+        {% endif %}
+      {% endwith %}
+    {% endif %}
   </div>
+
+  {% if pode_visualizar_contatos %}
+    <h2 class="mt-8 text-lg font-semibold text-neutral-900">{% trans "Contatos" %}</h2>
+    <div class="mt-4 space-y-4">
+      {% for contato in contatos %}
+        <div class="flex justify-between items-start bg-white border border-neutral-200 rounded-xl p-4">
+          <div class="text-sm">
+            <p class="font-medium text-neutral-800">{{ contato.nome }}</p>
+            <p class="text-neutral-600">{{ contato.cargo }}</p>
+            <p class="text-neutral-600">{{ contato.email }}</p>
+            <p class="text-neutral-600">{{ contato.telefone }}</p>
+          </div>
+          <div class="flex gap-2">
+            <a href="{% url 'empresas:contato_editar' contato.id %}" class="text-sm px-3 py-1 rounded-lg border border-neutral-300 text-neutral-700 hover:bg-neutral-100">{% trans "Editar" %}</a>
+            <a href="{% url 'empresas:contato_remover' contato.id %}" class="text-sm px-3 py-1 rounded-lg border border-red-300 text-red-700 hover:bg-red-100">{% trans "Remover" %}</a>
+          </div>
+        </div>
+      {% empty %}
+        <p class="text-sm text-neutral-500">{% trans "Nenhum contato cadastrado." %}</p>
+      {% endfor %}
+      <div>
+        <a href="{% url 'empresas:contato_novo' empresa.id %}" class="inline-block text-sm mt-2 px-4 py-2 rounded-xl bg-primary-600 text-white hover:bg-primary-700">{% trans "Adicionar" %}</a>
+      </div>
+    </div>
+  {% endif %}
 
   {% if empresa_tags %}
     <div class="mt-4">

--- a/empresas/urls.py
+++ b/empresas/urls.py
@@ -21,7 +21,7 @@ urlpatterns = [
         views.AvaliacaoUpdateView.as_view(),
         name="avaliacao_editar",
     ),
-    path("<int:empresa_id>/contatos/novo/", views.adicionar_contato, name="contato_novo"),
+    path("<uuid:empresa_id>/contatos/novo/", views.adicionar_contato, name="contato_novo"),
     path("contatos/<int:pk>/editar/", views.editar_contato, name="contato_editar"),
     path("contatos/<int:pk>/remover/", views.remover_contato, name="contato_remover"),
     path("<uuid:pk>/historico/", views.EmpresaChangeLogListView.as_view(), name="historico"),

--- a/empresas/views.py
+++ b/empresas/views.py
@@ -323,6 +323,10 @@ def detalhes_empresa(request, pk):
     avaliacao_usuario = None
     if request.user.is_authenticated:
         avaliacao_usuario = avaliacoes.filter(usuario=request.user).first()
+    pode_visualizar_contatos = pode_crud_empresa(request.user, empresa)
+    contatos = []
+    if pode_visualizar_contatos:
+        contatos = list(empresa.contatos.filter(deleted=False))
     context = {
         "empresa": empresa,
         "empresa_tags": empresa.tags.all(),
@@ -331,6 +335,8 @@ def detalhes_empresa(request, pk):
         "avaliacoes": avaliacoes,
         "media_avaliacoes": empresa.media_avaliacoes(),
         "avaliacao_usuario": avaliacao_usuario,
+        "contatos": contatos,
+        "pode_visualizar_contatos": pode_visualizar_contatos,
     }
     return render(request, "empresas/detail.htm", context)
 

--- a/tests/empresas/test_contatos_permissions.py
+++ b/tests/empresas/test_contatos_permissions.py
@@ -1,0 +1,53 @@
+import pytest
+from django.urls import reverse
+
+from accounts.models import UserType
+from accounts.factories import UserFactory
+from organizacoes.factories import OrganizacaoFactory
+from empresas.factories import EmpresaFactory
+from empresas.models import ContatoEmpresa
+
+
+@pytest.mark.django_db
+def test_contatos_visiveis_para_usuario_autorizado(client):
+    org = OrganizacaoFactory()
+    user = UserFactory(user_type=UserType.ADMIN.value, organizacao=org, nucleo_obj=None)
+    empresa = EmpresaFactory(usuario=user, organizacao=org)
+    contato = ContatoEmpresa.objects.create(
+        empresa=empresa,
+        nome="Fulano",
+        cargo="Dev",
+        email="f@example.com",
+        telefone="123",
+    )
+
+    client.force_login(user)
+    resp = client.get(reverse("empresas:detail", args=[empresa.pk]))
+    content = resp.content.decode()
+    assert contato.nome in content
+    assert reverse("empresas:contato_editar", args=[contato.id]) in content
+    assert reverse("empresas:contato_remover", args=[contato.id]) in content
+    assert reverse("empresas:contato_novo", args=[empresa.id]) in content
+
+
+@pytest.mark.django_db
+def test_contatos_invisiveis_para_usuario_nao_autorizado(client):
+    org = OrganizacaoFactory()
+    owner = UserFactory(user_type=UserType.NUCLEADO.value, organizacao=org, nucleo_obj=None)
+    empresa = EmpresaFactory(usuario=owner, organizacao=org)
+    contato = ContatoEmpresa.objects.create(
+        empresa=empresa,
+        nome="Fulano",
+        cargo="Dev",
+        email="f@example.com",
+        telefone="123",
+    )
+    other = UserFactory(user_type=UserType.NUCLEADO.value, organizacao=org, nucleo_obj=None)
+
+    client.force_login(other)
+    resp = client.get(reverse("empresas:detail", args=[empresa.pk]))
+    content = resp.content.decode()
+    assert contato.nome not in content
+    # tentativa de editar deve ser proibida
+    edit_url = reverse("empresas:contato_editar", args=[contato.id])
+    assert client.get(edit_url).status_code == 403


### PR DESCRIPTION
## Summary
- Exibe contatos da empresa com ações de adicionar, editar e remover
- Restringe visualização de contatos a usuários autorizados
- Garante cobertura de testes para permissões de acesso

## Testing
- `pytest tests/empresas/test_contatos_permissions.py -q --no-cov --nomigrations`


------
https://chatgpt.com/codex/tasks/task_e_68a73882a87c8325a35f0556018f37b0