### PR TITLE
feat(tokens): retry webhook with backoff

### DIFF
--- a/tests/tokens/test_webhook_retry.py
+++ b/tests/tokens/test_webhook_retry.py
@@ -1,0 +1,59 @@
+import uuid
+from types import SimpleNamespace
+
+import pytest
+from django.test import override_settings
+import requests
+
+from tokens.apps import TokensConfig
+import tokens
+from tokens import services
+from tokens.models import TokenWebhookEvent
+
+
+@override_settings(TOKEN_CREATED_WEBHOOK_URL="http://example.com")
+@pytest.mark.django_db
+def test_send_webhook_retry_success(monkeypatch):
+    config = TokensConfig("tokens", tokens)
+    config.ready()
+
+    calls = []
+
+    def fake_post(url, data, headers, timeout):
+        calls.append(1)
+        if len(calls) < 3:
+            raise requests.RequestException("boom")
+        return SimpleNamespace(status_code=200)
+
+    sleeps = []
+    monkeypatch.setattr("tokens.apps.requests.post", fake_post)
+    monkeypatch.setattr("tokens.apps.time.sleep", lambda s: sleeps.append(s))
+
+    token = SimpleNamespace(id=uuid.uuid4())
+    services.token_created(token, "raw")
+
+    assert len(calls) == 3
+    assert sleeps == [1, 2]
+    assert TokenWebhookEvent.objects.count() == 0
+
+
+@override_settings(TOKEN_CREATED_WEBHOOK_URL="http://example.com")
+@pytest.mark.django_db
+def test_send_webhook_logs_failure(monkeypatch):
+    config = TokensConfig("tokens", tokens)
+    config.ready()
+
+    def fake_post(url, data, headers, timeout):
+        raise requests.RequestException("boom")
+
+    sleeps = []
+    monkeypatch.setattr("tokens.apps.requests.post", fake_post)
+    monkeypatch.setattr("tokens.apps.time.sleep", lambda s: sleeps.append(s))
+
+    token = SimpleNamespace(id=uuid.uuid4())
+    services.token_created(token, "raw")
+
+    event = TokenWebhookEvent.objects.get()
+    assert event.url == "http://example.com"
+    assert event.attempts == 3
+    assert sleeps == [1, 2]

--- a/tokens/migrations/0010_merge_20250910_0000.py
+++ b/tokens/migrations/0010_merge_20250910_0000.py
@@ -1,0 +1,10 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("tokens", "0009_alter_apitoken_expires_at"),
+        ("tokens", "0009_codigoautenticacaolog"),
+    ]
+
+    operations = []

--- a/tokens/migrations/0011_tokenwebhookevent.py
+++ b/tokens/migrations/0011_tokenwebhookevent.py
@@ -1,0 +1,26 @@
+import django.utils.timezone
+import uuid
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("tokens", "0010_merge_20250910_0000"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="TokenWebhookEvent",
+            fields=[
+                ("created_at", models.DateTimeField(default=django.utils.timezone.now, editable=False)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                ("id", models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False, serialize=False)),
+                ("url", models.URLField()),
+                ("payload", models.JSONField()),
+                ("delivered", models.BooleanField(default=False)),
+                ("attempts", models.PositiveIntegerField(default=0)),
+                ("last_attempt_at", models.DateTimeField(null=True, blank=True)),
+            ],
+            options={"ordering": ["-created_at"]},
+        ),
+    ]

--- a/tokens/models.py
+++ b/tokens/models.py
@@ -210,6 +210,20 @@ class TokenUsoLog(TimeStampedModel, SoftDeleteModel):
         ordering = ["-created_at"]
 
 
+class TokenWebhookEvent(TimeStampedModel):
+    """Evento de webhook que falhou e aguarda reprocessamento."""
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    url = models.URLField()
+    payload = models.JSONField()
+    delivered = models.BooleanField(default=False)
+    attempts = models.PositiveIntegerField(default=0)
+    last_attempt_at = models.DateTimeField(null=True, blank=True)
+
+    class Meta:
+        ordering = ["-created_at"]
+
+
 class CodigoAutenticacao(TimeStampedModel, SoftDeleteModel):
     usuario = models.ForeignKey(
         get_user_model(),


### PR DESCRIPTION
## Summary
- add TokenWebhookEvent model to persist failed webhook attempts
- send token webhooks with exponential backoff and log failures
- cover retry and failure paths with tests

## Testing
- `pytest tests/tokens/test_webhook_retry.py -q --no-migrations --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68a75c471a4c8325a86305785b430d09