### PR TITLE
Optimize feed query for bookmarks and flags

### DIFF
--- a/feed/templates/feed/_grid.html
+++ b/feed/templates/feed/_grid.html
@@ -63,16 +63,16 @@
             <i class="fa-solid fa-share"></i>
             <span class="share-count">{{ post.share_count }}</span>
           </button>
-          <button type="button" data-post-id="{{ post.id }}" class="bookmark-btn hover:text-yellow-600 focus:outline-none focus:ring-2 focus:ring-yellow-500 rounded {% if post.bookmarks.filter(user=user).exists %}text-yellow-600{% endif %}" aria-label="{% trans 'Salvar' %}">
+          <button type="button" data-post-id="{{ post.id }}" class="bookmark-btn hover:text-yellow-600 focus:outline-none focus:ring-2 focus:ring-yellow-500 rounded {% if post.is_bookmarked %}text-yellow-600{% endif %}" aria-label="{% trans 'Salvar' %}">
             <i class="fa-solid fa-bookmark"></i>
           </button>
-          <button type="button" data-post-id="{{ post.id }}" class="flag-btn hover:text-red-600 focus:outline-none focus:ring-2 focus:ring-red-500 rounded {% if post.flags.filter(user=user).exists %}text-red-600 cursor-not-allowed{% endif %}" aria-label="{% trans 'Denunciar' %}" {% if post.flags.filter(user=user).exists %}disabled{% endif %}>
+          <button type="button" data-post-id="{{ post.id }}" class="flag-btn hover:text-red-600 focus:outline-none focus:ring-2 focus:ring-red-500 rounded {% if post.is_flagged %}text-red-600 cursor-not-allowed{% endif %}" aria-label="{% trans 'Denunciar' %}" {% if post.is_flagged %}disabled{% endif %}>
             <i class="fa-solid fa-flag"></i>
           </button>
         </div>
         <span>{{ post.comments.count }} {% trans 'comentários' %}</span>
       </div>
-    </article>
+      </article>
   {% empty %}
     <p class="col-span-full text-center text-neutral-500">{% trans "Nenhuma postagem encontrada." %}</p>
   {% endfor %}


### PR DESCRIPTION
## Summary
- Prefetch bookmarks and flags in feed list queryset
- Annotate `is_bookmarked` and `is_flagged` on posts and use them in grid template

## Testing
- `pytest feed` *(fails: ModuleNotFoundError: No module named 'django_redis', AssertionError: 0 != 1)*

------
https://chatgpt.com/codex/tasks/task_e_68a79f9f03848325ac199f174a6561cd