### PR TITLE
feat: search-based selectors for organization associations

### DIFF
--- a/organizacoes/api.py
+++ b/organizacoes/api.py
@@ -291,6 +291,23 @@ class OrganizacaoUserViewSet(OrganizacaoRelatedModelViewSet):
         org = self.get_organizacao()
         return org.users.all()
 
+    def list(self, request, *args, **kwargs):  # type: ignore[override]
+        org = self.get_organizacao()
+        qs = get_user_model().objects.filter(organizacao__isnull=True)
+        search = request.query_params.get("search")
+        if search:
+            qs = qs.filter(
+                Q(first_name__icontains=search)
+                | Q(last_name__icontains=search)
+                | Q(username__icontains=search)
+            )
+        page = self.paginate_queryset(qs)
+        if page is not None:
+            serializer = self.get_serializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+        serializer = self.get_serializer(qs, many=True)
+        return Response(serializer.data)
+
     def create(self, request, *args, **kwargs):  # type: ignore[override]
         org = self.get_organizacao()
         user_id = request.data.get("user_id")
@@ -321,6 +338,19 @@ class OrganizacaoNucleoViewSet(OrganizacaoRelatedModelViewSet):
         org = self.get_organizacao()
         return Nucleo.objects.filter(organizacao=org, deleted=False)
 
+    def list(self, request, *args, **kwargs):  # type: ignore[override]
+        org = self.get_organizacao()
+        qs = Nucleo.objects.filter(deleted=False).exclude(organizacao=org)
+        search = request.query_params.get("search")
+        if search:
+            qs = qs.filter(nome__icontains=search)
+        page = self.paginate_queryset(qs)
+        if page is not None:
+            serializer = self.get_serializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+        serializer = self.get_serializer(qs, many=True)
+        return Response(serializer.data)
+
     def create(self, request, *args, **kwargs):  # type: ignore[override]
         org = self.get_organizacao()
         nucleo_id = request.data.get("nucleo_id")
@@ -343,6 +373,19 @@ class OrganizacaoEventoViewSet(OrganizacaoRelatedModelViewSet):
     def get_queryset(self):
         org = self.get_organizacao()
         return Evento.objects.filter(organizacao=org, deleted=False)
+
+    def list(self, request, *args, **kwargs):  # type: ignore[override]
+        org = self.get_organizacao()
+        qs = Evento.objects.filter(deleted=False).exclude(organizacao=org)
+        search = request.query_params.get("search")
+        if search:
+            qs = qs.filter(titulo__icontains=search)
+        page = self.paginate_queryset(qs)
+        if page is not None:
+            serializer = self.get_serializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+        serializer = self.get_serializer(qs, many=True)
+        return Response(serializer.data)
 
     def create(self, request, *args, **kwargs):  # type: ignore[override]
         org = self.get_organizacao()
@@ -367,6 +410,19 @@ class OrganizacaoEmpresaViewSet(OrganizacaoRelatedModelViewSet):
         org = self.get_organizacao()
         return Empresa.objects.filter(organizacao=org, deleted=False)
 
+    def list(self, request, *args, **kwargs):  # type: ignore[override]
+        org = self.get_organizacao()
+        qs = Empresa.objects.filter(deleted=False).exclude(organizacao=org)
+        search = request.query_params.get("search")
+        if search:
+            qs = qs.filter(nome__icontains=search)
+        page = self.paginate_queryset(qs)
+        if page is not None:
+            serializer = self.get_serializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+        serializer = self.get_serializer(qs, many=True)
+        return Response(serializer.data)
+
     def create(self, request, *args, **kwargs):  # type: ignore[override]
         org = self.get_organizacao()
         empresa_id = request.data.get("empresa_id")
@@ -389,6 +445,19 @@ class OrganizacaoPostViewSet(OrganizacaoRelatedModelViewSet):
     def get_queryset(self):
         org = self.get_organizacao()
         return Post.objects.filter(organizacao=org, deleted=False)
