### PR TITLE
Log channel layer errors in configuration signals

### DIFF
--- a/configuracoes/signals.py
+++ b/configuracoes/signals.py
@@ -5,6 +5,7 @@ from django.dispatch import receiver
 from django.core.cache import cache
 from asgiref.sync import async_to_sync
 from channels.layers import get_channel_layer
+import sentry_sdk
 
 from .middleware import get_request_info
 from .models import (
@@ -79,7 +80,7 @@ def log_changes(sender, instance, created, **kwargs):
                 f"configuracoes_{instance.user.id}",
                 {"type": "configuracoes.message", "data": changes},
             )
-        except Exception:
-            pass
+        except Exception as exc:  # pragma: no cover - channels layer failure
+            sentry_sdk.capture_exception(exc)
     if sender is ConfiguracaoConta:
         cache.set(CACHE_KEY.format(id=instance.user_id), instance)

--- a/tests/configuracoes/test_signals.py
+++ b/tests/configuracoes/test_signals.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+
+from configuracoes.models import ConfiguracaoConta
+
+
+@pytest.mark.django_db
+def test_log_changes_channel_error(monkeypatch, admin_user):
+    class DummyLayer:
+        async def group_send(self, *args, **kwargs):
+            raise Exception("boom")
+
+    monkeypatch.setattr("configuracoes.signals.get_channel_layer", lambda: DummyLayer())
+    captured = Mock()
+    monkeypatch.setattr("configuracoes.signals.sentry_sdk.capture_exception", captured)
+
+    config = ConfiguracaoConta.objects.get(user=admin_user)
+    config.idioma = "en-US"
+    config.save()
+
+    assert captured.call_count == 1


### PR DESCRIPTION
## Summary
- capture channel layer errors in configuration signals with Sentry
- test logging when channel layer fails

## Testing
- `pytest tests/configuracoes/test_signals.py::test_log_changes_channel_error --no-cov -q`


------
https://chatgpt.com/codex/tasks/task_e_68a899618dc8832596ec8f866631b344