### PR TITLE
Add accessible captions to notification tables

### DIFF
--- a/notificacoes/templates/notificacoes/historico_table.html
+++ b/notificacoes/templates/notificacoes/historico_table.html
@@ -1,6 +1,7 @@
 {% load i18n %}
 <div class="overflow-x-auto bg-white border border-neutral-200 rounded-2xl shadow-sm">
   <table class="min-w-full divide-y divide-neutral-200 text-sm">
+    <caption class="sr-only">{% trans 'Histórico de notificações enviadas' %}</caption>
     <thead class="bg-neutral-50">
       <tr>
         <th class="px-4 py-2 text-left font-medium text-neutral-700">{% trans 'Enviado em' %}</th>

--- a/notificacoes/templates/notificacoes/logs_table.html
+++ b/notificacoes/templates/notificacoes/logs_table.html
@@ -1,6 +1,7 @@
 {% load i18n %}
 <div class="overflow-x-auto bg-white border border-neutral-200 rounded-2xl shadow-sm">
   <table class="min-w-full divide-y divide-neutral-200 text-sm">
+    <caption class="sr-only">{% trans 'Logs de notificações' %}</caption>
     <thead class="bg-neutral-50">
       <tr>
         <th class="px-4 py-2 text-left font-medium text-neutral-700">{% trans 'Data' %}</th>

--- a/notificacoes/templates/notificacoes/templates_list.html
+++ b/notificacoes/templates/notificacoes/templates_list.html
@@ -22,6 +22,7 @@
   {% if templates %}
   <div class="overflow-x-auto bg-white border border-neutral-200 rounded-2xl shadow-sm">
     <table class="min-w-full divide-y divide-neutral-200 text-sm">
+      <caption class="sr-only">{% trans 'Lista de templates de notificação' %}</caption>
       <thead class="bg-neutral-50">
         <tr>
           <th class="px-4 py-2 text-left font-medium text-neutral-700">{% trans 'Código' %}</th>


### PR DESCRIPTION
## Summary
- add descriptive captions to notification templates table
- add descriptive captions to logs table
- add descriptive captions to notification history table

## Testing
- `pytest`
- `npx -y @axe-core/cli notificacoes/templates/notificacoes/templates_list.html`

------
https://chatgpt.com/codex/tasks/task_e_68a785f2d1288325b27fb0a62b10b7a4