### PR TITLE
Use API endpoint for núcleo convites

### DIFF
--- a/nucleos/templates/nucleos/convites_modal.html
+++ b/nucleos/templates/nucleos/convites_modal.html
@@ -2,7 +2,7 @@
 <div class="p-4 bg-white rounded shadow max-w-md" id="convites-modal">
   <h2 class="text-lg font-semibold mb-2">{% trans 'Convites do núcleo' %}</h2>
   <p class="text-sm text-gray-600">{% trans 'Convites restantes hoje:' %} {{ convites_restantes }}</p>
-  <form class="mt-2 flex flex-col gap-2" hx-post="{{ create_url }}" hx-target="#convites-list" hx-swap="afterbegin">
+  <form id="convite-form" class="mt-2 flex flex-col gap-2" hx-post="{% url 'nucleos_api:nucleo-convites' nucleo.pk %}" hx-swap="none">
     {% csrf_token %}
     <input type="email" name="email" class="border rounded px-2 py-1" placeholder="{% trans 'email@example.com' %}" required />
     <select name="papel" class="border rounded px-2 py-1">
@@ -29,4 +29,21 @@
     <li class="text-sm text-gray-500">{% trans 'Nenhum convite pendente.' %}</li>
     {% endfor %}
   </ul>
+  <script>
+    document.getElementById('convite-form').addEventListener('htmx:afterRequest', function (event) {
+      if (event.detail.xhr.status === 201) {
+        const data = JSON.parse(event.detail.xhr.responseText);
+        const csrfToken = document.querySelector('#convite-form input[name="csrfmiddlewaretoken"]').value;
+        const deleteUrl = "{% url 'nucleos_api:nucleo-revogar-convite' nucleo.pk 0 %}".replace(/0\/$/, `${data.id}/`);
+        const li = document.createElement('li');
+        li.id = `convite-${data.id}`;
+        li.className = 'flex justify-between items-center';
+        li.innerHTML = `\n        <span>${data.email} - ${data.papel}</span>\n        <form hx-delete="${deleteUrl}" hx-target="#convite-${data.id}" hx-swap="outerHTML" hx-confirm="{% trans 'Confirmar revogação?' %}">\n          <input type="hidden" name="csrfmiddlewaretoken" value="${csrfToken}" />\n          <button type="submit" class="text-red-600">{% trans 'Revogar' %}</button>\n        </form>\n      `;
+        document.getElementById('convites-list').prepend(li);
+        event.target.reset();
+      } else if (event.detail.xhr.status === 429) {
+        alert(event.detail.xhr.responseText);
+      }
+    });
+  </script>
 </div>

--- a/nucleos/urls.py
+++ b/nucleos/urls.py
@@ -34,11 +34,6 @@ urlpatterns = [
         name="convites_modal",
     ),
     path(
-        "<int:pk>/convites/novo/",
-        views.ConviteCreateView.as_view(),
-        name="convite_create",
-    ),
-    path(
         "<int:pk>/membro/<int:participacao_id>/remover/",
         views.MembroRemoveView.as_view(),
         name="membro_remover",

--- a/nucleos/views.py
+++ b/nucleos/views.py
@@ -10,11 +10,9 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.cache import cache
 from django.db.models import Count, Q
 from django.http import HttpResponse
-from django.middleware.csrf import get_token
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse, reverse_lazy
 from django.utils import timezone
-from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import (
     CreateView,
@@ -278,42 +276,8 @@ class ConvitesModalView(GerenteRequiredMixin, LoginRequiredMixin, View):
                 "nucleo": nucleo,
                 "convites": convites,
                 "convites_restantes": restantes,
-                "create_url": reverse("nucleos:convite_create", args=[nucleo.pk]),
             },
         )
-
-
-class ConviteCreateView(GerenteRequiredMixin, LoginRequiredMixin, View):
-    def post(self, request, pk):
-        nucleo = get_object_or_404(Nucleo, pk=pk, deleted=False)
-        email = request.POST.get("email", "")
-        papel = request.POST.get("papel", "membro")
-        try:
-            convite = gerar_convite_nucleo(request.user, nucleo, email, papel)
-        except ValueError as exc:
-            return HttpResponse(str(exc), status=429)
-        csrf_token = get_token(request)
-        delete_url = reverse(
-            "nucleos_api:nucleo-revogar-convite", args=[nucleo.pk, convite.pk]
-        )
-        li_html = format_html(
-            '<li id="convite-{}" class="flex justify-between items-center">'
-            '<span>{} - {}</span>'
-            '<form hx-delete="{}" hx-target="#convite-{}" hx-swap="outerHTML" '
-            'hx-confirm="{}">'
-            '<input type="hidden" name="csrfmiddlewaretoken" value="{}" />'
-            '<button type="submit" class="text-red-600">{}</button>'
-            '</form></li>',
-            convite.id,
-            convite.email,
-            convite.papel,
-            delete_url,
-            convite.id,
-            _("Confirmar revogação?"),
-            csrf_token,
-            _("Revogar"),
-        )
-        return HttpResponse(li_html, status=201)
 
 
 class ParticipacaoCreateView(LoginRequiredMixin, View):


### PR DESCRIPTION
## Summary
- Post new núcleo invites to REST API and handle JSON response via htmx/JS
- Simplify ConvitesModalView and drop unused ConviteCreateView and URL

## Testing
- `pytest tests/nucleos/test_convites.py::test_convite_flow -q` *(fails: django.core.management.base.CommandError: Conflicting migrations detected)*

------
https://chatgpt.com/codex/tasks/task_e_68a7818c59dc8325852d9a6dfd9f5da3