### PR TITLE
Add CSRF headers to HTMX button actions

### DIFF
--- a/chat/templates/chat/moderacao.html
+++ b/chat/templates/chat/moderacao.html
@@ -8,8 +8,8 @@
     <div class="border p-2 mb-2" id="msg-{{ m.id }}">
       <p><strong>{{ m.remetente.username }}</strong>: {{ m.conteudo }}</p>
       <p>{% trans "Flags" %}: {{ m.flags_count }}</p>
-      <button hx-post="/api/chat/moderacao/messages/{{ m.id }}/approve/" hx-target="#msg-{{ m.id }}" hx-swap="outerHTML remove" class="text-green-600">{% trans "Aprovar" %}</button>
-      <button hx-post="/api/chat/moderacao/messages/{{ m.id }}/remove/" hx-target="#msg-{{ m.id }}" hx-swap="outerHTML remove" class="text-red-600 ml-2">{% trans "Remover" %}</button>
+      <button hx-post="/api/chat/moderacao/messages/{{ m.id }}/approve/" hx-target="#msg-{{ m.id }}" hx-swap="outerHTML remove" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}' class="text-green-600">{% trans "Aprovar" %}</button>
+      <button hx-post="/api/chat/moderacao/messages/{{ m.id }}/remove/" hx-target="#msg-{{ m.id }}" hx-swap="outerHTML remove" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}' class="text-red-600 ml-2">{% trans "Remover" %}</button>
     </div>
   {% empty %}
     <p>{% trans "Nenhuma mensagem sinalizada." %}</p>

--- a/configuracoes/templates/configuracoes/partials/preferencias.html
+++ b/configuracoes/templates/configuracoes/partials/preferencias.html
@@ -25,7 +25,7 @@
         <p class="text-xs text-gray-500">{{ preferencias_form.frequencia_notificacoes_email.help_text }}</p>
       {% endif %}
       <div class="mt-2 flex items-center gap-2">
-        <button type="button" class="text-xs text-blue-600 hover:underline" hx-post="{% url 'configuracoes_api:configuracoes-testar' %}" hx-vals='{"canal": "email"}' hx-include="[name=csrfmiddlewaretoken]" hx-swap="none" hx-on:afterRequest="document.getElementById('msg-email').innerText = event.detail.xhr.responseJSON.detail">
+        <button type="button" class="text-xs text-blue-600 hover:underline" hx-post="{% url 'configuracoes_api:configuracoes-testar' %}" hx-vals='{"canal": "email"}' hx-include="[name=csrfmiddlewaretoken]" hx-swap="none" hx-on:afterRequest="document.getElementById('msg-email').innerText = event.detail.xhr.responseJSON.detail" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
           {% trans 'Testar e-mail' %}
         </button>
         <span id="msg-email" class="text-xs text-gray-600" aria-live="polite"></span>
@@ -51,7 +51,7 @@
         <p class="text-xs text-gray-500">{{ preferencias_form.frequencia_notificacoes_whatsapp.help_text }}</p>
       {% endif %}
       <div class="mt-2 flex items-center gap-2">
-        <button type="button" class="text-xs text-blue-600 hover:underline" hx-post="{% url 'configuracoes_api:configuracoes-testar' %}" hx-vals='{"canal": "whatsapp"}' hx-include="[name=csrfmiddlewaretoken]" hx-swap="none" hx-on:afterRequest="document.getElementById('msg-whatsapp').innerText = event.detail.xhr.responseJSON.detail">
+        <button type="button" class="text-xs text-blue-600 hover:underline" hx-post="{% url 'configuracoes_api:configuracoes-testar' %}" hx-vals='{"canal": "whatsapp"}' hx-include="[name=csrfmiddlewaretoken]" hx-swap="none" hx-on:afterRequest="document.getElementById('msg-whatsapp').innerText = event.detail.xhr.responseJSON.detail" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
           {% trans 'Testar WhatsApp' %}
         </button>
         <span id="msg-whatsapp" class="text-xs text-gray-600" aria-live="polite"></span>
@@ -78,7 +78,7 @@
         <p class="text-xs text-gray-500">{{ preferencias_form.frequencia_notificacoes_push.help_text }}</p>
       {% endif %}
       <div class="mt-2 flex items-center gap-2">
