### PR TITLE
Render validation errors on social networks form

### DIFF
--- a/accounts/templates/perfil/redes_sociais.html
+++ b/accounts/templates/perfil/redes_sociais.html
@@ -11,10 +11,16 @@
   <form method="post" action="{% url 'accounts:redes_sociais' %}" class="space-y-6">
     {% csrf_token %}
 
-    <div>
-      {{ form.redes_sociais.label_tag }}
-      {{ form.redes_sociais }}
-    </div>
+      <div>
+        {{ form.redes_sociais.label_tag }}
+        {{ form.redes_sociais }}
+        {% if form.redes_sociais.errors %}
+          <p class="text-red-600 text-sm mt-1">{{ form.redes_sociais.errors }}</p>
+        {% endif %}
+        {% if form.non_field_errors %}
+          <p class="text-red-600 text-sm mt-1">{{ form.non_field_errors }}</p>
+        {% endif %}
+      </div>
 
     <div class="pt-4">
       <button type="submit"


### PR DESCRIPTION
## Summary
- show social network field errors on profile page
- display non-field errors for social network form

## Testing
- `pytest --no-cov tests/accounts/test_user_registration.py::test_user_creation_unique_email -q` *(fails: CommandError: Conflicting migrations detected)*

------
https://chatgpt.com/codex/tasks/task_e_68a7692929548325a8ec6edace99aa99