### PR TITLE
refactor: rename retention config endpoint

### DIFF
--- a/chat/README.md
+++ b/chat/README.md
@@ -67,6 +67,17 @@ GET /api/chat/channels/<id>/export/?formato=csv
 A chamada cria um `RelatorioChatExport` e, após processamento assíncrono,
 disponibiliza um arquivo JSON ou CSV com as mensagens visíveis.
 
+### Configurar política de retenção
+
+```http
+PATCH /api/chat/channels/<id>/config-retention/
+Content-Type: application/json
+
+{"retencao_dias": 30}
+```
+
+Define ou remove (`null`) o limite de dias para exclusão automática de mensagens do canal. Somente administradores podem alterar a configuração.
+
 ## Criptografia de ponta a ponta (E2EE)
 
 Quando um canal tem `e2ee_habilitado` ativado, o cliente deve cifrar o conteúdo

--- a/chat/api_urls.py
+++ b/chat/api_urls.py
@@ -43,7 +43,7 @@ chat_message_search = ChatMessageViewSet.as_view({"get": "search"})
 chat_message_favorite = ChatMessageViewSet.as_view({"post": "favorite", "delete": "favorite"})
 chat_message_create_item = ChatMessageViewSet.as_view({"post": "criar_item"})
 chat_message_mark_read = ChatMessageViewSet.as_view({"post": "mark_read"})
-chat_channel_config_retencao = ChatChannelViewSet.as_view({"patch": "config_retencao"})
+chat_channel_config_retention = ChatChannelViewSet.as_view({"patch": "config_retencao"})
 
 urlpatterns = router.urls + [
     path(
@@ -97,9 +97,9 @@ urlpatterns = router.urls + [
         name="chat-channel-message-criar-item",
     ),
     path(
-        "canais/<uuid:pk>/config-retencao/",
-        chat_channel_config_retencao,
-        name="chat-channel-config-retencao",
+        "channels/<uuid:pk>/config-retention/",
+        chat_channel_config_retention,
+        name="chat-channel-config-retention",
     ),
     path(
         "channels/<uuid:channel_pk>/messages/search/",

--- a/chat/api_views.py
+++ b/chat/api_views.py
@@ -325,7 +325,7 @@ class ChatChannelViewSet(viewsets.ModelViewSet):
     @action(
         detail=True,
         methods=["patch"],
-        url_path="config-retencao",
+        url_path="config-retention",
         permission_classes=[permissions.IsAuthenticated, IsChannelAdminOrOwner],
     )
     def config_retencao(self, request: Request, pk: str | None = None) -> Response:

--- a/chat/templates/chat/conversation_detail.html
+++ b/chat/templates/chat/conversation_detail.html
@@ -227,7 +227,7 @@
           retencaoFeedback.classList.remove('hidden');
           return;
         }
-        fetch(`/api/chat/canais/${channelId}/config-retencao/`, {
+        fetch(`/api/chat/channels/${channelId}/config-retention/`, {
           method:'PATCH',
           headers:{'Content-Type':'application/json','X-CSRFToken':csrfToken},
           body: JSON.stringify({retencao_dias: value || null})

--- a/tests/chat/test_retencao.py
+++ b/tests/chat/test_retencao.py
@@ -21,7 +21,7 @@ def test_config_retencao_updates_value(api_client: APIClient, admin_user) -> Non
     channel = ChatChannel.objects.create(contexto_tipo="privado")
     ChatParticipant.objects.create(channel=channel, user=admin_user, is_admin=True)
     api_client.force_authenticate(admin_user)
-    url = reverse("chat_api:chat-channel-config-retencao", args=[channel.pk])
+    url = reverse("chat_api:chat-channel-config-retention", args=[channel.pk])
     resp = api_client.patch(url, {"retencao_dias": 30}, format="json")
     assert resp.status_code == 200
     channel.refresh_from_db()
@@ -33,7 +33,7 @@ def test_config_retencao_requires_admin(api_client: APIClient, admin_user, coord
     ChatParticipant.objects.create(channel=channel, user=admin_user, is_admin=True)
     ChatParticipant.objects.create(channel=channel, user=coordenador_user)
     api_client.force_authenticate(coordenador_user)
-    url = reverse("chat_api:chat-channel-config-retencao", args=[channel.pk])
+    url = reverse("chat_api:chat-channel-config-retention", args=[channel.pk])
     resp = api_client.patch(url, {"retencao_dias": 10}, format="json")
     assert resp.status_code == 403
 
@@ -42,7 +42,7 @@ def test_config_retencao_validation(api_client: APIClient, admin_user) -> None:
     channel = ChatChannel.objects.create(contexto_tipo="privado")
     ChatParticipant.objects.create(channel=channel, user=admin_user, is_admin=True)
     api_client.force_authenticate(admin_user)
-    url = reverse("chat_api:chat-channel-config-retencao", args=[channel.pk])
+    url = reverse("chat_api:chat-channel-config-retention", args=[channel.pk])
     resp = api_client.patch(url, {"retencao_dias": 400}, format="json")
     assert resp.status_code == 400
 


### PR DESCRIPTION
## Summary
- rename channel retention configuration endpoint to `/api/chat/channels/<id>/config-retention/`
- update frontend fetch call and associated tests
- document new retention endpoint

## Testing
- `pytest tests/chat/test_retencao.py --nomigrations -o addopts='' -q` *(fails: tokens/urls.py IndentationError)*

------
https://chatgpt.com/codex/tasks/task_e_68a76907612083259f0f0514590ec4a0