### PR TITLE
Use translated theme label in contextual list

### DIFF
--- a/configuracoes/templates/configuracoes/contextual_list.html
+++ b/configuracoes/templates/configuracoes/contextual_list.html
@@ -19,7 +19,7 @@
 
       <li class="p-4 bg-white rounded-lg shadow space-y-2">
         <div class="flex items-center justify-between">
-          <span>{{ cfg.get_escopo_tipo_display }} {{ cfg.escopo_id }} - {{ cfg.tema }}</span>
+          <span>{{ cfg.get_escopo_tipo_display }} {{ cfg.escopo_id }} - {{ cfg.get_tema_display }}</span>
           <span class="space-x-2">
             <a
               href="{% url 'configuracoes-contextual-update' cfg.id %}"


### PR DESCRIPTION
## Summary
- Use `get_tema_display` to show translated theme name in contextual configurations list

## Testing
- `pytest --no-cov tests/configuracoes/test_contextual.py::test_contextual_unique_constraint -q` *(fails: Conflicting migrations detected)*

------
https://chatgpt.com/codex/tasks/task_e_68a768f76c38832597710fabc0242abc