### PR TITLE
Log all changed organization fields

### DIFF
--- a/organizacoes/views.py
+++ b/organizacoes/views.py
@@ -134,24 +134,21 @@ class OrganizacaoUpdateView(SuperadminRequiredMixin, LoginRequiredMixin, UpdateV
             antiga = serialize_organizacao(self.get_object())
             response = super().form_valid(form)
             nova = serialize_organizacao(self.object)
-            dif_antiga = {k: v for k, v in antiga.items() if antiga[k] != nova[k]}
-            dif_nova = {k: v for k, v in nova.items() if antiga[k] != nova[k]}
-            for campo in [
-                "nome",
-                "tipo",
-                "slug",
-                "cnpj",
-                "contato_nome",
-                "contato_email",
-            ]:
-                if campo in dif_antiga:
-                    OrganizacaoChangeLog.objects.create(
-                        organizacao=self.object,
-                        campo_alterado=campo,
-                        valor_antigo=str(dif_antiga[campo]),
-                        valor_novo=str(dif_nova[campo]),
-                        alterado_por=self.request.user,
-                    )
+            campos_alterados = [
+                campo
+                for campo in form.changed_data
+                if antiga.get(campo) != nova.get(campo)
+            ]
+            dif_antiga = {campo: antiga[campo] for campo in campos_alterados}
+            dif_nova = {campo: nova[campo] for campo in campos_alterados}
+            for campo in campos_alterados:
+                OrganizacaoChangeLog.objects.create(
+                    organizacao=self.object,
+                    campo_alterado=campo,
+                    valor_antigo=str(dif_antiga[campo]),
+                    valor_novo=str(dif_nova[campo]),
+                    alterado_por=self.request.user,
+                )
             registrar_log(
                 self.object,
                 self.request.user,

--- a/tests/organizacoes/test_views.py
+++ b/tests/organizacoes/test_views.py
@@ -10,7 +10,7 @@ from agenda.models import Evento
 from empresas.models import Empresa
 from feed.models import Post
 from nucleos.models import Nucleo
-from organizacoes.models import Organizacao
+from organizacoes.models import Organizacao, OrganizacaoChangeLog
 
 pytestmark = pytest.mark.django_db
 
@@ -119,6 +119,36 @@ def test_update_view_superadmin(superadmin_user, organizacao):
     assert organizacao.nome == "Editada"
     msgs = list(response.context["messages"])
     assert any("atualizada" in m.message.lower() for m in msgs)
+
+
+def test_change_logs_on_update_view(superadmin_user, organizacao):
+    url = reverse("organizacoes:update", args=[organizacao.pk])
+    data = {
+        "nome": "Editada",
+        "cnpj": organizacao.cnpj,
+        "slug": "editada",
+        "rua": "Rua X",
+        "cidade": "Cidade Y",
+        "estado": "ST",
+        "contato_nome": "Fulano",
+        "contato_email": "fulano@example.com",
+        "contato_telefone": "123456",
+    }
+    resp = superadmin_user.post(url, data=data, follow=True)
+    assert resp.status_code == 200
+    fields = [
+        "nome",
+        "rua",
+        "cidade",
+        "estado",
+        "contato_nome",
+        "contato_email",
+        "contato_telefone",
+    ]
+    for campo in fields:
+        assert OrganizacaoChangeLog.all_objects.filter(
+            organizacao=organizacao, campo_alterado=campo
+        ).exists()
 
 
 def test_update_view_denied_for_admin(admin_user, organizacao):


### PR DESCRIPTION
## Summary
- dynamically create change logs for every modified organization field
- test that updates to fields like address and contact info generate change logs

## Testing
- `pytest tests/organizacoes/test_views.py::test_change_logs_on_update_view --cov-fail-under=0 --nomigrations` *(fails: IndentationError in tokens/views.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a776fe368c8325bdc08d41474524b2