### PR TITLE
Define aporte externo como padrão e oculta opção interna

### DIFF
--- a/financeiro/templates/financeiro/aportes_form.html
+++ b/financeiro/templates/financeiro/aportes_form.html
@@ -21,8 +21,10 @@
   </div>
   <div class="mb-2">
     <span class="block text-sm font-medium">{{ _('Tipo') }}</span>
-    <label class="mr-4"><input type="radio" name="tipo" value="aporte_interno" checked /> {{ _('Interno') }}</label>
-    <label><input type="radio" name="tipo" value="aporte_externo" /> {{ _('Externo') }}</label>
+    {% if request.user.user_type == 'admin' %}
+    <label class="mr-4"><input type="radio" name="tipo" value="aporte_interno" /> {{ _('Interno') }}</label>
+    {% endif %}
+    <label><input type="radio" name="tipo" value="aporte_externo" checked /> {{ _('Externo') }}</label>
   </div>
   <div class="mb-2">
     <label for="id_descricao" class="block text-sm font-medium">{{ _('Descrição') }}</label>

--- a/financeiro/tests/test_aportes_template.py
+++ b/financeiro/tests/test_aportes_template.py
@@ -1,0 +1,29 @@
+import pytest
+from django.template.loader import render_to_string
+from django.test import RequestFactory
+
+from accounts.factories import UserFactory
+from accounts.models import UserType
+
+
+pytestmark = pytest.mark.django_db
+
+
+def _render_for(user):
+    request = RequestFactory().get("/")
+    request.user = user
+    return render_to_string("financeiro/aportes_form.html", {"centros": []}, request=request)
+
+
+def test_aportes_form_shows_internal_for_admin():
+    user = UserFactory(user_type=UserType.ADMIN)
+    html = _render_for(user)
+    assert 'value="aporte_externo" checked' in html
+    assert 'value="aporte_interno"' in html
+
+
+def test_aportes_form_hides_internal_for_non_admin():
+    user = UserFactory(user_type=UserType.ASSOCIADO)
+    html = _render_for(user)
+    assert 'value="aporte_externo" checked' in html
+    assert 'value="aporte_interno"' not in html


### PR DESCRIPTION
## Summary
- Ajusta o formulário de aportes para marcar "Externo" por padrão e esconder "Interno" quando o usuário não é admin
- Adiciona testes garantindo a visibilidade correta das opções

## Testing
- `pytest financeiro/tests/test_aportes_template.py::test_aportes_form_shows_internal_for_admin financeiro/tests/test_aportes_template.py::test_aportes_form_hides_internal_for_non_admin --nomigrations --cov=financeiro/tests/test_aportes_template.py --cov-fail-under=0 -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7415ce7a4832585a641ddb4fe7454