### PR TITLE
Add empty favorites placeholder via client-side check

### DIFF
--- a/empresas/templates/empresas/favoritos.html
+++ b/empresas/templates/empresas/favoritos.html
@@ -8,7 +8,11 @@
   <header class="mb-4">
     <h1 class="text-2xl font-bold text-neutral-900">{% translate "Empresas Favoritas" %}</h1>
   </header>
-  <ul class="space-y-4" id="lista-favoritos">
+  <ul
+    class="space-y-4"
+    id="lista-favoritos"
+    hx-on:afterRequest="if (this.children.length === 0) { const li=document.createElement('li'); li.className='text-neutral-600'; li.textContent='{{ _('Nenhuma empresa favorita.')|escapejs }}'; this.appendChild(li); }"
+  >
     {% for empresa in empresas %}
       <li id="empresa-{{ empresa.id }}" class="p-4 bg-white rounded shadow">
         <h2 class="text-lg font-semibold">{{ empresa.nome }}</h2>


### PR DESCRIPTION
## Summary
- Add `hx-on:afterRequest` handler to insert a 'Nenhuma empresa favorita.' message when the favorites list is emptied

## Testing
- `pytest empresas/tests/test_forms.py::test_tags_are_assigned_from_ids -q` *(fails: CommandError Conflicting migrations detected)*

------
https://chatgpt.com/codex/tasks/task_e_68a78628a578832586e6a2ed985b3243