### PR TITLE
Restrict dashboard list actions to owners

### DIFF
--- a/dashboard/templates/dashboard/config_list.html
+++ b/dashboard/templates/dashboard/config_list.html
@@ -11,8 +11,10 @@
         <span>{{ cfg.nome }}</span>
         <div class="space-x-2">
           <a href="{% url 'dashboard:config-apply' cfg.pk %}" class="text-primary-600 underline" aria-label="{% trans 'Aplicar configuração' %}">{% trans 'Aplicar' %}</a>
-          <a href="{% url 'dashboard:config-edit' cfg.pk %}" class="text-primary-600 underline" aria-label="{% trans 'Editar configuração' %}">{% trans 'Editar' %}</a>
-          <a href="{% url 'dashboard:config-delete' cfg.pk %}" class="text-danger-600 underline" aria-label="{% trans 'Excluir configuração' %}">{% trans 'Excluir' %}</a>
+          {% if cfg.user_id == request.user.id or request.user.user_type == 'admin' or request.user.user_type == 'root' %}
+            <a href="{% url 'dashboard:config-edit' cfg.pk %}" class="text-primary-600 underline" aria-label="{% trans 'Editar configuração' %}">{% trans 'Editar' %}</a>
+            <a href="{% url 'dashboard:config-delete' cfg.pk %}" class="text-danger-600 underline" aria-label="{% trans 'Excluir configuração' %}">{% trans 'Excluir' %}</a>
+          {% endif %}
         </div>
       </li>
     {% empty %}

--- a/dashboard/templates/dashboard/filter_list.html
+++ b/dashboard/templates/dashboard/filter_list.html
@@ -11,10 +11,13 @@
         <span>{{ f.nome }}</span>
         <span class="flex gap-2">
           <a href="{% url 'dashboard:filter-apply' f.pk %}" class="text-primary-600 underline" aria-label="{% trans 'Aplicar filtro' %}">{% trans 'Aplicar' %}</a>
-          <form method="post" action="{% url 'dashboard:filter-delete' f.pk %}">
-            {% csrf_token %}
-            <button type="submit" class="text-red-600 underline" aria-label="{% trans 'Excluir filtro' %}">{% trans 'Excluir' %}</button>
-          </form>
+          {% if f.user_id == request.user.id or request.user.user_type == 'admin' or request.user.user_type == 'root' %}
+            <a href="{% url 'dashboard:filter-edit' f.pk %}" class="text-primary-600 underline" aria-label="{% trans 'Editar filtro' %}">{% trans 'Editar' %}</a>
+            <form method="post" action="{% url 'dashboard:filter-delete' f.pk %}">
+              {% csrf_token %}
+              <button type="submit" class="text-red-600 underline" aria-label="{% trans 'Excluir filtro' %}">{% trans 'Excluir' %}</button>
+            </form>
+          {% endif %}
         </span>
       </li>
     {% empty %}

--- a/dashboard/templates/dashboard/layout_list.html
+++ b/dashboard/templates/dashboard/layout_list.html
@@ -4,9 +4,17 @@
 {% block content %}
 <main class="max-w-3xl mx-auto p-4" role="main" aria-label="{% trans 'Layouts' %}">
   <h1 class="text-2xl mb-4">{% trans "Meus Layouts" %}</h1>
-  <ul>
+  <ul class="space-y-2">
     {% for layout in object_list %}
-      <li class="mb-2"><a href="{% url 'dashboard:layout-edit' layout.pk %}" class="text-blue-600">{{ layout.nome }}</a></li>
+      <li class="flex justify-between items-center p-2 bg-white rounded shadow">
+        <span>{{ layout.nome }}</span>
+        {% if layout.user_id == request.user.id or request.user.user_type == 'admin' or request.user.user_type == 'root' %}
+          <span class="flex gap-2">
+            <a href="{% url 'dashboard:layout-edit' layout.pk %}" class="text-primary-600 underline" aria-label="{% trans 'Editar layout' %}">{% trans 'Editar' %}</a>
+            <a href="{% url 'dashboard:layout-delete' layout.pk %}" class="text-danger-600 underline" aria-label="{% trans 'Excluir layout' %}">{% trans 'Excluir' %}</a>
+          </span>
+        {% endif %}
+      </li>
     {% empty %}
       <li>{% trans "Nenhum layout" %}</li>
     {% endfor %}

