### PR TITLE
feat(login): improve totp accessibility

### DIFF
--- a/accounts/templates/login/login.html
+++ b/accounts/templates/login/login.html
@@ -22,7 +22,7 @@
         <input type="email" id="id_email" name="email"
                value="{{ form.email.value|default_if_none:'' }}"
                placeholder="{% trans 'Digite seu e-mail' %}"
-               data-check-url="{% url 'accounts:check_2fa' %}"
+               autocomplete="email"
                class="w-full p-3 border border-gray-300 rounded-lg text-sm placeholder-gray-400 shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
                required
                aria-describedby="email-error"
@@ -35,6 +35,7 @@
         <label for="id_password" class="block mb-1 text-sm font-medium text-gray-700">{% trans "Senha" %}</label>
         <input type="password" id="id_password" name="password"
                placeholder="{% trans 'Digite sua senha' %}"
+               autocomplete="current-password"
                class="w-full p-3 border border-gray-300 rounded-lg text-sm placeholder-gray-400 shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
                required
                aria-describedby="password-error"
@@ -43,11 +44,12 @@
           <div id="password-error" class="text-red-600 text-xs mt-1" role="alert">{{ form.password.errors }}</div>
         {% endif %}
       </div>
-      <div id="totp-field" style="display:none">
+      <div id="totp-field">
         <label for="id_totp" class="block mb-1 text-sm font-medium text-gray-700">{% trans "TOTP" %}</label>
         <input type="text" id="id_totp" name="totp"
                value="{{ form.totp.value|default_if_none:'' }}"
                placeholder="{% trans 'Código 2FA' %}"
+               autocomplete="one-time-code"
                class="w-full p-3 border border-gray-300 rounded-lg text-sm placeholder-gray-400 shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
                aria-describedby="totp-error"
                {% if form.totp.errors %}aria-invalid="true"{% endif %}>
@@ -80,14 +82,4 @@
     </div>
   </div>
 </main>
-<script>
-  const emailInput = document.getElementById('id_email');
-  const totpField = document.getElementById('totp-field');
-  emailInput.addEventListener('blur', () => {
-    const url = emailInput.dataset.checkUrl + '?email=' + encodeURIComponent(emailInput.value);
-    fetch(url).then(r => r.json()).then(data => {
-      totpField.style.display = data.enabled ? 'block' : 'none';
-    });
-  });
-</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add autocomplete hints and always render TOTP input on login page
- authenticate login with optional TOTP code server-side

## Testing
- `PYTEST_ADDOPTS="--no-cov" pytest tests/accounts/test_two_factor.py::test_login_requires_totp_when_enabled tests/accounts/test_totp_login.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a79f9dfe088325a52ef7cdb2e37023