### PR TITLE
Allow resending confirmation email without authentication

### DIFF
--- a/accounts/api.py
+++ b/accounts/api.py
@@ -30,7 +30,7 @@ class AccountViewSet(viewsets.GenericViewSet):
 
     def get_permissions(self):
 
-        if self.action in {"delete_me", "enable_2fa", "disable_2fa", "resend_confirmation"}:
+        if self.action in {"delete_me", "enable_2fa", "disable_2fa"}:
 
             return [IsAuthenticated()]
         return [AllowAny()]

--- a/tests/accounts/test_security_events.py
+++ b/tests/accounts/test_security_events.py
@@ -1,6 +1,7 @@
 import pyotp
 import pytest
 from django.contrib.auth import get_user_model
+from django.test import override_settings
 from django.urls import reverse
 from django.utils import timezone
 from rest_framework.test import APIClient
@@ -65,11 +66,13 @@ def test_reset_password_logs_security_event():
 
 
 @pytest.mark.django_db
+@override_settings(ROOT_URLCONF="tests.urls_accounts_api_only")
 def test_resend_confirmation_logs_security_event():
     user = User.objects.create_user(email="inactive@example.com", username="i", is_active=False)
     client = APIClient()
     resp = client.post(reverse("accounts_api:account-resend-confirmation"), {"email": user.email})
     assert resp.status_code == 204
+    assert resp.wsgi_request.user.is_anonymous
     assert SecurityEvent.objects.filter(usuario=user, evento="resend_confirmation").exists()
 
 

--- a/tests/urls_accounts_api_only.py
+++ b/tests/urls_accounts_api_only.py
@@ -1,0 +1,5 @@
+from django.urls import include, path
+
+urlpatterns = [
+    path("api/accounts/", include(("accounts.api_urls", "accounts_api"), namespace="accounts_api")),
+]


### PR DESCRIPTION
## Summary
- Remove `resend_confirmation` from authenticated actions so anonymous users can request new confirmation emails
- Adjust test to verify anonymous access and log security event
- Add minimal test URL configuration for accounts API endpoints

## Testing
- `pytest tests/accounts/test_security_events.py::test_resend_confirmation_logs_security_event -q --disable-warnings --no-cov --nomigrations`
- `pytest tests/accounts/test_email_confirmation.py::test_resend_and_confirm_email -q --disable-warnings --no-cov --nomigrations` *(fails: IndentationError in `organizacoes.views`)*

------
https://chatgpt.com/codex/tasks/task_e_68a7865f37388325baa393d36929bba0