### PR TITLE
Log budget changes in evento_orcamento

### DIFF
--- a/agenda/views.py
+++ b/agenda/views.py
@@ -1,6 +1,6 @@
 import calendar
 from datetime import date, timedelta
-from decimal import Decimal, InvalidOperation
+from decimal import Decimal
 from typing import Any
 
 from django.contrib import messages
@@ -11,6 +11,7 @@ from django.contrib.auth.mixins import (
     PermissionRequiredMixin,
     UserPassesTestMixin,
 )
+from django import forms
 from django.core.exceptions import PermissionDenied
 from django.db.models import F, Q
 from django.http import (
@@ -506,12 +507,37 @@ def evento_orcamento(request, pk: int):
     if request.user.user_type not in {UserType.ADMIN, UserType.COORDENADOR}:
         return HttpResponseForbidden()
     if request.method == "POST":
-        try:
-            evento.orcamento_estimado = Decimal(request.POST.get("orcamento_estimado", 0))
-            evento.valor_gasto = Decimal(request.POST.get("valor_gasto", 0))
-            evento.save(update_fields=["orcamento_estimado", "valor_gasto", "updated_at"])
-        except (TypeError, InvalidOperation):
-            return HttpResponse(status=400)
+        class _Form(forms.Form):
+            orcamento_estimado = forms.DecimalField(max_digits=10, decimal_places=2, required=False)
+            valor_gasto = forms.DecimalField(max_digits=10, decimal_places=2, required=False)
+
+        form = _Form(request.POST)
+        if not form.is_valid():
+            return JsonResponse({"errors": form.errors}, status=400)
+
+        orcamento_estimado = form.cleaned_data.get("orcamento_estimado") or Decimal("0")
+        valor_gasto = form.cleaned_data.get("valor_gasto") or Decimal("0")
+
+        old_orcamento = evento.orcamento_estimado
+        old_valor = evento.valor_gasto
+
+        evento.orcamento_estimado = orcamento_estimado
+        evento.valor_gasto = valor_gasto
+        evento.save(update_fields=["orcamento_estimado", "valor_gasto", "updated_at"])
+
+        detalhes: dict[str, dict[str, Decimal]] = {}
+        if old_orcamento != orcamento_estimado:
+            detalhes["orcamento_estimado"] = {"antes": old_orcamento, "depois": orcamento_estimado}
+        if old_valor != valor_gasto:
+            detalhes["valor_gasto"] = {"antes": old_valor, "depois": valor_gasto}
+        if detalhes:
+            EventoLog.objects.create(
+                evento=evento,
+                usuario=request.user,
+                acao="orcamento_atualizado",
+                detalhes=detalhes,
+            )
+
     data = {"orcamento_estimado": evento.orcamento_estimado, "valor_gasto": evento.valor_gasto}
     return JsonResponse(data)
 

--- a/tests/agenda/test_evento_orcamento_view.py
+++ b/tests/agenda/test_evento_orcamento_view.py
@@ -1,0 +1,58 @@
+import pytest
+from decimal import Decimal
+from django.urls import include, path
+from django.test import override_settings
+
+from accounts.factories import UserFactory
+from accounts.models import UserType
+from organizacoes.factories import OrganizacaoFactory
+from agenda.factories import EventoFactory
+from agenda.models import EventoLog
+
+
+pytestmark = pytest.mark.django_db
+
+urlpatterns = [
+    path("agenda/", include(("agenda.urls", "agenda"), namespace="agenda")),
+]
+
+
+def _admin_user():
+    org = OrganizacaoFactory()
+    user = UserFactory(user_type=UserType.ADMIN, organizacao=org, nucleo_obj=None)
+    return user
+
+
+@override_settings(ROOT_URLCONF=__name__)
+def test_evento_orcamento_atualiza_e_registra_log(client):
+    user = _admin_user()
+    evento = EventoFactory(
+        organizacao=user.organizacao,
+        coordenador=user,
+        orcamento_estimado=Decimal("100.00"),
+        valor_gasto=Decimal("50.00"),
+    )
+    client.force_login(user)
+    url = f"/agenda/api/eventos/{evento.pk}/orcamento/"
+    resp = client.post(url, {"orcamento_estimado": "150.50", "valor_gasto": "80.25"})
+    assert resp.status_code == 200
+    evento.refresh_from_db()
+    assert evento.orcamento_estimado == Decimal("150.50")
+    assert evento.valor_gasto == Decimal("80.25")
+    log = EventoLog.objects.get(evento=evento, acao="orcamento_atualizado")
+    assert log.usuario == user
+    assert log.detalhes["orcamento_estimado"] == {"antes": "100.00", "depois": "150.50"}
+    assert log.detalhes["valor_gasto"] == {"antes": "50.00", "depois": "80.25"}
+
+
+@override_settings(ROOT_URLCONF=__name__)
+def test_evento_orcamento_valores_invalidos(client):
+    user = _admin_user()
+    evento = EventoFactory(organizacao=user.organizacao, coordenador=user)
+    client.force_login(user)
+    url = f"/agenda/api/eventos/{evento.pk}/orcamento/"
+    resp = client.post(url, {"orcamento_estimado": "abc", "valor_gasto": "10"})
+    assert resp.status_code == 400
+    assert "errors" in resp.json()
+    assert EventoLog.objects.filter(evento=evento, acao="orcamento_atualizado").count() == 0
+


### PR DESCRIPTION
## Summary
- validate and sanitize decimal input in evento_orcamento view
- record budget changes in EventoLog with before/after values
- test budget update API and invalid decimal handling

## Testing
- `pytest tests/agenda/test_evento_orcamento_view.py -q --no-cov`

------
https://chatgpt.com/codex/tasks/task_e_68a880a0d7148325a89d202c91751db8