### PR TITLE
feat(chat): decrypt encrypted chat messages

### DIFF
--- a/chat/static/chat/js/chat_socket.js
+++ b/chat/static/chat/js/chat_socket.js
@@ -195,6 +195,59 @@
             return {cipher, alg:'AES-GCM', keyVersion:'1'};
         }
 
+        async function decryptMessage(container){
+            const keyB64 = window.chatKey;
+            if(!keyB64) return;
+            let key;
+            try{
+                const raw = Uint8Array.from(atob(keyB64), c=>c.charCodeAt(0));
+                key = await crypto.subtle.importKey('raw', raw, 'AES-GCM', false, ['decrypt']);
+            }catch(err){
+                console.error('Invalid key', err);
+                container.querySelectorAll('[data-cipher]').forEach(el=>{
+                    el.textContent = t('invalidKey','Chave inválida');
+                });
+                return;
+            }
+            const elements = container.querySelectorAll('[data-cipher]');
+            elements.forEach(async el=>{
+                const cipher = el.dataset.cipher;
+                const alg = el.dataset.alg || 'AES-GCM';
+                try{
+                    const data = Uint8Array.from(atob(cipher), c=>c.charCodeAt(0));
+                    const iv = data.slice(0,12);
+                    const enc = data.slice(12);
+                    const decrypted = await crypto.subtle.decrypt({name:alg, iv}, key, enc);
+                    const text = new TextDecoder().decode(decrypted);
+                    const tipo = el.dataset.type || 'text';
+                    if(tipo === 'image'){
+                        const img = document.createElement('img');
+                        img.src = text;
+                        img.alt = 'imagem';
+                        img.className = 'w-full max-w-xs h-auto rounded';
+                        el.replaceWith(img);
+                    }else if(tipo === 'video'){
+                        const video = document.createElement('video');
+                        video.src = text;
+                        video.controls = true;
+                        video.className = 'w-full max-w-xs h-auto';
+                        video.setAttribute('aria-label', t('videoPlayer','Player de vídeo'));
+                        el.replaceWith(video);
+                    }else if(tipo === 'file'){
+                        const fileDiv = document.createElement('div');
+                        fileDiv.className = 'chat-file';
+                        fileDiv.innerHTML = `<a href="${text}" target="_blank">📎 ${t('downloadFile','Baixar arquivo')}</a>`;
+                        el.replaceWith(fileDiv);
+                    }else{
+                        el.textContent = text;
+                    }
+                }catch(err){
+                    console.error('Decrypt failed', err);
+                    el.textContent = t('invalidKey','Chave inválida');
+                }
+            });
+        }
+
         function renderReactions(div, reactions, userReactions){
             const list = div.querySelector('.reactions');
             if(!list) return;
@@ -402,6 +455,9 @@
             });
         }
 
+        decryptMessage(messages);
+        if(pinned){ decryptMessage(pinned); }
+
         fetch('/api/chat/favorites/')
             .then(r=>r.ok ? r.json() : {})
             .then(data=>{
@@ -472,7 +528,7 @@
 
             let content;
             if(cipher){
-                content = `<span class="encrypted" data-cipher="${cipher}" data-alg="${alg||''}" data-key-version="${keyVersion||''}">🔒</span>`;
+                content = `<span class="encrypted" data-cipher="${cipher}" data-alg="${alg||''}" data-key-version="${keyVersion||''}" data-type="${tipo}">🔒</span>`;
             }else{
                 content = conteudo;
                 if(tipo === 'image'){
@@ -533,6 +589,8 @@
             if(id && remetente !== currentUser){
                 markReadObserver.observe(div);
             }
+
+            decryptMessage(div);
             return div;
         }
 


### PR DESCRIPTION
## Summary
- add `decryptMessage` to decode encrypted chat content using session key
- hook decryption into render and initialization to replace placeholders with plaintext

## Testing
- `npm test` *(fails: Missing script "test")*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_68a7864c919483259fda2b508bb37735