### PR TITLE
Ajusta URL de cancelamento em exclusão contextual

### DIFF
--- a/configuracoes/templates/configuracoes/contextual_confirm_delete.html
+++ b/configuracoes/templates/configuracoes/contextual_confirm_delete.html
@@ -10,7 +10,7 @@
     {% csrf_token %}
     <p>{% trans "Tem certeza que deseja excluir esta configuração?" %}</p>
     <div class="flex justify-between pt-4">
-      <a href="{% url 'configuracoes' %}" class="px-4 py-2 bg-gray-200 rounded-lg text-gray-700 hover:bg-gray-300">{% trans "Cancelar" %}</a>
+      <a href="{% url 'configuracoes-contextual-list' %}" class="px-4 py-2 bg-gray-200 rounded-lg text-gray-700 hover:bg-gray-300">{% trans "Cancelar" %}</a>
       <button type="submit" class="px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded-lg">{% trans "Confirmar" %}</button>
     </div>
   </form>


### PR DESCRIPTION
## Summary
- Atualiza link de cancelamento para `configuracoes-contextual-list` na tela de exclusão contextual

## Testing
- `pytest tests/configuracoes/test_views.py::test_view_get_autenticado -q --no-cov` *(falha: django.core.management.base.CommandError: Conflicting migrations detected)*

------
https://chatgpt.com/codex/tasks/task_e_68a768f66484832593849d955537dc1d