### PR TITLE
Add WeasyPrint dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -146,6 +146,7 @@ vine==5.1.0
 virtualenv==20.31.2
 watchfiles==1.1.0
 wcwidth==0.2.13
+weasyprint==66.0
 webencodings==0.5.1
 websockets==15.0.1
 zope.interface==7.2


### PR DESCRIPTION
## Summary
- include WeasyPrint with pinned version in requirements

## Testing
- `pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_68a8a172eb6c8325920708b124fdb92f