### PR TITLE
Restrict dashboard share option to administrators

### DIFF
--- a/dashboard/templates/dashboard/config_form.html
+++ b/dashboard/templates/dashboard/config_form.html
@@ -10,10 +10,14 @@
       <label for="id_nome" class="block text-sm font-medium text-neutral-700">{% trans 'Nome' %}</label>
       {{ form.nome }}
     </div>
+    {% if request.user.user_type in ['ROOT','ADMIN'] %}
     <div class="flex items-center gap-2">
       {{ form.publico }}
       <label for="id_publico" class="text-sm text-neutral-700">{% trans 'Público' %}</label>
     </div>
+    {% else %}
+    <p class="text-sm text-neutral-700">{% trans 'Apenas administradores podem publicar itens.' %}</p>
+    {% endif %}
     <button type="submit" class="px-4 py-2 bg-primary-600 text-white rounded focus:outline-none focus:ring" aria-label="{% trans 'Salvar configuração' %}">{% trans 'Salvar' %}</button>
   </form>
 </main>

--- a/dashboard/templates/dashboard/filter_form.html
+++ b/dashboard/templates/dashboard/filter_form.html
@@ -10,10 +10,14 @@
       <label for="id_nome" class="block text-sm font-medium text-neutral-700">{% trans 'Nome' %}</label>
       {{ form.nome }}
     </div>
+    {% if request.user.user_type in ['ROOT','ADMIN'] %}
     <div class="flex items-center gap-2">
       {{ form.publico }}
       <label for="id_publico" class="text-sm text-neutral-700">{% trans 'Público' %}</label>
     </div>
+    {% else %}
+    <p class="text-sm text-neutral-700">{% trans 'Apenas administradores podem publicar itens.' %}</p>
+    {% endif %}
     <button type="submit" class="px-4 py-2 bg-primary-600 text-white rounded focus:outline-none focus:ring" aria-label="{% trans 'Salvar filtro' %}">{% trans 'Salvar' %}</button>
   </form>
 </main>

--- a/dashboard/templates/dashboard/layout_form.html
+++ b/dashboard/templates/dashboard/layout_form.html
@@ -10,10 +10,14 @@
       <label for="id_nome" class="block mb-1">{% trans "Nome" %}</label>
       {{ form.nome }}
     </div>
+    {% if request.user.user_type in ['ROOT','ADMIN'] %}
     <div class="mb-4">
       <label for="id_publico" class="block">{{ form.publico.label }}</label>
       {{ form.publico }}
     </div>
+    {% else %}
+    <p class="mb-4 text-sm text-neutral-700">{% trans 'Apenas administradores podem publicar itens.' %}</p>
+    {% endif %}
     <input type="hidden" name="layout_json" id="layout_json" value="{{ object.layout_json|default:'{}' }}">
     <button type="submit" class="btn btn-primary">{% trans "Salvar" %}</button>
   </form>

--- a/tests/dashboard/test_publico_visibility.py
+++ b/tests/dashboard/test_publico_visibility.py
@@ -1,0 +1,30 @@
+import pytest
+from django.urls import reverse
+
+pytestmark = pytest.mark.urls("tests.dashboard.urls")
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("url_name", [
+    "dashboard:config-create",
+    "dashboard:filter-create",
+    "dashboard:layout-create",
+])
+def test_publico_field_visible_for_admin(client, admin_user, url_name):
+    client.force_login(admin_user)
+    resp = client.get(reverse(url_name))
+    assert "id_publico" in resp.content.decode()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("url_name", [
+    "dashboard:config-create",
+    "dashboard:filter-create",
+    "dashboard:layout-create",
+])
+def test_publico_field_hidden_for_non_admin(client, cliente_user, url_name):
+    client.force_login(cliente_user)
+    resp = client.get(reverse(url_name))
+    content = resp.content.decode()
+    assert "id_publico" not in content
+    assert "Apenas administradores podem publicar itens" in content

--- a/tests/dashboard/urls.py
+++ b/tests/dashboard/urls.py
@@ -1,5 +1,14 @@
 from django.urls import include, path
+from django.views.i18n import JavaScriptCatalog
+from django.http import HttpResponse
 
 urlpatterns = [
+    path("jsi18n/", JavaScriptCatalog.as_view(), name="javascript-catalog"),
+    path(
+        "empresas/",
+        include(([
+            path("", lambda request: HttpResponse(""), name="lista"),
+        ], "empresas")),
+    ),
     path("", include(("dashboard.urls", "dashboard"), namespace="dashboard")),
 ]


### PR DESCRIPTION
## Summary
- Hide "Público" checkbox from dashboard config, filter and layout forms unless the user is ROOT or ADMIN
- Show message to non-admins that only administrators can publish items
- Add tests covering visibility of the `publico` field

## Testing
- `pytest tests/dashboard/test_publico_visibility.py::test_publico_field_visible_for_admin[dashboard:config-create] --no-cov --nomigrations -q --maxfail=1 --tb=short` *(fails: Reverse for 'buscar' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a786362858832599099624092759de