### PR TITLE
Check company create permission

### DIFF
--- a/empresas/api.py
+++ b/empresas/api.py
@@ -135,6 +135,16 @@ class EmpresaViewSet(viewsets.ModelViewSet):
             self.permission_classes = [IsAuthenticated]
         return super().get_permissions()
 
+    def create(self, request, *args, **kwargs):
+        """Cria uma empresa após checar permissões.
+
+        Verifica ``pode_crud_empresa(request.user)`` antes de salvar a empresa,
+        retornando ``403 Forbidden`` caso o usuário não esteja autorizado.
+        """
+        if not pode_crud_empresa(request.user):
+            return Response(status=status.HTTP_403_FORBIDDEN)
+        return super().create(request, *args, **kwargs)
+
     def update(self, request, *args, **kwargs):
         empresa = self.get_object()
         if not (request.user == empresa.usuario or request.user.user_type in {UserType.ADMIN, UserType.ROOT}):

--- a/tests/empresas/test_api.py
+++ b/tests/empresas/test_api.py
@@ -65,6 +65,23 @@ def test_crud_empresa(api_client, gerente_user, tag_factory):
     EmpresaChangeLog.objects.get(empresa=empresa, campo_alterado="deleted", valor_novo="True")
 
 
+def test_criar_empresa_sem_permissao(api_client, associado_user):
+    api_client.force_authenticate(user=associado_user)
+    url = reverse("empresas_api:empresa-list")
+    data = {
+        "usuario": associado_user.id,
+        "organizacao": associado_user.organizacao.id,
+        "nome": "Empresa Y",
+        "cnpj": CNPJ().generate(),
+        "tipo": "mei",
+        "municipio": "Florianópolis",
+        "estado": "SC",
+    }
+    resp = api_client.post(url, data, format="json")
+    assert resp.status_code == status.HTTP_403_FORBIDDEN
+    assert not Empresa.objects.filter(nome="Empresa Y").exists()
+
+
 def test_busca_por_tag_e_palavra(api_client, gerente_user, tag_factory):
     api_client.force_authenticate(user=gerente_user)
     t1 = tag_factory(nome="servico", categoria="serv")


### PR DESCRIPTION
## Summary
- enforce `pode_crud_empresa` in `EmpresaViewSet.create`
- add test ensuring unauthorized users receive 403

## Testing
- `pytest tests/empresas/test_api.py::test_crud_empresa tests/empresas/test_api.py::test_criar_empresa_sem_permissao -q --nomigrations --cov-fail-under=0` *(fails: File "/workspace/ProjetoHubx/tokens/views.py", line 181)*

------
https://chatgpt.com/codex/tasks/task_e_68a768ca14148325b717bf4ed38fe107