### PR TITLE
Solicitar senha ao habilitar/desativar 2FA

### DIFF
--- a/accounts/templates/perfil/disable_2fa.html
+++ b/accounts/templates/perfil/disable_2fa.html
@@ -10,6 +10,10 @@
     <label for="code" class="block text-sm font-medium text-gray-700">{% trans "Código" %}</label>
     <input type="text" name="code" id="code" class="mt-1 block w-full border rounded-lg p-2 text-sm" required />
   </div>
+  <div>
+    <label for="password" class="block text-sm font-medium text-gray-700">{% trans "Senha" %}</label>
+    <input type="password" name="password" id="password" class="mt-1 block w-full border rounded-lg p-2 text-sm" required />
+  </div>
   <button type="submit" class="bg-primary text-white px-4 py-2 rounded-lg text-sm">{% trans "Desativar" %}</button>
 </form>
 {% endblock %}

--- a/accounts/templates/perfil/enable_2fa.html
+++ b/accounts/templates/perfil/enable_2fa.html
@@ -11,6 +11,10 @@
     <label for="code" class="block text-sm font-medium text-gray-700">{% trans "Código" %}</label>
     <input type="text" name="code" id="code" class="mt-1 block w-full border rounded-lg p-2 text-sm" required />
   </div>
+  <div>
+    <label for="password" class="block text-sm font-medium text-gray-700">{% trans "Senha" %}</label>
+    <input type="password" name="password" id="password" class="mt-1 block w-full border rounded-lg p-2 text-sm" required />
+  </div>
   <button type="submit" class="bg-primary text-white px-4 py-2 rounded-lg text-sm">{% trans "Ativar" %}</button>
 </form>
 {% endblock %}

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -133,25 +133,29 @@ def enable_2fa(request):
     img.save(buffer, format="PNG")
     qr_base64 = base64.b64encode(buffer.getvalue()).decode()
     if request.method == "POST":
-        code = request.POST.get("code")
-        if code and totp.verify(code):
-            user = request.user
-            user.two_factor_secret = secret
-            user.two_factor_enabled = True
-            user.save(update_fields=["two_factor_secret", "two_factor_enabled"])
-            TOTPDevice.all_objects.update_or_create(
-                usuario=user,
-                defaults={
-                    "secret": user.two_factor_secret,
-                    "confirmado": True,
-                    "deleted": False,
-                    "deleted_at": None,
-                },
-            )
-            del request.session["tmp_2fa_secret"]
-            messages.success(request, _("Verificação em duas etapas ativada."))
-            return redirect("accounts:seguranca")
-        messages.error(request, _("Código inválido."))
+        password = request.POST.get("password")
+        if request.user.check_password(password):
+            code = request.POST.get("code")
+            if code and totp.verify(code):
+                user = request.user
+                user.two_factor_secret = secret
+                user.two_factor_enabled = True
+                user.save(update_fields=["two_factor_secret", "two_factor_enabled"])
+                TOTPDevice.all_objects.update_or_create(
+                    usuario=user,
+                    defaults={
+                        "secret": user.two_factor_secret,
+                        "confirmado": True,
+                        "deleted": False,
+                        "deleted_at": None,
+                    },
+                )
+                del request.session["tmp_2fa_secret"]
+                messages.success(request, _("Verificação em duas etapas ativada."))
+                return redirect("accounts:seguranca")
+            messages.error(request, _("Código inválido."))
+        else:
+            messages.error(request, _("Senha incorreta."))
     return render(request, "perfil/enable_2fa.html", {"qr_base64": qr_base64})
 
 
@@ -160,16 +164,20 @@ def disable_2fa(request):
     if not request.user.two_factor_enabled:
         return redirect("accounts:seguranca")
     if request.method == "POST":
