### PR TITLE
refactor: use dynamic API URLs in organization modals

### DIFF
--- a/organizacoes/templates/organizacoes/empresas_modal.html
+++ b/organizacoes/templates/organizacoes/empresas_modal.html
@@ -1,7 +1,8 @@
 {% load i18n %}
+{% url 'organizacoes_api:organizacao-empresas-list' organizacao_pk=organizacao.id as api_url %}
 <div class="bg-white p-4 rounded shadow" hx-target="this">
   <h3 class="text-lg font-semibold mb-2">{% trans 'Gerenciar empresas' %}</h3>
-  <form hx-post="/api/organizacoes/{{ organizacao.id }}/empresas/" hx-on="htmx:afterRequest: htmx.ajax('GET', '{{ refresh_url }}', '#empresas-section'); this.closest('#modal').innerHTML='';" class="space-y-2">
+  <form hx-post="{{ api_url }}" hx-on="htmx:afterRequest: htmx.ajax('GET', '{{ refresh_url }}', '#empresas-section'); this.closest('#modal').innerHTML='';" class="space-y-2">
     {% csrf_token %}
     <label class="block text-sm" for="empresa-search">{% trans 'Buscar empresa' %}</label>
     <input
@@ -23,7 +24,7 @@
     {% for empresa in empresas %}
       <li class="flex justify-between items-center">
         {{ empresa.nome }}
-        <button hx-delete="/api/organizacoes/{{ organizacao.id }}/empresas/{{ empresa.id }}/" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}' hx-on="htmx:afterRequest: htmx.ajax('GET', '{{ refresh_url }}', '#empresas-section');" class="text-red-600 text-sm">{% trans 'Remover' %}</button>
+        <button hx-delete="{{ api_url }}{{ empresa.id }}/" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}' hx-on="htmx:afterRequest: htmx.ajax('GET', '{{ refresh_url }}', '#empresas-section');" class="text-red-600 text-sm">{% trans 'Remover' %}</button>
       </li>
     {% empty %}
       <li class="text-neutral-500 text-sm">{% trans 'Nenhuma empresa associada.' %}</li>

--- a/organizacoes/templates/organizacoes/eventos_modal.html
+++ b/organizacoes/templates/organizacoes/eventos_modal.html
@@ -1,7 +1,8 @@
 {% load i18n %}
+{% url 'organizacoes_api:organizacao-eventos-list' organizacao_pk=organizacao.id as api_url %}
 <div class="bg-white p-4 rounded shadow" hx-target="this">
   <h3 class="text-lg font-semibold mb-2">{% trans 'Gerenciar eventos' %}</h3>
-  <form hx-post="/api/organizacoes/{{ organizacao.id }}/eventos/" hx-on="htmx:afterRequest: htmx.ajax('GET', '{{ refresh_url }}', '#eventos-section'); this.closest('#modal').innerHTML='';" class="space-y-2">
+  <form hx-post="{{ api_url }}" hx-on="htmx:afterRequest: htmx.ajax('GET', '{{ refresh_url }}', '#eventos-section'); this.closest('#modal').innerHTML='';" class="space-y-2">
     {% csrf_token %}
     <label class="block text-sm" for="evento-search">{% trans 'Buscar evento' %}</label>
     <input
@@ -23,7 +24,7 @@
     {% for evento in eventos %}
       <li class="flex justify-between items-center">
         {{ evento.titulo }}
-        <button hx-delete="/api/organizacoes/{{ organizacao.id }}/eventos/{{ evento.id }}/" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}' hx-on="htmx:afterRequest: htmx.ajax('GET', '{{ refresh_url }}', '#eventos-section');" class="text-red-600 text-sm">{% trans 'Remover' %}</button>
+        <button hx-delete="{{ api_url }}{{ evento.id }}/" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}' hx-on="htmx:afterRequest: htmx.ajax('GET', '{{ refresh_url }}', '#eventos-section');" class="text-red-600 text-sm">{% trans 'Remover' %}</button>
       </li>
     {% empty %}
       <li class="text-neutral-500 text-sm">{% trans 'Nenhum evento associado.' %}</li>

--- a/organizacoes/templates/organizacoes/nucleos_modal.html
+++ b/organizacoes/templates/organizacoes/nucleos_modal.html
@@ -1,7 +1,8 @@
 {% load i18n %}
+{% url 'organizacoes_api:organizacao-nucleos-list' organizacao_pk=organizacao.id as api_url %}
 <div class="bg-white p-4 rounded shadow" hx-target="this">
   <h3 class="text-lg font-semibold mb-2">{% trans 'Gerenciar núcleos' %}</h3>
-  <form hx-post="/api/organizacoes/{{ organizacao.id }}/nucleos/" hx-on="htmx:afterRequest: htmx.ajax('GET', '{{ refresh_url }}', '#nucleos-section'); this.closest('#modal').innerHTML='';" class="space-y-2">
+  <form hx-post="{{ api_url }}" hx-on="htmx:afterRequest: htmx.ajax('GET', '{{ refresh_url }}', '#nucleos-section'); this.closest('#modal').innerHTML='';" class="space-y-2">
     {% csrf_token %}
     <label class="block text-sm" for="nucleo-search">{% trans 'Buscar núcleo' %}</label>
     <input
