### PR TITLE
Add HTMX delete option to feed comments

### DIFF
--- a/feed/templates/feed/_comment.html
+++ b/feed/templates/feed/_comment.html
@@ -3,7 +3,12 @@
   <p class="text-sm font-medium">{{ comment.user.get_full_name|default:comment.user.username }}</p>
   <p class="text-xs text-neutral-500">{{ comment.created_at|date:"SHORT_DATETIME_FORMAT" }}</p>
   <p class="text-sm text-neutral-800">{{ comment.texto }}</p>
-  <button type="button" class="text-primary-600 text-xs" hx-on:click="setReplyTo('{{ comment.id }}')">{% trans "Responder" %}</button>
+  <div class="flex gap-2">
+    <button type="button" class="text-primary-600 text-xs" hx-on:click="setReplyTo('{{ comment.id }}')">{% trans "Responder" %}</button>
+    {% if comment.user == request.user or request.user.is_staff %}
+      <button type="button" class="text-red-600 text-xs" hx-delete="/api/feed/comments/{{ comment.id }}/" hx-target="#comment-{{ comment.id }}" hx-swap="outerHTML" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}' hx-on:error="alert('{% trans "Erro ao excluir comentário" %}')">{% trans "Excluir" %}</button>
+    {% endif %}
+  </div>
   <ul class="mt-2 space-y-2 ml-4" id="replies-{{ comment.id }}">
     {% for reply in comment.replies.all %}
       {% include 'feed/_comment.html' with comment=reply %}


### PR DESCRIPTION
## Summary
- show delete button on comments for author and staff users
- send HTMX delete request with CSRF header and error handling

## Testing
- `pytest feed/tests/test_comment_api.py::CommentPermissionAPITest::test_other_user_cannot_delete_comment -q` (fails: Coverage failure and migration conflicts)


------
https://chatgpt.com/codex/tasks/task_e_68a73edb93b48325ba4ecaa0ff60363d