### PR TITLE
feat: show inactive badge on organization detail

### DIFF
--- a/organizacoes/templates/organizacoes/detail.html
+++ b/organizacoes/templates/organizacoes/detail.html
@@ -18,7 +18,12 @@
         {{ object.nome|make_list|first|upper }}
       </div>
     {% endif %}
-    <h1 class="text-2xl font-bold text-neutral-900">{{ object.nome }}</h1>
+    <div class="flex items-center justify-center">
+      <h1 class="text-2xl font-bold text-neutral-900">{{ object.nome }}</h1>
+      {% if object.inativa %}
+        <span class="ml-2 text-xs bg-yellow-200 text-yellow-800 px-2 py-0.5 rounded">{% trans 'Inativa' %}</span>
+      {% endif %}
+    </div>
   </div>
 
   <section>


### PR DESCRIPTION
## Summary
- show yellow 'Inativa' badge near organization title when inactive

## Testing
- `pytest -m "not slow"` *(fails: ModuleNotFoundError: No module named 'axe_core_python', bs4, playwright, httpx, pywebpush, django_redis)*

------
https://chatgpt.com/codex/tasks/task_e_68a7816d011083258d2a3c5a252e8643