### PR TITLE
Escape layout JSON for safe no-JS submission

### DIFF
--- a/dashboard/templates/dashboard/layout_form.html
+++ b/dashboard/templates/dashboard/layout_form.html
@@ -14,7 +14,7 @@
       <label for="id_publico" class="block">{{ form.publico.label }}</label>
       {{ form.publico }}
     </div>
-    <input type="hidden" name="layout_json" id="layout_json" value="{{ object.layout_json|default:'{}' }}">
+    <input type="hidden" name="layout_json" id="layout_json" value="{{ object.layout_json|default:'[]'|escapejs }}">
     <button type="submit" class="btn btn-primary">{% trans "Salvar" %}</button>
   </form>
   {% include 'dashboard/partials/metrics_list.html' %}

--- a/tests/dashboard/test_layouts.py
+++ b/tests/dashboard/test_layouts.py
@@ -36,6 +36,18 @@ def test_layout_crud(client, admin_user):
 
 
 @pytest.mark.django_db
+def test_layout_create_with_default_json(client, admin_user):
+    client.force_login(admin_user)
+    resp = client.post(
+        reverse("dashboard:layout-create"),
+        {"nome": "Def", "publico": False, "layout_json": "[]"},
+    )
+    assert resp.status_code == 302
+    layout = DashboardLayout.objects.get(nome="Def")
+    assert layout.layout_json == "[]"
+
+
+@pytest.mark.django_db
 def test_layout_permission(client, admin_user, cliente_user):
     layout = DashboardLayout.objects.create(user=admin_user, nome='X', layout_json='[]')
     client.force_login(cliente_user)


### PR DESCRIPTION
## Summary
- escape hidden layout_json field with `escapejs` and default to empty array
- add regression test for layout creation without JavaScript

## Testing
- `python -m pytest tests/dashboard/test_layouts.py::test_layout_create_with_default_json -q --no-cov --nomigrations`


------
https://chatgpt.com/codex/tasks/task_e_68a786372f6c8325993c2fcba7fc7f58