### PR TITLE
Add Pillow and clamd dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ pip install -r requirements.txt
 python manage.py migrate
 ```
 
+Essa etapa garante que bibliotecas como Pillow e clamd estejam disponíveis no ambiente virtual.
+
 > Isso criará o usuário padrão `root` necessário para alguns comandos administrativos.
 
 ---
@@ -318,6 +320,8 @@ ProjetoHubx/
 - Tailwind CSS 3
 - HTMX
 - Font Awesome 6
+- Pillow
+- clamd
 
 ---
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ channels==4.1.0
 channels_redis==4.2.1
 chardet==5.2.0
 charset-normalizer==3.4.2
+clamd==1.0.2
 click==8.2.1
 click-didyoumean==0.3.1
 click-plugins==1.1.1.2
@@ -90,7 +91,7 @@ pbr==6.1.1
 pdfminer.six==20250506
 pdfplumber==0.11.7
 phonenumbers==9.0.7
-pillow==11.2.1
+Pillow==11.3.0
 platformdirs==4.3.8
 pluggy==1.6.0
 prometheus_client==0.20.0


### PR DESCRIPTION
## Summary
- add Pillow and clamd to requirements
- document new dependencies in installation instructions

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'axe_core_python', No module named 'bs4', No module named 'playwright')*


------
https://chatgpt.com/codex/tasks/task_e_68a8891277488325b9bfa2c2f7049861