-        <button type="button" class="text-xs text-blue-600 hover:underline" hx-post="{% url 'configuracoes_api:configuracoes-testar' %}" hx-vals='{"canal": "push"}' hx-include="[name=csrfmiddlewaretoken]" hx-swap="none" hx-on:afterRequest="document.getElementById('msg-push').innerText = event.detail.xhr.responseJSON.detail">
+        <button type="button" class="text-xs text-blue-600 hover:underline" hx-post="{% url 'configuracoes_api:configuracoes-testar' %}" hx-vals='{"canal": "push"}' hx-include="[name=csrfmiddlewaretoken]" hx-swap="none" hx-on:afterRequest="document.getElementById('msg-push').innerText = event.detail.xhr.responseJSON.detail" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
           {% trans 'Testar push' %}
         </button>
         <span id="msg-push" class="text-xs text-gray-600" aria-live="polite"></span>

--- a/discussao/templates/discussao/comentario_item.html
+++ b/discussao/templates/discussao/comentario_item.html
@@ -40,10 +40,10 @@
     {% endif %}
 
       <div class="flex items-center gap-1">
-        <button hx-post="{% url 'discussao:interacao' resposta_content_type_id comentario.id 'up' %}" hx-swap="none" hx-on:afterRequest="document.getElementById('comment-score-{{ comentario.id }}').innerText = event.detail.xhr.responseJSON.score; document.getElementById('comment-votes-{{ comentario.id }}').innerText = event.detail.xhr.responseJSON.num_votos">&#9650;</button>
+        <button hx-post="{% url 'discussao:interacao' resposta_content_type_id comentario.id 'up' %}" hx-swap="none" hx-on:afterRequest="document.getElementById('comment-score-{{ comentario.id }}').innerText = event.detail.xhr.responseJSON.score; document.getElementById('comment-votes-{{ comentario.id }}').innerText = event.detail.xhr.responseJSON.num_votos" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>&#9650;</button>
         <span id="comment-score-{{ comentario.id }}">{{ comentario.score }}</span>
         <span class="text-xs">(<span id="comment-votes-{{ comentario.id }}">{{ comentario.num_votos }}</span>)</span>
-        <button hx-post="{% url 'discussao:interacao' resposta_content_type_id comentario.id 'down' %}" hx-swap="none" hx-on:afterRequest="document.getElementById('comment-score-{{ comentario.id }}').innerText = event.detail.xhr.responseJSON.score; document.getElementById('comment-votes-{{ comentario.id }}').innerText = event.detail.xhr.responseJSON.num_votos">&#9660;</button>
+        <button hx-post="{% url 'discussao:interacao' resposta_content_type_id comentario.id 'down' %}" hx-swap="none" hx-on:afterRequest="document.getElementById('comment-score-{{ comentario.id }}').innerText = event.detail.xhr.responseJSON.score; document.getElementById('comment-votes-{{ comentario.id }}').innerText = event.detail.xhr.responseJSON.num_votos" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>&#9660;</button>
       </div>
 
 

--- a/discussao/templates/discussao/topico_detail.html
+++ b/discussao/templates/discussao/topico_detail.html
@@ -33,18 +33,20 @@
     </form>
     {% endif %}
     <div class="flex items-center space-x-1 mt-2">
-      <button
-        hx-post="{% url 'discussao:interacao' content_type_id topico.id 'up' %}"
-        hx-swap="none"
-        hx-on:afterRequest="const r=event.detail.xhr.responseJSON;document.getElementById('topic-score').innerText=r.score;document.getElementById('topic-votes').innerText=r.num_votos"
-      >&#9650;</button>
+        <button
+          hx-post="{% url 'discussao:interacao' content_type_id topico.id 'up' %}"
+          hx-swap="none"
+          hx-on:afterRequest="const r=event.detail.xhr.responseJSON;document.getElementById('topic-score').innerText=r.score;document.getElementById('topic-votes').innerText=r.num_votos"
+          hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+        >&#9650;</button>
       <span id="topic-score">{{ topico.score }}</span>
       (<span id="topic-votes">{{ topico.num_votos }}</span>)
