### PR TITLE
fix lancamentos actions conditional

### DIFF
--- a/financeiro/templates/financeiro/lancamentos_list.html
+++ b/financeiro/templates/financeiro/lancamentos_list.html
@@ -87,7 +87,7 @@
                 <button hx-post="/api/financeiro/lancamentos/${l.id}/pagar/" hx-headers='{"X-CSRFToken": "${csrfToken}"}' hx-on="htmx:afterRequest: htmx.trigger('#filtros','submit')" class="text-green-600 hover:underline">{% trans "Pagar" %}</button>
                 <button hx-patch="/api/financeiro/lancamentos/${l.id}/" hx-vals='{"status":"cancelado"}' hx-headers='{"X-CSRFToken": "${csrfToken}"}' hx-on="htmx:afterRequest: htmx.trigger('#filtros','submit')" class="text-red-600 hover:underline">{% trans "Cancelar" %}</button>
                 <button hx-get="/financeiro/lancamentos/${l.id}/ajustar/" hx-target="#modal" class="text-blue-600 hover:underline">{% trans "Ajustar" %}</button>
-
+                ` : ''}
               </td>
             </tr>
           `)


### PR DESCRIPTION
## Summary
- fix conditional rendering of action buttons in launch list template

## Testing
- `pytest financeiro` *(fails: django.core.management.base.CommandError: Conflicting migrations detected)*
- `node - <<'NODE'
const csrfToken='token';
function cell(status){return `<td class="px-3 py-2 space-x-2">
                ${status === 'pendente' ? `ACTIONS` : ''}
              </td>`;}
console.log('pendente', cell('pendente'));
console.log('pago', cell('pago'));
console.log('cancelado', cell('cancelado'));
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68a785fd8b148325bbcbfb7753c65bd2