### PR TITLE
Use API endpoint for comment creation

### DIFF
--- a/feed/forms.py
+++ b/feed/forms.py
@@ -118,8 +118,10 @@ class PostForm(forms.ModelForm):
 class CommentForm(forms.ModelForm):
     class Meta:
         model = Comment
-        fields = ["texto", "reply_to"]
+        fields = ["post", "texto", "reply_to"]
         widgets = {
+            "post": forms.HiddenInput(),
+            "reply_to": forms.HiddenInput(),
             "texto": forms.Textarea(
                 attrs={
                     "class": "mt-1 block w-full rounded-xl border border-neutral-300 shadow-sm focus:ring-primary-500 focus:border-primary-500 text-sm",

--- a/feed/templates/feed/post_detail.html
+++ b/feed/templates/feed/post_detail.html
@@ -77,9 +77,10 @@
 
     <div class="mt-6">
       <h3 class="text-lg font-medium">{% trans "Comentários" %}</h3>
-      <form id="comment-form" method="post" action="{% url 'feed:create_comment' post.id %}" hx-post="{% url 'feed:create_comment' post.id %}" hx-target="#comments" hx-swap="afterbegin" class="space-y-2" hx-on:afterRequest="this.reset(); setReplyTo(null)">
+      <form id="comment-form" method="post" action="/api/feed/comments/" hx-post="/api/feed/comments/" hx-target="#comments" hx-swap="afterbegin" class="space-y-2" hx-on:afterRequest="this.reset(); setReplyTo(null)">
         {% csrf_token %}
-        {{ comment_form.reply_to.as_hidden }}
+        {{ comment_form.post }}
+        {{ comment_form.reply_to }}
         {{ comment_form.texto }}
         {% if comment_form.texto.errors %}
           <p class="text-red-500 text-xs">{{ comment_form.texto.errors }}</p>

--- a/feed/urls.py
+++ b/feed/urls.py
@@ -10,7 +10,6 @@ urlpatterns = [
     path("favoritos/", views.bookmark_list, name="bookmarks"),
     path("novo/", views.NovaPostagemView.as_view(), name="nova_postagem"),
     path("<uuid:pk>/", views.PostDetailView.as_view(), name="post_detail"),
-    path("<uuid:pk>/comentar/", views.create_comment, name="create_comment"),
     path("<uuid:pk>/curtir/", views.toggle_like, name="toggle_like"),
     path("<uuid:pk>/editar/", views.post_update, name="post_update"),
     path("<uuid:pk>/remover/", views.post_delete, name="post_delete"),

--- a/feed/views.py
+++ b/feed/views.py
@@ -299,31 +299,8 @@ class PostDetailView(LoginRequiredMixin, DetailView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["comment_form"] = CommentForm()
+        context["comment_form"] = CommentForm(initial={"post": self.object.id})
         return context
-
-
-@login_required
-def create_comment(request, pk):
-    post = get_object_or_404(Post.objects.filter(deleted=False), id=pk)
-    form = CommentForm(request.POST)
-    if form.is_valid():
-        comment = form.save(commit=False)
-        comment.user = request.user
-        comment.post = post
-        comment.save()
-        if request.headers.get("HX-Request"):
-            html = render_to_string("feed/_comment.html", {"comment": comment}, request=request)
-            return HttpResponse(html)
-        return redirect("feed:post_detail", pk=post.id)
-    if request.headers.get("HX-Request"):
-        html = render_to_string(
-            "feed/post_detail.html",
-            {"post": post, "comment_form": form},
-            request=request,
-        )
-        return HttpResponse(html, status=400)
-    return render(request, "feed/post_detail.html", {"post": post, "comment_form": form})
 
 
 @login_required

--- a/tests/feed/test_views.py
+++ b/tests/feed/test_views.py
@@ -4,6 +4,8 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.http import HttpResponseForbidden
 from django.urls import reverse
 
+from rest_framework.test import APIClient
+
 from feed.models import Comment, Post, Reacao, Tag
 
 pytestmark = pytest.mark.django_db
@@ -83,12 +85,12 @@ def test_novapostagem_file_upload(client, associado_user):
     assert post.pdf
 
 
-def test_create_comment(client, nucleado_user, posts):
-    client.force_login(nucleado_user)
+def test_create_comment(nucleado_user, posts):
+    client = APIClient()
+    client.force_authenticate(nucleado_user)
     post = posts[0]
-    url = reverse("feed:create_comment", args=[post.id])
-    resp = client.post(url, {"texto": "Oi"})
-    assert resp.status_code == 302
+    resp = client.post("/api/feed/comments/", {"post": post.id, "texto": "Oi"}, format="json")
+    assert resp.status_code == 201
     comment = Comment.objects.get(post=post, user=nucleado_user)
     assert comment.texto == "Oi"
 


### PR DESCRIPTION
## Summary
- Post detail form now posts comments to `/api/feed/comments/`
- CommentViewSet handles HTMX requests and removed old create_comment view
- Updated CommentForm and tests to work with new API

## Testing
- `pytest tests/feed/test_views.py::test_create_comment -q --nomigrations --cov-fail-under=0` *(fails: File "/workspace/ProjetoHubx/tokens/views.py", line 181)*


------
https://chatgpt.com/codex/tasks/task_e_68a77749dd7083258497ba456317dee8