### PR TITLE
Validate non-negative aporte value

### DIFF
--- a/financeiro/locale/en/LC_MESSAGES/django.po
+++ b/financeiro/locale/en/LC_MESSAGES/django.po
@@ -31,7 +31,7 @@ msgid "Valor negativo não permitido para este tipo"
 msgstr ""
 
 #: serializers/__init__.py:142
-msgid "Valor deve ser positivo"
+msgid "Valor não pode ser negativo"
 msgstr ""
 
 #: serializers/__init__.py:151

--- a/financeiro/locale/pt_BR/LC_MESSAGES/django.po
+++ b/financeiro/locale/pt_BR/LC_MESSAGES/django.po
@@ -31,7 +31,7 @@ msgid "Valor negativo não permitido para este tipo"
 msgstr ""
 
 #: serializers/__init__.py:142
-msgid "Valor deve ser positivo"
+msgid "Valor não pode ser negativo"
 msgstr ""
 
 #: serializers/__init__.py:151

--- a/financeiro/serializers/__init__.py
+++ b/financeiro/serializers/__init__.py
@@ -141,9 +141,9 @@ class AporteSerializer(serializers.ModelSerializer):
         extra_kwargs = {"tipo": {"required": False}}
 
     def validate_valor(self, value: Any) -> Any:  # type: ignore[override]
-        """Valida que o valor informado é positivo."""
-        if value <= 0:
-            raise serializers.ValidationError(_("Valor deve ser positivo"))
+        """Garante que o valor não seja negativo."""
+        if value < 0:
+            raise serializers.ValidationError(_("Valor não pode ser negativo"))
         return value
 
     def validate_tipo(self, value: str) -> str:  # type: ignore[override]

--- a/financeiro/templates/financeiro/aportes_form.html
+++ b/financeiro/templates/financeiro/aportes_form.html
@@ -2,7 +2,7 @@
 <form
   hx-post="/api/financeiro/aportes/"
   hx-target="#aportes-messages"
-  hx-on="htmx:afterRequest: if(event.detail.successful){this.reset();var resp=JSON.parse(event.detail.xhr.response);var msg='{{ _('Aporte registrado com sucesso') }}';if(resp.recibo_url){msg+=' <a href=\"'+resp.recibo_url+'\" target=\"_blank\">{{ _('Baixar recibo') }}</a>'; }document.getElementById('aportes-messages').innerHTML=msg;}else{document.getElementById('aportes-messages').textContent='{{ _('Erro ao registrar aporte') }}';}"
+  hx-on="htmx:afterRequest: if(event.detail.successful){this.reset();var resp=JSON.parse(event.detail.xhr.response);var msg='{{ _('Aporte registrado com sucesso') }}';if(resp.recibo_url){msg+=' <a href=\"'+resp.recibo_url+'\" target=\"_blank\">{{ _('Baixar recibo') }}</a>'; }document.getElementById('aportes-messages').innerHTML=msg;}else{var resp=JSON.parse(event.detail.xhr.response||'{}');var err=resp.valor?resp.valor[0]:'{{ _('Erro ao registrar aporte') }}';document.getElementById('aportes-messages').textContent=err;}"
   class="p-4 bg-white rounded shadow max-w-md"
   aria-live="assertive"
 >
@@ -17,7 +17,7 @@
   </div>
   <div class="mb-2">
     <label for="id_valor" class="block text-sm font-medium">{{ _('Valor') }}</label>
-    <input id="id_valor" type="number" step="0.01" name="valor" class="border p-2 w-full" required />
+    <input id="id_valor" type="number" step="0.01" name="valor" class="border p-2 w-full" required min="0" />
   </div>
   <div class="mb-2">
     <span class="block text-sm font-medium">{{ _('Tipo') }}</span>

--- a/financeiro/tests/test_aportes.py
+++ b/financeiro/tests/test_aportes.py
@@ -38,7 +38,7 @@ def _create_centro(user) -> CentroCusto:
     return CentroCusto.objects.create(nome="C", tipo="organizacao", organizacao=org)
 
 
-def test_valor_invalido(api_client, admin_user):
+def test_valor_negativo(api_client, admin_user):
     auth(api_client, admin_user)
     centro = _create_centro(admin_user)
     url = reverse("financeiro_api:financeiro-aportes")
@@ -46,7 +46,7 @@ def test_valor_invalido(api_client, admin_user):
         url,
         {
             "centro_custo": str(centro.id),
-            "valor": "0",
+            "valor": "-5",
             "descricao": "x",
         },
     )
@@ -67,6 +67,21 @@ def test_tipo_invalido(api_client, admin_user):
         },
     )
     assert resp.status_code == 400
+
+
+def test_valor_zero_valido(api_client, admin_user):
+    auth(api_client, admin_user)
+    centro = _create_centro(admin_user)
+    url = reverse("financeiro_api:financeiro-aportes")
+    resp = api_client.post(
+        url,
+        {
+            "centro_custo": str(centro.id),
+            "valor": "0",
+            "descricao": "x",
+        },
+    )
+    assert resp.status_code == 201, resp.data
 
 
 def test_aporte_interno_registra_originador(api_client, admin_user):


### PR DESCRIPTION
## Summary
- Enforce non-negative values in Aporte creation serializer
- Add client-side minimum and server error feedback for aporte form
- Test negative and zero aporte value behaviors

## Testing
- `pytest -p no:cov --nomigrations -c /tmp/pytest_empty.ini financeiro/tests/test_aportes.py::test_valor_negativo financeiro/tests/test_aportes.py::test_valor_zero_valido`

------
https://chatgpt.com/codex/tasks/task_e_68a77736d25483259d964c55d0f3cee0