### PR TITLE
Allow WebSocket notifications without push subscription

### DIFF
--- a/notificacoes/consumers.py
+++ b/notificacoes/consumers.py
@@ -1,21 +1,12 @@
 from __future__ import annotations
 
-from channels.db import database_sync_to_async
 from channels.generic.websocket import AsyncJsonWebsocketConsumer
-
-from .models import PushSubscription
 
 
 class NotificationConsumer(AsyncJsonWebsocketConsumer):
     async def connect(self):
         user = self.scope.get("user")
         if not user or not user.is_authenticated:
-            await self.close()
-            return
-        has_sub = await database_sync_to_async(
-            PushSubscription.objects.filter(user=user, ativo=True).exists
-        )()
-        if not has_sub:
             await self.close()
             return
         self.group_name = f"notificacoes_{user.id}"

--- a/tests/notificacoes/test_consumers.py
+++ b/tests/notificacoes/test_consumers.py
@@ -1,11 +1,15 @@
 import asyncio
+import os
 
 import pytest
+from asgiref.sync import sync_to_async
 from channels.testing import WebsocketCommunicator
 
 from Hubx.asgi import application
 from notificacoes.models import Canal, NotificationLog, NotificationTemplate, PushSubscription
 from notificacoes.tasks import enviar_notificacao_async
+
+os.environ.setdefault("DJANGO_ALLOW_ASYNC_UNSAFE", "true")
 
 pytestmark = pytest.mark.django_db(transaction=True)
 
@@ -15,7 +19,7 @@ def in_memory_channel_layer(settings):
     settings.CHANNEL_LAYERS = {"default": {"BACKEND": "channels.layers.InMemoryChannelLayer"}}
 
 
-def test_consumer_receives_message(admin_user, monkeypatch):
+def test_consumer_receives_message_with_subscription(admin_user, monkeypatch):
     async def inner():
         monkeypatch.setattr("notificacoes.tasks.send_push", lambda u, m: None)
         PushSubscription.objects.create(
@@ -31,7 +35,23 @@ def test_consumer_receives_message(admin_user, monkeypatch):
         assert connected
         template = NotificationTemplate.objects.create(codigo="t", assunto="A", corpo="B", canal=Canal.PUSH)
         log = NotificationLog.objects.create(user=admin_user, template=template, canal=Canal.PUSH)
-        await enviar_notificacao_async("A", "B", str(log.id))
+        await sync_to_async(enviar_notificacao_async)("A", "B", str(log.id))
+        response = await communicator.receive_json_from()
+        assert response["mensagem"] == "B"
+        await communicator.disconnect()
+    asyncio.run(inner())
+
+
+def test_consumer_receives_message_without_subscription(admin_user, monkeypatch):
+    async def inner():
+        monkeypatch.setattr("notificacoes.tasks.send_push", lambda u, m: None)
+        communicator = WebsocketCommunicator(application, "/ws/notificacoes/")
+        communicator.scope["user"] = admin_user
+        connected, _ = await communicator.connect()
+        assert connected
+        template = NotificationTemplate.objects.create(codigo="t", assunto="A", corpo="B", canal=Canal.PUSH)
+        log = NotificationLog.objects.create(user=admin_user, template=template, canal=Canal.PUSH)
+        await sync_to_async(enviar_notificacao_async)("A", "B", str(log.id))
         response = await communicator.receive_json_from()
         assert response["mensagem"] == "B"
         await communicator.disconnect()


### PR DESCRIPTION
## Summary
- allow NotificationConsumer to connect even if user lacks a PushSubscription
- test notification delivery with and without active subscription

## Testing
- `pytest tests/notificacoes/test_consumers.py -q --no-migrations --disable-warnings -o addopts="" -p no:cov`


------
https://chatgpt.com/codex/tasks/task_e_68a785f1f2308325a1f5d229ddcff8b7