### PR TITLE
Preserve dashboard metric filters

### DIFF
--- a/dashboard/templates/dashboard/admin.html
+++ b/dashboard/templates/dashboard/admin.html
@@ -13,7 +13,7 @@
 
   {% include 'dashboard/partials/filters_form.html' %}
 
-  <div hx-get="{% url 'dashboard:metrics-partial' %}" hx-trigger="load, every 10s" hx-target="#metrics" hx-swap="innerHTML">
+  <div hx-get="{% url 'dashboard:metrics-partial' %}?{{ request.GET.urlencode }}" hx-trigger="load, every 10s" hx-target="#metrics" hx-swap="innerHTML">
     {% include 'dashboard/partials/metrics_list.html' %}
   </div>
 

--- a/dashboard/templates/dashboard/cliente.html
+++ b/dashboard/templates/dashboard/cliente.html
@@ -13,7 +13,7 @@
 
   {% include 'dashboard/partials/filters_form.html' %}
 
-  <div hx-get="{% url 'dashboard:metrics-partial' %}" hx-trigger="load, every 10s" hx-target="#metrics" hx-swap="innerHTML">
+  <div hx-get="{% url 'dashboard:metrics-partial' %}?{{ request.GET.urlencode }}" hx-trigger="load, every 10s" hx-target="#metrics" hx-swap="innerHTML">
     {% include 'dashboard/partials/metrics_list.html' %}
   </div>
 

--- a/dashboard/templates/dashboard/gerente.html
+++ b/dashboard/templates/dashboard/gerente.html
@@ -13,7 +13,7 @@
 
   {% include 'dashboard/partials/filters_form.html' %}
 
-  <div hx-get="{% url 'dashboard:metrics-partial' %}" hx-trigger="load, every 10s" hx-target="#metrics" hx-swap="innerHTML">
+  <div hx-get="{% url 'dashboard:metrics-partial' %}?{{ request.GET.urlencode }}" hx-trigger="load, every 10s" hx-target="#metrics" hx-swap="innerHTML">
     {% include 'dashboard/partials/metrics_list.html' %}
   </div>
 

--- a/dashboard/templates/dashboard/root.html
+++ b/dashboard/templates/dashboard/root.html
@@ -13,7 +13,7 @@
 
   {% include 'dashboard/partials/filters_form.html' %}
 
-  <div hx-get="{% url 'dashboard:metrics-partial' %}" hx-trigger="load, every 10s" hx-target="#metrics" hx-swap="innerHTML">
+  <div hx-get="{% url 'dashboard:metrics-partial' %}?{{ request.GET.urlencode }}" hx-trigger="load, every 10s" hx-target="#metrics" hx-swap="innerHTML">
     {% include 'dashboard/partials/metrics_list.html' %}
   </div>
 


### PR DESCRIPTION
## Summary
- Forward query parameters in dashboard metric refresh URLs so filters persist

## Testing
- `pytest -q` *(fails: syntax error in tests/feed/test_services.py, missing onesignal_sdk)*

------
https://chatgpt.com/codex/tasks/task_e_68a78633f28083259825b15775e593d2