### PR TITLE
Use data_envio for notification metrics

### DIFF
--- a/tests/notificacoes/test_metrics.py
+++ b/tests/notificacoes/test_metrics.py
@@ -15,19 +15,28 @@ def test_metrics_dashboard(client):
     client.force_login(staff)
     user = UserFactory()
 
-    active_before = NotificationTemplate.objects.count()
-    inactive_before = NotificationTemplate.all_objects.filter(deleted=True).count()
+    active_before = NotificationTemplate.objects.filter(ativo=True).count()
 
     template = NotificationTemplate.objects.create(codigo="t", assunto="a", corpo="b", canal="email")
-    NotificationLog.objects.create(user=user, template=template, canal="email", status=NotificationStatus.ENVIADA)
-    log2 = NotificationLog.objects.create(user=user, template=template, canal="whatsapp", status=NotificationStatus.FALHA)
-    log2.created_at = timezone.now() - timedelta(days=30)
-    log2.save(update_fields=["created_at"])
+    NotificationLog.objects.create(
+        user=user,
+        template=template,
+        canal="email",
+        status=NotificationStatus.ENVIADA,
+        data_envio=timezone.now(),
+    )
+    NotificationLog.objects.create(
+        user=user,
+        template=template,
+        canal="whatsapp",
+        status=NotificationStatus.FALHA,
+        data_envio=timezone.now() - timedelta(days=30),
+    )
     url = reverse("notificacoes:metrics_dashboard")
     resp = client.get(url, {"inicio": timezone.now().date()})
     assert resp.status_code == 200
     ctx = resp.context
-    assert ctx["total_por_canal"].get("email") in {None, 1}
-    assert "whatsapp" not in ctx["total_por_canal"]
+    assert ctx["total_por_canal"].get("email") == 1
+    assert ctx["total_por_canal"].get("whatsapp") is None
     assert ctx["falhas_por_canal"].get("whatsapp") is None
-    assert ctx["templates_total"] == total_before + 1
+    assert ctx["templates_total"] == active_before + 1

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -5,6 +5,7 @@ urlpatterns = [
     path("", include(("accounts.urls", "accounts"), namespace="accounts")),
     path("core/", include(("core.urls", "core"), namespace="core")),
     path("api/notificacoes/", include("notificacoes.api_urls")),
+    path("notificacoes/", include(("notificacoes.urls", "notificacoes"), namespace="notificacoes")),
     path("chat/", include(("chat.urls", "chat"), namespace="chat")),
     path("financeiro/", include(("financeiro.urls", "financeiro"), namespace="financeiro")),
     path("accounts/", include(("accounts.urls", "accounts"), namespace="accounts")),


### PR DESCRIPTION
## Summary
- compute metrics based on `data_envio` to only count actual notifications sent
- adjust metrics dashboard test for the new effective-send logic
- wire notificacoes URLs into test URLconf

## Testing
- `pytest tests/notificacoes/test_metrics.py -q --nomigrations --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68a757cf93788325bf556b8466f5d9f6