### PR TITLE
Add empty state to logs table

### DIFF
--- a/notificacoes/templates/notificacoes/logs_rows.html
+++ b/notificacoes/templates/notificacoes/logs_rows.html
@@ -8,4 +8,8 @@
     <td class="px-4 py-2">{{ log.get_status_display }}</td>
     <td class="px-4 py-2 text-sm">{{ log.erro|default:_("-") }}</td>
   </tr>
+{% empty %}
+  <tr>
+    <td colspan="6" class="px-4 py-2 text-center text-neutral-500">{% trans 'Nenhum log encontrado.' %}</td>
+  </tr>
 {% endfor %}


### PR DESCRIPTION
## Summary
- show translated message when notification logs are empty

## Testing
- `pytest notificacoes -q` *(fails: Coverage failure: total of 9 is less than fail-under=90)*

------
https://chatgpt.com/codex/tasks/task_e_68a757cdaa988325b84f6f636aeb0cdd