### PR TITLE
Enhance dashboard filter error messaging

### DIFF
--- a/dashboard/templates/dashboard/partials/filters_form.html
+++ b/dashboard/templates/dashboard/partials/filters_form.html
@@ -1,4 +1,13 @@
 {% load i18n %}
+{% if messages %}
+<div id="filter-errors" class="mb-4" aria-live="polite">
+  {% for message in messages %}
+    <div class="bg-red-100 text-red-800 p-2 rounded" role="alert">{{ message }}</div>
+  {% endfor %}
+</div>
+{% else %}
+<div id="filter-errors" aria-live="polite"></div>
+{% endif %}
 <form method="get" class="mb-6 flex flex-wrap gap-4 items-end" aria-label="{% trans 'Filtros do dashboard' %}">
   <div>
     <label for="periodo" class="block text-sm font-medium text-neutral-700">{% trans 'Período' %}</label>


### PR DESCRIPTION
## Summary
- show filter errors in-place with aria-live alerts
- return filter form partial on `DashboardBaseView` HTMX errors

## Testing
- `pytest tests/dashboard/test_views.py::test_base_view_mixins -q --no-cov`
- `pytest tests/dashboard/test_templates.py::test_error_message_rendered -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68a8669ce90c8325b5607476a384fd9c