### PR TITLE
Use utility variation calculation in dashboard growth metric

### DIFF
--- a/dashboard/services.py
+++ b/dashboard/services.py
@@ -447,7 +447,7 @@ class DashboardService:
         )
         atual = aggregates["atual"] or 0
         anterior = aggregates["anterior"] or 0
-        crescimento = get_variation(anterior, atual) if anterior else (100.0 if atual else 0.0)
+        crescimento = get_variation(anterior, atual)
         return {"total": atual, "crescimento": crescimento}
 
     @staticmethod


### PR DESCRIPTION
## Summary
- Simplify `DashboardService.calcular_crescimento` to always use `get_variation`
- Remove special-case returns for 100/0 when previous value is missing

## Testing
- `pytest tests/dashboard/test_services.py` *(fails: FieldDoesNotExist: Evento has no field named 'created'; redis.exceptions.ConnectionError)*

------
https://chatgpt.com/codex/tasks/task_e_68a79137d1608325821710e38e765232