### PR TITLE
Validate owner on notification log updates

### DIFF
--- a/notificacoes/api.py
+++ b/notificacoes/api.py
@@ -67,6 +67,11 @@ class NotificationLogViewSet(mixins.UpdateModelMixin, viewsets.ReadOnlyModelView
         if request.data.get("status") != NotificationStatus.LIDA:
             return Response({"detail": _("Status inválido")}, status=status.HTTP_400_BAD_REQUEST)
         log = self.get_object()
+        if log.user != request.user:
+            return Response(
+                {"detail": _("Não é permitido alterar logs de outro usuário.")},
+                status=status.HTTP_403_FORBIDDEN,
+            )
         log.status = NotificationStatus.LIDA
         log.data_leitura = timezone.now()
         log.save(update_fields=["status", "data_leitura"])


### PR DESCRIPTION
## Summary
- block updates to notification logs by staff if they don't own the log
- test that staff receive 403 when patching another user's log

## Testing
- `pytest tests/notificacoes/test_api.py::test_usuario_staff_nao_marca_notificacao_de_outro --no-cov --nomigrations -q`


------
https://chatgpt.com/codex/tasks/task_e_68a785f2174c832596e40320785a6cdb