+
+    def list(self, request, *args, **kwargs):  # type: ignore[override]
+        org = self.get_organizacao()
+        qs = Post.objects.filter(deleted=False).exclude(organizacao=org)
+        search = request.query_params.get("search")
+        if search:
+            qs = qs.filter(conteudo__icontains=search)
+        page = self.paginate_queryset(qs)
+        if page is not None:
+            serializer = self.get_serializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+        serializer = self.get_serializer(qs, many=True)
+        return Response(serializer.data)
 
     def create(self, request, *args, **kwargs):  # type: ignore[override]
         org = self.get_organizacao()

--- a/organizacoes/templates/organizacoes/empresas_modal.html
+++ b/organizacoes/templates/organizacoes/empresas_modal.html
@@ -3,8 +3,20 @@
   <h3 class="text-lg font-semibold mb-2">{% trans 'Gerenciar empresas' %}</h3>
   <form hx-post="/api/organizacoes/{{ organizacao.id }}/empresas/" hx-on="htmx:afterRequest: htmx.ajax('GET', '{{ refresh_url }}', '#empresas-section'); this.closest('#modal').innerHTML='';" class="space-y-2">
     {% csrf_token %}
-    <label class="block text-sm" for="empresa_id">{% trans 'ID da empresa' %}</label>
-    <input type="text" name="empresa_id" class="w-full border px-2 py-1 rounded">
+    <label class="block text-sm" for="empresa-search">{% trans 'Buscar empresa' %}</label>
+    <input
+      type="text"
+      id="empresa-search"
+      name="search"
+      class="w-full border px-2 py-1 rounded"
+      hx-get="{{ api_url }}"
+      hx-trigger="keyup changed delay:500ms"
+      hx-target="#empresa-options"
+      hx-swap="none"
+      hx-include="[name=search]"
+      hx-on="htmx:afterRequest: renderEmpresas(event)"
+    >
+    <select name="empresa_id" id="empresa-options" class="w-full border px-2 py-1 rounded mt-2"></select>
     <button type="submit" class="mt-2 px-3 py-1 bg-blue-600 text-white rounded">{% trans 'Adicionar' %}</button>
   </form>
   <ul class="mt-4 space-y-1">
@@ -17,4 +29,21 @@
       <li class="text-neutral-500 text-sm">{% trans 'Nenhuma empresa associada.' %}</li>
     {% endfor %}
   </ul>
+  <script src="{% url 'javascript-catalog' %}"></script>
+  <script>
+    function renderEmpresas(evt) {
+      const sel = document.querySelector('#empresa-options');
+      sel.innerHTML = '';
+      try {
+        const data = JSON.parse(evt.detail.xhr.response);
+        const itens = data.results || data;
+        sel.innerHTML =
+          itens
+            .map(e => `<option value="${e.id}">${e.nome}</option>`)
+            .join('') || `<option value="">${gettext('Nenhum resultado')}</option>`;
+      } catch (err) {
+        sel.innerHTML = `<option value="">${gettext('Erro ao carregar')}</option>`;
+      }
+    }
+  </script>
 </div>

--- a/organizacoes/templates/organizacoes/eventos_modal.html
+++ b/organizacoes/templates/organizacoes/eventos_modal.html
@@ -3,8 +3,20 @@
   <h3 class="text-lg font-semibold mb-2">{% trans 'Gerenciar eventos' %}</h3>
   <form hx-post="/api/organizacoes/{{ organizacao.id }}/eventos/" hx-on="htmx:afterRequest: htmx.ajax('GET', '{{ refresh_url }}', '#eventos-section'); this.closest('#modal').innerHTML='';" class="space-y-2">
     {% csrf_token %}
