### PR TITLE
Move preferencias scripts to dedicated static file

### DIFF
--- a/configuracoes/README.md
+++ b/configuracoes/README.md
@@ -87,3 +87,9 @@ Para gerar e compilar as traduções (inglês e espanhol):
 python manage.py makemessages -l en -l es
 python manage.py compilemessages
 ```
+
+## Frontend
+
+A lógica de alternância de campos e atualização de idioma/tema da aba
+**Preferências** está localizada em `static/configuracoes/preferencias.js` e é
+incluída nos templates via tag `{% static %}`.

--- a/configuracoes/templates/configuracoes/partials/preferencias.html
+++ b/configuracoes/templates/configuracoes/partials/preferencias.html
@@ -1,4 +1,4 @@
-{% load widget_tweaks i18n %}
+{% load widget_tweaks i18n static %}
 {% get_current_language as LANGUAGE_CODE %}
 <form method="post" hx-post="{% url 'configuracoes' %}?tab=preferencias" hx-target="#content" class="space-y-4">
   {% csrf_token %}
@@ -135,62 +135,16 @@
   <div class="text-right pt-2">
     <button type="submit" aria-label="{% trans 'Salvar Alterações' %}" class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500">{% trans 'Salvar Alterações' %}</button>
   </div>
+  <div id="preferencias-config"
+       data-chk-email="{{ preferencias_form.receber_notificacoes_email.auto_id }}"
+       data-chk-whats="{{ preferencias_form.receber_notificacoes_whatsapp.auto_id }}"
+       data-chk-push="{{ preferencias_form.receber_notificacoes_push.auto_id }}"
+       data-sel-email="{{ preferencias_form.frequencia_notificacoes_email.auto_id }}"
+       data-sel-whats="{{ preferencias_form.frequencia_notificacoes_whatsapp.auto_id }}"
+       data-sel-push="{{ preferencias_form.frequencia_notificacoes_push.auto_id }}"
+       data-tema="{{ preferencias_form.instance.tema }}"
+       data-idioma="{{ preferencias_form.instance.idioma }}"
+       data-updated-preferences="{{ updated_preferences|yesno:'true,false' }}">
+  </div>
+  <script src="{% static 'configuracoes/preferencias.js' %}"></script>
 </form>
-<script>
-  (function() {
-    const chkEmail = document.getElementById('{{ preferencias_form.receber_notificacoes_email.auto_id }}');
-    const chkWhats = document.getElementById('{{ preferencias_form.receber_notificacoes_whatsapp.auto_id }}');
-    const chkPush = document.getElementById('{{ preferencias_form.receber_notificacoes_push.auto_id }}');
-    const selEmail = document.getElementById('{{ preferencias_form.frequencia_notificacoes_email.auto_id }}');
-    const selWhats = document.getElementById('{{ preferencias_form.frequencia_notificacoes_whatsapp.auto_id }}');
-    const selPush = document.getElementById('{{ preferencias_form.frequencia_notificacoes_push.auto_id }}');
-
-    function toggleFields() {
-      selEmail.disabled = !chkEmail.checked;
-      selEmail.classList.toggle('hidden', !chkEmail.checked);
-      selWhats.disabled = !chkWhats.checked;
-      selWhats.classList.toggle('hidden', !chkWhats.checked);
-      selPush.disabled = !chkPush.checked;
-      selPush.classList.toggle('hidden', !chkPush.checked);
-
-      const freqEmail = chkEmail.checked ? selEmail.value : '';
-      const freqWhats = chkWhats.checked ? selWhats.value : '';
-      const freqPush = chkPush.checked ? selPush.value : '';
-
-      const showDaily = freqEmail === 'diaria' || freqWhats === 'diaria' || freqPush === 'diaria';
-      const showWeekly = freqEmail === 'semanal' || freqWhats === 'semanal' || freqPush === 'semanal';
-      const hasHoraDiariaError = document.querySelector('#campo-hora-diaria [role="alert"]') !== null;
-      const hasHoraSemanalError = document.querySelector('#campo-hora-semanal [role="alert"]') !== null;
-      const hasDiaSemanalError = document.querySelector('#campo-dia-semanal [role="alert"]') !== null;
-
-      document.getElementById('campo-hora-diaria').classList.toggle('hidden', !(showDaily || hasHoraDiariaError));
-      document.getElementById('campo-hora-semanal').classList.toggle('hidden', !(showWeekly || hasHoraSemanalError));
-      document.getElementById('campo-dia-semanal').classList.toggle('hidden', !(showWeekly || hasDiaSemanalError));
-    }
-
-    selEmail.addEventListener('change', toggleFields);
-    selWhats.addEventListener('change', toggleFields);
-    selPush.addEventListener('change', toggleFields);
-    chkEmail.addEventListener('change', toggleFields);
-    chkWhats.addEventListener('change', toggleFields);
-    chkPush.addEventListener('change', toggleFields);
-
-    toggleFields();
-  })();
-</script>
-{% if updated_preferences %}
-<script>
-  (function () {
-    const tema = "{{ preferencias_form.instance.tema }}";
-    const idioma = "{{ preferencias_form.instance.idioma }}";
-    localStorage.setItem('tema', tema);
-    document.cookie = `tema=${tema};path=/`;
-    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-    const theme = tema === 'automatico' ? (prefersDark ? 'escuro' : 'claro') : tema;
-    document.documentElement.classList.toggle('dark', theme === 'escuro');
-    localStorage.setItem('idioma', idioma);
-    document.cookie = `django_language=${idioma};path=/`;
-    document.documentElement.setAttribute('lang', idioma);
-  })();
-</script>
-{% endif %}

--- a/static/configuracoes/preferencias.js
+++ b/static/configuracoes/preferencias.js
@@ -1,0 +1,99 @@
+// Logic for preferencias toggle fields and theme/language updates
+
+function initPreferencias() {
+  const configEl = document.getElementById('preferencias-config');
+  if (!configEl) return;
+
+  const {
+    chkEmail,
+    chkWhats,
+    chkPush,
+    selEmail,
+    selWhats,
+    selPush,
+    tema,
+    idioma,
+    updatedPreferences,
+  } = configEl.dataset;
+
+  const chkEmailEl = document.getElementById(chkEmail);
+  const chkWhatsEl = document.getElementById(chkWhats);
+  const chkPushEl = document.getElementById(chkPush);
+  const selEmailEl = document.getElementById(selEmail);
+  const selWhatsEl = document.getElementById(selWhats);
+  const selPushEl = document.getElementById(selPush);
+
+  if (!chkEmailEl || !chkWhatsEl || !chkPushEl || !selEmailEl || !selWhatsEl || !selPushEl) {
+    return;
+  }
+
+  function toggleFields() {
+    selEmailEl.disabled = !chkEmailEl.checked;
+    selEmailEl.classList.toggle('hidden', !chkEmailEl.checked);
+    selWhatsEl.disabled = !chkWhatsEl.checked;
+    selWhatsEl.classList.toggle('hidden', !chkWhatsEl.checked);
+    selPushEl.disabled = !chkPushEl.checked;
+    selPushEl.classList.toggle('hidden', !chkPushEl.checked);
+
+    const freqEmail = chkEmailEl.checked ? selEmailEl.value : '';
+    const freqWhats = chkWhatsEl.checked ? selWhatsEl.value : '';
+    const freqPush = chkPushEl.checked ? selPushEl.value : '';
+
+    const showDaily =
+      freqEmail === 'diaria' ||
+      freqWhats === 'diaria' ||
+      freqPush === 'diaria';
+    const showWeekly =
+      freqEmail === 'semanal' ||
+      freqWhats === 'semanal' ||
+      freqPush === 'semanal';
+
+    const hasHoraDiariaError = document.querySelector('#campo-hora-diaria [role="alert"]') !== null;
+    const hasHoraSemanalError = document.querySelector('#campo-hora-semanal [role="alert"]') !== null;
+    const hasDiaSemanalError = document.querySelector('#campo-dia-semanal [role="alert"]') !== null;
+
+    document
+      .getElementById('campo-hora-diaria')
+      .classList.toggle('hidden', !(showDaily || hasHoraDiariaError));
+    document
+      .getElementById('campo-hora-semanal')
+      .classList.toggle('hidden', !(showWeekly || hasHoraSemanalError));
+    document
+      .getElementById('campo-dia-semanal')
+      .classList.toggle('hidden', !(showWeekly || hasDiaSemanalError));
+  }
+
+  selEmailEl.addEventListener('change', toggleFields);
+  selWhatsEl.addEventListener('change', toggleFields);
+  selPushEl.addEventListener('change', toggleFields);
+  chkEmailEl.addEventListener('change', toggleFields);
+  chkWhatsEl.addEventListener('change', toggleFields);
+  chkPushEl.addEventListener('change', toggleFields);
+
+  toggleFields();
+
+  if (updatedPreferences === 'true') {
+    const temaValue = tema;
+    const idiomaValue = idioma;
+    localStorage.setItem('tema', temaValue);
+    document.cookie = `tema=${temaValue};path=/`;
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const theme =
+      temaValue === 'automatico'
+        ? prefersDark
+          ? 'escuro'
+          : 'claro'
+        : temaValue;
+    document.documentElement.classList.toggle('dark', theme === 'escuro');
+    localStorage.setItem('idioma', idiomaValue);
+    document.cookie = `django_language=${idiomaValue};path=/`;
+    document.documentElement.setAttribute('lang', idiomaValue);
+  }
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initPreferencias);
+} else {
+  initPreferencias();
+}
+


### PR DESCRIPTION
## Summary
- Extract toggleFields and theme/language update logic into `static/configuracoes/preferencias.js`
- Reference the new script from preferencias template via `{% static %}`
- Document the new script location in `configuracoes/README.md`

## Testing
- `pytest tests/configuracoes -q` *(fails: No module named 'django_redis')*

------
https://chatgpt.com/codex/tasks/task_e_68a899663aa88325a53aa6446b565efa