### PR TITLE
chore: add aria-hidden to dashboard icons

### DIFF
--- a/dashboard/templates/dashboard/root.html
+++ b/dashboard/templates/dashboard/root.html
@@ -60,20 +60,20 @@
   <section class="mb-8">
     <h2 class="text-xl font-semibold mb-4">{% trans "Ações Rápidas" %}</h2>
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-      <a href="{% url 'admin:index' %}" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50">
-        <i class="fa-solid fa-wrench mb-2"></i>
-        <span class="block">{% trans "Django Admin" %}</span>
-      </a>
-      <a href="{% url 'dashboard:custom-metrics' %}" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50">
-        <i class="fa-solid fa-chart-line mb-2"></i>
-        <span class="block">{% trans "Métricas Personalizadas" %}</span>
-      </a>
-      <a href="{% url 'dashboard:achievements' %}" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50">
-        <i class="fa-solid fa-trophy mb-2"></i>
-        <span class="block">{% trans "Conquistas" %}</span>
-      </a>
-    </div>
-  </section>
+        <a href="{% url 'admin:index' %}" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50">
+          <i class="fa-solid fa-wrench mb-2" aria-hidden="true"></i>
+          <span class="block">{% trans "Django Admin" %}</span>
+        </a>
+        <a href="{% url 'dashboard:custom-metrics' %}" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50">
+          <i class="fa-solid fa-chart-line mb-2" aria-hidden="true"></i>
+          <span class="block">{% trans "Métricas Personalizadas" %}</span>
+        </a>
+        <a href="{% url 'dashboard:achievements' %}" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50">
+          <i class="fa-solid fa-trophy mb-2" aria-hidden="true"></i>
+          <span class="block">{% trans "Conquistas" %}</span>
+        </a>
+      </div>
+    </section>
 
 </main>
 {% endblock %}


### PR DESCRIPTION
## Summary
- improve dashboard accessibility by hiding decorative icons from screen readers

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'axe_core_python', bs4, playwright, httpx, pywebpush, django_redis)*

------
https://chatgpt.com/codex/tasks/task_e_68a79f9e436c8325a176fb44efe7a600