### PR TITLE
Validate uploaded file MIME types for event materials and registrations

### DIFF
--- a/agenda/forms.py
+++ b/agenda/forms.py
@@ -3,6 +3,8 @@ from django.utils.translation import gettext_lazy as _
 from django_select2 import forms as s2forms
 import os
 
+from .validators import validate_uploaded_file
+
 from .models import (
     BriefingEvento,
     Evento,
@@ -106,15 +108,7 @@ class InscricaoEventoForm(forms.ModelForm):
         arquivo = self.cleaned_data.get("comprovante_pagamento")
         if not arquivo:
             return arquivo
-        ext = os.path.splitext(arquivo.name)[1].lower()
-        if ext in {".jpg", ".jpeg", ".png"}:
-            max_size = 10 * 1024 * 1024
-        elif ext == ".pdf":
-            max_size = 20 * 1024 * 1024
-        else:
-            raise forms.ValidationError(_("Formato de arquivo não permitido."))
-        if arquivo.size > max_size:
-            raise forms.ValidationError(_("Arquivo excede o tamanho máximo permitido."))
+        validate_uploaded_file(arquivo)
         return arquivo
 
 
@@ -141,15 +135,7 @@ class MaterialDivulgacaoEventoForm(forms.ModelForm):
         arquivo = self.cleaned_data.get("arquivo")
         if not arquivo:
             return arquivo
-        ext = os.path.splitext(arquivo.name)[1].lower()
-        if ext in {".jpg", ".jpeg", ".png"}:
-            max_size = 10 * 1024 * 1024
-        elif ext == ".pdf":
-            max_size = 20 * 1024 * 1024
-        else:
-            raise forms.ValidationError(_("Formato de arquivo não permitido."))
-        if arquivo.size > max_size:
-            raise forms.ValidationError(_("Arquivo excede o tamanho máximo permitido."))
+        validate_uploaded_file(arquivo)
         return arquivo
 
     def clean_imagem_thumb(self):

--- a/agenda/validators.py
+++ b/agenda/validators.py
@@ -1,0 +1,27 @@
+import os
+import mimetypes
+from django.core.exceptions import ValidationError
+from django.utils.translation import gettext_lazy as _
+
+SAFE_MIME_TYPES = {
+    "image/jpeg": {".jpg", ".jpeg"},
+    "image/png": {".png"},
+    "application/pdf": {".pdf"},
+}
+
+
+def validate_uploaded_file(f):
+    """Valida tipo, extensão e tamanho de arquivos de upload."""
+    ext = os.path.splitext(f.name)[1].lower()
+    content_type = getattr(f, "content_type", "") or mimetypes.guess_type(f.name)[0] or ""
+    allowed_exts = SAFE_MIME_TYPES.get(content_type)
+    if not allowed_exts:
+        raise ValidationError(_("Tipo de arquivo não permitido."))
+    if ext not in allowed_exts:
+        raise ValidationError(_("Extensão do arquivo não corresponde ao tipo MIME."))
+    if content_type == "application/pdf":
+        max_size = 20 * 1024 * 1024
+    else:
+        max_size = 10 * 1024 * 1024
+    if f.size > max_size:
+        raise ValidationError(_("Arquivo excede o tamanho máximo permitido."))

--- a/tests/agenda/test_inscricao_comprovante.py
+++ b/tests/agenda/test_inscricao_comprovante.py
@@ -1,0 +1,70 @@
+import pytest
+from django.contrib.auth import get_user_model
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from accounts.models import UserType
+from agenda.factories import EventoFactory
+from agenda.forms import InscricaoEventoForm
+from organizacoes.factories import OrganizacaoFactory
+
+User = get_user_model()
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def organizacao():
+    return OrganizacaoFactory()
+
+
+@pytest.fixture
+def admin_user(organizacao):
+    return User.objects.create_user(
+        username="admin",
+        email="admin@example.com",
+        password="pass",
+        user_type=UserType.ADMIN,
+        organizacao=organizacao,
+    )
+
+
+@pytest.fixture
+def cliente_user(organizacao):
+    return User.objects.create_user(
+        username="cliente",
+        email="cliente@example.com",
+        password="pass",
+        user_type=UserType.ASSOCIADO,
+        organizacao=organizacao,
+    )
+
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+
+def _form_data():
+    return {"valor_pago": "10.00", "metodo_pagamento": "pix", "observacao": ""}
+
+
+def test_inscricao_form_rejeita_mime_divergente(admin_user):
+    evento = EventoFactory(organizacao=admin_user.organizacao, coordenador=admin_user)
+    arquivo = SimpleUploadedFile("fake.png", b"%PDF-1.4", content_type="application/pdf")
+    form = InscricaoEventoForm(data=_form_data(), files={"comprovante_pagamento": arquivo})
+    assert not form.is_valid()
+    assert "Extensão" in form.errors["comprovante_pagamento"][0]
+
+
+def test_inscricao_api_rejeita_mime_divergente(api_client, cliente_user):
+    evento = EventoFactory(organizacao=cliente_user.organizacao, coordenador=cliente_user)
+    arquivo = SimpleUploadedFile("fake.png", b"%PDF-1.4", content_type="application/pdf")
+    data = {"evento": evento.id, "comprovante_pagamento": arquivo}
+    api_client.force_authenticate(cliente_user)
+    url = reverse("agenda_api:inscricao-list")
+    resp = api_client.post(url, data, format="multipart")
+    assert resp.status_code == status.HTTP_400_BAD_REQUEST
+    assert "Extensão" in resp.data["comprovante_pagamento"][0]

--- a/tests/agenda/test_material.py
+++ b/tests/agenda/test_material.py
@@ -63,7 +63,15 @@ def test_material_form_rejeita_extensao_invalida(admin_user):
     arquivo = SimpleUploadedFile("malware.exe", b"xx", content_type="application/octet-stream")
     form = MaterialDivulgacaoEventoForm(data=_form_data(evento), files={"arquivo": arquivo})
     assert not form.is_valid()
-    assert "Formato" in form.errors["arquivo"][0]
+    assert "Tipo" in form.errors["arquivo"][0]
+
+
+def test_material_form_rejeita_mime_divergente(admin_user):
+    evento = EventoFactory(organizacao=admin_user.organizacao, coordenador=admin_user)
+    arquivo = SimpleUploadedFile("img.png", b"%PDF-1.4", content_type="application/pdf")
+    form = MaterialDivulgacaoEventoForm(data=_form_data(evento), files={"arquivo": arquivo})
+    assert not form.is_valid()
+    assert "Extensão" in form.errors["arquivo"][0]
 
 
 def test_material_form_limita_tamanho_imagem(admin_user):
@@ -144,7 +152,19 @@ def test_material_api_rejeita_extensao_invalida(api_client, admin_user):
     url = reverse("agenda_api:material-list")
     resp = api_client.post(url, data, format="multipart")
     assert resp.status_code == status.HTTP_400_BAD_REQUEST
-    assert "Formato" in resp.data["arquivo"][0]
+    assert "Tipo" in resp.data["arquivo"][0]
+
+
+def test_material_api_rejeita_mime_divergente(api_client, admin_user):
+    evento = EventoFactory(organizacao=admin_user.organizacao, coordenador=admin_user)
+    arquivo = SimpleUploadedFile("img.png", b"%PDF-1.4", content_type="application/pdf")
+    data = _form_data(evento)
+    data["arquivo"] = arquivo
+    api_client.force_authenticate(admin_user)
+    url = reverse("agenda_api:material-list")
+    resp = api_client.post(url, data, format="multipart")
+    assert resp.status_code == status.HTTP_400_BAD_REQUEST
+    assert "Extensão" in resp.data["arquivo"][0]
 
 
 def test_material_api_limita_tamanho_imagem(api_client, admin_user):


### PR DESCRIPTION
## Summary
- add shared validator enforcing safe MIME types and extension checks for uploads
- apply validator to MaterialDivulgacaoEvento and InscricaoEvento in forms and serializers
- test rejection when file extension mismatches its MIME type

## Testing
- `PYTEST_ADDOPTS="--no-cov" pytest tests/agenda/test_material.py::test_material_form_rejeita_extensao_invalida tests/agenda/test_material.py::test_material_form_rejeita_mime_divergente tests/agenda/test_material.py::test_material_api_rejeita_extensao_invalida tests/agenda/test_material.py::test_material_api_rejeita_mime_divergente tests/agenda/test_inscricao_comprovante.py::test_inscricao_form_rejeita_mime_divergente tests/agenda/test_inscricao_comprovante.py::test_inscricao_api_rejeita_mime_divergente`

------
https://chatgpt.com/codex/tasks/task_e_68a880abe4f08325bb44ed801f626a82