### PR TITLE
Add status filter to finance reports

### DIFF
--- a/financeiro/services/relatorios.py
+++ b/financeiro/services/relatorios.py
@@ -42,6 +42,7 @@ def gerar_relatorio(
     periodo_inicial: datetime | None = None,
     periodo_final: datetime | None = None,
     tipo: str | None = None,
+    status: str | None = None,
 ) -> dict[str, Any]:
     """Computa séries temporais e dados de inadimplência."""
     qs = _base_queryset(centro, nucleo, periodo_inicial, periodo_final)
@@ -49,6 +50,8 @@ def gerar_relatorio(
         qs = qs.filter(valor__gt=0)
     elif tipo == "despesas":
         qs = qs.filter(valor__lt=0)
+    if status:
+        qs = qs.filter(status=status)
 
     valores = (
         qs.annotate(mes=TruncMonth("data_lancamento"))

--- a/financeiro/templates/financeiro/relatorios.html
+++ b/financeiro/templates/financeiro/relatorios.html
@@ -37,6 +37,25 @@
         <input id="rel-periodo-final" type="month" name="periodo_final" class="mt-1 block w-full border rounded p-2" />
       </div>
     </div>
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <div>
+        <label for="rel-tipo" class="block text-sm font-medium text-gray-700">{% trans "Tipo" %}</label>
+        <select id="rel-tipo" name="tipo" class="mt-1 block w-full border rounded p-2">
+          <option value="">{% trans "Todos" %}</option>
+          <option value="receitas">{% trans "Receitas" %}</option>
+          <option value="despesas">{% trans "Despesas" %}</option>
+        </select>
+      </div>
+      <div>
+        <label for="rel-status" class="block text-sm font-medium text-gray-700">{% trans "Status" %}</label>
+        <select id="rel-status" name="status" class="mt-1 block w-full border rounded p-2">
+          <option value="">{% trans "Todos" %}</option>
+          <option value="pendente">{% trans "Pendente" %}</option>
+          <option value="pago">{% trans "Pago" %}</option>
+          <option value="cancelado">{% trans "Cancelado" %}</option>
+        </select>
+      </div>
+    </div>
     <button type="button" id="gerar-relatorio" class="bg-primary text-white px-4 py-2 rounded"
             hx-get="/api/financeiro/relatorios/"
             hx-target="#relatorio"
@@ -66,9 +85,13 @@
           <p class=\"mb-2 font-medium\">{% trans "Saldo atual" %}: ${data.saldo_atual}</p>
           <p class=\"mb-2 font-medium\">{% trans "Total inadimplentes" %}: ${data.total_inadimplentes}</p>
           <table class=\"min-w-full divide-y divide-gray-200\"><thead><tr><th class=\"px-2 py-1 text-left text-xs font-medium text-gray-500\">{% trans "Mês" %}</th><th class=\"px-2 py-1 text-left text-xs font-medium text-gray-500\">{% trans "Receitas" %}</th><th class=\"px-2 py-1 text-left text-xs font-medium text-gray-500\">{% trans "Despesas" %}</th><th class=\"px-2 py-1 text-left text-xs font-medium text-gray-500\">{% trans "Saldo" %}</th></tr></thead><tbody>${rows}</tbody></table>`;
-        const params = new URLSearchParams(new FormData(document.getElementById('relatorio-form')));
-        document.getElementById('export-csv').href = '/api/financeiro/relatorios/?' + params.toString() + '&format=csv';
-        document.getElementById('export-xlsx').href = '/api/financeiro/relatorios/?' + params.toString() + '&format=xlsx';
+        const form = document.getElementById('relatorio-form');
+        const params = new URLSearchParams(new FormData(form));
+        params.set('tipo', form.querySelector('[name="tipo"]').value);
+        params.set('status', form.querySelector('[name="status"]').value);
+        const query = params.toString();
+        document.getElementById('export-csv').href = `/api/financeiro/relatorios/?${query}&format=csv`;
+        document.getElementById('export-xlsx').href = `/api/financeiro/relatorios/?${query}&format=xlsx`;
       } catch (e) {
         container.textContent = gettext('Erro ao gerar relatório');
       }

--- a/financeiro/views/__init__.py
+++ b/financeiro/views/__init__.py
@@ -274,9 +274,10 @@ class FinanceiroViewSet(viewsets.ViewSet):
                     centro_id = centros_user
 
         tipo = params.get("tipo")
+        status = params.get("status")
         cache_centro = "|".join(sorted(centro_id)) if isinstance(centro_id, list) else centro_id
         cache_key = (
-            f"rel:{cache_centro}:{nucleo_id}:{params.get('periodo_inicial')}:{params.get('periodo_final')}:{tipo}"
+            f"rel:{cache_centro}:{nucleo_id}:{params.get('periodo_inicial')}:{params.get('periodo_final')}:{tipo}:{status}"
         )
         result = cache.get(cache_key)
         if result is None:
@@ -286,6 +287,7 @@ class FinanceiroViewSet(viewsets.ViewSet):
                 periodo_inicial=inicio,
                 periodo_final=fim,
                 tipo=tipo,
+                status=status,
             )
             cache.set(cache_key, result, 600)
 
@@ -296,6 +298,8 @@ class FinanceiroViewSet(viewsets.ViewSet):
                 qs_csv = qs_csv.filter(valor__gt=0)
             elif tipo == "despesas":
                 qs_csv = qs_csv.filter(valor__lt=0)
+            if status:
+                qs_csv = qs_csv.filter(status=status)
             linhas = [
                 [
                     lanc.data_lancamento.date(),

--- a/tests/test_relatorios.py
+++ b/tests/test_relatorios.py
@@ -76,6 +76,29 @@ def test_tipo_filter_relatorio():
     assert data["serie"][0]["receitas"] == 0.0
 
 
+def test_status_filter_relatorio():
+    org = OrganizacaoFactory()
+    centro = CentroCusto.objects.create(nome="C", tipo="organizacao", organizacao=org)
+    LancamentoFinanceiro.objects.create(
+        centro_custo=centro,
+        valor=100,
+        tipo=LancamentoFinanceiro.Tipo.APORTE_INTERNO,
+        data_lancamento=timezone.now(),
+        status=LancamentoFinanceiro.Status.PENDENTE,
+    )
+    LancamentoFinanceiro.objects.create(
+        centro_custo=centro,
+        valor=50,
+        tipo=LancamentoFinanceiro.Tipo.APORTE_INTERNO,
+        data_lancamento=timezone.now(),
+        status=LancamentoFinanceiro.Status.PAGO,
+    )
+    data = gerar_relatorio(centro=str(centro.id), status=LancamentoFinanceiro.Status.PAGO)
+    assert data["serie"][0]["receitas"] == 50.0
+    data = gerar_relatorio(centro=str(centro.id), status=LancamentoFinanceiro.Status.PENDENTE)
+    assert data["serie"][0]["receitas"] == 100.0
+
+
 def test_total_inadimplentes():
     org = OrganizacaoFactory()
     centro = CentroCusto.objects.create(nome="C", tipo="organizacao", organizacao=org)


### PR DESCRIPTION
## Summary
- allow filtering finance reports by status and include in exports
- expose tipo and status filters in reports UI
- cover status filtering with tests

## Testing
- `pytest tests/test_relatorios.py::test_status_filter_relatorio --no-cov --nomigrations -q`


------
https://chatgpt.com/codex/tasks/task_e_68a785fe1d58832596cea5986519fb18