-    <label class="block text-sm" for="evento_id">{% trans 'ID do evento' %}</label>
-    <input type="text" name="evento_id" class="w-full border px-2 py-1 rounded">
+    <label class="block text-sm" for="evento-search">{% trans 'Buscar evento' %}</label>
+    <input
+      type="text"
+      id="evento-search"
+      name="search"
+      class="w-full border px-2 py-1 rounded"
+      hx-get="{{ api_url }}"
+      hx-trigger="keyup changed delay:500ms"
+      hx-target="#evento-options"
+      hx-swap="none"
+      hx-include="[name=search]"
+      hx-on="htmx:afterRequest: renderEventos(event)"
+    >
+    <select name="evento_id" id="evento-options" class="w-full border px-2 py-1 rounded mt-2"></select>
     <button type="submit" class="mt-2 px-3 py-1 bg-blue-600 text-white rounded">{% trans 'Adicionar' %}</button>
   </form>
   <ul class="mt-4 space-y-1">
@@ -17,4 +29,21 @@
       <li class="text-neutral-500 text-sm">{% trans 'Nenhum evento associado.' %}</li>
     {% endfor %}
   </ul>
+  <script src="{% url 'javascript-catalog' %}"></script>
+  <script>
+    function renderEventos(evt) {
+      const sel = document.querySelector('#evento-options');
+      sel.innerHTML = '';
+      try {
+        const data = JSON.parse(evt.detail.xhr.response);
+        const itens = data.results || data;
+        sel.innerHTML =
+          itens
+            .map(e => `<option value="${e.id}">${e.titulo}</option>`)
+            .join('') || `<option value="">${gettext('Nenhum resultado')}</option>`;
+      } catch (err) {
+        sel.innerHTML = `<option value="">${gettext('Erro ao carregar')}</option>`;
+      }
+    }
+  </script>
 </div>

--- a/organizacoes/templates/organizacoes/nucleos_modal.html
+++ b/organizacoes/templates/organizacoes/nucleos_modal.html
@@ -3,8 +3,20 @@
   <h3 class="text-lg font-semibold mb-2">{% trans 'Gerenciar núcleos' %}</h3>
   <form hx-post="/api/organizacoes/{{ organizacao.id }}/nucleos/" hx-on="htmx:afterRequest: htmx.ajax('GET', '{{ refresh_url }}', '#nucleos-section'); this.closest('#modal').innerHTML='';" class="space-y-2">
     {% csrf_token %}
-    <label class="block text-sm" for="nucleo_id">{% trans 'ID do núcleo' %}</label>
-    <input type="text" name="nucleo_id" class="w-full border px-2 py-1 rounded">
+    <label class="block text-sm" for="nucleo-search">{% trans 'Buscar núcleo' %}</label>
+    <input
+      type="text"
+      id="nucleo-search"
+      name="search"
+      class="w-full border px-2 py-1 rounded"
+      hx-get="{{ api_url }}"
+      hx-trigger="keyup changed delay:500ms"
+      hx-target="#nucleo-options"
+      hx-swap="none"
+      hx-include="[name=search]"
+      hx-on="htmx:afterRequest: renderNucleos(event)"
+    >
+    <select name="nucleo_id" id="nucleo-options" class="w-full border px-2 py-1 rounded mt-2"></select>
     <button type="submit" class="mt-2 px-3 py-1 bg-blue-600 text-white rounded">{% trans 'Adicionar' %}</button>
   </form>
   <ul class="mt-4 space-y-1">
@@ -17,4 +29,21 @@
       <li class="text-neutral-500 text-sm">{% trans 'Nenhum núcleo associado.' %}</li>
     {% endfor %}
   </ul>
+  <script src="{% url 'javascript-catalog' %}"></script>
+  <script>
+    function renderNucleos(evt) {
+      const sel = document.querySelector('#nucleo-options');
+      sel.innerHTML = '';
+      try {
+        const data = JSON.parse(evt.detail.xhr.response);
+        const itens = data.results || data;
+        sel.innerHTML =
+          itens
+            .map(n => `<option value="${n.id}">${n.nome}</option>`)
+            .join('') || `<option value="">${gettext('Nenhum resultado')}</option>`;
+      } catch (e) {
+        sel.innerHTML = `<option value="">${gettext('Erro ao carregar')}</option>`;
+      }
+    }
+  </script>
 </div>

