### PR TITLE
Add tests for agenda workflows

### DIFF
--- a/tests/agenda/test_avaliacao_api.py
+++ b/tests/agenda/test_avaliacao_api.py
@@ -1,0 +1,100 @@
+import pytest
+from django.urls import reverse
+from django.utils import timezone
+from django.test.utils import override_settings
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from accounts.factories import UserFactory
+from accounts.models import UserType
+from organizacoes.factories import OrganizacaoFactory
+from empresas.factories import EmpresaFactory
+from agenda.factories import EventoFactory
+from agenda.models import InscricaoEvento, ParceriaEvento
+
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def api_client() -> APIClient:
+    return APIClient()
+
+
+def _user(organizacao, user_type=UserType.ASSOCIADO):
+    return UserFactory(organizacao=organizacao, user_type=user_type, nucleo_obj=None)
+
+
+@override_settings(ROOT_URLCONF="Hubx.urls")
+def test_avaliar_evento(api_client: APIClient) -> None:
+    org = OrganizacaoFactory()
+    user = _user(org)
+    evento = EventoFactory(
+        organizacao=org,
+        coordenador=user,
+        data_inicio=timezone.now() - timezone.timedelta(days=2),
+        data_fim=timezone.now() - timezone.timedelta(days=1),
+    )
+    inscricao = InscricaoEvento.objects.create(
+        evento=evento,
+        user=user,
+        status="confirmada",
+        data_confirmacao=timezone.now(),
+        presente=True,
+    )
+    api_client.force_authenticate(user)
+    url = reverse("agenda_api:inscricao-avaliar", args=[inscricao.pk])
+    resp = api_client.post(url, {"nota": 4, "feedback": "bom"})
+    assert resp.status_code == status.HTTP_200_OK
+    inscricao.refresh_from_db()
+    assert inscricao.avaliacao == 4
+    assert inscricao.feedback == "bom"
+
+
+@override_settings(ROOT_URLCONF="Hubx.urls")
+def test_avaliar_evento_antes_do_fim(api_client: APIClient) -> None:
+    org = OrganizacaoFactory()
+    user = _user(org)
+    evento = EventoFactory(
+        organizacao=org,
+        coordenador=user,
+        data_inicio=timezone.now() + timezone.timedelta(hours=1),
+        data_fim=timezone.now() + timezone.timedelta(days=1),
+    )
+    inscricao = InscricaoEvento.objects.create(
+        evento=evento,
+        user=user,
+        status="confirmada",
+        data_confirmacao=timezone.now(),
+        presente=False,
+    )
+    api_client.force_authenticate(user)
+    url = reverse("agenda_api:inscricao-avaliar", args=[inscricao.pk])
+    resp = api_client.post(url, {"nota": 5})
+    assert resp.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@override_settings(ROOT_URLCONF="Hubx.urls")
+def test_avaliar_parceria(api_client: APIClient) -> None:
+    org = OrganizacaoFactory()
+    admin = _user(org, UserType.ADMIN)
+    evento = EventoFactory(organizacao=org, coordenador=admin)
+    empresa = EmpresaFactory(organizacao=org, usuario=admin)
+    parceria = ParceriaEvento.objects.create(
+        evento=evento,
+        empresa=empresa,
+        cnpj="12345678000199",
+        contato="c",
+        representante_legal="r",
+        data_inicio=timezone.now().date(),
+        data_fim=timezone.now().date(),
+        tipo_parceria="patrocinio",
+    )
+    api_client.force_authenticate(admin)
+    url = reverse("agenda_api:parceria-avaliar", args=[parceria.pk])
+    resp = api_client.post(url, {"avaliacao": 5, "comentario": "ok"})
+    assert resp.status_code == status.HTTP_200_OK
+    parceria.refresh_from_db()
+    assert parceria.avaliacao == 5
+    assert parceria.comentario == "ok"
+

