### PR TITLE
feat: render media types in detail template

### DIFF
--- a/accounts/templates/perfil/midia_detail.html
+++ b/accounts/templates/perfil/midia_detail.html
@@ -5,7 +5,25 @@
 
 {% block perfil_content %}
 <section class="space-y-4">
-  <img src="{{ media.file.url }}" alt="{{ media.descricao }}" class="rounded shadow max-w-full mx-auto" />
+  {% if media.media_type == 'image' %}
+    <img src="{{ media.file.url }}" alt="{{ media.descricao }}" class="rounded shadow max-w-full mx-auto" />
+  {% elif media.media_type == 'video' %}
+    <video src="{{ media.file.url }}" class="rounded shadow max-w-full mx-auto" controls aria-label="{{ media.descricao }}">
+      {% trans "Seu navegador não suporta o elemento de vídeo." %}
+    </video>
+  {% elif media.media_type == 'pdf' %}
+    <object data="{{ media.file.url }}" type="application/pdf" class="rounded shadow max-w-full mx-auto" aria-label="{{ media.descricao }}" width="100%" height="600">
+      <embed src="{{ media.file.url }}" type="application/pdf" />
+      <p class="text-center text-gray-700">
+        {% trans "Este navegador não suporta visualização de PDF." %}
+        <a href="{{ media.file.url }}" class="text-primary hover:underline" download>{% trans "Baixar PDF" %}</a>
+      </p>
+    </object>
+  {% else %}
+    <p class="text-center">
+      <a href="{{ media.file.url }}" class="text-primary hover:underline" download>{{ media.file.name }}</a>
+    </p>
+  {% endif %}
   <p class="text-center text-gray-700">{{ media.descricao }}</p>
   <div class="text-center">
     <a href="{% url 'accounts:midias' %}" class="text-sm text-primary hover:underline">← {% trans "Voltar para mídias" %}</a>


### PR DESCRIPTION
## Summary
- handle multiple media types in profile detail template with appropriate HTML tags
- add accessible fallbacks for video and PDF content

## Testing
- `pytest -q` *(fails: No module named 'axe_core_python', No module named 'bs4', No module named 'playwright', No module named 'httpx', No module named 'pywebpush', No module named 'django_redis')*


------
https://chatgpt.com/codex/tasks/task_e_68a78662abf88325ae18b8b396fbf08b