--- a/tests/dashboard/test_filters.py
+++ b/tests/dashboard/test_filters.py
@@ -28,3 +28,16 @@ def test_filter_crud_with_audit(client, admin_user):
     assert not DashboardFilter.objects.filter(pk=filtro.pk).exists()
     assert AuditLog.objects.filter(action="DELETE_FILTER", object_id=str(filtro.pk)).exists()
 
+
+@pytest.mark.django_db
+def test_filter_list_permissions(client, admin_user, cliente_user):
+    own = DashboardFilter.objects.create(user=cliente_user, nome="Own", filtros={})
+    other = DashboardFilter.objects.create(user=admin_user, nome="Other", filtros={})
+    client.force_login(cliente_user)
+    resp = client.get(reverse("dashboard:filters"))
+    content = resp.content.decode()
+    assert reverse("dashboard:filter-edit", args=[own.pk]) in content
+    assert reverse("dashboard:filter-delete", args=[own.pk]) in content
+    assert reverse("dashboard:filter-edit", args=[other.pk]) not in content
+    assert reverse("dashboard:filter-delete", args=[other.pk]) not in content
+

--- a/tests/dashboard/test_layouts.py
+++ b/tests/dashboard/test_layouts.py
@@ -64,6 +64,19 @@ def test_layout_list_includes_public(client, admin_user, cliente_user):
 
 
 @pytest.mark.django_db
+def test_layout_list_permissions(client, admin_user, cliente_user):
+    own = DashboardLayout.objects.create(user=cliente_user, nome="Own", layout_json="[]")
+    other = DashboardLayout.objects.create(user=admin_user, nome="Other", layout_json="[]")
+    client.force_login(cliente_user)
+    resp = client.get(reverse("dashboard:layouts"))
+    content = resp.content.decode()
+    assert reverse("dashboard:layout-edit", args=[own.pk]) in content
+    assert reverse("dashboard:layout-delete", args=[own.pk]) in content
+    assert reverse("dashboard:layout-edit", args=[other.pk]) not in content
+    assert reverse("dashboard:layout-delete", args=[other.pk]) not in content
+
+
+@pytest.mark.django_db
 def test_comparativo_endpoint(client, admin_user):
     org2 = OrganizacaoFactory()
     User.objects.create_user(username='admin2', email='a2@example.com', password='pass', user_type=UserType.ADMIN, organizacao=org2)

--- a/tests/dashboard/test_views.py
+++ b/tests/dashboard/test_views.py
@@ -327,3 +327,17 @@ def test_filter_save_and_apply(client, admin_user, gerente_user):
     resp = client.get(reverse("dashboard:filter-apply", args=[filtro.pk]))
     assert resp.status_code == 302
     assert "metricas=num_users" in resp["Location"]
+
+
+@pytest.mark.django_db
+@pytest.mark.urls("tests.dashboard.urls")
+def test_config_list_permissions(client, admin_user, cliente_user):
+    own = DashboardConfig.objects.create(user=cliente_user, nome="Own", config={})
+    other = DashboardConfig.objects.create(user=admin_user, nome="Other", config={})
+    client.force_login(cliente_user)
+    resp = client.get(reverse("dashboard:configs"))
+    content = resp.content.decode()
+    assert reverse("dashboard:config-edit", args=[own.pk]) in content
+    assert reverse("dashboard:config-delete", args=[own.pk]) in content
+    assert reverse("dashboard:config-edit", args=[other.pk]) not in content
+    assert reverse("dashboard:config-delete", args=[other.pk]) not in content

--- a/tests/dashboard/urls.py
+++ b/tests/dashboard/urls.py
@@ -1,5 +1,7 @@
 from django.urls import include, path
+from django.views.i18n import JavaScriptCatalog
 
 urlpatterns = [
+    path("jsi18n/", JavaScriptCatalog.as_view(), name="javascript-catalog"),
     path("", include(("dashboard.urls", "dashboard"), namespace="dashboard")),
 ]


### PR DESCRIPTION
## Summary
- limit edit/delete buttons in dashboard filter, config and layout lists to owners or admins
- display edit option for filters and layouts
- cover list permissions in tests

## Testing
- `pytest tests/dashboard/test_filters.py::test_filter_list_permissions -q -o addopts="" --nomigrations` *(fails: NoReverseMatch: 'empresas' is not a registered namespace)*

------
https://chatgpt.com/codex/tasks/task_e_68a786354314832597c4e3f71cd24d8b