### PR TITLE
Set auth code user from request and add admin form

### DIFF
--- a/tests/tokens/test_views.py
+++ b/tests/tokens/test_views.py
@@ -96,7 +96,7 @@ def test_gerar_codigo_autenticacao_view(client):
     _login(client, user)
     resp = client.post(
         reverse("tokens:gerar_codigo"),
-        {"usuario": user.pk},
+        {},
         HTTP_USER_AGENT="ua-gerar",
     )
     assert resp.status_code == 200

--- a/tokens/forms.py
+++ b/tokens/forms.py
@@ -52,7 +52,27 @@ class ValidarTokenConviteForm(forms.Form):
 
 
 class GerarCodigoAutenticacaoForm(forms.Form):
+    def __init__(self, *args, usuario: User | None = None, **kwargs):
+        self.usuario = usuario
+        super().__init__(*args, **kwargs)
+
+    def save(self, commit: bool = True) -> CodigoAutenticacao:
+        codigo = CodigoAutenticacao(usuario=self.usuario)
+        if commit:
+            codigo.save()
+        return codigo
+
+
+class GerarCodigoAutenticacaoAdminForm(forms.Form):
     usuario = forms.ModelChoiceField(queryset=User.objects.all())
+
+    def __init__(self, *args, user: User | None = None, **kwargs):
+        self.user = user
+        super().__init__(*args, **kwargs)
+        if not self.user or not self.user.has_perm("tokens.add_codigoautenticacao"):
+            from django.core.exceptions import PermissionDenied
+
+            raise PermissionDenied
 
     def save(self, commit: bool = True) -> CodigoAutenticacao:
         codigo = CodigoAutenticacao(usuario=self.cleaned_data["usuario"])

--- a/tokens/views.py
+++ b/tokens/views.py
@@ -226,7 +226,7 @@ class ValidarTokenConviteView(LoginRequiredMixin, View):
 
 class GerarCodigoAutenticacaoView(LoginRequiredMixin, View):
     def post(self, request, *args, **kwargs):
-        form = GerarCodigoAutenticacaoForm(request.POST)
+        form = GerarCodigoAutenticacaoForm(request.POST, usuario=request.user)
         if form.is_valid():
             codigo = form.save()
             ip = request.META.get("REMOTE_ADDR", "")


### PR DESCRIPTION
## Summary
- use request.user when generating auth codes
- add admin auth code form with permission check
- adjust tests for new forms and view

## Testing
- `pytest tests/tokens/test_forms.py::test_gerar_codigo_autenticacao_form_save tests/tokens/test_forms.py::test_gerar_codigo_autenticacao_admin_form_permission tests/tokens/test_views.py::test_gerar_codigo_autenticacao_view -q --disable-warnings --nomigrations --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68a75c438a8c832580bd511d9c0cc725