### PR TITLE
Restrict nucleo pages to authenticated users

### DIFF
--- a/nucleos/views.py
+++ b/nucleos/views.py
@@ -188,7 +188,7 @@ class NucleoDeleteView(AdminRequiredMixin, LoginRequiredMixin, View):
         return redirect("nucleos:list")
 
 
-class NucleoDetailView(GerenteRequiredMixin, LoginRequiredMixin, DetailView):
+class NucleoDetailView(LoginRequiredMixin, DetailView):
     model = Nucleo
     template_name = "nucleos/detail.html"
 
@@ -206,7 +206,11 @@ class NucleoDetailView(GerenteRequiredMixin, LoginRequiredMixin, DetailView):
         nucleo = self.object
         ctx["membros_ativos"] = nucleo.participacoes.filter(status="ativo")
         ctx["coordenadores"] = nucleo.participacoes.filter(status="ativo", papel="coordenador")
-        if self.request.user.user_type in {UserType.ADMIN, UserType.COORDENADOR}:
+        if self.request.user.user_type in {
+            UserType.ADMIN,
+            UserType.COORDENADOR,
+            UserType.ROOT,
+        }:
             ctx["membros_pendentes"] = nucleo.participacoes.filter(status="pendente")
             ctx["suplentes"] = nucleo.coordenadores_suplentes.all()
             ctx["convites_pendentes"] = nucleo.convitenucleo_set.filter(usado_em__isnull=True).count()
@@ -220,7 +224,7 @@ class NucleoDetailView(GerenteRequiredMixin, LoginRequiredMixin, DetailView):
         return ctx
 
 
-class NucleoMetricsView(GerenteRequiredMixin, LoginRequiredMixin, DetailView):
+class NucleoMetricsView(LoginRequiredMixin, DetailView):
     model = Nucleo
     template_name = "nucleos/metrics.html"
 


### PR DESCRIPTION
## Summary
- allow any logged-in member to view nucleo details and metrics
- keep admin-only actions limited to admin, coordinator, or root types

## Testing
- `ruff format nucleos/views.py && black nucleos/views.py && isort nucleos/views.py && ruff check nucleos/views.py`
- `pytest --no-cov tests/test_cobranca_recorrente.py::test_cobrancas_geradas_e_metricas -q` *(fails: Conflicting migrations detected)*

------
https://chatgpt.com/codex/tasks/task_e_68a7771f12a883258722f6baeadf221c