### PR TITLE
Ajusta permissão para campo Público no dashboard

### DIFF
--- a/dashboard/templates/dashboard/config_form.html
+++ b/dashboard/templates/dashboard/config_form.html
@@ -10,7 +10,7 @@
       <label for="id_nome" class="block text-sm font-medium text-neutral-700">{% trans 'Nome' %}</label>
       {{ form.nome }}
     </div>
-    {% if request.user.user_type in ['ROOT','ADMIN'] %}
+    {% if request.user.user_type in ['root','admin'] %}
     <div class="flex items-center gap-2">
       {{ form.publico }}
       <label for="id_publico" class="text-sm text-neutral-700">{% trans 'Público' %}</label>

--- a/dashboard/templates/dashboard/filter_form.html
+++ b/dashboard/templates/dashboard/filter_form.html
@@ -10,7 +10,7 @@
       <label for="id_nome" class="block text-sm font-medium text-neutral-700">{% trans 'Nome' %}</label>
       {{ form.nome }}
     </div>
-    {% if request.user.user_type in ['ROOT','ADMIN'] %}
+    {% if request.user.user_type in ['root','admin'] %}
     <div class="flex items-center gap-2">
       {{ form.publico }}
       <label for="id_publico" class="text-sm text-neutral-700">{% trans 'Público' %}</label>

--- a/dashboard/templates/dashboard/layout_form.html
+++ b/dashboard/templates/dashboard/layout_form.html
@@ -10,7 +10,7 @@
       <label for="id_nome" class="block mb-1">{% trans "Nome" %}</label>
       {{ form.nome }}
     </div>
-    {% if request.user.user_type in ['ROOT','ADMIN'] %}
+    {% if request.user.user_type in ['root','admin'] %}
     <div class="mb-4">
       <label for="id_publico" class="block">{{ form.publico.label }}</label>
       {{ form.publico }}


### PR DESCRIPTION
## Summary
- Corrige verificação de tipos de usuário para exibir campo **Público** apenas a root e admin

## Testing
- `pytest tests/dashboard/test_publico_visibility.py -q` *(fails: File "tests/dashboard/urls.py", line 8 SyntaxError)*

------
https://chatgpt.com/codex/tasks/task_e_68a7912cbe0c83259d3977a51891fd74