--- a/organizacoes/templates/organizacoes/posts_modal.html
+++ b/organizacoes/templates/organizacoes/posts_modal.html
@@ -3,8 +3,20 @@
   <h3 class="text-lg font-semibold mb-2">{% trans 'Gerenciar posts' %}</h3>
   <form hx-post="/api/organizacoes/{{ organizacao.id }}/posts/" hx-on="htmx:afterRequest: htmx.ajax('GET', '{{ refresh_url }}', '#posts-section'); this.closest('#modal').innerHTML='';" class="space-y-2">
     {% csrf_token %}
-    <label class="block text-sm" for="post_id">{% trans 'ID do post' %}</label>
-    <input type="text" name="post_id" class="w-full border px-2 py-1 rounded">
+    <label class="block text-sm" for="post-search">{% trans 'Buscar post' %}</label>
+    <input
+      type="text"
+      id="post-search"
+      name="search"
+      class="w-full border px-2 py-1 rounded"
+      hx-get="{{ api_url }}"
+      hx-trigger="keyup changed delay:500ms"
+      hx-target="#post-options"
+      hx-swap="none"
+      hx-include="[name=search]"
+      hx-on="htmx:afterRequest: renderPosts(event)"
+    >
+    <select name="post_id" id="post-options" class="w-full border px-2 py-1 rounded mt-2"></select>
     <button type="submit" class="mt-2 px-3 py-1 bg-blue-600 text-white rounded">{% trans 'Adicionar' %}</button>
   </form>
   <ul class="mt-4 space-y-1">
@@ -17,4 +29,21 @@
       <li class="text-neutral-500 text-sm">{% trans 'Nenhum post associado.' %}</li>
     {% endfor %}
   </ul>
+  <script src="{% url 'javascript-catalog' %}"></script>
+  <script>
+    function renderPosts(evt) {
+      const sel = document.querySelector('#post-options');
+      sel.innerHTML = '';
+      try {
+        const data = JSON.parse(evt.detail.xhr.response);
+        const itens = data.results || data;
+        sel.innerHTML =
+          itens
+            .map(p => `<option value="${p.id}">${p.conteudo?.slice(0,50) || ''}</option>`)
+            .join('') || `<option value="">${gettext('Nenhum resultado')}</option>`;
+      } catch (err) {
+        sel.innerHTML = `<option value="">${gettext('Erro ao carregar')}</option>`;
+      }
+    }
+  </script>
 </div>

--- a/organizacoes/templates/organizacoes/usuarios_modal.html
+++ b/organizacoes/templates/organizacoes/usuarios_modal.html
@@ -3,8 +3,20 @@
   <h3 class="text-lg font-semibold mb-2">{% trans 'Gerenciar usuários' %}</h3>
   <form hx-post="/api/organizacoes/{{ organizacao.id }}/usuarios/" hx-on="htmx:afterRequest: htmx.ajax('GET', '{{ refresh_url }}', '#usuarios-section'); this.closest('#modal').innerHTML='';" class="space-y-2">
     {% csrf_token %}
-    <label class="block text-sm" for="user_id">{% trans 'ID do usuário' %}</label>
-    <input type="text" name="user_id" class="w-full border px-2 py-1 rounded">
+    <label class="block text-sm" for="user-search">{% trans 'Buscar usuário' %}</label>
+    <input
+      type="text"
+      id="user-search"
+      name="search"
+      class="w-full border px-2 py-1 rounded"
+      hx-get="{{ api_url }}"
+      hx-trigger="keyup changed delay:500ms"
+      hx-target="#user-options"
+      hx-swap="none"
+      hx-include="[name=search]"
+      hx-on="htmx:afterRequest: renderUsuarios(event)"
+    >
+    <select name="user_id" id="user-options" class="w-full border px-2 py-1 rounded mt-2"></select>
     <button type="submit" class="mt-2 px-3 py-1 bg-blue-600 text-white rounded">{% trans 'Adicionar' %}</button>
   </form>
   <ul class="mt-4 space-y-1">
