### PR TITLE
Require contexto_id for private chat channels

### DIFF
--- a/chat/serializers.py
+++ b/chat/serializers.py
@@ -50,6 +50,15 @@ class ChatChannelSerializer(serializers.ModelSerializer):
         ]
         read_only_fields = ["id", "created_at", "updated_at", "e2ee_habilitado"]
 
+    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
+        contexto_tipo = attrs.get("contexto_tipo")
+        contexto_id = attrs.get("contexto_id")
+        if contexto_tipo == "privado" and not contexto_id:
+            raise serializers.ValidationError(
+                {"contexto_id": "Obrigatório para canal privado"}
+            )
+        return attrs
+
     def create(self, validated_data: dict[str, Any]) -> ChatChannel:
         request = self.context["request"]
         participantes_ids = self.initial_data.get("participantes") or []

--- a/chat/services.py
+++ b/chat/services.py
@@ -69,7 +69,12 @@ def _usuario_no_contexto(user: User, contexto_tipo: str, contexto_id: Optional[s
     """Retorna ``True`` se o ``user`` pertence ao contexto especificado."""
     if contexto_tipo == "organizacao":
         return str(user.organizacao_id) == str(contexto_id)
-    if contexto_tipo in {"nucleo", "privado"}:
+    if contexto_tipo == "privado":
+        if not contexto_id:
+            return False
+        participa, info, suspenso = user_belongs_to_nucleo(user, contexto_id)
+        return participa and info.endswith("ativo") and not suspenso
+    if contexto_tipo == "nucleo":
         if not contexto_id:
             return True
         participa, info, suspenso = user_belongs_to_nucleo(user, contexto_id)

--- a/chat/views.py
+++ b/chat/views.py
@@ -224,7 +224,7 @@ def modal_room(request, user_id):
         channel = criar_canal(
             criador=request.user,
             contexto_tipo="privado",
-            contexto_id=None,
+            contexto_id=request.user.nucleo_id,
             titulo="",
             descricao="",
             participantes=[other],

--- a/tests/chat/conftest.py
+++ b/tests/chat/conftest.py
@@ -4,7 +4,7 @@ from django.utils.timezone import now
 
 from accounts.models import UserType
 from agenda.models import Evento
-from nucleos.models import Nucleo
+from nucleos.models import Nucleo, ParticipacaoNucleo
 from organizacoes.models import Organizacao
 
 User = get_user_model()
@@ -27,6 +27,16 @@ def celery_eager(settings):
 @pytest.fixture(autouse=True)
 def in_memory_channel_layer(settings):
     settings.CHANNEL_LAYERS = {"default": {"BACKEND": "channels.layers.InMemoryChannelLayer"}}
+
+
+@pytest.fixture(autouse=True)
+def default_participacoes(admin_user, coordenador_user, nucleo):
+    ParticipacaoNucleo.objects.get_or_create(
+        user=admin_user, nucleo=nucleo, defaults={"status": "ativo"}
+    )
+    ParticipacaoNucleo.objects.get_or_create(
+        user=coordenador_user, nucleo=nucleo, defaults={"status": "ativo"}
+    )
 
 
 @pytest.fixture

--- a/tests/chat/test_consumers.py
+++ b/tests/chat/test_consumers.py
@@ -22,12 +22,12 @@ def in_memory_channel_layer(settings):
     settings.CHANNEL_LAYERS = {"default": {"BACKEND": "channels.layers.InMemoryChannelLayer"}}
 
 
-def test_consumer_connect_send_message_and_reaction(admin_user, coordenador_user):
+def test_consumer_connect_send_message_and_reaction(admin_user, coordenador_user, nucleo):
     async def inner():
         canal = await database_sync_to_async(criar_canal)(
             criador=admin_user,
             contexto_tipo="privado",
-            contexto_id=None,
+            contexto_id=nucleo.id,
             titulo="Privado",
             descricao="",
             participantes=[coordenador_user],
@@ -51,12 +51,12 @@ def test_consumer_connect_send_message_and_reaction(admin_user, coordenador_user
     asyncio.run(inner())
 
 
-def test_consumer_send_file_url(admin_user, coordenador_user):
+def test_consumer_send_file_url(admin_user, coordenador_user, nucleo):
     async def inner():
         canal = await database_sync_to_async(criar_canal)(
             criador=admin_user,
             contexto_tipo="privado",
-            contexto_id=None,
+            contexto_id=nucleo.id,
             titulo="Privado",
             descricao="",
             participantes=[coordenador_user],
@@ -76,12 +76,12 @@ def test_consumer_send_file_url(admin_user, coordenador_user):
     asyncio.run(inner())
 
 
-def test_consumer_send_reply(admin_user, coordenador_user):
+def test_consumer_send_reply(admin_user, coordenador_user, nucleo):
     async def inner():
         canal = await database_sync_to_async(criar_canal)(
             criador=admin_user,
             contexto_tipo="privado",
-            contexto_id=None,
+            contexto_id=nucleo.id,
             titulo="Privado",
             descricao="",
             participantes=[coordenador_user],
@@ -102,12 +102,12 @@ def test_consumer_send_reply(admin_user, coordenador_user):
     asyncio.run(inner())
 
 
-def test_consumer_rejects_non_participant(admin_user, associado_user):
+def test_consumer_rejects_non_participant(admin_user, associado_user, nucleo):
     async def inner():
         canal = await database_sync_to_async(criar_canal)(
             criador=admin_user,
             contexto_tipo="privado",
-            contexto_id=None,
+            contexto_id=nucleo.id,
             titulo="Privado",
             descricao="",
             participantes=[],
@@ -121,7 +121,7 @@ def test_consumer_rejects_non_participant(admin_user, associado_user):
     asyncio.run(inner())
 
 
-def test_flag_via_websocket_hides_message(admin_user):
+def test_flag_via_websocket_hides_message(admin_user, nucleo):
     from django.contrib.auth import get_user_model
 
     async def inner():
@@ -129,10 +129,19 @@ def test_flag_via_websocket_hides_message(admin_user):
         u2 = User.objects.create_user(username="u2", email="u2@x.com", password="x")
         u3 = User.objects.create_user(username="u3", email="u3@x.com", password="x")
         u4 = User.objects.create_user(username="u4", email="u4@x.com", password="x")
+        await database_sync_to_async(ParticipacaoNucleo.objects.create)(
+            user=u2, nucleo=nucleo, status="ativo"
+        )
+        await database_sync_to_async(ParticipacaoNucleo.objects.create)(
+            user=u3, nucleo=nucleo, status="ativo"
+        )
+        await database_sync_to_async(ParticipacaoNucleo.objects.create)(
+            user=u4, nucleo=nucleo, status="ativo"
+        )
         canal = await database_sync_to_async(criar_canal)(
             criador=admin_user,
             contexto_tipo="privado",
-            contexto_id=None,
+            contexto_id=nucleo.id,
             titulo="Privado",
             descricao="",
             participantes=[u2, u3, u4],
@@ -166,12 +175,12 @@ def test_flag_via_websocket_hides_message(admin_user):
     asyncio.run(inner())
 
 
-def test_notification_consumer_receives(admin_user, coordenador_user):
+def test_notification_consumer_receives(admin_user, coordenador_user, nucleo):
     async def inner():
         canal = await database_sync_to_async(criar_canal)(
             criador=admin_user,
             contexto_tipo="privado",
-            contexto_id=None,
+            contexto_id=nucleo.id,
             titulo="Privado",
             descricao="",
             participantes=[coordenador_user],
@@ -195,11 +204,11 @@ def test_notification_consumer_receives(admin_user, coordenador_user):
     asyncio.run(inner())
 
 
-def test_react_endpoint_broadcasts(admin_user, coordenador_user, client):
+def test_react_endpoint_broadcasts(admin_user, coordenador_user, client, nucleo):
     canal = criar_canal(
         criador=admin_user,
         contexto_tipo="privado",
-        contexto_id=None,
+        contexto_id=nucleo.id,
         titulo="Privado",
         descricao="",
         participantes=[coordenador_user],
@@ -223,12 +232,12 @@ def test_react_endpoint_broadcasts(admin_user, coordenador_user, client):
     asyncio.run(inner())
 
 
-def test_typing_indicator_broadcasts_and_auto_stops(admin_user, coordenador_user):
+def test_typing_indicator_broadcasts_and_auto_stops(admin_user, coordenador_user, nucleo):
     async def inner():
         canal = await database_sync_to_async(criar_canal)(
             criador=admin_user,
             contexto_tipo="privado",
-            contexto_id=None,
+            contexto_id=nucleo.id,
             titulo="Privado",
             descricao="",
             participantes=[coordenador_user],

--- a/tests/chat/test_services.py
+++ b/tests/chat/test_services.py
@@ -12,11 +12,11 @@ User = get_user_model()
 pytestmark = pytest.mark.django_db
 
 
-def test_criar_canal_adiciona_participantes(admin_user, coordenador_user):
+def test_criar_canal_adiciona_participantes(admin_user, coordenador_user, nucleo):
     canal = criar_canal(
         criador=admin_user,
         contexto_tipo="privado",
-        contexto_id=None,
+        contexto_id=nucleo.id,
         titulo="Privado",
         descricao="",
         participantes=[coordenador_user],
@@ -27,16 +27,22 @@ def test_criar_canal_adiciona_participantes(admin_user, coordenador_user):
     assert owner.is_owner and owner.is_admin
 
 
+def test_criar_canal_privado_sem_nucleo(admin_user):
+    with pytest.raises(PermissionError):
+        criar_canal(
+            criador=admin_user,
+            contexto_tipo="privado",
+            contexto_id=None,
+            titulo="Privado",
+            descricao="",
+            participantes=[],
+        )
+
+
 def test_criar_canal_valida_contexto_nucleo(
     coordenador_user, admin_user, associado_user, nucleo
 ):
     """Garante que apenas usuários do núcleo informado participem."""
-    ParticipacaoNucleo.objects.create(
-        user=coordenador_user, nucleo=nucleo, status="ativo"
-    )
-    ParticipacaoNucleo.objects.create(
-        user=admin_user, nucleo=nucleo, status="ativo"
-    )
     criar_canal(
         criador=coordenador_user,
         contexto_tipo="nucleo",
@@ -68,10 +74,6 @@ def test_criar_canal_valida_contexto_nucleo(
 def test_criar_canal_privado_valida_nucleo(
     admin_user, coordenador_user, associado_user, nucleo
 ):
-    ParticipacaoNucleo.objects.create(user=admin_user, nucleo=nucleo, status="ativo")
-    ParticipacaoNucleo.objects.create(
-        user=coordenador_user, nucleo=nucleo, status="ativo"
-    )
     canal = criar_canal(
         criador=admin_user,
         contexto_tipo="privado",
@@ -101,11 +103,11 @@ def test_criar_canal_privado_valida_nucleo(
         )
 
 
-def test_enviar_mensagem_valida_participacao(admin_user, coordenador_user, associado_user):
+def test_enviar_mensagem_valida_participacao(admin_user, coordenador_user, associado_user, nucleo):
     canal = criar_canal(
         criador=admin_user,
         contexto_tipo="privado",
-        contexto_id=None,
+        contexto_id=nucleo.id,
         titulo="Privado",
         descricao="",
         participantes=[coordenador_user],
@@ -116,11 +118,11 @@ def test_enviar_mensagem_valida_participacao(admin_user, coordenador_user, assoc
         enviar_mensagem(canal, associado_user, "text", conteudo="ola")
 
 
-def test_enviar_mensagem_url_sem_arquivo(admin_user, coordenador_user):
+def test_enviar_mensagem_url_sem_arquivo(admin_user, coordenador_user, nucleo):
     canal = criar_canal(
         criador=admin_user,
         contexto_tipo="privado",
-        contexto_id=None,
+        contexto_id=nucleo.id,
         titulo="Privado",
         descricao="",
         participantes=[coordenador_user],
@@ -132,11 +134,11 @@ def test_enviar_mensagem_url_sem_arquivo(admin_user, coordenador_user):
         enviar_mensagem(canal, admin_user, "image", conteudo="not-url")
 
 
-def test_enviar_mensagem_reply_to(admin_user, coordenador_user):
+def test_enviar_mensagem_reply_to(admin_user, coordenador_user, nucleo):
     canal = criar_canal(
         criador=admin_user,
         contexto_tipo="privado",
-        contexto_id=None,
+        contexto_id=nucleo.id,
         titulo="Privado",
         descricao="",
         participantes=[coordenador_user],
@@ -146,11 +148,11 @@ def test_enviar_mensagem_reply_to(admin_user, coordenador_user):
     assert msg2.reply_to == msg1
 
 
-def test_enviar_mensagem_reply_to_invalid_channel(admin_user, coordenador_user):
+def test_enviar_mensagem_reply_to_invalid_channel(admin_user, coordenador_user, nucleo):
     canal1 = criar_canal(
         criador=admin_user,
         contexto_tipo="privado",
-        contexto_id=None,
+        contexto_id=nucleo.id,
         titulo="Privado",
         descricao="",
         participantes=[coordenador_user],
@@ -158,7 +160,7 @@ def test_enviar_mensagem_reply_to_invalid_channel(admin_user, coordenador_user):
     canal2 = criar_canal(
         criador=admin_user,
         contexto_tipo="privado",
-        contexto_id=None,
+        contexto_id=nucleo.id,
         titulo="Privado2",
         descricao="",
         participantes=[coordenador_user],
@@ -168,11 +170,11 @@ def test_enviar_mensagem_reply_to_invalid_channel(admin_user, coordenador_user):
         enviar_mensagem(canal2, admin_user, "text", conteudo="ola", reply_to=msg1)
 
 
-def test_adicionar_reacao_incrementa_e_limita(admin_user, coordenador_user):
+def test_adicionar_reacao_incrementa_e_limita(admin_user, coordenador_user, nucleo):
     canal = criar_canal(
         criador=admin_user,
         contexto_tipo="privado",
-        contexto_id=None,
+        contexto_id=nucleo.id,
         titulo="Privado",
         descricao="",
         participantes=[coordenador_user],
@@ -186,11 +188,11 @@ def test_adicionar_reacao_incrementa_e_limita(admin_user, coordenador_user):
     assert msg.reaction_counts()["👍"] == 1
 
 
-def test_enviar_mensagem_com_attachment_id(admin_user, coordenador_user):
+def test_enviar_mensagem_com_attachment_id(admin_user, coordenador_user, nucleo):
     canal = criar_canal(
         criador=admin_user,
         contexto_tipo="privado",
-        contexto_id=None,
+        contexto_id=nucleo.id,
         titulo="Privado",
         descricao="",
         participantes=[coordenador_user],

--- a/tests/chat/test_spam_detection.py
+++ b/tests/chat/test_spam_detection.py
@@ -8,11 +8,11 @@ from chat.services import criar_canal, enviar_mensagem
 pytestmark = pytest.mark.django_db
 
 
-def test_repeated_messages_marked_as_spam(admin_user, coordenador_user):
+def test_repeated_messages_marked_as_spam(admin_user, coordenador_user, nucleo):
     canal = criar_canal(
         criador=admin_user,
         contexto_tipo="privado",
-        contexto_id=None,
+        contexto_id=nucleo.id,
         titulo="Privado",
         descricao="",
         participantes=[coordenador_user],
@@ -24,11 +24,11 @@ def test_repeated_messages_marked_as_spam(admin_user, coordenador_user):
     assert ChatModerationLog.objects.filter(message=msg, action="spam").exists()
 
 
-def test_many_links_marked_as_spam(admin_user, coordenador_user):
+def test_many_links_marked_as_spam(admin_user, coordenador_user, nucleo):
     canal = criar_canal(
         criador=admin_user,
         contexto_tipo="privado",
-        contexto_id=None,
+        contexto_id=nucleo.id,
         titulo="Privado",
         descricao="",
         participantes=[coordenador_user],

--- a/tests/chat/test_tasks.py
+++ b/tests/chat/test_tasks.py
@@ -12,11 +12,11 @@ from chat.tasks import exportar_historico_chat, limpar_exports_antigos
 pytestmark = pytest.mark.django_db
 
 
-def test_exportar_historico_chat_gera_arquivo(media_root, admin_user, coordenador_user):
+def test_exportar_historico_chat_gera_arquivo(media_root, admin_user, coordenador_user, nucleo):
     canal = criar_canal(
         criador=admin_user,
         contexto_tipo="privado",
-        contexto_id=None,
+        contexto_id=nucleo.id,
         titulo="Privado",
         descricao="",
         participantes=[coordenador_user],
@@ -35,11 +35,11 @@ def test_exportar_historico_chat_gera_arquivo(media_root, admin_user, coordenado
     assert rel.arquivo_path
 
 
-def test_exportar_historico_chat_com_filtro(media_root, admin_user, coordenador_user):
+def test_exportar_historico_chat_com_filtro(media_root, admin_user, coordenador_user, nucleo):
     canal = criar_canal(
         criador=admin_user,
         contexto_tipo="privado",
-        contexto_id=None,
+        contexto_id=nucleo.id,
         titulo="Privado",
         descricao="",
         participantes=[coordenador_user],
@@ -64,11 +64,11 @@ def test_exportar_historico_chat_com_filtro(media_root, admin_user, coordenador_
     assert len(data) == 1 and data[0]["tipo"] == "image"
 
 
-def test_limpar_exports_antigos_remove_arquivos(media_root, admin_user, coordenador_user):
+def test_limpar_exports_antigos_remove_arquivos(media_root, admin_user, coordenador_user, nucleo):
     canal = criar_canal(
         criador=admin_user,
         contexto_tipo="privado",
-        contexto_id=None,
+        contexto_id=nucleo.id,
         titulo="Privado",
         descricao="",
         participantes=[coordenador_user],

--- a/tests/chat/test_upload_notifications.py
+++ b/tests/chat/test_upload_notifications.py
@@ -11,11 +11,11 @@ pytestmark = pytest.mark.django_db(transaction=True)
 
 
 @pytest.mark.xfail(reason="Pending database issue with soft delete migrations")
-def test_upload_and_notification(admin_user, coordenador_user, client):
+def test_upload_and_notification(admin_user, coordenador_user, client, nucleo):
     canal = criar_canal(
         criador=admin_user,
         contexto_tipo="privado",
-        contexto_id=None,
+        contexto_id=nucleo.id,
         titulo="Privado",
         descricao="",
         participantes=[coordenador_user],

--- a/tests/chat/test_views.py
+++ b/tests/chat/test_views.py
@@ -105,11 +105,11 @@ def test_modal_users_lists_other_users(client, admin_user, coordenador_user):
     assert admin_user not in users
 
 
-def test_modal_room_loads_messages(client, admin_user, coordenador_user):
+def test_modal_room_loads_messages(client, admin_user, coordenador_user, nucleo):
     canal = criar_canal(
         criador=admin_user,
         contexto_tipo="privado",
-        contexto_id=None,
+        contexto_id=nucleo.id,
         titulo="",
         descricao="",
         participantes=[coordenador_user],


### PR DESCRIPTION
## Summary
- ensure _usuario_no_contexto rejects private channels without contexto_id
- require contexto_id for private channels in ChatChannelSerializer
- add tests enforcing contexto_id for private chats

## Testing
- `pytest tests/chat/test_services.py tests/chat/test_api_views.py::test_create_private_channel_requires_context tests/chat/test_api_views.py::test_create_channel_requires_permission tests/chat/test_views.py::test_modal_room_loads_messages tests/chat/test_tasks.py::test_exportar_historico_chat_gera_arquivo tests/chat/test_spam_detection.py::test_repeated_messages_marked_as_spam tests/chat/test_trending.py::test_calcular_trending_topics_endpoint tests/chat/test_consumers.py::test_consumer_connect_send_message_and_reaction --cov-fail-under=0 -q`

------
https://chatgpt.com/codex/tasks/task_e_68a88924fe308325afb0db7d9d190713