--- a/tests/agenda/test_briefing_flow_api.py
+++ b/tests/agenda/test_briefing_flow_api.py
@@ -1,0 +1,102 @@
+import pytest
+from django.urls import reverse
+from django.utils import timezone
+from django.test.utils import override_settings
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from accounts.factories import UserFactory
+from accounts.models import UserType
+from organizacoes.factories import OrganizacaoFactory
+from agenda.factories import EventoFactory
+from agenda.models import BriefingEvento, EventoLog
+
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def api_client() -> APIClient:
+    return APIClient()
+
+
+def _admin_user(organizacao):
+    return UserFactory(
+        organizacao=organizacao,
+        user_type=UserType.ADMIN,
+        is_superuser=True,
+        is_staff=True,
+        nucleo_obj=None,
+    )
+
+
+@override_settings(ROOT_URLCONF="Hubx.urls")
+def test_briefing_orcamentar(api_client: APIClient) -> None:
+    org = OrganizacaoFactory()
+    user = _admin_user(org)
+    evento = EventoFactory(organizacao=org, coordenador=user)
+    briefing = BriefingEvento.objects.create(
+        evento=evento,
+        objetivos="obj",
+        publico_alvo="pub",
+        requisitos_tecnicos="req",
+    )
+    api_client.force_authenticate(user)
+    url = reverse("agenda_api:briefing-orcamentar", args=[briefing.pk])
+    prazo = (timezone.now() + timezone.timedelta(days=5)).isoformat()
+    resp = api_client.post(url, {"prazo_limite_resposta": prazo})
+    assert resp.status_code == status.HTTP_200_OK
+    briefing.refresh_from_db()
+    assert briefing.status == "orcamentado"
+    assert briefing.orcamento_enviado_em is not None
+    assert briefing.prazo_limite_resposta.isoformat() == prazo
+    assert EventoLog.objects.filter(evento=evento, acao="briefing_orcamentado").exists()
+
+
+@override_settings(ROOT_URLCONF="Hubx.urls")
+def test_briefing_aprovar(api_client: APIClient) -> None:
+    org = OrganizacaoFactory()
+    user = _admin_user(org)
+    evento = EventoFactory(organizacao=org, coordenador=user)
+    briefing = BriefingEvento.objects.create(
+        evento=evento,
+        objetivos="obj",
+        publico_alvo="pub",
+        requisitos_tecnicos="req",
+    )
+    api_client.force_authenticate(user)
+    url = reverse("agenda_api:briefing-aprovar", args=[briefing.pk])
+    resp = api_client.post(url)
+    assert resp.status_code == status.HTTP_200_OK
+    briefing.refresh_from_db()
+    assert briefing.status == "aprovado"
+    assert briefing.aprovado_em is not None
+    assert EventoLog.objects.filter(evento=evento, acao="briefing_aprovado").exists()
+
+
+@override_settings(ROOT_URLCONF="Hubx.urls")
+def test_briefing_recusar(api_client: APIClient) -> None:
+    org = OrganizacaoFactory()
+    user = _admin_user(org)
+    evento = EventoFactory(organizacao=org, coordenador=user)
+    briefing = BriefingEvento.objects.create(
+        evento=evento,
+        objetivos="obj",
+        publico_alvo="pub",
+        requisitos_tecnicos="req",
+    )
+    api_client.force_authenticate(user)
+    url = reverse("agenda_api:briefing-recusar", args=[briefing.pk])
+    motivo = "Sem verba"
+    resp = api_client.post(url, {"motivo_recusa": motivo})
+    assert resp.status_code == status.HTTP_200_OK
+    briefing.refresh_from_db()
+    assert briefing.status == "recusado"
+    assert briefing.motivo_recusa == motivo
+    assert briefing.recusado_por == user
+    assert briefing.recusado_em is not None
+    assert EventoLog.objects.filter(
+        evento=evento,
+        acao="briefing_recusado",
+        detalhes__motivo_recusa=motivo,
+    ).exists()

