### PR TITLE
Use growth calculation for confirmed registrations

### DIFF
--- a/dashboard/services.py
+++ b/dashboard/services.py
@@ -683,7 +683,12 @@ class DashboardMetricsService:
                 qs = qs.filter(evento__nucleo_id=nucleo_id)
             if evento_id:
                 qs = qs.filter(evento_id=evento_id)
-            metrics["inscricoes_confirmadas"] = {"total": qs.count(), "crescimento": 0.0}
+            metrics["inscricoes_confirmadas"] = DashboardService.calcular_crescimento(
+                qs,
+                inicio,
+                fim,
+                campo="data_confirmacao",
+            )
 
         if not metricas or "num_posts_feed_recent" in metricas:
             metrics["num_posts_feed_recent"] = {

--- a/tests/dashboard/test_api.py
+++ b/tests/dashboard/test_api.py
@@ -121,7 +121,7 @@ def test_metrics_cache(api_client: APIClient, admin_user, monkeypatch) -> None:
     url = reverse("dashboard_api:dashboard-list")
     api_client.get(url)
     api_client.get(url)
-    assert calls["c"] == 10
+    assert calls["c"] == 11
 
 
 def test_dashboard_new_metrics(api_client: APIClient, admin_user) -> None:

--- a/tests/dashboard/test_integration.py
+++ b/tests/dashboard/test_integration.py
@@ -18,5 +18,5 @@ def test_admin_view_invokes_service_methods(client, admin_user):
     ) as spy:
         client.force_login(admin_user)
         client.get(reverse("dashboard:admin"))
-        assert spy.call_count == 6
+        assert spy.call_count == 7
 


### PR DESCRIPTION
## Summary
- compute growth for confirmed event registrations via `calcular_crescimento`
- test variation calculation for confirmed registrations
- update cache-related tests for new metric

## Testing
- `pytest tests/dashboard/test_services.py::test_get_metrics_inscricoes_confirmadas -q --no-cov --nomigrations`
- `pytest tests/dashboard/test_api.py::test_metrics_cache -q --no-cov --nomigrations` *(fails: IndentationError in tokens/views.py)*
- `pytest tests/dashboard/test_integration.py::test_admin_view_invokes_service_methods -q --no-cov --nomigrations` *(fails: IndentationError in tokens/views.py)*


------
https://chatgpt.com/codex/tasks/task_e_68a768e90c4c8325986a579a6faf7775