### PR TITLE
Restrict organization history to root

### DIFF
--- a/organizacoes/api.py
+++ b/organizacoes/api.py
@@ -27,7 +27,12 @@ from nucleos.serializers import NucleoSerializer
 
 from core.permissions import IsOrgAdminOrSuperuser, IsRoot
 
-from .models import Organizacao, OrganizacaoAtividadeLog, OrganizacaoRecurso
+from .models import (
+    Organizacao,
+    OrganizacaoAtividadeLog,
+    OrganizacaoChangeLog,
+    OrganizacaoRecurso,
+)
 from .serializers import (
     FeedPluginConfigSerializer,
     OrganizacaoAtividadeLogSerializer,
@@ -117,9 +122,10 @@ class OrganizacaoViewSet(viewsets.ModelViewSet):
             "update",
             "inativar",
             "reativar",
+            "history",
         }:
             self.permission_classes = [IsAuthenticated, IsRoot]
-        elif self.action in {"history", "list", "retrieve"}:
+        elif self.action in {"list", "retrieve"}:
             self.permission_classes = [IsAuthenticated, IsOrgAdminOrSuperuser]
         return super().get_permissions()
 

--- a/organizacoes/views.py
+++ b/organizacoes/views.py
@@ -302,13 +302,6 @@ class OrganizacaoHistoryView(LoginRequiredMixin, View):
                 user.is_superuser
                 or getattr(user, "user_type", None) == UserType.ROOT.value
                 or user.get_tipo_usuario == UserType.ROOT.value
-                or (
-                    (
-                        user.get_tipo_usuario == UserType.ADMIN.value
-                        or getattr(user, "user_type", None) == UserType.ADMIN.value
-                    )
-                    and getattr(user, "organizacao_id", None) == org.id
-                )
             ):
                 return HttpResponseForbidden()
 


### PR DESCRIPTION
## Summary
- limit organization history API action to root users
- remove admin access to organization history view
- test history endpoints for admin 403 and root 200 responses

## Testing
- `pytest --no-cov --nomigrations tests/organizacoes/test_api.py::test_history_requires_root tests/organizacoes/test_views.py::test_logs_view_permission -q`


------
https://chatgpt.com/codex/tasks/task_e_68a75c2983688325ac5d1e28ff5eaec0