### PR TITLE
Use API endpoint for member export

### DIFF
--- a/nucleos/README.md
+++ b/nucleos/README.md
@@ -7,7 +7,7 @@ Views principais:
 - `nucleos:create` – criação de núcleo vinculado à organização do usuário.
 - `nucleos:update` – edição de dados básicos do núcleo.
 - `nucleos:toggle_active` – inativa ou reativa um núcleo.
-- `nucleos:exportar_membros` – exporta membros em CSV.
+- `nucleos_api:nucleo-exportar-membros` – exporta membros em CSV.
 
 Fluxo de participação:
 

--- a/nucleos/templates/nucleos/detail.html
+++ b/nucleos/templates/nucleos/detail.html
@@ -111,13 +111,13 @@
   <div class="mt-6 space-x-2">
     <div class="inline-block relative">
       <a
-        href="{% url 'nucleos:exportar_membros' object.pk %}?formato=csv"
+        href="{% url 'nucleos_api:nucleo-exportar-membros' object.pk %}?formato=csv"
         class="text-blue-600"
         hx-boost="false"
         download="nucleo-{{ object.pk }}-membros.csv"
       >{% trans 'Exportar CSV' %}</a>
       <a
-        href="{% url 'nucleos:exportar_membros' object.pk %}?formato=xls"
+        href="{% url 'nucleos_api:nucleo-exportar-membros' object.pk %}?formato=xls"
         class="text-blue-600"
         hx-boost="false"
         download="nucleo-{{ object.pk }}-membros.xlsx"

--- a/nucleos/urls.py
+++ b/nucleos/urls.py
@@ -59,11 +59,6 @@ urlpatterns = [
         name="suplente_remover",
     ),
     path(
-        "<int:pk>/membros/exportar/",
-        views.ExportarMembrosView.as_view(),
-        name="exportar_membros",
-    ),
-    path(
         "<int:pk>/toggle-active/",
         views.NucleoToggleActiveView.as_view(),
         name="toggle_active",

--- a/nucleos/views.py
+++ b/nucleos/views.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 
-import tablib
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import get_user_model
@@ -38,7 +37,6 @@ from .forms import (
 from .models import CoordenadorSuplente, Nucleo, ParticipacaoNucleo
 from .services import gerar_convite_nucleo
 from .tasks import (
-    notify_exportacao_membros,
     notify_participacao_aprovada,
     notify_participacao_recusada,
     notify_suplente_designado,
@@ -417,59 +415,6 @@ class SuplenteDeleteView(GerenteRequiredMixin, LoginRequiredMixin, View):
         suplente.delete()
         messages.success(request, _("Suplente removido."))
         return redirect("nucleos:detail", pk=pk)
-
-
-class ExportarMembrosView(GerenteRequiredMixin, LoginRequiredMixin, View):
-    def get(self, request, pk):
-        nucleo = get_object_or_404(Nucleo, pk=pk, deleted=False)
-        formato = request.GET.get("formato", "csv")
-        participacoes = nucleo.participacoes.select_related("user")
-        now = timezone.now()
-        suplentes = set(
-            CoordenadorSuplente.objects.filter(
-                nucleo=nucleo,
-                periodo_inicio__lte=now,
-                periodo_fim__gte=now,
-                deleted=False,
-            ).values_list("usuario_id", flat=True)
-        )
-        data = tablib.Dataset(
-            headers=[
-                "Nome",
-                "Email",
-                "Status",
-                "papel",
-                "is_suplente",
-                "data_ingresso",
-            ]
-        )
-        for p in participacoes:
-            nome = p.user.get_full_name() or p.user.username
-            data.append(
-                [
-                    nome,
-                    p.user.email,
-                    p.status,
-                    p.papel,
-                    p.user_id in suplentes,
-                    (p.data_decisao or p.data_solicitacao).isoformat(),
-                ]
-            )
-        notify_exportacao_membros.delay(nucleo.id)
-        logger.info(
-            "Exportação de membros",
-            extra={"nucleo_id": nucleo.id, "user_id": request.user.id, "formato": formato},
-        )
-        if formato == "xls":
-            response = HttpResponse(
-                data.export("xlsx"),
-                content_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-            )
-            response["Content-Disposition"] = f"attachment; filename=nucleo-{nucleo.id}-membros.xlsx"
-            return response
-        response = HttpResponse(data.export("csv"), content_type="text/csv")
-        response["Content-Disposition"] = f"attachment; filename=nucleo-{nucleo.id}-membros.csv"
-        return response
 
 
 class NucleoToggleActiveView(GerenteRequiredMixin, LoginRequiredMixin, View):

--- a/tests/nucleos/test_views.py
+++ b/tests/nucleos/test_views.py
@@ -1,4 +1,3 @@
-import csv
 from datetime import timedelta
 
 import pytest
@@ -54,7 +53,6 @@ def patch_tasks(monkeypatch):
 
     monkeypatch.setattr("nucleos.views.notify_participacao_aprovada", Dummy())
     monkeypatch.setattr("nucleos.views.notify_participacao_recusada", Dummy())
-    monkeypatch.setattr("nucleos.views.notify_exportacao_membros", Dummy())
     monkeypatch.setattr("nucleos.views.notify_suplente_designado", Dummy())
 
 
@@ -94,26 +92,6 @@ def test_participacao_flow(client, admin_user, membro_user, organizacao):
     part.refresh_from_db()
     assert part.status == "ativo"
     assert list(nucleo.membros) == [membro_user]
-
-
-def test_exportar_membros_csv(client, admin_user, organizacao):
-    nucleo = Nucleo.objects.create(nome="N", slug="n", organizacao=organizacao)
-    ParticipacaoNucleo.objects.create(
-        user=admin_user, nucleo=nucleo, status="ativo", papel="coordenador"
-    )
-    client.force_login(admin_user)
-    resp = client.get(reverse("nucleos:exportar_membros", args=[nucleo.pk]))
-    assert resp.status_code == 200
-    reader = csv.reader(resp.content.decode().splitlines())
-    rows = list(reader)
-    assert rows[0] == [
-        "Nome",
-        "Email",
-        "Status",
-        "papel",
-        "is_suplente",
-        "data_ingresso",
-    ]
 
 
 def test_toggle_active(client, admin_user, organizacao):


### PR DESCRIPTION
## Summary
- switch nucleus member export links to API endpoint
- remove legacy ExportarMembrosView and its URL
- adjust docs and tests accordingly

## Testing
- `pytest tests/nucleos/test_api.py::test_exportar_membros tests/nucleos/test_views.py::test_toggle_active -q --no-cov` *(fails: Conflicting migrations detected)*

------
https://chatgpt.com/codex/tasks/task_e_68a7818b56308325bd97dbbbe0aeb1d2