### PR TITLE
Remove toggle_like API action

### DIFF
--- a/feed/README.md
+++ b/feed/README.md
@@ -57,7 +57,9 @@ Reações permitem registrar `like` ou `share` em posts através dos endpoints:
 
 - `POST /api/feed/posts/{post_id}/reacoes/` com corpo `{ "vote": "like" | "share" }`
 - `GET /api/feed/posts/{post_id}/reacoes/` retorna contagem agregada e reação do usuário
-- `DELETE /api/feed/posts/{post_id}/reacoes/{vote}/` remove a reação do usuário
+- Repetir o `POST` com o mesmo `vote` remove a reação existente
+
+O endpoint dedicado `toggle_like` foi removido; para curtir utilize o `POST` acima com `vote="like"`.
 
 ## Visualizações
 

--- a/feed/api.py
+++ b/feed/api.py
@@ -369,34 +369,6 @@ class PostViewSet(viewsets.ModelViewSet):
         return Response({"bookmarked": True}, status=status.HTTP_201_CREATED)
 
     @action(detail=True, methods=["post"], permission_classes=[permissions.IsAuthenticated])
-    def toggle_like(self, request, pk=None):
-        post = self.get_object()
-        reacao = Reacao.all_objects.filter(post=post, user=request.user, vote="like").first()
-        if reacao and not reacao.deleted:
-            reacao.deleted = True
-            reacao.save(update_fields=["deleted"])
-            _dec_counter(REACTIONS_TOTAL.labels(vote="like"))
-            cache.delete(f"post_reacoes:{post.id}")
-            return Response(status=status.HTTP_204_NO_CONTENT)
-        if is_ratelimited(
-            request,
-            group="feed_reactions_create",
-            key="user",
-            rate=_read_rate(None, request),
-            method="POST",
-            increment=True,
-        ):
-            return ratelimit_exceeded(request, None)
-        if reacao:
-            reacao.deleted = False
-            reacao.save(update_fields=["deleted"])
-        else:
-            reacao = Reacao.all_objects.create(post=post, user=request.user, vote="like")
-        REACTIONS_TOTAL.labels(vote="like").inc()
-        cache.delete(f"post_reacoes:{post.id}")
-        return Response({"vote": "like"}, status=status.HTTP_201_CREATED)
-
-    @action(detail=True, methods=["post"], permission_classes=[permissions.IsAuthenticated])
     def flag(self, request, pk=None):
         post = self.get_object()
         use_case = DenunciarPost()


### PR DESCRIPTION
## Summary
- remove redundant `toggle_like` action from post API
- document using `/reacoes/` endpoint with explicit `vote` for likes

## Testing
- `pytest --nomigrations feed/tests/test_reactions.py::ReactionToggleAPITest::test_toggle_reaction -q --maxfail=1` *(fails: NoReverseMatch: Reverse for 'javascript-catalog' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7774acfbc8325bd4661e6ee504492