### PR TITLE
Log scan failures

### DIFF
--- a/chat/api_views.py
+++ b/chat/api_views.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import mimetypes
 from datetime import timedelta
 from io import BytesIO
+import sentry_sdk
 
 from asgiref.sync import async_to_sync
 from channels.layers import get_channel_layer
@@ -73,7 +74,8 @@ def _scan_file(path: str) -> bool:  # pragma: no cover - depends on external ser
         result = cd.scan(path)
         if result:
             return any(status == "FOUND" for _, (status, _) in result.items())
-    except Exception:
+    except Exception as exc:
+        sentry_sdk.capture_exception(exc)
         return False
     return False
 

--- a/chat/tasks.py
+++ b/chat/tasks.py
@@ -8,6 +8,7 @@ from datetime import timedelta
 from typing import Sequence
 
 from celery import shared_task  # type: ignore
+import sentry_sdk
 from django.contrib.auth import get_user_model
 from django.core.files.base import ContentFile
 from django.core.files.storage import default_storage
@@ -39,7 +40,8 @@ def _scan_file(path: str) -> bool:  # pragma: no cover - depends on external ser
         result = cd.scan(path)
         if result:
             return any(status == "FOUND" for _, (status, _) in result.items())
-    except Exception:
+    except Exception as exc:
+        sentry_sdk.capture_exception(exc)
         return False
     return False
 

--- a/tests/chat/test_tasks.py
+++ b/tests/chat/test_tasks.py
@@ -1,7 +1,10 @@
-import pytest
-
+import importlib
+import sys
 from datetime import timedelta
+from unittest.mock import Mock
+import types
 
+import pytest
 from django.core.files.storage import default_storage
 from django.utils import timezone
 
@@ -10,6 +13,23 @@ from chat.services import criar_canal, enviar_mensagem
 from chat.tasks import exportar_historico_chat, limpar_exports_antigos
 
 pytestmark = pytest.mark.django_db
+
+
+@pytest.mark.parametrize("module_path", ["chat.tasks", "chat.api_views"])
+def test_scan_file_logs_exception(monkeypatch, module_path):
+    class DummySocket:
+        def scan(self, path):  # pragma: no cover - test stub
+            raise RuntimeError("fail")
+
+    dummy_module = types.SimpleNamespace(ClamdNetworkSocket=DummySocket)
+    monkeypatch.setitem(sys.modules, "clamd", dummy_module)
+
+    captured = Mock()
+    monkeypatch.setattr(f"{module_path}.sentry_sdk.capture_exception", captured)
+
+    mod = importlib.import_module(module_path)
+    assert mod._scan_file("/tmp/test") is False
+    assert captured.call_count == 1
 
 
 def test_exportar_historico_chat_gera_arquivo(media_root, admin_user, coordenador_user):


### PR DESCRIPTION
## Summary
- capture and report file scan errors using Sentry in chat views and tasks
- add regression test ensuring scan errors are logged

## Testing
- `pytest tests/chat/test_tasks.py::test_scan_file_logs_exception -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68a8893903bc83258d3a3a155e3fb28e