### PR TITLE
Validate dashboard exported image path

### DIFF
--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -558,8 +558,12 @@ class DashboardExportedImageView(LoginRequiredMixin, View):
     def get(self, request, filename: str):
         if request.user.user_type not in {UserType.ROOT, UserType.ADMIN, UserType.COORDENADOR}:
             return HttpResponse(status=403)
-        path = EXPORT_DIR / filename
-        if not path.exists():
+        try:
+            path = (EXPORT_DIR / filename).resolve(strict=True)
+            path.relative_to(EXPORT_DIR.resolve())
+        except (FileNotFoundError, ValueError):
+            return HttpResponse(status=404)
+        if not path.is_file():
             return HttpResponse(status=404)
         return FileResponse(open(path, "rb"), content_type="image/png")
 


### PR DESCRIPTION
## Summary
- ensure exported image path stays inside export directory

## Testing
- `pytest --no-cov tests/dashboard/test_views.py::test_export_view_png -q`

------
https://chatgpt.com/codex/tasks/task_e_68a8a175984c83259ccf858af3bd675b