### PR TITLE
Restringe controles de exclusão a usuários root

### DIFF
--- a/organizacoes/templates/organizacoes/detail.html
+++ b/organizacoes/templates/organizacoes/detail.html
@@ -79,10 +79,10 @@
     {% if perms.organizacoes.change_organizacao %}
       <a href="{% url 'organizacoes:update' object.id %}" class="text-sm px-4 py-2 rounded-xl bg-yellow-100 text-yellow-700 hover:bg-yellow-200">{% trans 'Editar' %}</a>
     {% endif %}
-    {% if perms.organizacoes.delete_organizacao %}
-      <a href="{% url 'organizacoes:delete' object.id %}" class="text-sm px-4 py-2 rounded-xl bg-red-100 text-red-700 hover:bg-red-200">{% trans 'Excluir' %}</a>
-    {% endif %}
     {% if request.user.user_type == 'root' %}
+      {% if perms.organizacoes.delete_organizacao %}
+        <a href="{% url 'organizacoes:delete' object.id %}" class="text-sm px-4 py-2 rounded-xl bg-red-100 text-red-700 hover:bg-red-200">{% trans 'Excluir' %}</a>
+      {% endif %}
       <form method="post" action="{% url 'organizacoes:toggle' object.id %}">
         {% csrf_token %}
         <button type="submit" class="text-sm px-4 py-2 rounded-xl bg-neutral-100 text-neutral-700 hover:bg-neutral-200">

--- a/organizacoes/templates/organizacoes/partials/list_section.html
+++ b/organizacoes/templates/organizacoes/partials/list_section.html
@@ -88,10 +88,10 @@
             {% if perms.organizacoes.change_organizacao %}
             <a href="{% url 'organizacoes:update' organizacao.id %}" class="text-yellow-700 hover:underline" aria-label="{% trans 'Editar' %}">{% trans 'Editar' %}</a>
             {% endif %}
-            {% if perms.organizacoes.delete_organizacao %}
-            <a href="{% url 'organizacoes:delete' organizacao.id %}" class="text-red-700 hover:underline" aria-label="{% trans 'Remover' %}" hx-confirm="{% trans 'Confirmar remoção?' %}">{% trans 'Remover' %}</a>
-            {% endif %}
             {% if request.user.user_type == 'root' %}
+              {% if perms.organizacoes.delete_organizacao %}
+              <a href="{% url 'organizacoes:delete' organizacao.id %}" class="text-red-700 hover:underline" aria-label="{% trans 'Remover' %}" hx-confirm="{% trans 'Confirmar remoção?' %}">{% trans 'Remover' %}</a>
+              {% endif %}
               <form method="post" action="{% url 'organizacoes:toggle' organizacao.id %}" hx-confirm="{% trans 'Tem certeza?' %}">
                 {% csrf_token %}
                 {% if organizacao.inativa %}


### PR DESCRIPTION
## Summary
- Restringe links de remoção a usuários com `user_type` root
- Envolve inativação e histórico em checagem de usuário root

## Testing
- `make test` *(fails: tests/configuracoes/test_accessibility.py, tests/dashboard/test_views.py, tests/e2e/test_notificacoes_e2e.py, tests/e2e/test_pwa_offline.py, tests/feed/test_services.py, tests/notificacoes/test_clients.py, tests/notificacoes/test_push_sender.py, tests/test_i18n_templates.py, tests/tokens/test_metrics.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a78183270c832584149b4bb448eb4c