### PR TITLE
Add importações list view and template

### DIFF
--- a/financeiro/templates/financeiro/importacoes_list.html
+++ b/financeiro/templates/financeiro/importacoes_list.html
@@ -1,0 +1,76 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Importações de Pagamentos" %}{% endblock %}
+
+{% block content %}
+<main class="p-4 max-w-5xl mx-auto">
+  <h1 class="text-2xl font-semibold mb-4">{% trans "Importações de Pagamentos" %}</h1>
+  <div id="importacoes"
+       hx-get="/api/financeiro/importacoes/"
+       hx-trigger="load"
+       hx-target="#importacoes"
+       hx-swap="none"
+       hx-on="htmx:afterRequest: renderImportacoes(event)">
+    <table class="min-w-full divide-y divide-gray-200">
+      <thead class="bg-gray-50">
+        <tr>
+          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{% trans "Arquivo" %}</th>
+          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{% trans "Status" %}</th>
+          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{% trans "Processados" %}</th>
+          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{% trans "Ações" %}</th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+    <div id="paginacao" class="mt-4 flex justify-between"></div>
+  </div>
+  <script>
+    const csrfToken = "{{ csrf_token }}";
+    function basename(path) {
+      return path.split('/').pop();
+    }
+    function renderImportacoes(evt) {
+      const tbody = document.querySelector('#importacoes tbody');
+      const pag = document.getElementById('paginacao');
+      tbody.innerHTML = '';
+      pag.innerHTML = '';
+      try {
+        const data = JSON.parse(evt.detail.xhr.response);
+        const itens = data.results || data;
+        const rows = itens.map(i => {
+          const token = basename(i.arquivo);
+          const acao = (i.erros && i.erros.length)
+            ? `<div class="space-y-1">
+                 <a href="/media/importacoes/${token}.errors.csv" download class="text-blue-600 underline">{{ _('Baixar erros') }}</a>
+                 <form hx-post="/api/financeiro/importar-pagamentos/reprocessar/${token}/"
+                       hx-target="closest tr"
+                       hx-encoding="multipart/form-data"
+                       hx-headers='{"X-CSRFToken": "${csrfToken}"}'
+                       class="space-y-1">
+                   <input type="file" name="file" accept=".csv,.xlsx" class="block w-full border p-1 rounded" required />
+                   <button type="submit" class="bg-primary text-white px-2 py-1 rounded">{{ _('Reprocessar') }}</button>
+                 </form>
+               </div>`
+            : '';
+          return `<tr>
+                    <td class="px-3 py-2">${token}</td>
+                    <td class="px-3 py-2">${i.status}</td>
+                    <td class="px-3 py-2">${i.total_processado}</td>
+                    <td class="px-3 py-2">${acao}</td>
+                  </tr>`;
+        }).join('');
+        tbody.innerHTML = rows || `<tr><td colspan="4" class="px-3 py-2 text-center">{{ _('Nenhuma importação') }}</td></tr>`;
+        if (data.previous) {
+          pag.innerHTML += `<button class="px-3 py-1 bg-gray-200 rounded" hx-get="${data.previous}" hx-target="#importacoes" hx-swap="none">{{ _('Anterior') }}</button>`;
+        }
+        if (data.next) {
+          pag.innerHTML += `<button class="px-3 py-1 bg-gray-200 rounded ml-auto" hx-get="${data.next}" hx-target="#importacoes" hx-swap="none">{{ _('Próximo') }}</button>`;
+        }
+      } catch (e) {
+        tbody.innerHTML = `<tr><td colspan="4" class="px-3 py-2 text-center text-red-600">{{ _('Erro ao carregar') }}</td></tr>`;
+      }
+    }
+  </script>
+</main>
+{% endblock %}

--- a/financeiro/templates/financeiro/importar_pagamentos.html
+++ b/financeiro/templates/financeiro/importar_pagamentos.html
@@ -7,6 +7,9 @@
 <main class="max-w-3xl mx-auto p-4">
   <section>
     <h1 class="text-2xl font-semibold mb-4">{% trans "Importar Pagamentos" %}</h1>
+    <div class="mb-4">
+      <a href="{% url 'financeiro:importacoes' %}" class="text-blue-600 underline">{% trans "Ver importações" %}</a>
+    </div>
     <form id="upload-form" method="post" enctype="multipart/form-data" class="space-y-4 border p-4 rounded-lg bg-white">
       {% csrf_token %}
       <label for="file" class="block text-sm font-medium text-gray-700">{% trans "Arquivo" %}</label>

--- a/financeiro/urls.py
+++ b/financeiro/urls.py
@@ -15,6 +15,7 @@ from .views import (
     repasses_view,
     integracoes_list_view,
     integracao_form_view,
+    importacoes_list_view,
     task_log_detail_view,
     task_logs_view,
 )
@@ -32,6 +33,7 @@ urlpatterns = [
     path("integracoes/form/", integracao_form_view, name="integracao_form"),
     path("integracoes/form/<uuid:pk>/", integracao_form_view, name="integracao_form_edit"),
     path("integracoes/", integracoes_list_view, name="integracoes"),
+    path("importacoes/", importacoes_list_view, name="importacoes"),
     path("lancamentos/", lancamentos_list_view, name="lancamentos"),
     path("lancamentos/<int:pk>/ajustar/", lancamento_ajuste_modal_view, name="lancamento_ajustar"),
     path("repasses/", repasses_view, name="repasses"),

--- a/financeiro/views/__init__.py
+++ b/financeiro/views/__init__.py
@@ -484,6 +484,13 @@ def integracao_form_view(request, pk: uuid.UUID | None = None):
     return render(request, "financeiro/integracao_form.html", {"integracao": integracao})
 
 
+@login_required
+@user_passes_test(_is_financeiro_or_admin)
+def importacoes_list_view(request):
+    """Lista de importações de pagamentos."""
+    return render(request, "financeiro/importacoes_list.html")
+
+
 
 @login_required
 @user_passes_test(_is_financeiro_or_admin)


### PR DESCRIPTION
## Summary
- add `importacoes_list_view` to render import history
- create `importacoes_list.html` with paginated table and reprocess support
- expose `/financeiro/importacoes/` route and link from import page

## Testing
- `pytest tests/test_importacoes_api.py::test_fluxo_importacao_listagem -q --no-cov` *(fails: Conflicting migrations detected; multiple leaf nodes in the migration graph)*

------
https://chatgpt.com/codex/tasks/task_e_68a785ff5a2c832584c44bdacd5a6260