-      <button
-        hx-post="{% url 'discussao:interacao' content_type_id topico.id 'down' %}"
-        hx-swap="none"
-        hx-on:afterRequest="const r=event.detail.xhr.responseJSON;document.getElementById('topic-score').innerText=r.score;document.getElementById('topic-votes').innerText=r.num_votos"
-      >&#9660;</button>
+        <button
+          hx-post="{% url 'discussao:interacao' content_type_id topico.id 'down' %}"
+          hx-swap="none"
+          hx-on:afterRequest="const r=event.detail.xhr.responseJSON;document.getElementById('topic-score').innerText=r.score;document.getElementById('topic-votes').innerText=r.num_votos"
+          hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+        >&#9660;</button>
     </div>
     <div class="mt-2">
       <button type="button" class="text-xs text-red-600" onclick="document.getElementById('denuncia-topico-form').classList.toggle('hidden')">{% trans "Denunciar" %}</button>

--- a/discussao/templates/discussao/topicos_list.html
+++ b/discussao/templates/discussao/topicos_list.html
@@ -19,21 +19,23 @@
     <td class="px-4 py-2">{{ topico.autor.get_full_name|default:topico.autor.username }}</td>
     <td class="px-4 py-2">{{ topico.created_at|date:SHORT_DATE_FORMAT }}</td>
     <td class="px-4 py-2 text-center">
-      <div class="flex items-center justify-center space-x-1">
-        <button
-          hx-post="{% url 'discussao:interacao' content_type_id topico.id 'up' %}"
-          hx-swap="none"
-          hx-on:afterRequest="const r=event.detail.xhr.responseJSON;document.getElementById('score-{{topico.id}}').innerText=r.score;document.getElementById('votes-{{topico.id}}').innerText=r.num_votos"
-        >&#9650;</button>
-        <span id="score-{{ topico.id }}">{{ topico.score }}</span>
-        (<span id="votes-{{ topico.id }}">{{ topico.num_votos }}</span>)
-        <button
-          hx-post="{% url 'discussao:interacao' content_type_id topico.id 'down' %}"
-          hx-swap="none"
-          hx-on:afterRequest="const r=event.detail.xhr.responseJSON;document.getElementById('score-{{topico.id}}').innerText=r.score;document.getElementById('votes-{{topico.id}}').innerText=r.num_votos"
-        >&#9660;</button>
-      </div>
-    </td>
+        <div class="flex items-center justify-center space-x-1">
+          <button
+            hx-post="{% url 'discussao:interacao' content_type_id topico.id 'up' %}"
+            hx-swap="none"
+            hx-on:afterRequest="const r=event.detail.xhr.responseJSON;document.getElementById('score-{{topico.id}}').innerText=r.score;document.getElementById('votes-{{topico.id}}').innerText=r.num_votos"
+            hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+          >&#9650;</button>
+          <span id="score-{{ topico.id }}">{{ topico.score }}</span>
+          (<span id="votes-{{ topico.id }}">{{ topico.num_votos }}</span>)
+          <button
+            hx-post="{% url 'discussao:interacao' content_type_id topico.id 'down' %}"
+            hx-swap="none"
+            hx-on:afterRequest="const r=event.detail.xhr.responseJSON;document.getElementById('score-{{topico.id}}').innerText=r.score;document.getElementById('votes-{{topico.id}}').innerText=r.num_votos"
+            hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+          >&#9660;</button>
+        </div>
+      </td>
     <td class="px-4 py-2 text-center">{{ topico.num_comentarios }}</td>
     <td class="px-4 py-2 text-center">{{ topico.numero_visualizacoes }}</td>
     <td class="px-4 py-2">{{ topico.last_activity|date:SHORT_DATETIME_FORMAT }}</td>

--- a/empresas/templates/empresas/detail.htm
+++ b/empresas/templates/empresas/detail.htm
@@ -124,6 +124,7 @@
       {% else %}
         hx-post="{% url 'empresas_api:empresa-favoritar' empresa.id %}"
       {% endif %}
