### PR TITLE
Add autocomplete options for contextual scope selection

### DIFF
--- a/configuracoes/forms.py
+++ b/configuracoes/forms.py
@@ -38,19 +38,11 @@ class ConfiguracaoContaForm(forms.ModelForm):
             "dia_semana_notificacao": forms.Select(),
         }
         help_texts = {
-            "frequencia_notificacoes_email": _(
-                "Aplicável apenas se notificações por e-mail estiverem ativas."
-            ),
-            "frequencia_notificacoes_whatsapp": _(
-                "Aplicável apenas se notificações por WhatsApp estiverem ativas."
-            ),
-            "frequencia_notificacoes_push": _(
-                "Aplicável apenas se notificações push estiverem ativas."
-            ),
+            "frequencia_notificacoes_email": _("Aplicável apenas se notificações por e-mail estiverem ativas."),
+            "frequencia_notificacoes_whatsapp": _("Aplicável apenas se notificações por WhatsApp estiverem ativas."),
+            "frequencia_notificacoes_push": _("Aplicável apenas se notificações push estiverem ativas."),
             "hora_notificacao_diaria": _("Horário para envio das notificações diárias."),
-            "hora_notificacao_semanal": _(
-                "Horário para envio das notificações semanais."
-            ),
+            "hora_notificacao_semanal": _("Horário para envio das notificações semanais."),
             "dia_semana_notificacao": _("Dia da semana para notificações semanais."),
         }
 
@@ -59,45 +51,29 @@ class ConfiguracaoContaForm(forms.ModelForm):
         if not data.get("receber_notificacoes_email"):
             data["frequencia_notificacoes_email"] = self.instance.frequencia_notificacoes_email
         if not data.get("receber_notificacoes_whatsapp"):
-            data["frequencia_notificacoes_whatsapp"] = (
-                self.instance.frequencia_notificacoes_whatsapp
-            )
+            data["frequencia_notificacoes_whatsapp"] = self.instance.frequencia_notificacoes_whatsapp
         if not data.get("receber_notificacoes_push"):
-            data["frequencia_notificacoes_push"] = (
-                self.instance.frequencia_notificacoes_push
-            )
+            data["frequencia_notificacoes_push"] = self.instance.frequencia_notificacoes_push
 
         freq_email = data.get("frequencia_notificacoes_email")
         freq_whats = data.get("frequencia_notificacoes_whatsapp")
         freq_push = data.get("frequencia_notificacoes_push")
 
-        if (
-            freq_email == "diaria"
-            or freq_whats == "diaria"
-            or freq_push == "diaria"
-        ):
+        if freq_email == "diaria" or freq_whats == "diaria" or freq_push == "diaria":
             if not data.get("hora_notificacao_diaria"):
-                self.add_error(
-                    "hora_notificacao_diaria", _("Obrigatório para frequência diária.")
-                )
-        if (
-            freq_email == "semanal"
-            or freq_whats == "semanal"
-            or freq_push == "semanal"
-        ):
+                self.add_error("hora_notificacao_diaria", _("Obrigatório para frequência diária."))
+        if freq_email == "semanal" or freq_whats == "semanal" or freq_push == "semanal":
             if not data.get("hora_notificacao_semanal"):
-                self.add_error(
-                    "hora_notificacao_semanal", _("Obrigatório para frequência semanal.")
-                )
+                self.add_error("hora_notificacao_semanal", _("Obrigatório para frequência semanal."))
             if data.get("dia_semana_notificacao") is None:
-                self.add_error(
-                    "dia_semana_notificacao", _("Obrigatório para frequência semanal.")
-                )
+                self.add_error("dia_semana_notificacao", _("Obrigatório para frequência semanal."))
         return data
 
 
 class ConfiguracaoContextualForm(forms.ModelForm):
     """Formulário simples para CRUD de ``ConfiguracaoContextual``."""
+
+    escopo_id = forms.UUIDField(required=True, widget=forms.Select())
 
     class Meta:
         model = ConfiguracaoContextual
