### PR TITLE
Annotate reaction counts for efficient feed rendering

### DIFF
--- a/feed/templates/feed/_grid.html
+++ b/feed/templates/feed/_grid.html
@@ -61,7 +61,7 @@
           </div>
           <button type="button" data-post-id="{{ post.id }}" class="share-btn inline-flex items-center gap-1 hover:text-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 rounded {% if post.reacoes.filter(vote='share', user=user).exists %}text-blue-600{% endif %}" aria-label="{% trans 'Compartilhar' %}">
             <i class="fa-solid fa-share"></i>
-            <span class="share-count">{{ post.reacoes.filter(vote='share').count }}</span>
+            <span class="share-count">{{ post.share_count }}</span>
           </button>
           <button type="button" data-post-id="{{ post.id }}" class="bookmark-btn hover:text-yellow-600 focus:outline-none focus:ring-2 focus:ring-yellow-500 rounded {% if post.bookmarks.filter(user=user).exists %}text-yellow-600{% endif %}" aria-label="{% trans 'Salvar' %}">
             <i class="fa-solid fa-bookmark"></i>

--- a/feed/templates/feed/_like_button.html
+++ b/feed/templates/feed/_like_button.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-{% with liked=post.reacoes.filter(user=user, vote='like', deleted=False).exists count=post.reacoes.filter(vote='like', deleted=False).count %}
+{% with liked=post.reacoes.filter(user=user, vote='like', deleted=False).exists count=post.like_count %}
 <button
   hx-post="/api/feed/posts/{{ post.id }}/reacoes/"
   hx-ext="json-enc"

--- a/feed/templates/feed/post_detail.html
+++ b/feed/templates/feed/post_detail.html
@@ -60,7 +60,7 @@
       </div>
       <button type="button" data-post-id="{{ post.id }}" class="share-btn inline-flex items-center gap-1 hover:text-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 rounded {% if post.reacoes.filter(vote='share', user=user).exists %}text-blue-600{% endif %}" aria-label="{% trans 'Compartilhar' %}">
         <i class="fa-solid fa-share"></i>
-        <span class="share-count">{{ post.reacoes.filter(vote='share').count }}</span>
+        <span class="share-count">{{ post.share_count }}</span>
       </button>
       <button type="button" data-post-id="{{ post.id }}" class="bookmark-btn hover:text-yellow-600 focus:outline-none focus:ring-2 focus:ring-yellow-500 rounded {% if post.bookmarks.filter(user=user).exists %}text-yellow-600{% endif %}" aria-label="{% trans 'Salvar' %}">
         <i class="fa-solid fa-bookmark"></i>

--- a/feed/tests/test_feed_queries.py
+++ b/feed/tests/test_feed_queries.py
@@ -1,0 +1,44 @@
+from django.db import connection
+from django.test import RequestFactory, TestCase, override_settings
+from django.test.utils import CaptureQueriesContext
+
+from accounts.factories import UserFactory
+from feed.factories import PostFactory
+from feed.models import Post, Reacao
+from feed.views import FeedListView
+from organizacoes.factories import OrganizacaoFactory
+
+
+@override_settings(NOTIFICATIONS_ENABLED=False)
+class FeedQueryCountTest(TestCase):
+    def setUp(self) -> None:
+        org = OrganizacaoFactory()
+        self.user = UserFactory(organizacao=org)
+        self.rf = RequestFactory()
+
+    def _get_queryset(self):
+        request = self.rf.get("/")
+        request.user = self.user
+        view = FeedListView()
+        view.request = request
+        return view.get_queryset()
+
+    def test_feed_list_annotated_counts_reduce_queries(self) -> None:
+        for _ in range(2):
+            post = PostFactory(autor=self.user)
+            Reacao.objects.create(post=post, user=self.user, vote="like")
+            Reacao.objects.create(post=post, user=self.user, vote="share")
+
+        with CaptureQueriesContext(connection) as ctx_annotated:
+            list(self._get_queryset())
+        annotated_queries = len(ctx_annotated)
+
+        with CaptureQueriesContext(connection) as ctx_manual:
+            posts = list(Post.objects.all())
+            for post in posts:
+                Reacao.objects.filter(post=post, vote="like").count()
+                Reacao.objects.filter(post=post, vote="share").count()
+        manual_queries = len(ctx_manual)
+
+        self.assertLess(annotated_queries, manual_queries)
+

--- a/feed/views.py
+++ b/feed/views.py
@@ -8,7 +8,7 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.postgres.search import SearchQuery, SearchRank, SearchVector
 from django.core.cache import cache
 from django.db import connection
-from django.db.models import Q, OuterRef, Subquery
+from django.db.models import Q, OuterRef, Subquery, Count
 from django.http import HttpResponse, HttpResponseForbidden
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template.loader import render_to_string
@@ -145,7 +145,23 @@ class FeedListView(LoginRequiredMixin, ListView):
         qs = Post.objects.select_related("autor", "organizacao", "nucleo", "evento").prefetch_related(
             "reacoes", "comments", "tags"
         )
-        qs = qs.filter(deleted=False).annotate(mod_status=Subquery(latest_status)).exclude(mod_status="rejeitado")
+        qs = (
+            qs.filter(deleted=False)
+            .annotate(mod_status=Subquery(latest_status))
+            .exclude(mod_status="rejeitado")
+            .annotate(
+                like_count=Count(
+                    "reacoes",
+                    filter=Q(reacoes__vote="like", reacoes__deleted=False),
+                    distinct=True,
+                ),
+                share_count=Count(
+                    "reacoes",
+                    filter=Q(reacoes__vote="share", reacoes__deleted=False),
+                    distinct=True,
+                ),
+            )
+        )
         if not user.is_staff:
             qs = qs.filter(Q(mod_status="aprovado") | Q(autor=user))
         qs = qs.distinct()
@@ -302,7 +318,23 @@ class PostDetailView(LoginRequiredMixin, DetailView):
     def get_queryset(self):
         latest_status = ModeracaoPost.objects.filter(post=OuterRef("pk")).order_by("-created_at").values("status")[:1]
         qs = Post.objects.select_related("autor", "organizacao", "nucleo", "evento").prefetch_related("tags")
-        qs = qs.filter(deleted=False).annotate(mod_status=Subquery(latest_status)).exclude(mod_status="rejeitado")
+        qs = (
+            qs.filter(deleted=False)
+            .annotate(mod_status=Subquery(latest_status))
+            .exclude(mod_status="rejeitado")
+            .annotate(
+                like_count=Count(
+                    "reacoes",
+                    filter=Q(reacoes__vote="like", reacoes__deleted=False),
+                    distinct=True,
+                ),
+                share_count=Count(
+                    "reacoes",
+                    filter=Q(reacoes__vote="share", reacoes__deleted=False),
+                    distinct=True,
+                ),
+            )
+        )
         if not self.request.user.is_staff:
             qs = qs.filter(Q(mod_status="aprovado") | Q(autor=self.request.user))
         return qs


### PR DESCRIPTION
## Summary
- annotate like and share counts in feed queries
- use precomputed reaction counts in feed templates
- add regression test ensuring annotated counts lower DB queries

## Testing
- `pytest feed/tests/test_feed_queries.py -q --no-cov --nomigrations`


------
https://chatgpt.com/codex/tasks/task_e_68a786173f808325bf86ec8fed073c05