+      hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
       hx-swap="none"
       hx-on:afterRequest="
         if (event.detail.xhr.status === 201) {

--- a/empresas/templates/empresas/favoritos.html
+++ b/empresas/templates/empresas/favoritos.html
@@ -15,6 +15,7 @@
         <button
           class="text-sm text-red-600 hover:underline"
           hx-delete="{% url 'empresas_api:empresa-favoritar' empresa.id %}"
+          hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
           hx-target="#empresa-{{ empresa.id }}"
           hx-swap="outerHTML"
         >{% translate "Remover" %}</button>

--- a/empresas/templates/empresas/includes/empresas_table.html
+++ b/empresas/templates/empresas/includes/empresas_table.html
@@ -39,6 +39,7 @@
           {% else %}
             hx-post="{% url 'empresas_api:empresa-favoritar' empresa.id %}"
           {% endif %}
+          hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
           hx-swap="none"
           hx-on:afterRequest="
             if (event.detail.xhr.status === 201) {

--- a/financeiro/templates/financeiro/centros_list.html
+++ b/financeiro/templates/financeiro/centros_list.html
@@ -33,9 +33,9 @@
           <td class="px-3 py-2">{{ c.saldo }}</td>
           <td class="px-3 py-2 text-right space-x-2">
               <button class="text-primary underline" hx-get="/financeiro/centros/form/{{ c.id }}/" hx-target="#modal" hx-trigger="click">{% trans "Editar" %}</button>
-              <button class="text-red-600 underline" hx-delete="/api/financeiro/centros/{{ c.id }}/" hx-target="closest tr" hx-confirm='{% trans "Tem certeza?" %}'>{% trans "Excluir" %}</button>
-          </td>
-        </tr>
+                <button class="text-red-600 underline" hx-delete="/api/financeiro/centros/{{ c.id }}/" hx-target="closest tr" hx-confirm='{% trans "Tem certeza?" %}' hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>{% trans "Excluir" %}</button>
+            </td>
+          </tr>
         {% empty %}
         <tr>
           <td colspan="5" class="px-3 py-2 text-center text-sm text-gray-500">{% trans "Nenhum centro encontrado." %}</td>

--- a/financeiro/templates/financeiro/importar_pagamentos.html
+++ b/financeiro/templates/financeiro/importar_pagamentos.html
@@ -12,13 +12,14 @@
       <label for="file" class="block text-sm font-medium text-gray-700">{% trans "Arquivo" %}</label>
       <input id="file" type="file" name="file" accept=".csv,.xlsx" class="block w-full border p-2 rounded" required />
     </form>
-    <button id="preview-btn"
-            class="mt-2 bg-primary text-white px-4 py-2 rounded"
-            hx-post="/api/financeiro/importar-pagamentos/"
-            hx-target="#preview"
-            hx-trigger="change from:#file"
-            hx-include="#upload-form"
-            hx-on="htmx:afterRequest: renderPreview(event)">
+      <button id="preview-btn"
+              class="mt-2 bg-primary text-white px-4 py-2 rounded"
+              hx-post="/api/financeiro/importar-pagamentos/"
+              hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+              hx-target="#preview"
+              hx-trigger="change from:#file"
+              hx-include="#upload-form"
+              hx-on="htmx:afterRequest: renderPreview(event)">
       {% trans "Pré-visualizar" %}
     </button>
     <div id="preview" class="mt-6" aria-live="polite"></div>
@@ -29,18 +30,20 @@
       <input type="hidden" id="confirm-id" name="id" />
     </form>
     <div class="mt-4 flex items-center gap-2">
-      <button id="confirm-btn" disabled
-              hx-post="/api/financeiro/importar-pagamentos/confirmar/"
-              hx-target="#messages"
-              hx-include="#confirm-form"
-              hx-indicator="#loading"
-              class="bg-secondary text-white px-4 py-2 rounded">
+        <button id="confirm-btn" disabled
+                hx-post="/api/financeiro/importar-pagamentos/confirmar/"
+                hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+                hx-target="#messages"
+                hx-include="#confirm-form"
+                hx-indicator="#loading"
+                class="bg-secondary text-white px-4 py-2 rounded">
         {% trans "Confirmar Importação" %}
       </button>
       <span id="loading" class="htmx-indicator text-sm">{% trans "Processando..." %}</span>
     </div>
   </section>
   <script>
+    const csrfToken = "{{ csrf_token }}";
     function renderPreview(evt) {
       const preview = document.getElementById('preview');
       const messages = document.getElementById('messages');
@@ -64,7 +67,7 @@
         }
         if (data.token_erros) {
           const token = data.token_erros;
-          reprocess.innerHTML = `<div class="space-y-2"><a href="/media/importacoes/${token}.errors.csv" download class="text-blue-600 underline">{% trans "Baixar arquivo de erros" %}</a><form id="reprocess-form" class="space-y-2" enctype="multipart/form-data">{% csrf_token %}<input type="file" name="file" accept=".csv,.xlsx" class="block w-full border p-2 rounded" required /><button type="submit" class="bg-primary text-white px-4 py-2 rounded" hx-post="/api/financeiro/importar-pagamentos/reprocessar/${token}/" hx-target="#messages" hx-include="#reprocess-form" hx-encoding="multipart/form-data">{% trans "Reprocessar" %}</button></form></div>`;
+            reprocess.innerHTML = `<div class="space-y-2"><a href="/media/importacoes/${token}.errors.csv" download class="text-blue-600 underline">{% trans "Baixar arquivo de erros" %}</a><form id="reprocess-form" class="space-y-2" enctype="multipart/form-data">{% csrf_token %}<input type="file" name="file" accept=".csv,.xlsx" class="block w-full border p-2 rounded" required /><button type="submit" class="bg-primary text-white px-4 py-2 rounded" hx-post="/api/financeiro/importar-pagamentos/reprocessar/${token}/" hx-target="#messages" hx-include="#reprocess-form" hx-encoding="multipart/form-data" hx-headers='{"X-CSRFToken": "${csrfToken}"}'>{% trans "Reprocessar" %}</button></form></div>`;
         }
       } catch (e) {
         messages.textContent = '{% trans "Erro ao processar pré-visualização" %}';

--- a/nucleos/templates/nucleos/detail.html
+++ b/nucleos/templates/nucleos/detail.html
@@ -66,8 +66,8 @@
         <td>{{ part.user.get_full_name|default:part.user.username }}</td>
         <td>{{ part.data_solicitacao|date:'d/m/Y' }}</td>
         <td class="space-x-2">
-          <button class="text-sm text-green-600" hx-post="{% url 'nucleos_api:nucleo-aprovar-membro' object.pk part.user.pk %}" hx-target="#pendente-{{ part.id }}" hx-swap="none" hx-on="htmx:afterRequest: this.closest('tr').remove()" hx-confirm="{% trans 'Confirmar aprovação?' %}">{% trans 'Aprovar' %}</button>
-          <button class="text-sm text-red-600" hx-post="{% url 'nucleos_api:nucleo-recusar-membro' object.pk part.user.pk %}" hx-target="#pendente-{{ part.id }}" hx-swap="none" hx-on="htmx:afterRequest: this.closest('tr').remove()" hx-confirm="{% trans 'Confirmar recusa?' %}">{% trans 'Recusar' %}</button>
+          <button class="text-sm text-green-600" hx-post="{% url 'nucleos_api:nucleo-aprovar-membro' object.pk part.user.pk %}" hx-target="#pendente-{{ part.id }}" hx-swap="none" hx-on="htmx:afterRequest: this.closest('tr').remove()" hx-confirm="{% trans 'Confirmar aprovação?' %}" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>{% trans 'Aprovar' %}</button>
+          <button class="text-sm text-red-600" hx-post="{% url 'nucleos_api:nucleo-recusar-membro' object.pk part.user.pk %}" hx-target="#pendente-{{ part.id }}" hx-swap="none" hx-on="htmx:afterRequest: this.closest('tr').remove()" hx-confirm="{% trans 'Confirmar recusa?' %}" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>{% trans 'Recusar' %}</button>
         </td>
       </tr>
     {% endfor %}


### PR DESCRIPTION
## Summary
- Add `hx-headers` with CSRF token to HTMX buttons for favoriting companies
- Ensure HTMX moderation and voting buttons send CSRF token
- Include CSRF headers for finance import and other HTMX actions outside forms

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'axe_core_python', 'bs4', 'playwright', 'httpx', 'pywebpush', 'django_redis')*

------
https://chatgpt.com/codex/tasks/task_e_68a768c728248325819bdc68ae0c6e3f