### PR TITLE
feat: improve item menu accessibility

### DIFF
--- a/chat/static/chat/js/chat_socket.js
+++ b/chat/static/chat/js/chat_socket.js
@@ -313,20 +313,55 @@
             const btn = div.querySelector('.action-btn');
             const menu = div.querySelector('.action-menu');
             if(!btn || !menu || !id) return;
+            function focusableItems(){
+                return Array.from(menu.querySelectorAll('button, [href], [tabindex]:not([tabindex="-1"])'));
+            }
+            function openMenu(){
+                menu.classList.remove('hidden');
+                btn.setAttribute('aria-expanded','true');
+                const first = focusableItems()[0];
+                if(first){ first.focus(); }
+            }
+            function closeMenu(){
+                menu.classList.add('hidden');
+                btn.setAttribute('aria-expanded','false');
+                btn.focus();
+            }
             btn.addEventListener('click', ()=>{
-                const hidden = menu.classList.toggle('hidden');
-                btn.setAttribute('aria-expanded', hidden ? 'false' : 'true');
+                if(menu.classList.contains('hidden')){
+                    openMenu();
+                }else{
+                    closeMenu();
+                }
+            });
+            menu.addEventListener('keydown', e=>{
+                const items = focusableItems();
+                const index = items.indexOf(document.activeElement);
+                if(e.key === 'Escape'){
+                    e.preventDefault();
+                    closeMenu();
+                }else if(e.key === 'Tab'){
+                    e.preventDefault();
+                    const next = (index + (e.shiftKey ? -1 : 1) + items.length) % items.length;
+                    items[next].focus();
+                }else if(e.key === 'ArrowDown'){
+                    e.preventDefault();
+                    const next = (index + 1) % items.length;
+                    items[next].focus();
+                }else if(e.key === 'ArrowUp'){
+                    e.preventDefault();
+                    const next = (index - 1 + items.length) % items.length;
+                    items[next].focus();
+                }
             });
             menu.addEventListener('click', e=>{
                 const createOpt = e.target.closest('.create-item');
                 const flagOpt = e.target.closest('.flag-message');
                 if(createOpt){
-                    menu.classList.add('hidden');
-                    btn.setAttribute('aria-expanded','false');
+                    closeMenu();
                     openItemModal(id);
                 } else if(flagOpt){
-                    menu.classList.add('hidden');
-                    btn.setAttribute('aria-expanded','false');
+                    closeMenu();
                     if(confirm(t('confirmFlag','Tem certeza que deseja denunciar?'))){
                         fetch(`/api/chat/channels/${destinatarioId}/messages/${id}/flag/`,{
                             method:'POST',


### PR DESCRIPTION
## Summary
- enhance chat item menu keyboard navigation
- allow closing menu with Esc and manage focus

## Testing
- `npm test` *(fails: Missing script: "test")*
- `pytest -q` *(fails: Module import errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a7864dc87883258d6fb8444e8f6e0d