### PR TITLE
Prevent calendar day request on event click

### DIFF
--- a/agenda/templates/agenda/calendario.html
+++ b/agenda/templates/agenda/calendario.html
@@ -41,7 +41,7 @@
                 <a href="{% url 'agenda:evento_detalhe' ev.id %}"
                    class="block bg-emerald-50 border border-emerald-200 text-emerald-800 rounded px-1.5 py-0.5 text-xs leading-tight hover:bg-emerald-100 transition line-clamp-3"
                    hx-get="{% url 'agenda:evento_detalhe' ev.id %}"
-                   hx-target="#modal" hx-trigger="click">
+                   hx-target="#modal" hx-trigger="click" hx-stop-propagation="click">
                   {{ ev.titulo }}
                 </a>
               </li>


### PR DESCRIPTION
## Summary
- stop day trigger when clicking an event by adding `hx-stop-propagation` to event links

## Testing
- `pytest` *(fails: could not import required modules; see errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a77e73bac08325840f84c062230023