### PR TITLE
Add accessibility attributes to avatar fallbacks

### DIFF
--- a/accounts/templates/perfil/conexoes.html
+++ b/accounts/templates/perfil/conexoes.html
@@ -39,7 +39,7 @@
             {% if connection.avatar %}
               <img src="{{ connection.avatar.url }}" alt="{{ connection.username }}" class="w-10 h-10 rounded-full object-cover" />
             {% else %}
-              <div class="w-10 h-10 rounded-full bg-gray-200 flex items-center justify-center text-sm font-semibold text-gray-600">
+              <div class="w-10 h-10 rounded-full bg-gray-200 flex items-center justify-center text-sm font-semibold text-gray-600" role="img" aria-label="{{ connection.username }}">
                 {{ connection.username|first|upper }}
               </div>
             {% endif %}
@@ -74,7 +74,7 @@
             {% if solicitante.avatar %}
               <img src="{{ solicitante.avatar.url }}" alt="{{ solicitante.username }}" class="w-10 h-10 rounded-full object-cover" />
             {% else %}
-              <div class="w-10 h-10 rounded-full bg-gray-200 flex items-center justify-center text-sm font-semibold text-gray-600">
+              <div class="w-10 h-10 rounded-full bg-gray-200 flex items-center justify-center text-sm font-semibold text-gray-600" role="img" aria-label="{{ solicitante.username }}">
                 {{ solicitante.username|first|upper }}
               </div>
             {% endif %}

--- a/accounts/templates/perfil/perfil.html
+++ b/accounts/templates/perfil/perfil.html
@@ -13,7 +13,7 @@
         <img src="{{ user.avatar.url }}" alt="{{ user.username }}"
              class="w-28 h-28 rounded-full object-cover shadow mb-3">
       {% else %}
-        <div class="w-28 h-28 rounded-full bg-gray-200 flex items-center justify-center text-2xl font-semibold text-primary shadow mb-3">
+        <div class="w-28 h-28 rounded-full bg-gray-200 flex items-center justify-center text-2xl font-semibold text-primary shadow mb-3" role="img" aria-label="{{ user.username }}">
           {{ user.username|first|upper }}
         </div>
       {% endif %}

--- a/accounts/templates/perfil/publico.html
+++ b/accounts/templates/perfil/publico.html
@@ -8,7 +8,7 @@
       {% if perfil.avatar %}
         <img src="{{ perfil.avatar.url }}" alt="{{ perfil.username }}" class="w-20 h-20 rounded-full object-cover">
       {% else %}
-        <div class="w-20 h-20 rounded-full bg-gray-200 flex items-center justify-center text-xl font-semibold text-primary">
+        <div class="w-20 h-20 rounded-full bg-gray-200 flex items-center justify-center text-xl font-semibold text-primary" role="img" aria-label="{{ perfil.username }}">
           {{ perfil.username|first|upper }}
         </div>
       {% endif %}

--- a/agenda/templates/agenda/detail.html
+++ b/agenda/templates/agenda/detail.html
@@ -7,7 +7,7 @@
 
   <!-- Cabeçalho -->
   <div class="text-center mb-6">
-    <div class="mx-auto w-20 h-20 bg-neutral-100 rounded-xl flex items-center justify-center text-2xl font-bold text-neutral-700 mb-4">
+    <div class="mx-auto w-20 h-20 bg-neutral-100 rounded-xl flex items-center justify-center text-2xl font-bold text-neutral-700 mb-4" role="img" aria-label="{{ object.titulo }}">
       {{ object.titulo|make_list|first|upper }}
     </div>
     <h1 class="text-2xl font-semibold text-neutral-900">{{ object.titulo }}</h1>
@@ -105,7 +105,7 @@
           {% if inscrito.avatar %}
             <img src="{{ inscrito.avatar.url }}" alt="{{ inscrito.username }}" class="w-12 h-12 rounded-full object-cover">
           {% else %}
-            <div class="w-12 h-12 rounded-full bg-neutral-100 flex items-center justify-center text-sm font-semibold text-neutral-700">
+            <div class="w-12 h-12 rounded-full bg-neutral-100 flex items-center justify-center text-sm font-semibold text-neutral-700" role="img" aria-label="{{ inscrito.username }}">
               {{ inscrito.username|make_list|first|upper }}
             </div>
           {% endif %}

--- a/chat/templates/chat/modal_user_list.html
+++ b/chat/templates/chat/modal_user_list.html
@@ -23,7 +23,7 @@
           hx-target="body"
           class="w-full text-left cursor-pointer group border border-neutral-200 rounded-2xl p-4 bg-white shadow-sm hover:shadow-md transition-all flex items-center gap-4"
         >
-          <div class="w-12 h-12 flex items-center justify-center rounded-full bg-neutral-100 overflow-hidden">
+          <div class="w-12 h-12 flex items-center justify-center rounded-full bg-neutral-100 overflow-hidden" {% if not u.avatar %}role="img" aria-label="{{ u.username }}"{% endif %}>
             {% if u.avatar %}
               <img src="{{ u.avatar.url }}" alt="{{ u.username }}" class="w-full h-full object-cover rounded-full" />
             {% else %}

--- a/chat/templates/chat/partials/message.html
+++ b/chat/templates/chat/partials/message.html
@@ -6,7 +6,7 @@
       {% blocktrans with username=m.remetente.username asvar alt_text %}Avatar de {{ username }}{% endblocktrans %}
       <img src="{{ m.remetente.profile.avatar.url }}" alt="{{ alt_text }}" class="w-8 h-8 rounded-full" />
       {% else %}
