### PR TITLE
Use POST to toggle notification templates

### DIFF
--- a/notificacoes/templates/notificacoes/templates_list.html
+++ b/notificacoes/templates/notificacoes/templates_list.html
@@ -43,9 +43,15 @@
             <div class="flex items-center gap-2">
               <a href="{% url 'notificacoes:template_edit' tpl.codigo %}" class="text-sm text-primary-600 hover:underline">{% trans 'Editar' %}</a>
               {% if tpl.ativo %}
-                <a href="{% url 'notificacoes:templates_list' %}?toggle={{ tpl.codigo }}" class="text-sm text-neutral-600 hover:underline">{% trans 'Desativar' %}</a>
+                <form method="post" action="{% url 'notificacoes:template_toggle' tpl.codigo %}" class="inline">
+                  {% csrf_token %}
+                  <button type="submit" class="text-sm text-neutral-600 hover:underline">{% trans 'Desativar' %}</button>
+                </form>
               {% else %}
-                <a href="{% url 'notificacoes:templates_list' %}?toggle={{ tpl.codigo }}" class="text-sm text-neutral-600 hover:underline">{% trans 'Ativar' %}</a>
+                <form method="post" action="{% url 'notificacoes:template_toggle' tpl.codigo %}" class="inline">
+                  {% csrf_token %}
+                  <button type="submit" class="text-sm text-neutral-600 hover:underline">{% trans 'Ativar' %}</button>
+                </form>
               {% endif %}
               <a href="{% url 'notificacoes:template_delete' tpl.codigo %}" class="text-sm text-red-600 hover:underline">{% trans 'Excluir' %}</a>
             </div>

--- a/notificacoes/urls.py
+++ b/notificacoes/urls.py
@@ -8,6 +8,7 @@ urlpatterns = [
     path("templates/", views.list_templates, name="templates_list"),
     path("templates/novo/", views.create_template, name="template_create"),
     path("templates/<slug:codigo>/editar/", views.edit_template, name="template_edit"),
+    path("templates/<slug:codigo>/toggle/", views.toggle_template, name="template_toggle"),
     path("templates/<slug:codigo>/excluir/", views.delete_template, name="template_delete"),
     path("logs/", views.list_logs, name="logs_list"),
     path("historico/", views.historico_notificacoes, name="historico"),

--- a/notificacoes/views.py
+++ b/notificacoes/views.py
@@ -28,19 +28,22 @@ logger = logging.getLogger(__name__)
 @login_required
 @permission_required("notificacoes.change_notificationtemplate", raise_exception=True)
 def list_templates(request):
-    codigo_toggle = request.GET.get("toggle")
-    if codigo_toggle:
-        template = get_object_or_404(NotificationTemplate, codigo=codigo_toggle)
+    templates = NotificationTemplate.objects.all()
+    return render(request, "notificacoes/templates_list.html", {"templates": templates})
+
+
+@login_required
+@permission_required("notificacoes.change_notificationtemplate", raise_exception=True)
+def toggle_template(request, codigo: str):
+    template = get_object_or_404(NotificationTemplate, codigo=codigo)
+    if request.method == "POST":
         template.ativo = not template.ativo
         template.save(update_fields=["ativo"])
         if template.ativo:
             messages.success(request, _("Template ativado com sucesso."))
         else:
             messages.success(request, _("Template desativado com sucesso."))
-        return redirect("notificacoes:templates_list")
-
-    templates = NotificationTemplate.objects.all()
-    return render(request, "notificacoes/templates_list.html", {"templates": templates})
+    return redirect("notificacoes:templates_list")
 
 
 @login_required

--- a/tests/notificacoes/test_templates_view.py
+++ b/tests/notificacoes/test_templates_view.py
@@ -1,0 +1,30 @@
+import pytest
+from django.urls import reverse
+from django.contrib.auth.models import Permission
+
+from accounts.factories import UserFactory
+from notificacoes.models import NotificationTemplate
+
+
+pytestmark = pytest.mark.django_db
+
+
+def test_toggle_template(client):
+    user = UserFactory()
+    perm = Permission.objects.get(codename="change_notificationtemplate")
+    user.user_permissions.add(perm)
+    client.force_login(user)
+
+    template = NotificationTemplate.objects.create(
+        codigo="t1", assunto="a", corpo="b", canal="email", ativo=True
+    )
+
+    url = reverse("notificacoes:template_toggle", args=[template.codigo])
+    response = client.post(url)
+    assert response.status_code == 302
+    template.refresh_from_db()
+    assert template.ativo is False
+
+    response = client.post(url)
+    template.refresh_from_db()
+    assert template.ativo is True


### PR DESCRIPTION
## Summary
- replace GET toggle links with POST forms and CSRF protection
- add dedicated view and route for toggling notification templates
- cover toggle workflow with tests

## Testing
- `pytest tests/notificacoes/test_templates_view.py tests/notificacoes/test_metrics.py tests/notificacoes/test_integration.py -q --no-cov`

------
https://chatgpt.com/codex/tasks/task_e_68a7a6cd565083259e5e9a6bcf4fd3a6