@@ -23,7 +24,7 @@
     {% for nucleo in nucleos %}
       <li class="flex justify-between items-center">
         {{ nucleo.nome }}
-        <button hx-delete="/api/organizacoes/{{ organizacao.id }}/nucleos/{{ nucleo.id }}/" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}' hx-on="htmx:afterRequest: htmx.ajax('GET', '{{ refresh_url }}', '#nucleos-section');" class="text-red-600 text-sm">{% trans 'Remover' %}</button>
+        <button hx-delete="{{ api_url }}{{ nucleo.id }}/" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}' hx-on="htmx:afterRequest: htmx.ajax('GET', '{{ refresh_url }}', '#nucleos-section');" class="text-red-600 text-sm">{% trans 'Remover' %}</button>
       </li>
     {% empty %}
       <li class="text-neutral-500 text-sm">{% trans 'Nenhum núcleo associado.' %}</li>

--- a/organizacoes/templates/organizacoes/posts_modal.html
+++ b/organizacoes/templates/organizacoes/posts_modal.html
@@ -1,7 +1,8 @@
 {% load i18n %}
+{% url 'organizacoes_api:organizacao-posts-list' organizacao_pk=organizacao.id as api_url %}
 <div class="bg-white p-4 rounded shadow" hx-target="this">
   <h3 class="text-lg font-semibold mb-2">{% trans 'Gerenciar posts' %}</h3>
-  <form hx-post="/api/organizacoes/{{ organizacao.id }}/posts/" hx-on="htmx:afterRequest: htmx.ajax('GET', '{{ refresh_url }}', '#posts-section'); this.closest('#modal').innerHTML='';" class="space-y-2">
+  <form hx-post="{{ api_url }}" hx-on="htmx:afterRequest: htmx.ajax('GET', '{{ refresh_url }}', '#posts-section'); this.closest('#modal').innerHTML='';" class="space-y-2">
     {% csrf_token %}
     <label class="block text-sm" for="post-search">{% trans 'Buscar post' %}</label>
     <input
@@ -23,7 +24,7 @@
     {% for post in posts %}
       <li class="flex justify-between items-center">
         {{ post.conteudo|truncatewords:10 }}
-        <button hx-delete="/api/organizacoes/{{ organizacao.id }}/posts/{{ post.id }}/" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}' hx-on="htmx:afterRequest: htmx.ajax('GET', '{{ refresh_url }}', '#posts-section');" class="text-red-600 text-sm">{% trans 'Remover' %}</button>
+        <button hx-delete="{{ api_url }}{{ post.id }}/" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}' hx-on="htmx:afterRequest: htmx.ajax('GET', '{{ refresh_url }}', '#posts-section');" class="text-red-600 text-sm">{% trans 'Remover' %}</button>
       </li>
     {% empty %}
       <li class="text-neutral-500 text-sm">{% trans 'Nenhum post associado.' %}</li>

--- a/organizacoes/templates/organizacoes/usuarios_modal.html
+++ b/organizacoes/templates/organizacoes/usuarios_modal.html
@@ -1,7 +1,8 @@
 {% load i18n %}
+{% url 'organizacoes_api:organizacao-usuarios-list' organizacao_pk=organizacao.id as api_url %}
 <div class="bg-white p-4 rounded shadow" hx-target="this">
   <h3 class="text-lg font-semibold mb-2">{% trans 'Gerenciar usuários' %}</h3>
-  <form hx-post="/api/organizacoes/{{ organizacao.id }}/usuarios/" hx-on="htmx:afterRequest: htmx.ajax('GET', '{{ refresh_url }}', '#usuarios-section'); this.closest('#modal').innerHTML='';" class="space-y-2">
+  <form hx-post="{{ api_url }}" hx-on="htmx:afterRequest: htmx.ajax('GET', '{{ refresh_url }}', '#usuarios-section'); this.closest('#modal').innerHTML='';" class="space-y-2">
     {% csrf_token %}
     <label class="block text-sm" for="user-search">{% trans 'Buscar usuário' %}</label>
     <input
@@ -23,7 +24,7 @@
     {% for user in usuarios %}
       <li class="flex justify-between items-center">
         {{ user.get_full_name|default:user.username }}
-        <button hx-delete="/api/organizacoes/{{ organizacao.id }}/usuarios/{{ user.id }}/" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}' hx-on="htmx:afterRequest: htmx.ajax('GET', '{{ refresh_url }}', '#usuarios-section');" class="text-red-600 text-sm">{% trans 'Remover' %}</button>
+        <button hx-delete="{{ api_url }}{{ user.id }}/" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}' hx-on="htmx:afterRequest: htmx.ajax('GET', '{{ refresh_url }}', '#usuarios-section');" class="text-red-600 text-sm">{% trans 'Remover' %}</button>
       </li>
     {% empty %}
       <li class="text-neutral-500 text-sm">{% trans 'Nenhum usuário associado.' %}</li>


### PR DESCRIPTION
## Summary
- replace hardcoded API paths with `{% url %}`-generated `api_url` in organization modals
- update HTMX `hx-post` and `hx-delete` to use `api_url`

## Testing
- `pytest tests/organizacoes -q --maxfail=1` *(fails: Conflicting migrations detected; multiple leaf nodes in the migration graph)*

------
https://chatgpt.com/codex/tasks/task_e_68a776fd9a088325ab53d4d4d7d6230f