### PR TITLE
Add CSRF header and test for finance integration delete

### DIFF
--- a/financeiro/templates/financeiro/integracoes_list.html
+++ b/financeiro/templates/financeiro/integracoes_list.html
@@ -35,7 +35,8 @@
                     hx-target="#modal" hx-trigger="click">{% trans "Editar" %}</button>
             <button class="text-red-600 underline"
                     hx-delete="/api/financeiro/integracoes/{{ i.id }}/"
-                    hx-target="closest tr" hx-confirm='{% trans "Tem certeza?" %}'>{% trans "Excluir" %}</button>
+                    hx-target="closest tr" hx-confirm='{% trans "Tem certeza?" %}'
+                    hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>{% trans "Excluir" %}</button>
           </td>
         </tr>
         {% empty %}

--- a/tests/test_integracoes_api.py
+++ b/tests/test_integracoes_api.py
@@ -1,0 +1,36 @@
+import pytest
+from django.urls import include, path, reverse
+from django.test import override_settings
+from rest_framework.test import APIClient
+
+from accounts.factories import UserFactory
+from accounts.models import UserType
+from organizacoes.factories import OrganizacaoFactory
+from financeiro.models import IntegracaoConfig
+
+urlpatterns = [
+    path("api/financeiro/", include(("financeiro.api_urls", "financeiro_api"), namespace="financeiro_api")),
+]
+
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+
+@override_settings(ROOT_URLCONF=__name__)
+@pytest.mark.django_db
+def test_delete_integracao(api_client):
+    user = UserFactory(user_type=UserType.ADMIN)
+    api_client.force_authenticate(user=user)
+    org = OrganizacaoFactory()
+    integracao = IntegracaoConfig.objects.create(
+        organizacao=org,
+        nome="Test",
+        tipo="erp",
+        base_url="http://example.com",
+    )
+    url = reverse("financeiro_api:integracao-detail", args=[integracao.id])
+    response = api_client.delete(url)
+    assert response.status_code == 204
+    assert not IntegracaoConfig.objects.filter(id=integracao.id).exists()


### PR DESCRIPTION
## Summary
- Include CSRF token header on integration delete button so HTMX DELETE requests authenticate
- Add API test confirming integration delete returns HTTP 204 and removes the record

## Testing
- `pytest tests/test_integracoes_api.py -q --no-cov --nomigrations`


------
https://chatgpt.com/codex/tasks/task_e_68a777347c508325bf22f65e72703c35