### PR TITLE
Validate event dates and positive values

### DIFF
--- a/tests/agenda/test_evento_clean.py
+++ b/tests/agenda/test_evento_clean.py
@@ -1,0 +1,37 @@
+from datetime import timedelta
+from decimal import Decimal
+
+import pytest
+from django.core.exceptions import ValidationError
+from django.utils import timezone
+
+from agenda.factories import EventoFactory
+
+
+@pytest.mark.django_db
+def test_evento_data_fim_posterior_data_inicio():
+    inicio = timezone.now()
+    evento = EventoFactory.build(data_inicio=inicio, data_fim=inicio - timedelta(hours=1))
+    with pytest.raises(ValidationError) as excinfo:
+        evento.clean()
+    assert "data_fim" in excinfo.value.message_dict
+
+
+@pytest.mark.parametrize(
+    "campo, valor",
+    [
+        ("numero_convidados", -1),
+        ("numero_presentes", -1),
+        ("valor_ingresso", Decimal("-1")),
+        ("orcamento", Decimal("-1")),
+        ("orcamento_estimado", Decimal("-1")),
+        ("valor_gasto", Decimal("-1")),
+        ("participantes_maximo", -1),
+    ],
+)
+@pytest.mark.django_db
+def test_evento_campos_devem_ser_positivos(campo, valor):
+    evento = EventoFactory.build(**{campo: valor})
+    with pytest.raises(ValidationError) as excinfo:
+        evento.clean()
+    assert campo in excinfo.value.message_dict


### PR DESCRIPTION
## Summary
- enforce end date after start and positive numeric fields in Evento.clean
- add tests verifying Evento validation logic

## Testing
- `ruff check agenda/models.py tests/agenda/test_evento_clean.py`
- `pytest -q` *(fails: SyntaxError in tests/feed/test_services.py and missing onesignal_sdk)*

------
https://chatgpt.com/codex/tasks/task_e_68a880a957e88325a03099bd46b9964c