@@ -114,6 +90,7 @@ class ConfiguracaoContextualForm(forms.ModelForm):
             "tema",
         )
         widgets = {
+            "escopo_id": forms.Select(),
             "receber_notificacoes_email": forms.CheckboxInput(),
             "receber_notificacoes_whatsapp": forms.CheckboxInput(),
             "receber_notificacoes_push": forms.CheckboxInput(),
@@ -124,29 +101,17 @@ class ConfiguracaoContextualForm(forms.ModelForm):
             "tema": forms.Select(),
         }
         help_texts = {
-            "frequencia_notificacoes_email": _(
-                "Aplicável apenas se notificações por e-mail estiverem ativas."
-            ),
-            "frequencia_notificacoes_whatsapp": _(
-                "Aplicável apenas se notificações por WhatsApp estiverem ativas."
-            ),
-            "frequencia_notificacoes_push": _(
-                "Aplicável apenas se notificações push estiverem ativas."
-            ),
+            "frequencia_notificacoes_email": _("Aplicável apenas se notificações por e-mail estiverem ativas."),
+            "frequencia_notificacoes_whatsapp": _("Aplicável apenas se notificações por WhatsApp estiverem ativas."),
+            "frequencia_notificacoes_push": _("Aplicável apenas se notificações push estiverem ativas."),
         }
 
     def clean(self) -> dict[str, object]:
         data = super().clean()
         if not data.get("receber_notificacoes_email"):
-            data["frequencia_notificacoes_email"] = (
-                self.instance.frequencia_notificacoes_email
-            )
+            data["frequencia_notificacoes_email"] = self.instance.frequencia_notificacoes_email
         if not data.get("receber_notificacoes_whatsapp"):
-            data["frequencia_notificacoes_whatsapp"] = (
-                self.instance.frequencia_notificacoes_whatsapp
-            )
+            data["frequencia_notificacoes_whatsapp"] = self.instance.frequencia_notificacoes_whatsapp
         if not data.get("receber_notificacoes_push"):
-            data["frequencia_notificacoes_push"] = (
-                self.instance.frequencia_notificacoes_push
-            )
+            data["frequencia_notificacoes_push"] = self.instance.frequencia_notificacoes_push
         return data

--- a/configuracoes/templates/configuracoes/contextual_form.html
+++ b/configuracoes/templates/configuracoes/contextual_form.html
@@ -30,4 +30,38 @@
     </div>
   </form>
 </div>
+<script>
+  (function () {
+    const escopoTipo = document.getElementById('id_escopo_tipo');
+    const escopoSelect = document.getElementById('id_escopo_id');
+    const endpoints = {
+      organizacao: '/api/organizacoes/organizacoes/?page_size=100',
+      nucleo: '/api/nucleos/nucleos/?page_size=100',
+      evento: '/api/agenda/eventos/?page_size=100'
+    };
+
+    function loadEscopoOptions() {
+      const tipo = escopoTipo.value;
+      escopoSelect.innerHTML = '<option value="">---------</option>';
+      if (!endpoints[tipo]) {
+        return;
+      }
+      fetch(endpoints[tipo])
+        .then(r => r.json())
+        .then(data => {
+          const results = data.results || data;
+          results.forEach(item => {
+            const opt = document.createElement('option');
+            opt.value = item.id;
+            opt.textContent = item.nome || item.titulo;
+            escopoSelect.appendChild(opt);
+          });
+        })
+        .catch(() => {});
+    }
+
+    escopoTipo.addEventListener('change', loadEscopoOptions);
+    document.addEventListener('DOMContentLoaded', loadEscopoOptions);
+  })();
+</script>
 {% endblock %}

--- a/nucleos/api.py
+++ b/nucleos/api.py
@@ -129,11 +129,15 @@ class NucleoViewSet(viewsets.ModelViewSet):
         return [p() for p in perms]
 
     def get_queryset(self):
-        return (
+        qs = (
             Nucleo.objects.filter(deleted=False)
             .select_related("organizacao")
             .prefetch_related("coordenadores_suplentes")
         )
+        search = self.request.query_params.get("search")
+        if search:
+            qs = qs.filter(nome__icontains=search)
+        return qs
 
     def list(self, request, *args, **kwargs):
         queryset = self.filter_queryset(self.get_queryset())


### PR DESCRIPTION
## Summary
- replace `escopo_id` with selectable UUID field in contextual config form
- add JS widget to fetch organizations, nuclei or events dynamically
- expose simple search filters for nucleus and event API endpoints

## Testing
- `make format` *(fails: Expected a statement in tests/feed/test_services.py)*
- `make vet` *(fails: import blocks unsorted across repository)*
- `ruff check agenda/api.py configuracoes/forms.py nucleos/api.py`
- `pytest -m "not slow"` *(fails: ModuleNotFoundError: axe_core_python, bs4, playwright, httpx, pywebpush, django_redis)*
- `bandit -r . --exclude .venv,migrations,static` *(fails: syntax error in tests/feed/test_services.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a77e7dcb7c8325bcd3bf93af23584e