### PR TITLE
Add admin-only filter for deleted companies

### DIFF
--- a/empresas/templates/empresas/includes/empresas_table.html
+++ b/empresas/templates/empresas/includes/empresas_table.html
@@ -29,10 +29,6 @@
       </td>
       <td class="px-3 py-2 text-center space-x-2">
         <a href="{% url 'empresas:empresa_editar' empresa.pk %}" class="text-blue-600 hover:underline">{% translate "Editar" %}</a>
-
-        <a href="{% url 'empresas:remover' empresa.pk %}" class="text-red-600 hover:underline">
-          {% translate "Remover" %}
-        </a>
         {% translate "Favoritar" as txt_favoritar %}
         {% translate "Desfavoritar" as txt_desfavoritar %}
         <button
@@ -58,22 +54,22 @@
           {% if empresa.favoritado %}{{ txt_desfavoritar }}{% else %}{{ txt_favoritar }}{% endif %}
         </button>
 
-        {% if empresa.deleted %}
-          <form hx-post="{% url 'empresas_api:empresa-restaurar' empresa.pk %}" hx-on="htmx:afterRequest: location.reload()" class="inline">
-            {% csrf_token %}
-            <button type="submit" class="text-green-600 hover:underline">{% translate "Restaurar" %}</button>
-          </form>
-          {% if request.user.user_type == 'admin' or request.user.user_type == 'root' %}
-            <button hx-delete="{% url 'empresas_api:empresa-purgar' empresa.pk %}"
-                    hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
-                    hx-on="htmx:afterRequest: location.reload()"
-                    class="text-red-600 hover:underline">{% translate "Purgar" %}</button>
+          {% if empresa.deleted %}
+            <form hx-post="{% url 'empresas_api:empresa-restaurar' empresa.pk %}" hx-on="htmx:afterRequest: location.reload()" class="inline">
+              {% csrf_token %}
+              <button type="submit" class="text-green-600 hover:underline">{% translate "Restaurar" %}</button>
+            </form>
+            {% if request.user.user_type == 'admin' or request.user.user_type == 'root' %}
+              <button hx-delete="{% url 'empresas_api:empresa-purgar' empresa.pk %}"
+                      hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+                      hx-on="htmx:afterRequest: location.reload()"
+                      class="text-red-600 hover:underline">{% translate "Purgar" %}</button>
+            {% endif %}
+          {% else %}
+            <a href="{% url 'empresas:remover' empresa.pk %}" class="text-red-600 hover:underline">
+              {% translate "Remover" %}
+            </a>
           {% endif %}
-        {% else %}
-          <a href="{% url 'empresas:remover' empresa.pk %}" class="text-red-600 hover:underline">
-            {% translate "Remover" %}
-          </a>
-        {% endif %}
 
       </td>
     </tr>

--- a/empresas/templates/empresas/lista.html
+++ b/empresas/templates/empresas/lista.html
@@ -58,6 +58,14 @@
       <label for="q" class="block text-sm font-medium text-neutral-700">{% translate "Busca" %}</label>
       <input type="text" id="q" name="q" value="{{ request.GET.q }}" class="w-full p-2 border rounded" />
     </div>
+    {% if request.user.user_type == 'admin' or request.user.user_type == 'root' %}
+    <div class="flex items-end">
+      <label for="mostrar_excluidas" class="inline-flex items-center text-sm font-medium text-neutral-700">
+        <input type="checkbox" id="mostrar_excluidas" name="mostrar_excluidas" value="1" class="mr-2" {% if mostrar_excluidas == '1' %}checked{% endif %}>
+        {% translate "Mostrar excluídas" %}
+      </label>
+    </div>
+    {% endif %}
     <div class="flex items-end">
       <button type="submit" class="w-full bg-primary-600 text-white p-2 rounded hover:bg-primary-700">{% translate "Filtrar" %}</button>
     </div>

--- a/empresas/views.py
+++ b/empresas/views.py
@@ -80,6 +80,7 @@ class EmpresaListView(LoginRequiredMixin, ListView):
         context["tags"] = list_all_tags()
         context["selected_tags"] = self.request.GET.getlist("tags")
         context["empresas"] = context.get("object_list")
+        context["mostrar_excluidas"] = self.request.GET.get("mostrar_excluidas", "")
         if self.request.user.is_superuser or self.request.user.user_type == UserType.ADMIN:
             context["organizacoes"] = Organizacao.objects.all()
         else:

--- a/tests/empresas/test_views.py
+++ b/tests/empresas/test_views.py
@@ -108,6 +108,16 @@ def test_admin_can_list_deleted(client, admin_user):
 
 
 @pytest.mark.django_db
+def test_admin_sees_restore_and_purge_actions(client, admin_user):
+    emp = EmpresaFactory(usuario=admin_user, organizacao=admin_user.organizacao, deleted=True)
+    client.force_login(admin_user)
+    resp = client.get(reverse("empresas:lista"), {"mostrar_excluidas": "1"})
+    content = resp.content.decode()
+    assert "Restaurar" in content
+    assert "Purgar" in content
+
+
+@pytest.mark.django_db
 def test_admin_excludes_deleted_by_default(client, admin_user):
     emp = EmpresaFactory(usuario=admin_user, organizacao=admin_user.organizacao, deleted=True)
     client.force_login(admin_user)


### PR DESCRIPTION
## Summary
- allow admin/root users to toggle display of deleted companies
- show restore and purge actions for deleted companies
- test deleted company management actions

## Testing
- `pytest tests/empresas/test_views.py --no-cov --nomigrations -q`


------
https://chatgpt.com/codex/tasks/task_e_68a73882cd1c832599e6e487ddcd13a5