### PR TITLE
Add indice_reajuste to organization form and templates

### DIFF
--- a/organizacoes/forms.py
+++ b/organizacoes/forms.py
@@ -24,9 +24,11 @@ class OrganizacaoForm(forms.ModelForm):
             "avatar",
             "cover",
             "rate_limit_multiplier",
+            "indice_reajuste",
         ]
         labels = {
             "rate_limit_multiplier": _("Multiplicador de limite de taxa"),
+            "indice_reajuste": _("Índice de reajuste"),
         }
 
     def __init__(self, *args, **kwargs) -> None:
@@ -36,12 +38,21 @@ class OrganizacaoForm(forms.ModelForm):
             existing = field.widget.attrs.get("class", "")
             field.widget.attrs["class"] = f"{existing} {base_cls}".strip()
         self.fields["slug"].required = False
+        self.fields["indice_reajuste"].widget.attrs["min"] = 0
+        self.fields["indice_reajuste"].min_value = 0
+
 
     def clean_rate_limit_multiplier(self):
         mult = self.cleaned_data.get("rate_limit_multiplier")
         if mult is not None and mult <= 0:
             raise forms.ValidationError(_("Deve ser maior que zero."))
         return mult
+
+    def clean_indice_reajuste(self):
+        indice = self.cleaned_data.get("indice_reajuste")
+        if indice is not None and indice < 0:
+            raise forms.ValidationError(_("Deve ser maior ou igual a zero."))
+        return indice
 
     def clean_cnpj(self):
         cnpj = validate_cnpj(self.cleaned_data.get("cnpj"))

--- a/organizacoes/templates/organizacoes/create.html
+++ b/organizacoes/templates/organizacoes/create.html
@@ -120,6 +120,14 @@
     </div>
 
     <div>
+      <label for="{{ form.indice_reajuste.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.indice_reajuste.label }}</label>
+      {{ form.indice_reajuste }}
+      {% if form.indice_reajuste.errors %}
+        <p class="text-red-500 text-xs mt-1">{{ form.indice_reajuste.errors }}</p>
+      {% endif %}
+    </div>
+
+    <div>
       <label for="{{ form.avatar.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.avatar.label }}</label>
       {{ form.avatar }}
       {% if form.avatar.errors %}

--- a/organizacoes/templates/organizacoes/update.html
+++ b/organizacoes/templates/organizacoes/update.html
@@ -124,6 +124,14 @@
     </div>
 
     <div>
+      <label for="{{ form.indice_reajuste.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.indice_reajuste.label }}</label>
+      {{ form.indice_reajuste }}
+      {% if form.indice_reajuste.errors %}
+        <p class="text-red-500 text-xs mt-1">{{ form.indice_reajuste.errors }}</p>
+      {% endif %}
+    </div>
+
+    <div>
       <label for="{{ form.avatar.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.avatar.label }}</label>
       {{ form.avatar }}
       {% if form.avatar.errors %}


### PR DESCRIPTION
## Summary
- include indice_reajuste field in OrganizacaoForm with validation
- display indice_reajuste field on organization create and update templates

## Testing
- `pytest tests/organizacoes/test_forms.py::test_form_fields -q --maxfail=1 -x --no-cov` *(fails: Conflicting migrations detected; multiple leaf nodes in the migration graph)*

------
https://chatgpt.com/codex/tasks/task_e_68a7816bbe9483259664e58a27146046