### PR TITLE
fix: open user chat rooms via modal

### DIFF
--- a/chat/templates/chat/modal_user_list.html
+++ b/chat/templates/chat/modal_user_list.html
@@ -19,7 +19,7 @@
     <div class="grid sm:grid-cols-2 md:grid-cols-3 gap-4">
       {% for u in users %}
         <button
-          hx-post="/chat/iniciar/{{ u.id }}/"
+          hx-get="{% url 'chat:modal_room' u.id %}"
           hx-target="body"
           class="w-full text-left cursor-pointer group border border-neutral-200 rounded-2xl p-4 bg-white shadow-sm hover:shadow-md transition-all flex items-center gap-4"
         >


### PR DESCRIPTION
## Summary
- use existing `modal_room` route when selecting users in chat modal

## Testing
- `pytest tests/chat/test_views.py::test_modal_room_loads_messages tests/chat/test_templates.py -q` *(fails: Conflicting migrations detected; multiple leaf nodes in the migration graph)*

------
https://chatgpt.com/codex/tasks/task_e_68a769056cb88325908614038456b1cc