--- a/tests/agenda/test_material_workflow_api.py
+++ b/tests/agenda/test_material_workflow_api.py
@@ -1,0 +1,84 @@
+import pytest
+from django.urls import reverse
+from django.utils import timezone
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test.utils import override_settings
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from accounts.factories import UserFactory
+from accounts.models import UserType
+from organizacoes.factories import OrganizacaoFactory
+from agenda.factories import EventoFactory
+from agenda.models import MaterialDivulgacaoEvento, EventoLog
+
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def api_client() -> APIClient:
+    return APIClient()
+
+
+def _admin_user(organizacao):
+    return UserFactory(
+        organizacao=organizacao,
+        user_type=UserType.ADMIN,
+        is_superuser=True,
+        is_staff=True,
+        nucleo_obj=None,
+    )
+
+
+@override_settings(ROOT_URLCONF="Hubx.urls")
+def test_material_aprovar_devolver(api_client: APIClient) -> None:
+    org = OrganizacaoFactory()
+    user = _admin_user(org)
+    evento = EventoFactory(organizacao=org, coordenador=user)
+    arquivo = SimpleUploadedFile("m.pdf", b"%PDF-1.4")
+    material = MaterialDivulgacaoEvento.objects.create(
+        evento=evento,
+        titulo="M",
+        tipo="banner",
+        arquivo=arquivo,
+    )
+    api_client.force_authenticate(user)
+    url_aprovar = reverse("agenda_api:material-aprovar", args=[material.pk])
+    resp = api_client.post(url_aprovar)
+    assert resp.status_code == status.HTTP_200_OK
+    material.refresh_from_db()
+    assert material.status == "aprovado"
+    assert material.avaliado_por == user
+    assert material.avaliado_em is not None
+    assert EventoLog.objects.filter(evento=evento, acao="material_aprovado").exists()
+
+    url_devolver = reverse("agenda_api:material-devolver", args=[material.pk])
+    resp = api_client.post(url_devolver, {"motivo_devolucao": "erro"})
+    assert resp.status_code == status.HTTP_200_OK
+    material.refresh_from_db()
+    assert material.status == "devolvido"
+    assert material.motivo_devolucao == "erro"
+    assert EventoLog.objects.filter(
+        evento=evento,
+        acao="material_devolvido",
+        detalhes__motivo_devolucao="erro",
+    ).exists()
+
+
+@override_settings(ROOT_URLCONF="Hubx.urls")
+def test_material_devolver_exige_motivo(api_client: APIClient) -> None:
+    org = OrganizacaoFactory()
+    user = _admin_user(org)
+    evento = EventoFactory(organizacao=org, coordenador=user)
+    arquivo = SimpleUploadedFile("m.pdf", b"%PDF-1.4")
+    material = MaterialDivulgacaoEvento.objects.create(
+        evento=evento,
+        titulo="M",
+        tipo="banner",
+        arquivo=arquivo,
+    )
+    api_client.force_authenticate(user)
+    url = reverse("agenda_api:material-devolver", args=[material.pk])
+    resp = api_client.post(url, {})
+    assert resp.status_code == status.HTTP_400_BAD_REQUEST

--- a/tests/agenda/test_tarefa_logging.py
+++ b/tests/agenda/test_tarefa_logging.py
@@ -1,0 +1,65 @@
+import pytest
+from django.urls import reverse
+from django.utils import timezone
+from django.test.utils import override_settings
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from accounts.factories import UserFactory
+from accounts.models import UserType
+from organizacoes.factories import OrganizacaoFactory
+from agenda.models import Tarefa, TarefaLog
+
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def api_client() -> APIClient:
+    return APIClient()
+
+
+def _admin_user(organizacao):
+    return UserFactory(
+        organizacao=organizacao,
+        user_type=UserType.ADMIN,
+        is_superuser=True,
+        is_staff=True,
+        nucleo_obj=None,
+    )
+
+
+def _tarefa_data():
+    now = timezone.now()
+    return {
+        "titulo": "T",
+        "descricao": "d",
+        "data_inicio": now.isoformat(),
+        "data_fim": (now + timezone.timedelta(hours=1)).isoformat(),
+    }
+
+
+@override_settings(ROOT_URLCONF="Hubx.urls")
+def test_tarefa_logs(api_client: APIClient) -> None:
+    org = OrganizacaoFactory()
+    user = _admin_user(org)
+    api_client.force_authenticate(user)
+
+    url = reverse("agenda_api:tarefa-list")
+    resp = api_client.post(url, _tarefa_data(), format="json")
+    assert resp.status_code == status.HTTP_201_CREATED
+    tarefa_id = resp.data["id"]
+    assert TarefaLog.objects.filter(tarefa_id=tarefa_id, acao="tarefa_criada", usuario=user).exists()
+
+    url_detail = reverse("agenda_api:tarefa-detail", args=[tarefa_id])
+    resp = api_client.patch(url_detail, {"descricao": "nova"}, format="json")
+    assert resp.status_code == status.HTTP_200_OK
+    assert TarefaLog.objects.filter(tarefa_id=tarefa_id, acao="tarefa_atualizada").exists()
+
+    url_concluir = reverse("agenda_api:tarefa-concluir", args=[tarefa_id])
+    resp = api_client.post(url_concluir)
+    assert resp.status_code == status.HTTP_200_OK
+    assert TarefaLog.objects.filter(tarefa_id=tarefa_id, acao="tarefa_concluida").exists()
+
+    api_client.delete(url_detail)
+    assert TarefaLog.objects.filter(tarefa_id=tarefa_id, acao="tarefa_excluida").exists()


### PR DESCRIPTION
## Summary
- test material approval and return workflows
- cover briefing budget/approve/reject actions
- validate event and partnership evaluation endpoints
- ensure task actions emit logs

## Testing
- `pytest --no-cov tests/agenda/test_material_workflow_api.py tests/agenda/test_briefing_flow_api.py tests/agenda/test_avaliacao_api.py tests/agenda/test_tarefa_logging.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a880aa6fb88325a95646da58be9dd5