### PR TITLE
Use dynamic URLs for contextual scope selection

### DIFF
--- a/configuracoes/templates/configuracoes/contextual_form.html
+++ b/configuracoes/templates/configuracoes/contextual_form.html
@@ -6,7 +6,10 @@
 {% block content %}
 <div class="max-w-4xl mx-auto px-4 py-8">
   <h1 class="text-2xl font-bold mb-4">{% trans "Configuração Contextual" %}</h1>
-  <form method="post" class="bg-white p-6 rounded-md shadow space-y-4">
+  <form method="post" class="bg-white p-6 rounded-md shadow space-y-4"
+          data-organizacao-url="{% url 'organizacoes_api:organizacao-list' %}?page_size=100"
+          data-nucleo-url="{% url 'nucleos_api:nucleo-list' %}?page_size=100"
+          data-evento-url="{% url 'agenda_api:evento-list' %}?page_size=100">
     {% csrf_token %}
     {% for field in form %}
       <div>
@@ -34,10 +37,11 @@
   (function () {
     const escopoTipo = document.getElementById('id_escopo_tipo');
     const escopoSelect = document.getElementById('id_escopo_id');
+    const formEl = document.querySelector('form');
     const endpoints = {
-      organizacao: '/api/organizacoes/organizacoes/?page_size=100',
-      nucleo: '/api/nucleos/nucleos/?page_size=100',
-      evento: '/api/agenda/eventos/?page_size=100'
+      organizacao: formEl.dataset.organizacaoUrl,
+      nucleo: formEl.dataset.nucleoUrl,
+      evento: formEl.dataset.eventoUrl
     };
 
     function loadEscopoOptions() {

--- a/tests/e2e/test_configuracoes_escopo_e2e.py
+++ b/tests/e2e/test_configuracoes_escopo_e2e.py
@@ -1,0 +1,43 @@
+import pytest
+from django.urls import reverse
+from rest_framework.test import APIClient
+from playwright.sync_api import sync_playwright
+
+from accounts.factories import UserFactory
+from organizacoes.factories import OrganizacaoFactory
+from nucleos.factories import NucleoFactory
+from agenda.factories import EventoFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def test_contextual_scope_selection(live_server):
+    user = UserFactory(password="pw")
+    organizacao = OrganizacaoFactory(nome="Org Test")
+    nucleo = NucleoFactory(organizacao=organizacao, nome="Nucleo Test")
+    evento = EventoFactory(organizacao=organizacao, nucleo=nucleo, titulo="Evento Test")
+
+    client = APIClient()
+    client.force_login(user)
+    sessionid = client.cookies.get("sessionid").value
+
+    with sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        context = browser.new_context(base_url=live_server.url)
+        context.add_cookies([{"name": "sessionid", "value": sessionid, "url": live_server.url}])
+        page = context.new_page()
+        page.goto(reverse("configuracoes-contextual-create"))
+
+        page.select_option("#id_escopo_tipo", "organizacao")
+        page.wait_for_selector(f"#id_escopo_id option[value='{organizacao.id}']")
+        assert page.locator(f"#id_escopo_id option[value='{organizacao.id}']").inner_text() == organizacao.nome
+
+        page.select_option("#id_escopo_tipo", "nucleo")
+        page.wait_for_selector(f"#id_escopo_id option[value='{nucleo.id}']")
+        assert page.locator(f"#id_escopo_id option[value='{nucleo.id}']").inner_text() == nucleo.nome
+
+        page.select_option("#id_escopo_tipo", "evento")
+        page.wait_for_selector(f"#id_escopo_id option[value='{evento.id}']")
+        assert page.locator(f"#id_escopo_id option[value='{evento.id}']").inner_text() == evento.titulo
+
+        browser.close()


### PR DESCRIPTION
## Summary
- replace hardcoded API endpoints in contextual form with dynamic URLs from data attributes
- load runtime endpoints in JS and add Playwright test ensuring scope selection populates options

## Testing
- `./.venv/bin/python -m pytest tests/e2e/test_configuracoes_escopo_e2e.py::test_contextual_scope_selection -vv -o addopts=""` *(fails: BrowserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium-1140/chrome-linux/chrome)*

------
https://chatgpt.com/codex/tasks/task_e_68a8995bfed483258632423830a96a83