### PR TITLE
Log security event on resend confirmation

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -572,6 +572,11 @@ def resend_confirmation(request):
                     ip_gerado=request.META.get("REMOTE_ADDR"),
                 )
                 send_confirmation_email.delay(token.id)
+                SecurityEvent.objects.create(
+                    usuario=user,
+                    evento="resend_confirmation",
+                    ip=request.META.get("REMOTE_ADDR"),
+                )
         messages.success(
             request,
             _("Se o e-mail estiver cadastrado, enviaremos nova confirmação."),

--- a/tests/accounts/test_resend_confirmation_view.py
+++ b/tests/accounts/test_resend_confirmation_view.py
@@ -1,13 +1,14 @@
 import pytest
-from django.urls import reverse
 from django.utils import timezone
 from django.contrib.auth import get_user_model
+from django.test import override_settings
 
-from accounts.models import AccountToken
+from accounts.models import AccountToken, SecurityEvent
 
 User = get_user_model()
 
 
+@override_settings(ROOT_URLCONF="tests.urls_accounts")
 @pytest.mark.django_db
 def test_resend_confirmation_invalidates_previous_tokens(client):
     user = User.objects.create_user(email="u@example.com", username="u", is_active=False)
@@ -16,7 +17,7 @@ def test_resend_confirmation_invalidates_previous_tokens(client):
         tipo=AccountToken.Tipo.EMAIL_CONFIRMATION,
         expires_at=timezone.now() + timezone.timedelta(hours=24),
     )
-    resp = client.post(reverse("accounts:resend_confirmation"), {"email": user.email})
+    resp = client.post("/resend-confirmation/", {"email": user.email})
     assert resp.status_code == 302
     old.refresh_from_db()
     assert old.used_at is not None
@@ -27,3 +28,13 @@ def test_resend_confirmation_invalidates_previous_tokens(client):
     )
     assert tokens.count() == 1
     assert tokens.first().expires_at > timezone.now()
+
+
+@override_settings(ROOT_URLCONF="tests.urls_accounts")
+@pytest.mark.django_db
+def test_resend_confirmation_logs_security_event(client):
+    user = User.objects.create_user(email="inactive@example.com", username="i", is_active=False)
+    resp = client.post("/resend-confirmation/", {"email": user.email})
+    assert resp.status_code == 302
+    event = SecurityEvent.objects.get(usuario=user, evento="resend_confirmation")
+    assert event.ip == "127.0.0.1"

--- a/tests/urls_accounts.py
+++ b/tests/urls_accounts.py
@@ -1,0 +1,8 @@
+from django.urls import include, path
+from django.views.i18n import JavaScriptCatalog
+
+urlpatterns = [
+    path('', include(('accounts.urls', 'accounts'), namespace='accounts')),
+    path('api/accounts/', include(('accounts.api_urls', 'accounts_api'), namespace='accounts_api')),
+    path('jsi18n/', JavaScriptCatalog.as_view(), name='javascript-catalog'),
+]


### PR DESCRIPTION
## Summary
- create a `SecurityEvent` when resend confirmation token is generated
- test that resending confirmation logs a security event with the request IP

## Testing
- `pytest tests/accounts/test_resend_confirmation_view.py --nomigrations -o addopts="" -q`

------
https://chatgpt.com/codex/tasks/task_e_68a7866099648325bfa5fe627c1faf73