### PR TITLE
Add connection search functionality

### DIFF
--- a/accounts/templates/perfil/conexoes.html
+++ b/accounts/templates/perfil/conexoes.html
@@ -21,10 +21,16 @@
 
     <!-- MINHAS CONEXÕES -->
     <div class="tab-pane" id="minhas-conexoes">
-      <div class="flex gap-2 mb-4">
-        <input type="text" placeholder="{% trans 'Buscar conexões...' %}" class="flex-grow border rounded-lg p-2 text-sm" />
-        <button class="text-gray-600 text-sm" aria-label="{% trans 'Buscar' %}">🔍</button>
-      </div>
+      <form method="get" class="flex gap-2 mb-4">
+        <input
+          type="text"
+          name="q"
+          value="{{ q }}"
+          placeholder="{% trans 'Buscar conexões...' %}"
+          class="flex-grow border rounded-lg p-2 text-sm"
+        />
+        <button type="submit" class="text-gray-600 text-sm" aria-label="{% trans 'Buscar' %}">🔍</button>
+      </form>
 
       <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
         {% for connection in connections %}

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -180,12 +180,32 @@ def check_2fa(request):
 
 @login_required
 def perfil_conexoes(request):
-    connections = request.user.connections.all() if hasattr(request.user, "connections") else []
-    connection_requests = request.user.followers.all() if hasattr(request.user, "followers") else []
+    q = request.GET.get("q", "").strip()
+    connections = (
+        request.user.connections.all()
+        if hasattr(request.user, "connections")
+        else User.objects.none()
+    )
+    connection_requests = (
+        request.user.followers.all()
+        if hasattr(request.user, "followers")
+        else User.objects.none()
+    )
+
+    if q:
+        filters = (
+            Q(username__icontains=q)
+            | Q(first_name__icontains=q)
+            | Q(last_name__icontains=q)
+            | Q(nome_completo__icontains=q)
+        )
+        connections = connections.filter(filters)
+        connection_requests = connection_requests.filter(filters)
 
     context = {
         "connections": connections,
         "connection_requests": connection_requests,
+        "q": q,
     }
 
     return render(request, "perfil/conexoes.html", context)


### PR DESCRIPTION
## Summary
- enable searching by name or username in connections view
- support GET-based search form in connections template

## Testing
- `pytest --override-ini="addopts=" tests/accounts/test_connections.py::test_aceitar_conexao -q` *(fails: Conflicting migrations detected; multiple leaf nodes in the migration graph)*

------
https://chatgpt.com/codex/tasks/task_e_68a7692768b08325ab64e49aea6c8fc0