### PR TITLE
Fix token validation log action for invites

### DIFF
--- a/tests/tokens/test_views.py
+++ b/tests/tokens/test_views.py
@@ -8,7 +8,8 @@ from accounts.factories import UserFactory
 from accounts.models import UserType
 from nucleos.factories import NucleoFactory
 from organizacoes.factories import OrganizacaoFactory
-from tokens.models import CodigoAutenticacao, CodigoAutenticacaoLog, TokenAcesso
+from tokens.models import CodigoAutenticacao, CodigoAutenticacaoLog, TokenAcesso, TokenUsoLog
+from tokens.services import create_invite_token
 
 pytestmark = pytest.mark.django_db
 
@@ -78,14 +79,17 @@ def test_convite_daily_limit(client):
 def test_validar_token_convite_view(client):
     user = UserFactory()
     gerador = UserFactory(is_staff=True)
-    token = TokenAcesso.objects.create(gerado_por=gerador, tipo_destino=TokenAcesso.TipoUsuario.ASSOCIADO)
+    token, codigo = create_invite_token(gerado_por=gerador, tipo_destino=TokenAcesso.TipoUsuario.ASSOCIADO)
 
     _login(client, user)
-    resp = client.post(reverse("tokens:validar_token"), {"codigo": token.codigo})
+    resp = client.post(reverse("tokens:validar_token"), {"codigo": codigo})
     assert resp.status_code == 200
     token.refresh_from_db()
     assert token.estado == TokenAcesso.Estado.USADO
     assert token.usuario == user
+    log = TokenUsoLog.objects.get(token=token)
+    assert log.acao == TokenUsoLog.Acao.USO
+    assert log.usuario == user
 
     resp = client.post(reverse("tokens:validar_token"), {"codigo": token.codigo})
     assert resp.status_code == 400

--- a/tokens/views.py
+++ b/tokens/views.py
@@ -210,7 +210,7 @@ class ValidarTokenConviteView(LoginRequiredMixin, View):
             TokenUsoLog.objects.create(
                 token=token,
                 usuario=request.user,
-                acao=TokenUsoLog.Acao.VALIDACAO,
+                acao=TokenUsoLog.Acao.USO,
                 ip=ip,
                 user_agent=request.META.get("HTTP_USER_AGENT", ""),
             )


### PR DESCRIPTION
## Summary
- log token usage with `Acao.USO` instead of `VALIDACAO`
- test invite token validation logs usage action

## Testing
- `pytest tests/tokens/test_views.py::test_validar_token_convite_view -q --nomigrations --cov=tokens/views.py --cov=tests/tokens/test_views.py --cov-fail-under=0` (fails: assert 400 == 200)


------
https://chatgpt.com/codex/tasks/task_e_68a75c4001448325b6683459cfbdb1ea