### PR TITLE
Add modal to view chat summary details

### DIFF
--- a/chat/api_views.py
+++ b/chat/api_views.py
@@ -382,6 +382,20 @@ class ChatChannelViewSet(viewsets.ModelViewSet):
 
     @action(
         detail=True,
+        methods=["get"],
+        url_path=r"resumos/(?P<resumo_id>[0-9a-f-]+)",
+        permission_classes=[permissions.IsAuthenticated, IsChannelParticipant],
+    )
+    def resumo_detail(
+        self, request: Request, pk: str | None = None, resumo_id: str | None = None
+    ) -> Response:
+        channel = self.get_object()
+        resumo = get_object_or_404(channel.resumos, pk=resumo_id)
+        serializer = ResumoChatSerializer(resumo)
+        return Response(serializer.data)
+
+    @action(
+        detail=True,
         methods=["post"],
         permission_classes=[permissions.IsAuthenticated, IsChannelParticipant],
         url_path="gerar-resumo",

--- a/chat/templates/chat/conversation_detail.html
+++ b/chat/templates/chat/conversation_detail.html
@@ -121,6 +121,8 @@
     </form>
   </div>
   <div id="modal"></div>
+  <dialog id="resumo-modal" class="p-4 rounded max-w-xl w-full"></dialog>
+  <template id="resumo-template">{% include "chat/partials/resumo_detail.html" %}</template>
   <dialog id="item-modal" class="p-4 rounded max-w-md w-full">
     <form method="dialog" class="space-y-2" id="item-form">
       <label class="block" for="item-type">{% trans 'Tipo' %}
@@ -178,6 +180,29 @@
     const retencaoForm = document.getElementById('retencao-form');
     const retencaoFeedback = document.getElementById('retencao-feedback');
     const leaveBtn = document.getElementById('leave-channel');
+    const resumoModal = document.getElementById('resumo-modal');
+    const resumoTemplate = document.getElementById('resumo-template');
+
+    resumosList.addEventListener('click', async function(e){
+      const btn = e.target.closest('button[data-id]');
+      if(!btn) return;
+      const id = btn.dataset.id;
+      resumoModal.innerHTML = '<p>{% trans "Carregando..." %}</p>';
+      try{
+        const r = await fetch(`/api/chat/channels/${channelId}/resumos/${id}/`);
+        const data = await r.json();
+        const frag = resumoTemplate.content.cloneNode(true);
+        frag.getElementById('resumo-conteudo').textContent = data.conteudo;
+        frag.getElementById('resumo-detalhes').textContent = JSON.stringify(data.detalhes, null, 2);
+        resumoModal.innerHTML = '';
+        resumoModal.appendChild(frag);
+      }catch(err){
+        resumoModal.innerHTML = '<p>{% trans "Erro ao carregar" %}</p>';
+      }
+      const closeBtn = resumoModal.querySelector('[data-close]');
+      if(closeBtn){ closeBtn.addEventListener('click', ()=>resumoModal.close()); }
+      resumoModal.showModal();
+    });
 
     async function carregarResumos(){
       resumosList.innerHTML = '<li>{% trans "Carregando..." %}</li>';
@@ -188,7 +213,12 @@
         data.forEach(item=>{
           const li=document.createElement('li');
           const dt=new Date(item.created_at).toLocaleString();
-          li.textContent=`${item.periodo} - ${dt}`;
+          const btn=document.createElement('button');
+          btn.type='button';
+          btn.className='text-blue-600 hover:underline';
+          btn.dataset.id=item.id;
+          btn.textContent=`${item.periodo} - ${dt}`;
+          li.appendChild(btn);
           resumosList.appendChild(li);
         });
       }catch(e){

--- a/chat/templates/chat/partials/resumo_detail.html
+++ b/chat/templates/chat/partials/resumo_detail.html
@@ -1,0 +1,9 @@
+{% load i18n %}
+<div class="bg-white p-4 border rounded max-w-xl">
+  <h4 class="text-lg font-semibold mb-2">{% trans "Resumo" %}</h4>
+  <div id="resumo-conteudo" class="whitespace-pre-wrap mb-2"></div>
+  <pre id="resumo-detalhes" class="text-xs bg-neutral-100 p-2 rounded overflow-auto"></pre>
+  <div class="text-right mt-2">
+    <button type="button" data-close class="px-3 py-1 border rounded">{% trans "Fechar" %}</button>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- allow fetching individual chat summary via API
- add modal with template to display summary content

## Testing
- `pytest` *(fails: ModuleNotFoundError for axe_core_python, bs4, playwright, httpx, pywebpush, django_redis)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a32f356c83259b06cdd6cd52a054