### PR TITLE
Exibir nome do escopo nas configurações contextuais

### DIFF
--- a/configuracoes/models.py
+++ b/configuracoes/models.py
@@ -132,6 +132,41 @@ class ConfiguracaoContextual(TimeStampedModel, SoftDeleteModel):
             )
         ]
 
+    @property
+    def escopo_nome(self) -> str | None:
+        """Retorna o nome do escopo associado ao ``escopo_id``.
+
+        O campo retornado varia conforme o tipo de escopo:
+
+        - ``organizacao``: ``Organizacao.nome``
+        - ``nucleo``: ``Nucleo.nome``
+        - ``evento``: ``Evento.titulo``
+
+        Caso o registro não seja encontrado, retorna ``None``.
+        """
+
+        from organizacoes.models import Organizacao
+        from nucleos.models import Nucleo
+        from agenda.models import Evento
+
+        model_info = {
+            self.Escopo.ORGANIZACAO: (Organizacao, "nome"),
+            self.Escopo.NUCLEO: (Nucleo, "nome"),
+            self.Escopo.EVENTO: (Evento, "titulo"),
+        }.get(self.escopo_tipo)
+
+        if not model_info:
+            return None
+
+        model, attr = model_info
+
+        try:
+            obj = model.objects.get(pk=self.escopo_id)
+        except model.DoesNotExist:  # type: ignore[attr-defined]
+            return None
+
+        return getattr(obj, attr, None)
+
 
 class ConfiguracaoContaLog(TimeStampedModel):
     """Registro de alterações nas configurações de conta."""

--- a/configuracoes/templates/configuracoes/contextual_list.html
+++ b/configuracoes/templates/configuracoes/contextual_list.html
@@ -19,7 +19,11 @@
 
       <li class="p-4 bg-white rounded-lg shadow space-y-2">
         <div class="flex items-center justify-between">
-          <span>{{ cfg.get_escopo_tipo_display }} {{ cfg.escopo_id }} - {{ cfg.get_tema_display }}</span>
+          <span>
+            {{ cfg.get_escopo_tipo_display }}
+            {{ cfg.escopo_nome|default:cfg.escopo_id }} -
+            {{ cfg.get_tema_display }}
+          </span>
           <span class="space-x-2">
             <a
               href="{% url 'configuracoes-contextual-update' cfg.id %}"


### PR DESCRIPTION
## Summary
- Mostrar nome do escopo associado (`organização`, `núcleo` ou `evento`) na listagem de configurações contextuais
- Adicionar property `escopo_nome` em `ConfiguracaoContextual` para resolver o nome conforme `escopo_tipo` e `escopo_id`
- Cobrir property com testes para organização, núcleo e evento

## Testing
- `ruff format configuracoes/models.py tests/configuracoes/test_contextual.py`
- `ruff check configuracoes/models.py tests/configuracoes/test_contextual.py`
- `pytest tests/configuracoes/test_contextual.py -q --no-cov --nomigrations`

------
https://chatgpt.com/codex/tasks/task_e_68a77e8053ec83258879ca6353907580