### PR TITLE
Log empresa deletion

### DIFF
--- a/empresas/views.py
+++ b/empresas/views.py
@@ -152,6 +152,13 @@ class EmpresaDeleteView(LoginRequiredMixin, UserPassesTestMixin, DeleteView):
     def delete(self, request, *args, **kwargs):  # type: ignore[override]
         empresa = self.get_object()
         empresa.soft_delete()
+        EmpresaChangeLog.objects.create(
+            empresa=empresa,
+            usuario=request.user,
+            campo_alterado="deleted",
+            valor_antigo="False",
+            valor_novo="True",
+        )
         if request.headers.get("HX-Request"):
             return JsonResponse({"message": "Empresa removida com sucesso."}, status=HTTP_204_NO_CONTENT)
         messages.success(request, _("Empresa removida com sucesso."))

--- a/tests/empresas/test_views.py
+++ b/tests/empresas/test_views.py
@@ -81,6 +81,13 @@ def test_soft_delete_marks_deleted(client, nucleado_user):
     assert resp.status_code in (302, 200)
     empresa.refresh_from_db()
     assert empresa.deleted
+    EmpresaChangeLog.objects.get(
+        empresa=empresa,
+        usuario=nucleado_user,
+        campo_alterado="deleted",
+        valor_antigo="False",
+        valor_novo="True",
+    )
     resp = client.get(reverse("empresas:lista"))
     assert empresa.nome not in resp.content.decode()
 


### PR DESCRIPTION
## Summary
- log empresa soft delete in change log
- test soft delete creates change log entry

## Testing
- `pytest` *(fails: django.core.management.base.CommandError: Conflicting migrations detected)*
- `pytest -o addopts='' tests/empresas/test_views.py::test_soft_delete_marks_deleted tests/empresas/test_api.py::test_crud_empresa -q --nomigrations` *(fails: IndentationError in tokens/views.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a768c8d79c8325a8842631c58d09a2