### PR TITLE
Restringe acesso ao escopo global no dashboard

### DIFF
--- a/dashboard/templates/dashboard/partials/filters_form.html
+++ b/dashboard/templates/dashboard/partials/filters_form.html
@@ -13,7 +13,9 @@
     <label for="escopo" class="block text-sm font-medium text-neutral-700">{% trans 'Escopo' %}</label>
     <select id="escopo" name="escopo" class="mt-1 block border-gray-300 rounded" aria-label="{% trans 'Selecionar escopo' %}">
       <option value="auto" {% if escopo == 'auto' %}selected{% endif %}>{% trans 'Automático' %}</option>
+      {% if request.user.user_type == 'root' %}
       <option value="global" {% if escopo == 'global' %}selected{% endif %}>{% trans 'Global' %}</option>
+      {% endif %}
       <option value="organizacao" {% if escopo == 'organizacao' %}selected{% endif %}>{% trans 'Organização' %}</option>
       <option value="nucleo" {% if escopo == 'nucleo' %}selected{% endif %}>{% trans 'Núcleo' %}</option>
       <option value="evento" {% if escopo == 'evento' %}selected{% endif %}>{% trans 'Evento' %}</option>


### PR DESCRIPTION
## Summary
- oculta opção de escopo global no formulário de filtros quando o usuário não é root
- bloqueia acesso ao escopo global no serviço do dashboard para usuários não root

## Testing
- `ruff check dashboard/services.py`
- `pytest -m "not slow" tests/dashboard` *(falha: redis.exceptions.ConnectionError, django.core.exceptions.FieldError)*

------
https://chatgpt.com/codex/tasks/task_e_68a7914bc3708325b0570bf3c1d52ab6