### PR TITLE
Add rate limiting to notification test endpoint

### DIFF
--- a/Hubx/settings.py
+++ b/Hubx/settings.py
@@ -256,6 +256,7 @@ REST_FRAMEWORK = {
     "DEFAULT_THROTTLE_RATES": {
         "chat_upload": "20/hour",
         "chat_flag": "10/minute",
+        "testar_notificacao": "5/minute",
     },
 }
 

--- a/configuracoes/api.py
+++ b/configuracoes/api.py
@@ -19,6 +19,8 @@ from notificacoes.models import NotificationTemplate, Canal
 from notificacoes.services.notificacoes import enviar_para_usuario
 from notificacoes.services.whatsapp_client import send_whatsapp
 
+from .throttles import TestarNotificacaoThrottle
+
 
 class ConfiguracaoContaViewSet(ViewSet):
     """ViewSet para leitura e atualização das preferências do usuário."""
@@ -122,6 +124,7 @@ class ConfiguracaoContextualViewSet(ModelViewSet):
 
 class TestarNotificacaoView(APIView):
     permission_classes = [IsAuthenticated]
+    throttle_classes = [TestarNotificacaoThrottle]
 
     def post(self, request):
         canal = request.data.get("canal", Canal.EMAIL)

--- a/configuracoes/throttles.py
+++ b/configuracoes/throttles.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from rest_framework.throttling import SimpleRateThrottle
+
+
+class TestarNotificacaoThrottle(SimpleRateThrottle):
+    scope = "testar_notificacao"
+
+    def get_cache_key(self, request, view):  # type: ignore[override]
+        if not request.user or not request.user.is_authenticated:
+            return None
+        return self.cache_format % {"scope": self.scope, "ident": request.user.pk}


### PR DESCRIPTION
## Summary
- add per-user throttle configuration for TestarNotificacaoView
- enforce throttle in TestarNotificacaoView
- test rate limiting behavior of TestarNotificacaoView

## Testing
- `pytest -q -o addopts='' tests/configuracoes/test_contextual.py::test_testar_notificacao_throttling`


------
https://chatgpt.com/codex/tasks/task_e_68a899532da88325a13806a459802844