### PR TITLE
Add rate limiting to account recovery endpoints

### DIFF
--- a/accounts/api.py
+++ b/accounts/api.py
@@ -11,6 +11,8 @@ from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
+from django.utils.decorators import method_decorator
+from django_ratelimit.decorators import ratelimit
 
 from audit.models import AuditLog
 from audit.services import hash_ip, log_audit
@@ -58,6 +60,7 @@ class AccountViewSet(viewsets.GenericViewSet):
         return Response({"detail": _("Email confirmado.")})
 
     @action(detail=False, methods=["post"], url_path="resend-confirmation")
+    @method_decorator(ratelimit(key="ip", rate="5/h", method="POST", block=True))
     def resend_confirmation(self, request):
         email = request.data.get("email")
         if not email:
@@ -83,6 +86,7 @@ class AccountViewSet(viewsets.GenericViewSet):
         return Response(status=204)
 
     @action(detail=False, methods=["post"], url_path="request-password-reset")
+    @method_decorator(ratelimit(key="ip", rate="5/h", method="POST", block=True))
     def request_password_reset(self, request):
         email = request.data.get("email")
         if not email:

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -24,6 +24,7 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from django.views import View
+from django_ratelimit.decorators import ratelimit
 from rest_framework import viewsets
 from rest_framework.permissions import IsAuthenticated
 
@@ -426,6 +427,7 @@ def excluir_conta(request):
     return redirect("core:home")
 
 
+@ratelimit(key="ip", rate="5/h", method="POST", block=True)
 def password_reset(request):
     """Solicita redefinição de senha."""
     if request.method == "POST":
@@ -563,6 +565,7 @@ def cancel_delete(request, token: str):
     return render(request, "accounts/cancel_delete.html", {"status": "sucesso"})
 
 
+@ratelimit(key="ip", rate="5/h", method="POST", block=True)
 def resend_confirmation(request):
     if request.method == "POST":
         email = request.POST.get("email")


### PR DESCRIPTION
## Summary
- limit password reset and email confirmation resend endpoints to 5 requests per hour per IP
- guard AccountViewSet methods with same rate limits

## Testing
- `pytest tests/accounts/test_resend_confirmation_view.py::test_resend_confirmation_invalidates_previous_tokens tests/accounts/test_token_expiry.py::test_password_reset_token_default_expiry_and_invalidation tests/accounts/test_password_reset_request.py::test_request_password_reset tests/accounts/test_email_confirmation.py::test_resend_and_confirm_email -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68a8773823208325926647b007af32f7