-        code = request.POST.get("code")
-        if code and pyotp.TOTP(request.user.two_factor_secret).verify(code):
-            user = request.user
-            user.two_factor_secret = None
-            user.two_factor_enabled = False
-            user.save(update_fields=["two_factor_secret", "two_factor_enabled"])
-            TOTPDevice.objects.filter(usuario=user).delete()
-            messages.success(request, _("Verificação em duas etapas desativada."))
-            return redirect("accounts:seguranca")
-        messages.error(request, _("Código inválido."))
+        password = request.POST.get("password")
+        if request.user.check_password(password):
+            code = request.POST.get("code")
+            if code and pyotp.TOTP(request.user.two_factor_secret).verify(code):
+                user = request.user
+                user.two_factor_secret = None
+                user.two_factor_enabled = False
+                user.save(update_fields=["two_factor_secret", "two_factor_enabled"])
+                TOTPDevice.objects.filter(usuario=user).delete()
+                messages.success(request, _("Verificação em duas etapas desativada."))
+                return redirect("accounts:seguranca")
+            messages.error(request, _("Código inválido."))
+        else:
+            messages.error(request, _("Senha incorreta."))
     return render(request, "perfil/disable_2fa.html")
 
 
@@ -188,16 +196,8 @@ def check_2fa(request):
 @login_required
 def perfil_conexoes(request):
     q = request.GET.get("q", "").strip()
-    connections = (
-        request.user.connections.all()
-        if hasattr(request.user, "connections")
-        else User.objects.none()
-    )
-    connection_requests = (
-        request.user.followers.all()
-        if hasattr(request.user, "followers")
-        else User.objects.none()
-    )
+    connections = request.user.connections.all() if hasattr(request.user, "connections") else User.objects.none()
+    connection_requests = request.user.followers.all() if hasattr(request.user, "followers") else User.objects.none()
 
     if q:
         filters = (

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,6 +1,8 @@
 from django.urls import include, path
 from django.views.i18n import JavaScriptCatalog
 
+from configuracoes.views import ConfiguracoesView
+
 urlpatterns = [
     path("", include(("accounts.urls", "accounts"), namespace="accounts")),
     path("core/", include(("core.urls", "core"), namespace="core")),
@@ -17,47 +19,39 @@ urlpatterns = [
     path("nucleos/", include(("nucleos.urls", "nucleos"), namespace="nucleos")),
     path("organizacoes/", include(("organizacoes.urls", "organizacoes"), namespace="organizacoes")),
     path("tokens/", include(("tokens.urls", "tokens"), namespace="tokens")),
-
+    path("configuracoes/", ConfiguracoesView.as_view(), name="configuracoes"),
     path(
         "api/financeiro/",
         include(("financeiro.api_urls", "financeiro_api"), namespace="financeiro_api"),
     ),
-
     path(
         "api/nucleos/",
         include(("nucleos.api_urls", "nucleos_api"), namespace="nucleos_api"),
     ),
-
     path(
         "api/organizacoes/",
         include(("organizacoes.api_urls", "organizacoes_api"), namespace="organizacoes_api"),
     ),
-
     path(
         "api/empresas/",
         include(("empresas.api_urls", "empresas_api"), namespace="empresas_api"),
     ),
-
     path(
         "api/tokens/",
         include(("tokens.api_urls", "tokens_api"), namespace="tokens_api"),
     ),
-
     path(
         "api/accounts/",
         include(("accounts.api_urls", "accounts_api"), namespace="accounts_api"),
     ),
-
     path(
         "api/agenda/",
         include(("agenda.api_urls", "agenda_api"), namespace="agenda_api"),
     ),
-
     path(
         "api/dashboard/",
         include(("dashboard.api_urls", "dashboard_api"), namespace="dashboard_api"),
     ),
-
     path("jsi18n/", JavaScriptCatalog.as_view(), name="javascript-catalog"),
     path("select2/", include("django_select2.urls")),
 ]


### PR DESCRIPTION
## Summary
- Requisita e valida a senha do usuário para ativar e desativar 2FA
- Adiciona campo de senha aos formulários de 2FA
- Ajusta testes de 2FA e rota de configurações em ambiente de testes

## Testing
- `pytest tests/accounts/test_two_factor.py::test_enable_2fa_wrong_password tests/accounts/test_two_factor.py::test_disable_2fa_wrong_password -q` *(falhou: Required test coverage of 90% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_68a877372efc832596275490047fa1c2