### PR TITLE
Redirect to channel list after leaving a conversation

### DIFF
--- a/chat/templates/chat/conversation_detail.html
+++ b/chat/templates/chat/conversation_detail.html
@@ -278,13 +278,16 @@
         fetch(`/api/chat/channels/${channelId}/leave/`, {
           method: 'POST',
           headers: {'X-CSRFToken': csrfToken}
-        }).then(r => {
-          if(r.ok){
-            leaveBtn.outerHTML = `<span class="text-green-600">${leaveBtn.dataset.success}</span>`;
-          }else{
-            r.json().then(data=>{alert(data.erro || 'Erro');});
-          }
-        }).catch(()=>alert('{% trans "Erro ao sair do canal." %}'));
+        })
+          .then(r => r.json().then(data => ({ok: r.ok, data})))
+          .then(({ok, data}) => {
+            if(ok && data.status === 'ok'){
+              window.location.href = '{% url "chat:conversation_list" %}';
+            }else{
+              alert(data.erro || 'Erro');
+            }
+          })
+          .catch(() => alert('{% trans "Erro ao sair do canal." %}'));
       });
     }
 


### PR DESCRIPTION
## Summary
- redirect to conversation list after leaving a channel
- confirm backend leave action returns status ok

## Testing
- `pytest --no-cov tests/chat/test_api_views.py::test_leave_channel -q`
- `pytest --no-cov tests/chat/test_templates.py::test_conversation_detail_has_aria_labels -q` *(fails: 'chat_api' is not a registered namespace)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a331b3148325bd264e21923ac75c