### PR TITLE
Add scope params to notification test buttons

### DIFF
--- a/configuracoes/templates/configuracoes/partials/preferencias.html
+++ b/configuracoes/templates/configuracoes/partials/preferencias.html
@@ -3,6 +3,8 @@
 <form method="post" hx-post="{% url 'configuracoes' %}?tab=preferencias" hx-target="#content" class="space-y-4">
   {% csrf_token %}
   <input type="hidden" name="tab" value="preferencias">
+  <input type="hidden" name="escopo_tipo" id="escopo_tipo">
+  <input type="hidden" name="escopo_id" id="escopo_id">
   <fieldset class="space-y-4">
     <legend class="sr-only">{% trans 'Notificações' %}</legend>
     <div>
@@ -25,7 +27,7 @@
         <p class="text-xs text-gray-500">{{ preferencias_form.frequencia_notificacoes_email.help_text }}</p>
       {% endif %}
       <div class="mt-2 flex items-center gap-2">
-        <button type="button" class="text-xs text-blue-600 hover:underline" hx-post="{% url 'configuracoes_api:configuracoes-testar' %}" hx-vals='{"canal": "email"}' hx-include="[name=csrfmiddlewaretoken]" hx-swap="none" hx-on:afterRequest="document.getElementById('msg-email').innerText = event.detail.xhr.responseJSON.detail" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
+        <button type="button" class="text-xs text-blue-600 hover:underline" hx-post="{% url 'configuracoes_api:configuracoes-testar' %}" hx-vals='{"canal": "email"}' hx-include="[name=csrfmiddlewaretoken],#escopo_tipo,#escopo_id" hx-swap="none" hx-on:afterRequest="document.getElementById('msg-email').innerText = event.detail.xhr.responseJSON.detail" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
           {% trans 'Testar e-mail' %}
         </button>
         <span id="msg-email" class="text-xs text-gray-600" aria-live="polite"></span>
@@ -51,7 +53,7 @@
         <p class="text-xs text-gray-500">{{ preferencias_form.frequencia_notificacoes_whatsapp.help_text }}</p>
       {% endif %}
       <div class="mt-2 flex items-center gap-2">
-        <button type="button" class="text-xs text-blue-600 hover:underline" hx-post="{% url 'configuracoes_api:configuracoes-testar' %}" hx-vals='{"canal": "whatsapp"}' hx-include="[name=csrfmiddlewaretoken]" hx-swap="none" hx-on:afterRequest="document.getElementById('msg-whatsapp').innerText = event.detail.xhr.responseJSON.detail" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
+        <button type="button" class="text-xs text-blue-600 hover:underline" hx-post="{% url 'configuracoes_api:configuracoes-testar' %}" hx-vals='{"canal": "whatsapp"}' hx-include="[name=csrfmiddlewaretoken],#escopo_tipo,#escopo_id" hx-swap="none" hx-on:afterRequest="document.getElementById('msg-whatsapp').innerText = event.detail.xhr.responseJSON.detail" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
           {% trans 'Testar WhatsApp' %}
         </button>
         <span id="msg-whatsapp" class="text-xs text-gray-600" aria-live="polite"></span>
@@ -78,7 +80,7 @@
         <p class="text-xs text-gray-500">{{ preferencias_form.frequencia_notificacoes_push.help_text }}</p>
       {% endif %}
       <div class="mt-2 flex items-center gap-2">
-        <button type="button" class="text-xs text-blue-600 hover:underline" hx-post="{% url 'configuracoes_api:configuracoes-testar' %}" hx-vals='{"canal": "push"}' hx-include="[name=csrfmiddlewaretoken]" hx-swap="none" hx-on:afterRequest="document.getElementById('msg-push').innerText = event.detail.xhr.responseJSON.detail" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
+        <button type="button" class="text-xs text-blue-600 hover:underline" hx-post="{% url 'configuracoes_api:configuracoes-testar' %}" hx-vals='{"canal": "push"}' hx-include="[name=csrfmiddlewaretoken],#escopo_tipo,#escopo_id" hx-swap="none" hx-on:afterRequest="document.getElementById('msg-push').innerText = event.detail.xhr.responseJSON.detail" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
           {% trans 'Testar push' %}
         </button>
         <span id="msg-push" class="text-xs text-gray-600" aria-live="polite"></span>


### PR DESCRIPTION
## Summary
- include hidden inputs for `escopo_tipo` and `escopo_id`
- send scope fields in HTMX requests when testing notifications

## Testing
- `pytest tests/configuracoes/test_views.py::test_view_post_atualiza_preferencias -q` *(fails: Conflicting migrations detected; Coverage failure: total of 11 is less than fail-under=90)*


------
https://chatgpt.com/codex/tasks/task_e_68a77e7fb17c83259e671ac8521dd71e