-      <span class="inline-block w-8 h-8 rounded-full bg-gray-300 text-sm flex items-center justify-center">{{ m.remetente.username|first|upper }}</span>
+      <span class="inline-block w-8 h-8 rounded-full bg-gray-300 text-sm flex items-center justify-center" role="img" aria-label="{{ m.remetente.username }}">{{ m.remetente.username|first|upper }}</span>
     {% endif %}
   </div>
   <div class="flex-1">
@@ -147,7 +147,7 @@
         {% for user in m.lido_por.all %}
           <li
             class="w-4 h-4 rounded-full bg-gray-300 text-[0.5rem] flex items-center justify-center"
-            data-username="{{ user.username }}"
+            data-username="{{ user.username }}" {% if not user.profile.avatar %}role="img" aria-label="{{ user.username }}"{% endif %}
           >
             {% if user.profile.avatar %}
               <img src="{{ user.profile.avatar.url }}" alt="{{ user.username }}" class="w-4 h-4 rounded-full" />

--- a/empresas/templates/empresas/detail.html
+++ b/empresas/templates/empresas/detail.html
@@ -8,7 +8,7 @@
     {% if empresa.logo %}
       <img src="{{ empresa.logo.url }}" alt="{{ empresa.nome }}" class="h-20 w-20 mx-auto rounded-xl object-cover" />
     {% else %}
-      <div class="h-20 w-20 mx-auto rounded-xl bg-neutral-100 flex items-center justify-center text-xl font-bold text-neutral-700">
+      <div class="h-20 w-20 mx-auto rounded-xl bg-neutral-100 flex items-center justify-center text-xl font-bold text-neutral-700" role="img" aria-label="{{ empresa.nome }}">
         {{ empresa.nome|make_list|first|upper }}
       </div>
     {% endif %}

--- a/feed/templates/feed/_grid.html
+++ b/feed/templates/feed/_grid.html
@@ -18,7 +18,7 @@
           {% if post.autor.avatar %}
             <img src="{{ post.autor.avatar.url }}" alt="{{ post.autor.username }}" class="w-10 h-10 rounded-full object-cover">
           {% else %}
-            <div class="w-10 h-10 rounded-full bg-neutral-200 flex items-center justify-center text-neutral-600 font-bold">
+            <div class="w-10 h-10 rounded-full bg-neutral-200 flex items-center justify-center text-neutral-600 font-bold" role="img" aria-label="{{ post.autor.username }}">
               {{ post.autor.username|first|upper }}
             </div>
           {% endif %}

--- a/feed/templates/feed/_post_list.html
+++ b/feed/templates/feed/_post_list.html
@@ -6,7 +6,7 @@
     <article class="border border-neutral-200 bg-white rounded-2xl shadow-sm p-6 space-y-4">
 
       <div class="flex items-center gap-4">
-        <div class="w-10 h-10 rounded-full bg-neutral-200 flex items-center justify-center text-neutral-600 font-bold">
+        <div class="w-10 h-10 rounded-full bg-neutral-200 flex items-center justify-center text-neutral-600 font-bold" role="img" aria-label="{{ post.autor.username }}">
           {{ post.autor.username|first|upper }}
         </div>
         <div>

--- a/feed/templates/feed/post_detail.html
+++ b/feed/templates/feed/post_detail.html
@@ -13,7 +13,7 @@
       {% if post.autor.avatar %}
         <img src="{{ post.autor.avatar.url }}" alt="{{ post.autor.username }}" class="w-10 h-10 rounded-full object-cover">
       {% else %}
-        <div class="w-10 h-10 rounded-full bg-neutral-200 flex items-center justify-center text-neutral-600 font-bold">
+        <div class="w-10 h-10 rounded-full bg-neutral-200 flex items-center justify-center text-neutral-600 font-bold" role="img" aria-label="{{ post.autor.username }}">
           {{ post.autor.username|first|upper }}
         </div>
       {% endif %}

--- a/organizacoes/templates/organizacoes/detail.html
+++ b/organizacoes/templates/organizacoes/detail.html
@@ -14,7 +14,7 @@
     {% if object.avatar %}
       <img src="{{ object.avatar.url }}" alt="{{ object.nome }}" class="w-24 h-24 rounded-full object-cover mx-auto mb-4">
     {% else %}
-      <div class="w-24 h-24 bg-neutral-200 rounded-full flex items-center justify-center mx-auto mb-4 text-xl font-semibold text-neutral-600">
+      <div class="w-24 h-24 bg-neutral-200 rounded-full flex items-center justify-center mx-auto mb-4 text-xl font-semibold text-neutral-600" role="img" aria-label="{{ object.nome }}">
         {{ object.nome|make_list|first|upper }}
       </div>
     {% endif %}

--- a/organizacoes/templates/organizacoes/partials/list_section.html
+++ b/organizacoes/templates/organizacoes/partials/list_section.html
@@ -67,7 +67,7 @@
         <tr class="hover:bg-neutral-50">
           <td class="px-4 py-2 whitespace-nowrap">
             <div class="flex items-center gap-2">
-              <div class="w-10 h-10 bg-neutral-100 rounded-xl flex items-center justify-center overflow-hidden">
+              <div class="w-10 h-10 bg-neutral-100 rounded-xl flex items-center justify-center overflow-hidden" {% if not organizacao.avatar %}role="img" aria-label="{{ organizacao.nome }}"{% endif %}>
                 {% if organizacao.avatar %}
                   <img src="{{ organizacao.avatar.url }}" alt="{{ organizacao.nome }}" class="w-full h-full object-cover rounded-xl" />
                 {% else %}


### PR DESCRIPTION
## Summary
- include `role="img"` and appropriate `aria-label` on default avatar elements in profile, connection lists, posts and other templates to improve accessibility

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'axe_core_python', bs4, playwright, httpx, pywebpush, django_redis; SyntaxError in tests/feed/test_services.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a86219b1ac8325938861fadbd993f3