@@ -17,4 +29,21 @@
       <li class="text-neutral-500 text-sm">{% trans 'Nenhum usuário associado.' %}</li>
     {% endfor %}
   </ul>
+  <script src="{% url 'javascript-catalog' %}"></script>
+  <script>
+    function renderUsuarios(evt) {
+      const sel = document.querySelector('#user-options');
+      sel.innerHTML = '';
+      try {
+        const data = JSON.parse(evt.detail.xhr.response);
+        const itens = data.results || data;
+        sel.innerHTML =
+          itens
+            .map(u => `<option value="${u.id}">${u.username}</option>`)
+            .join('') || `<option value="">${gettext('Nenhum resultado')}</option>`;
+      } catch (e) {
+        sel.innerHTML = `<option value="">${gettext('Erro ao carregar')}</option>`;
+      }
+    }
+  </script>
 </div>

--- a/organizacoes/views.py
+++ b/organizacoes/views.py
@@ -373,6 +373,9 @@ class OrganizacaoUsuariosModalView(AdminRequiredMixin, LoginRequiredMixin, View)
                 "organizacao": org,
                 "usuarios": usuarios,
                 "refresh_url": reverse("organizacoes:detail", args=[org.pk]) + "?section=usuarios",
+                "api_url": reverse(
+                    "organizacoes_api:organizacao-usuarios-list", kwargs={"organizacao_pk": org.pk}
+                ),
             },
         )
 
@@ -388,6 +391,9 @@ class OrganizacaoNucleosModalView(AdminRequiredMixin, LoginRequiredMixin, View):
                 "organizacao": org,
                 "nucleos": nucleos,
                 "refresh_url": reverse("organizacoes:detail", args=[org.pk]) + "?section=nucleos",
+                "api_url": reverse(
+                    "organizacoes_api:organizacao-nucleos-list", kwargs={"organizacao_pk": org.pk}
+                ),
             },
         )
 
@@ -403,6 +409,9 @@ class OrganizacaoEventosModalView(AdminRequiredMixin, LoginRequiredMixin, View):
                 "organizacao": org,
                 "eventos": eventos,
                 "refresh_url": reverse("organizacoes:detail", args=[org.pk]) + "?section=eventos",
+                "api_url": reverse(
+                    "organizacoes_api:organizacao-eventos-list", kwargs={"organizacao_pk": org.pk}
+                ),
             },
         )
 
@@ -418,6 +427,9 @@ class OrganizacaoEmpresasModalView(AdminRequiredMixin, LoginRequiredMixin, View)
                 "organizacao": org,
                 "empresas": empresas,
                 "refresh_url": reverse("organizacoes:detail", args=[org.pk]) + "?section=empresas",
+                "api_url": reverse(
+                    "organizacoes_api:organizacao-empresas-list", kwargs={"organizacao_pk": org.pk}
+                ),
             },
         )
 
@@ -433,5 +445,8 @@ class OrganizacaoPostsModalView(AdminRequiredMixin, LoginRequiredMixin, View):
                 "organizacao": org,
                 "posts": posts,
                 "refresh_url": reverse("organizacoes:detail", args=[org.pk]) + "?section=posts",
+                "api_url": reverse(
+                    "organizacoes_api:organizacao-posts-list", kwargs={"organizacao_pk": org.pk}
+                ),
             },
         )


### PR DESCRIPTION
## Summary
- replace ID fields in organization modals with HTMX-powered search selectors
- expose paginated list endpoints with search for organization associations
- wire modal views to provide API URLs for dynamic option loading

## Testing
- `pytest tests/organizacoes -q` *(fails: Conflicting migrations detected; multiple leaf nodes in the migration graph)*

------
https://chatgpt.com/codex/tasks/task_e_68a75c2a05108325ad8177aec91a3946