### PR TITLE
feat(nucleos): handle request status on solicitação modal

### DIFF
--- a/nucleos/templates/nucleos/solicitar_modal.html
+++ b/nucleos/templates/nucleos/solicitar_modal.html
@@ -3,7 +3,7 @@
   <h2 class="text-lg font-semibold mb-4">{% trans 'Confirmar solicitação de participação?' %}</h2>
   <form hx-post="{% url 'nucleos_api:nucleo-solicitar' nucleo.pk %}"
         hx-swap="none"
-        hx-on="htmx:afterRequest: document.getElementById('solicitar-btn').outerHTML='<p class=\'text-green-600\'>{% trans 'Solicitação enviada' %}</p>'; document.getElementById('modal').innerHTML='';">
+        hx-on="htmx:afterRequest: handleSolicitar(event)">
     {% csrf_token %}
 
     <p class="mb-4">{% trans 'Mensalidade' %}: {{ nucleo.mensalidade|localize }}</p>
@@ -14,9 +14,26 @@
       {% endblocktrans %}
     </p>
 
+    <p id="solicitar-error" class="mb-4 text-sm text-red-600 hidden"></p>
+
     <div class="flex justify-end gap-2">
       <button type="button" class="px-3 py-1 border rounded" hx-on="click: document.getElementById('modal').innerHTML=''">{% trans 'Cancelar' %}</button>
       <button type="submit" class="px-3 py-1 bg-blue-600 text-white rounded">{% trans 'Confirmar' %}</button>
     </div>
   </form>
 </div>
+
+<script>
+function handleSolicitar(event) {
+  if (event.detail.xhr.status === 201) {
+    document.getElementById('solicitar-btn').outerHTML = '<p class="text-green-600">{% trans "Solicitação enviada" %}</p>';
+    document.getElementById('modal').innerHTML = '';
+  } else {
+    const errorEl = document.getElementById('solicitar-error');
+    if (errorEl) {
+      errorEl.textContent = "{% trans 'Erro ao enviar solicitação' %}";
+      errorEl.classList.remove('hidden');
+    }
+  }
+}
+</script>


### PR DESCRIPTION
## Summary
- handle request status when sending join request
- show error message if request fails

## Testing
- `pytest tests/nucleos/test_api.py::test_solicitar_aprovar_recusar -q --maxfail=1 --disable-warnings` *(fails: Conflicting migrations detected)*

------
https://chatgpt.com/codex/tasks/task_e_68a77720aee08325a8a2811235e9323e