### PR TITLE
Include CNPJ in empresa search

### DIFF
--- a/empresas/README.md
+++ b/empresas/README.md
@@ -6,7 +6,7 @@ fornecendo campos padronizados de criação/atualização e exclusão lógica.
 
 ## Rotas principais
 
-- `/empresas/` – listagem com filtros por nome, município, estado, tags e busca textual (`q`). Administradores podem visualizar registros excluídos passando `?mostrar_excluidas=1`.
+- `/empresas/` – listagem com filtros por nome, município, estado, tags e busca textual (`q`) que procura em nome, CNPJ, descrição, palavras-chave e tags. Administradores podem visualizar registros excluídos passando `?mostrar_excluidas=1`.
 - `/empresas/nova/` – criação.
 - `/empresas/<id>/editar/` – edição.
 - `/empresas/<id>/` – detalhes da empresa com avaliações e ações.

--- a/empresas/services.py
+++ b/empresas/services.py
@@ -7,6 +7,7 @@ manutenção das views.
 
 from django.contrib.postgres.search import SearchQuery, SearchRank, SearchVector
 from django.db import connection
+from django.db.models import Q
 from django.utils import timezone
 
 from accounts.models import UserType
@@ -69,6 +70,7 @@ def search_empresas(user, params):
         if connection.vendor == "postgresql":
             vector = (
                 SearchVector("nome", weight="A")
+                + SearchVector("cnpj", weight="A")
                 + SearchVector("descricao", weight="B")
                 + SearchVector("palavras_chave", weight="B")
                 + SearchVector("tags__nome", weight="C")
@@ -76,7 +78,7 @@ def search_empresas(user, params):
             query = SearchQuery(q)
             qs = qs.annotate(rank=SearchRank(vector, query)).filter(rank__gt=0).order_by("-rank")
         else:
-            qs = qs.filter(search_vector__icontains=q)
+            qs = qs.filter(Q(search_vector__icontains=q) | Q(cnpj__icontains=q))
     return qs.distinct()
 
 

--- a/empresas/signals.py
+++ b/empresas/signals.py
@@ -11,7 +11,13 @@ from .tasks import criar_post_empresa, validar_cnpj_empresa
 def _update_search_vector(instance: Empresa) -> None:
     """Atualiza o campo ``search_vector`` com os textos relevantes."""
     tags_text = " ".join(instance.tags.values_list("nome", flat=True))
-    parts = [instance.nome, instance.descricao, instance.palavras_chave, tags_text]
+    parts = [
+        instance.nome,
+        instance.cnpj,
+        instance.descricao,
+        instance.palavras_chave,
+        tags_text,
+    ]
     texto = " ".join(filter(None, parts))
     Empresa.objects.filter(pk=instance.pk).update(search_vector=texto)
 

--- a/empresas/tests/test_search.py
+++ b/empresas/tests/test_search.py
@@ -1,0 +1,17 @@
+import pytest
+from django.http import QueryDict
+
+from accounts.factories import UserFactory
+from accounts.models import UserType
+from empresas.factories import EmpresaFactory
+from empresas.services import search_empresas
+
+
+@pytest.mark.django_db
+def test_search_empresas_by_cnpj():
+    empresa = EmpresaFactory(cnpj="12.345.678/0001-90")
+    user = UserFactory(is_superuser=True, user_type=UserType.ROOT)
+    params = QueryDict(mutable=True)
+    params["q"] = empresa.cnpj
+    qs = search_empresas(user, params)
+    assert list(qs) == [empresa]


### PR DESCRIPTION
## Summary
- index company CNPJ in search vector
- allow querying by CNPJ in full-text search
- document search coverage and add CNPJ search test

## Testing
- `pytest ProjetoHubx/empresas/tests/test_search.py::test_search_empresas_by_cnpj --nomigrations --no-cov -q`
- `pytest ProjetoHubx/empresas/tests --nomigrations --no-cov -q` *(fails: IndentationError: expected an indented block in organizacoes/views.py)*


------
https://chatgpt.com/codex/tasks/task_e_68a78626bc28832585a12adb9e0089ca