### PR TITLE
Standardize chat message updates to PATCH

### DIFF
--- a/chat/api_urls.py
+++ b/chat/api_urls.py
@@ -29,7 +29,6 @@ chat_message_list = ChatMessageViewSet.as_view({"get": "list", "post": "create"}
 chat_message_detail = ChatMessageViewSet.as_view(
     {
         "get": "retrieve",
-        "put": "update",
         "patch": "partial_update",
         "delete": "destroy",
     }


### PR DESCRIPTION
## Summary
- remove PUT route from chat message detail so updates rely on PATCH

## Testing
- `python -m py_compile chat/api_urls.py`
- `pytest tests/chat/test_api_views.py::test_edit_and_delete_message -q --no-cov --maxfail=1 --log-level=CRITICAL` *(fails: Conflicting migrations detected; multiple leaf nodes in the migration graph)*

------
https://chatgpt.com/codex/tasks/task_e_68a76906819c83259ec679e121b28d4e