### PR TITLE
refactor: centralize file scanning util

### DIFF
--- a/chat/api_views.py
+++ b/chat/api_views.py
@@ -61,21 +61,9 @@ from .serializers import (
 from .services import criar_item_de_mensagem, sinalizar_mensagem
 from .tasks import exportar_historico_chat, gerar_resumo_chat
 from .throttles import FlagRateThrottle, UploadRateThrottle
+from .utils import _scan_file
 
 User = get_user_model()
-
-
-def _scan_file(path: str) -> bool:  # pragma: no cover - depends on external service
-    try:
-        import clamd  # type: ignore
-
-        cd = clamd.ClamdNetworkSocket()
-        result = cd.scan(path)
-        if result:
-            return any(status == "FOUND" for _, (status, _) in result.items())
-    except Exception:
-        return False
-    return False
 
 
 class ChatChannelCategoryViewSet(viewsets.ModelViewSet):

--- a/chat/tasks.py
+++ b/chat/tasks.py
@@ -30,18 +30,7 @@ from .models import (
 
 User = get_user_model()
 
-
-def _scan_file(path: str) -> bool:  # pragma: no cover - depends on external service
-    try:
-        import clamd  # type: ignore
-
-        cd = clamd.ClamdNetworkSocket()
-        result = cd.scan(path)
-        if result:
-            return any(status == "FOUND" for _, (status, _) in result.items())
-    except Exception:
-        return False
-    return False
+from .utils import _scan_file
 
 
 @shared_task

--- a/chat/utils.py
+++ b/chat/utils.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+
+def _scan_file(path: str) -> bool:  # pragma: no cover - depends on external service
+    try:
+        import clamd  # type: ignore
+
+        cd = clamd.ClamdNetworkSocket()
+        result = cd.scan(path)
+        if result:
+            return any(status == "FOUND" for _, (status, _) in result.items())
+    except Exception:
+        return False
+    return False

--- a/tests/chat/test_utils.py
+++ b/tests/chat/test_utils.py
@@ -1,0 +1,33 @@
+import sys
+import types
+
+from chat.utils import _scan_file
+
+def test_scan_file_infected(monkeypatch):
+    fake = types.SimpleNamespace(
+        ClamdNetworkSocket=lambda: types.SimpleNamespace(
+            scan=lambda path: {path: ("FOUND", "virus")}
+        )
+    )
+    monkeypatch.setitem(sys.modules, "clamd", fake)
+    assert _scan_file("dummy") is True
+
+
+def test_scan_file_clean(monkeypatch):
+    fake = types.SimpleNamespace(
+        ClamdNetworkSocket=lambda: types.SimpleNamespace(
+            scan=lambda path: {path: ("OK", None)}
+        )
+    )
+    monkeypatch.setitem(sys.modules, "clamd", fake)
+    assert _scan_file("dummy") is False
+
+
+def test_scan_file_error(monkeypatch):
+    class DummySocket:
+        def __init__(self):
+            raise RuntimeError("fail")
+
+    fake = types.SimpleNamespace(ClamdNetworkSocket=DummySocket)
+    monkeypatch.setitem(sys.modules, "clamd", fake)
+    assert _scan_file("dummy") is False


### PR DESCRIPTION
## Summary
- add shared `_scan_file` helper
- reuse helper in API upload and scheduled tasks
- cover `_scan_file` behavior with unit tests

## Testing
- `PYTEST_ADDOPTS="--no-cov" pytest tests/chat/test_utils.py tests/chat/test_tasks.py::test_exportar_historico_chat_gera_arquivo -q`


------
https://chatgpt.com/codex/tasks/task_e_68a88914c0cc8325b2bbc4b3fa3d39dc