### PR TITLE
Add payment action and button for pending transactions

### DIFF
--- a/financeiro/templates/financeiro/lancamentos_list.html
+++ b/financeiro/templates/financeiro/lancamentos_list.html
@@ -83,9 +83,11 @@
               <td class="px-3 py-2">${l.status}</td>
               <td class="px-3 py-2">${l.data_vencimento || ''}</td>
               <td class="px-3 py-2 space-x-2">
-                <button hx-patch="/api/financeiro/lancamentos/${l.id}/" hx-vals='{"status":"pago"}' hx-headers='{"X-CSRFToken": "${csrfToken}"}' hx-on="htmx:afterRequest: htmx.trigger('#filtros','submit')" class="text-green-600 hover:underline">{% trans "Pagar" %}</button>
+                ${l.status === 'pendente' ? `
+                <button hx-post="/api/financeiro/lancamentos/${l.id}/pagar/" hx-headers='{"X-CSRFToken": "${csrfToken}"}' hx-on="htmx:afterRequest: htmx.trigger('#filtros','submit')" class="text-green-600 hover:underline">{% trans "Pagar" %}</button>
                 <button hx-patch="/api/financeiro/lancamentos/${l.id}/" hx-vals='{"status":"cancelado"}' hx-headers='{"X-CSRFToken": "${csrfToken}"}' hx-on="htmx:afterRequest: htmx.trigger('#filtros','submit')" class="text-red-600 hover:underline">{% trans "Cancelar" %}</button>
                 <button hx-post="/api/financeiro/lancamentos/${l.id}/ajustar/" hx-vals='js:{valor_corrigido: prompt(gettext("Valor corrigido?")), descricao_motivo: prompt(gettext("Motivo?"))}' hx-headers='{"X-CSRFToken": "${csrfToken}"}' hx-on="htmx:afterRequest: htmx.trigger('#filtros','submit')" class="text-blue-600 hover:underline">{% trans "Ajustar" %}</button>
+                ` : ''}
               </td>
             </tr>
           `)


### PR DESCRIPTION
## Summary
- add `pagar` action to `LancamentoFinanceiroViewSet` with audit logging
- show payment button for pending rows that posts to new endpoint
- cover new pay endpoint with tests

## Testing
- `pytest financeiro/tests/test_quitar.py::test_pagar_endpoint -q --nomigrations` *(fails: setup_test_environment() was already called and can't be called again)*

------
https://chatgpt.com/codex/tasks/task_e_68a77739110083259e06accfdd36fdb2