### PR TITLE
Use yesno filter directly on message tags

### DIFF
--- a/agenda/templates/agenda/briefing_list.html
+++ b/agenda/templates/agenda/briefing_list.html
@@ -16,7 +16,7 @@
   {% if messages %}
     <div class="mb-4 space-y-2">
       {% for message in messages %}
-        <p class="rounded-xl px-4 py-2 text-sm {{ message.tags == 'success'|yesno:'bg-green-100 text-green-700,bg-red-100 text-red-700' }}">{{ message }}</p>
+        <p class="rounded-xl px-4 py-2 text-sm {{ message.tags|yesno:'bg-green-100 text-green-700,bg-red-100 text-red-700' }}">{{ message }}</p>
       {% endfor %}
     </div>
   {% endif %}


### PR DESCRIPTION
## Summary
- simplify status message styles in briefing list by applying `yesno` directly to `message.tags`

## Testing
- `pytest` *(fails: tests/configuracoes/test_accessibility.py, tests/dashboard/test_views.py, tests/e2e/test_notificacoes_e2e.py, tests/e2e/test_pwa_offline.py, tests/feed/test_services.py, tests/notificacoes/test_clients.py, tests/notificacoes/test_push_sender.py, tests/test_i18n_templates.py, tests/tokens/test_metrics.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a77e72a3c083258a7361a450db0988