### PR TITLE
Add HTML view for núcleo invites

### DIFF
--- a/nucleos/templates/nucleos/convites_modal.html
+++ b/nucleos/templates/nucleos/convites_modal.html
@@ -2,7 +2,7 @@
 <div class="p-4 bg-white rounded shadow max-w-md" id="convites-modal">
   <h2 class="text-lg font-semibold mb-2">{% trans 'Convites do núcleo' %}</h2>
   <p class="text-sm text-gray-600">{% trans 'Convites restantes hoje:' %} {{ convites_restantes }}</p>
-  <form class="mt-2 flex flex-col gap-2" hx-post="{% url 'nucleos_api:nucleo-convites' nucleo.pk %}" hx-target="#convites-list" hx-swap="afterbegin">
+  <form class="mt-2 flex flex-col gap-2" hx-post="{{ create_url }}" hx-target="#convites-list" hx-swap="afterbegin">
     {% csrf_token %}
     <input type="email" name="email" class="border rounded px-2 py-1" placeholder="{% trans 'email@example.com' %}" required />
     <select name="papel" class="border rounded px-2 py-1">

--- a/nucleos/urls.py
+++ b/nucleos/urls.py
@@ -34,6 +34,11 @@ urlpatterns = [
         name="convites_modal",
     ),
     path(
+        "<int:pk>/convites/novo/",
+        views.ConviteCreateView.as_view(),
+        name="convite_create",
+    ),
+    path(
         "<int:pk>/membro/<int:participacao_id>/remover/",
         views.MembroRemoveView.as_view(),
         name="membro_remover",

--- a/nucleos/views.py
+++ b/nucleos/views.py
@@ -10,9 +10,11 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.cache import cache
 from django.db.models import Count, Q
 from django.http import HttpResponse
+from django.middleware.csrf import get_token
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse, reverse_lazy
 from django.utils import timezone
+from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import (
     CreateView,
@@ -34,6 +36,7 @@ from .forms import (
     SuplenteForm,
 )
 from .models import CoordenadorSuplente, Nucleo, ParticipacaoNucleo
+from .services import gerar_convite_nucleo
 from .tasks import (
     notify_exportacao_membros,
     notify_participacao_aprovada,
@@ -267,8 +270,46 @@ class ConvitesModalView(GerenteRequiredMixin, LoginRequiredMixin, View):
         return render(
             request,
             "nucleos/convites_modal.html",
-            {"nucleo": nucleo, "convites": convites, "convites_restantes": restantes},
+            {
+                "nucleo": nucleo,
+                "convites": convites,
+                "convites_restantes": restantes,
+                "create_url": reverse("nucleos:convite_create", args=[nucleo.pk]),
+            },
         )
+
+
+class ConviteCreateView(GerenteRequiredMixin, LoginRequiredMixin, View):
+    def post(self, request, pk):
+        nucleo = get_object_or_404(Nucleo, pk=pk, deleted=False)
+        email = request.POST.get("email", "")
+        papel = request.POST.get("papel", "membro")
+        try:
+            convite = gerar_convite_nucleo(request.user, nucleo, email, papel)
+        except ValueError as exc:
+            return HttpResponse(str(exc), status=429)
+        csrf_token = get_token(request)
+        delete_url = reverse(
+            "nucleos_api:nucleo-revogar-convite", args=[nucleo.pk, convite.pk]
+        )
+        li_html = format_html(
+            '<li id="convite-{}" class="flex justify-between items-center">'
+            '<span>{} - {}</span>'
+            '<form hx-delete="{}" hx-target="#convite-{}" hx-swap="outerHTML" '
+            'hx-confirm="{}">'
+            '<input type="hidden" name="csrfmiddlewaretoken" value="{}" />'
+            '<button type="submit" class="text-red-600">{}</button>'
+            '</form></li>',
+            convite.id,
+            convite.email,
+            convite.papel,
+            delete_url,
+            convite.id,
+            _("Confirmar revogação?"),
+            csrf_token,
+            _("Revogar"),
+        )
+        return HttpResponse(li_html, status=201)
 
 
 class ParticipacaoCreateView(LoginRequiredMixin, View):


### PR DESCRIPTION
## Summary
- Serve invite list items via new ConviteCreateView
- Wire up URLs and modal template to use the HTML view

## Testing
- `pytest tests/nucleos/test_convites.py` *(fails: Conflicting migrations detected)*

------
https://chatgpt.com/codex/tasks/task_e_68a7771e19248325b568de4087be9f04