### PR TITLE
Improve payment import preview trigger

### DIFF
--- a/financeiro/templates/financeiro/importar_pagamentos.html
+++ b/financeiro/templates/financeiro/importar_pagamentos.html
@@ -10,14 +10,20 @@
     <form id="upload-form" method="post" enctype="multipart/form-data" class="space-y-4 border p-4 rounded-lg bg-white">
       {% csrf_token %}
       <label for="file" class="block text-sm font-medium text-gray-700">{% trans "Arquivo" %}</label>
-      <input id="file" type="file" name="file" accept=".csv,.xlsx" class="block w-full border p-2 rounded" required />
+      <input id="file" type="file" name="file" accept=".csv,.xlsx" class="block w-full border p-2 rounded" required
+             hx-post="/api/financeiro/importar-pagamentos/"
+             hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+             hx-target="#preview"
+             hx-trigger="change"
+             hx-include="#upload-form"
+             hx-on="htmx:afterRequest: renderPreview(event)" />
     </form>
       <button id="preview-btn"
               class="mt-2 bg-primary text-white px-4 py-2 rounded"
               hx-post="/api/financeiro/importar-pagamentos/"
               hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
               hx-target="#preview"
-              hx-trigger="change from:#file"
+              hx-trigger="click"
               hx-include="#upload-form"
               hx-on="htmx:afterRequest: renderPreview(event)">
       {% trans "Pré-visualizar" %}


### PR DESCRIPTION
## Summary
- Support automatic preview when file changes and manual trigger via button

## Testing
- `pytest financeiro/tests/test_templates_htmx.py -q` *(fails: Conflicting migrations)*
- `pytest financeiro/tests/test_templates_htmx.py::test_importar_pagamentos_template_structure --nomigrations --no-cov -q` *(fails: IndentationError in organizacoes/views.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a785fc73188325bac9fe349b9c7e09