### PR TITLE
Allow empresa reviews with comments

### DIFF
--- a/empresas/templates/empresas/includes/avaliacoes.html
+++ b/empresas/templates/empresas/includes/avaliacoes.html
@@ -5,14 +5,53 @@
     {% trans "Média" %}: {{ media_avaliacoes|floatformat:1 }}/5 - {{ avaliacoes|length }} {% trans "avaliações" %}
   </p>
   {% if request.user.is_authenticated %}
-  <form hx-post="{% if avaliacao_usuario %}{% url 'empresas:avaliacao_editar' empresa.id %}{% else %}{% url 'empresas:avaliacao_criar' empresa.id %}{% endif %}" hx-target="#avaliacoes" hx-swap="outerHTML" class="flex gap-1 mt-2">
+  <form
+    hx-post="{% if avaliacao_usuario %}{% url 'empresas:avaliacao_editar' empresa.id %}{% else %}{% url 'empresas:avaliacao_criar' empresa.id %}{% endif %}"
+    hx-target="#avaliacoes"
+    hx-swap="outerHTML"
+    class="flex flex-col gap-2 mt-2"
+  >
     {% csrf_token %}
-    {% for _ in '12345' %}
-      <button type="submit" name="nota" value="{{ forloop.counter }}" class="text-yellow-400" aria-label="{% trans 'Avaliar com' %} {{ forloop.counter }} {% trans 'estrelas' %}">
-        <i class="{% if avaliacao_usuario and forloop.counter <= avaliacao_usuario.nota %}fa-solid{% else %}fa-regular{% endif %} fa-star"></i>
-      </button>
-    {% endfor %}
+    <div class="flex gap-1">
+      <input type="hidden" name="nota" id="avaliacao-nota" value="{{ avaliacao_usuario.nota|default:0 }}" />
+      {% for _ in '12345' %}
+        <button
+          type="button"
+          data-star="{{ forloop.counter }}"
+          class="text-yellow-400"
+          aria-label="{% trans 'Avaliar com' %} {{ forloop.counter }} {% trans 'estrelas' %}"
+        >
+          <i class="{% if avaliacao_usuario and forloop.counter <= avaliacao_usuario.nota %}fa-solid{% else %}fa-regular{% endif %} fa-star"></i>
+        </button>
+      {% endfor %}
+    </div>
+    <input
+      type="text"
+      name="comentario"
+      value="{{ avaliacao_usuario.comentario|default:'' }}"
+      placeholder="{% trans 'Comentário (opcional)' %}"
+      class="border border-neutral-300 rounded px-2 py-1 text-sm"
+    />
+    <button type="submit" class="self-start btn btn-primary">{% trans "Enviar" %}</button>
   </form>
+  <script>
+    document.querySelectorAll('#avaliacoes [data-star]').forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        var notaInput = document.getElementById('avaliacao-nota');
+        notaInput.value = this.dataset.star;
+        document.querySelectorAll('#avaliacoes [data-star]').forEach(function (b) {
+          var icon = b.querySelector('i');
+          if (parseInt(b.dataset.star) <= notaInput.value) {
+            icon.classList.remove('fa-regular');
+            icon.classList.add('fa-solid');
+          } else {
+            icon.classList.remove('fa-solid');
+            icon.classList.add('fa-regular');
+          }
+        });
+      });
+    });
+  </script>
   {% endif %}
   {% if avaliacoes %}
     <ul class="mt-2 space-y-2">

--- a/tests/empresas/test_views.py
+++ b/tests/empresas/test_views.py
@@ -100,6 +100,22 @@ def test_avaliacao_unica_e_media(client, nucleado_user, admin_user):
 
 
 @pytest.mark.django_db
+def test_avaliacao_comentario_hx_request(client, nucleado_user):
+    empresa = EmpresaFactory(usuario=nucleado_user, organizacao=nucleado_user.organizacao)
+    client.force_login(nucleado_user)
+    url = reverse("empresas:avaliacao_criar", args=[empresa.pk])
+    resp = client.post(
+        url,
+        {"nota": 5, "comentario": "Ótimo"},
+        HTTP_HX_REQUEST="true",
+    )
+    assert resp.status_code == 200
+    avaliacao = AvaliacaoEmpresa.objects.get(empresa=empresa, usuario=nucleado_user)
+    assert avaliacao.nota == 5
+    assert avaliacao.comentario == "Ótimo"
+
+
+@pytest.mark.django_db
 def test_admin_can_list_deleted(client, admin_user):
     emp = EmpresaFactory(usuario=admin_user, organizacao=admin_user.organizacao, deleted=True)
     client.force_login(admin_user)


### PR DESCRIPTION
## Summary
- Enable inline empresa reviews to include optional comment text and send button
- Verify backend stores comment when submitted via HTMX request

## Testing
- `pytest -q` (fails: ModuleNotFoundError: No module named 'axe_core_python', bs4, playwright, httpx, pywebpush, django_redis)
- `pytest tests/empresas/test_views.py::test_avaliacao_comentario_hx_request -q` (fails: Conflicting migrations detected; multiple leaf nodes in the migration graph)


------
https://chatgpt.com/codex/tasks/task_e_68a7388504308325987c8c191da9202e