### PR TITLE
feat: versioned cache keys

### DIFF
--- a/core/cache.py
+++ b/core/cache.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from django.core.cache import cache
+
+
+def get_cache_version(namespace: str) -> int:
+    """Return the current cache version for the given namespace."""
+    key = f"cache_version:{namespace}"
+    cache.add(key, 1)
+    return int(cache.get(key) or 1)
+
+
+def bump_cache_version(namespace: str) -> None:
+    """Increment the cache version for the given namespace."""
+    key = f"cache_version:{namespace}"
+    try:
+        cache.incr(key)
+    except ValueError:
+        cache.set(key, 2)

--- a/feed/signals.py
+++ b/feed/signals.py
@@ -5,6 +5,8 @@ from django.core.cache import cache
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 
+from core.cache import bump_cache_version
+
 from .models import Comment, Post, Reacao
 from .tasks import notificar_autor_sobre_interacao
 
@@ -29,5 +31,5 @@ def notificar_comment(sender, instance, created, **kwargs):
 
 @receiver([post_save, post_delete], sender=Post)
 def limpar_cache_feed(**_kwargs) -> None:
-    """Remove entradas de cache após alterações em posts."""
-    cache.clear()
+    """Atualiza a versão do cache do feed após alterações em posts."""
+    bump_cache_version("feed_list")

--- a/nucleos/signals.py
+++ b/nucleos/signals.py
@@ -1,28 +1,23 @@
 from __future__ import annotations
 
-from django.core.cache import cache
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 
-from .models import CoordenadorSuplente, ParticipacaoNucleo
+from core.cache import bump_cache_version
 from financeiro import atualizar_cobranca
 
-
-def _delete_pattern(pattern: str) -> None:
-    if hasattr(cache, "delete_pattern"):
-        cache.delete_pattern(pattern)
-    else:  # pragma: no cover - backend sem suporte
-        cache.clear()
+from .models import CoordenadorSuplente, ParticipacaoNucleo
 
 
 @receiver([post_save, post_delete], sender=ParticipacaoNucleo)
 def invalidate_participacao(sender, instance, **kwargs):
     nucleo_id = instance.nucleo_id
     org_id = instance.nucleo.organizacao_id
-    _delete_pattern(f"nucleo_{nucleo_id}_membros*")
-    _delete_pattern(f"nucleo_{nucleo_id}_metrics*")
-    _delete_pattern(f"nucleos_list_{org_id}*")
-    _delete_pattern(f"org_{org_id}_taxa_participacao")
+    bump_cache_version("nucleos_list")
+    bump_cache_version("nucleos_meus")
+    bump_cache_version(f"nucleo_{nucleo_id}_membros")
+    bump_cache_version(f"nucleo_{nucleo_id}_metrics")
+    bump_cache_version(f"nucleos_list_{org_id}")
 
 
 @receiver(post_save, sender=ParticipacaoNucleo)
@@ -35,6 +30,8 @@ def sync_financeiro(sender, instance, **kwargs):
 def invalidate_suplente(sender, instance, **kwargs):
     nucleo_id = instance.nucleo_id
     org_id = instance.nucleo.organizacao_id
-    _delete_pattern(f"nucleo_{nucleo_id}_membros*")
-    _delete_pattern(f"nucleo_{nucleo_id}_metrics*")
-    _delete_pattern(f"nucleos_list_{org_id}*")
+    bump_cache_version("nucleos_list")
+    bump_cache_version("nucleos_meus")
+    bump_cache_version(f"nucleo_{nucleo_id}_membros")
+    bump_cache_version(f"nucleo_{nucleo_id}_metrics")
+    bump_cache_version(f"nucleos_list_{org_id}")

--- a/nucleos/views.py
+++ b/nucleos/views.py
@@ -23,14 +23,10 @@ from django.views.generic import (
 )
 
 from accounts.models import UserType
+from core.cache import get_cache_version
 from core.permissions import AdminRequiredMixin, GerenteRequiredMixin
 
-from .forms import (
-    NucleoForm,
-    NucleoSearchForm,
-    ParticipacaoDecisaoForm,
-    SuplenteForm,
-)
+from .forms import NucleoForm, NucleoSearchForm, ParticipacaoDecisaoForm, SuplenteForm
 from .models import CoordenadorSuplente, Nucleo, ParticipacaoNucleo
 from .services import gerar_convite_nucleo
 from .tasks import (
@@ -52,7 +48,8 @@ class NucleoListView(LoginRequiredMixin, ListView):
     def get_queryset(self):
         user = self.request.user
         q = self.request.GET.get("q", "")
-        cache_key = f"nucleos_list:{user.id}:{q}"
+        version = get_cache_version("nucleos_list")
+        cache_key = f"nucleos_list:v{version}:{user.id}:{q}"
         cached = cache.get(cache_key)
         if cached is not None:
             return cached
@@ -99,7 +96,8 @@ class NucleoMeusView(LoginRequiredMixin, ListView):
     def get_queryset(self):
         user = self.request.user
         q = self.request.GET.get("q", "")
-        cache_key = f"nucleos_meus:{user.id}:{q}"
+        version = get_cache_version("nucleos_meus")
+        cache_key = f"nucleos_meus:v{version}:{user.id}:{q}"
         cached = cache.get(cache_key)
         if cached is not None:
             return cached
@@ -315,6 +313,7 @@ class MembroRemoveView(GerenteRequiredMixin, LoginRequiredMixin, View):
             return HttpResponse("")
         messages.success(request, _("Membro removido do núcleo."))
         return redirect("nucleos:detail", pk=pk)
+
 
 class MembroPromoverView(GerenteRequiredMixin, LoginRequiredMixin, View):
     def post(self, request, pk, participacao_id):

--- a/organizacoes/api.py
+++ b/organizacoes/api.py
@@ -1,21 +1,23 @@
 from __future__ import annotations
 
 from django.contrib.auth import get_user_model
+from django.core.cache import cache
 from django.db.models import Q
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
-from django.core.cache import cache
-from sentry_sdk import capture_exception
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
+from sentry_sdk import capture_exception
 
 from accounts.models import UserType
 from accounts.serializers import UserSerializer
 from agenda.models import Evento
 from agenda.serializers import EventoSerializer
+from core.cache import get_cache_version
+from core.permissions import IsOrgAdminOrSuperuser, IsRoot
 from empresas.models import Empresa
 from empresas.serializers import EmpresaSerializer
 from feed.api import PostSerializer
@@ -25,8 +27,7 @@ from financeiro.serializers import CentroCustoSerializer
 from nucleos.models import Nucleo
 from nucleos.serializers import NucleoSerializer
 
-from core.permissions import IsOrgAdminOrSuperuser, IsRoot
-
+from .metrics import detail_latency_seconds, list_latency_seconds
 from .models import (
     Organizacao,
     OrganizacaoAtividadeLog,
@@ -41,7 +42,6 @@ from .serializers import (
     OrganizacaoSerializer,
 )
 from .tasks import organizacao_alterada
-from .metrics import list_latency_seconds, detail_latency_seconds
 
 
 class OrganizacaoViewSet(viewsets.ModelViewSet):
@@ -51,12 +51,7 @@ class OrganizacaoViewSet(viewsets.ModelViewSet):
     cache_timeout = 60
 
     def get_queryset(self):
-        qs = (
-            super()
-            .get_queryset()
-            .select_related("created_by")
-            .prefetch_related("users")
-        )
+        qs = super().get_queryset().select_related("created_by").prefetch_related("users")
         user = self.request.user
         if (
             user.is_superuser
@@ -120,6 +115,7 @@ class OrganizacaoViewSet(viewsets.ModelViewSet):
 
     def _cache_key(self, request) -> str:
         params = request.query_params
+        version = get_cache_version("organizacoes_list")
         keys = [
             str(getattr(request.user, "pk", "")),
             params.get("search", ""),
@@ -131,7 +127,7 @@ class OrganizacaoViewSet(viewsets.ModelViewSet):
             params.get("page", ""),
             params.get("page_size", ""),
         ]
-        return "organizacoes_list_" + "_".join(keys)
+        return f"organizacoes_list_v{version}_" + "_".join(keys)
 
     def list(self, request, *args, **kwargs):  # type: ignore[override]
         with list_latency_seconds.time():
@@ -207,9 +203,7 @@ class OrganizacaoViewSet(viewsets.ModelViewSet):
                 usuario=request.user,
                 acao="inactivated",
             )
-            organizacao_alterada.send(
-                sender=self.__class__, organizacao=organizacao, acao="inactivated"
-            )
+            organizacao_alterada.send(sender=self.__class__, organizacao=organizacao, acao="inactivated")
             serializer = self.get_serializer(organizacao)
             return Response(serializer.data)
         except Exception as e:  # pragma: no cover - auditing
@@ -229,9 +223,7 @@ class OrganizacaoViewSet(viewsets.ModelViewSet):
                 usuario=request.user,
                 acao="reactivated",
             )
-            organizacao_alterada.send(
-                sender=self.__class__, organizacao=organizacao, acao="reactivated"
-            )
+            organizacao_alterada.send(sender=self.__class__, organizacao=organizacao, acao="reactivated")
             serializer = self.get_serializer(organizacao)
             return Response(serializer.data)
         except Exception as e:  # pragma: no cover - auditing
@@ -248,17 +240,10 @@ class OrganizacaoViewSet(viewsets.ModelViewSet):
                 from django.http import HttpResponse
 
                 response = HttpResponse(content_type="text/csv")
-                response[
-                    "Content-Disposition"
-                ] = f'attachment; filename="organizacao_{organizacao.pk}_logs.csv"'
+                response["Content-Disposition"] = f'attachment; filename="organizacao_{organizacao.pk}_logs.csv"'
                 writer = csv.writer(response)
-                writer.writerow(
-                    ["tipo", "campo/acao", "valor_antigo", "valor_novo", "usuario", "data"]
-                )
-                for log in (
-                    OrganizacaoChangeLog.all_objects.filter(organizacao=organizacao)
-                    .order_by("-created_at")
-                ):
+                writer.writerow(["tipo", "campo/acao", "valor_antigo", "valor_novo", "usuario", "data"])
+                for log in OrganizacaoChangeLog.all_objects.filter(organizacao=organizacao).order_by("-created_at"):
                     writer.writerow(
                         [
                             "change",
@@ -269,10 +254,7 @@ class OrganizacaoViewSet(viewsets.ModelViewSet):
                             log.created_at.isoformat(),
                         ]
                     )
-                for log in (
-                    OrganizacaoAtividadeLog.all_objects.filter(organizacao=organizacao)
-                    .order_by("-created_at")
-                ):
+                for log in OrganizacaoAtividadeLog.all_objects.filter(organizacao=organizacao).order_by("-created_at"):
                     writer.writerow(
                         [
                             "activity",
@@ -284,14 +266,10 @@ class OrganizacaoViewSet(viewsets.ModelViewSet):
                         ]
                     )
                 return response
-            change_logs = (
-                OrganizacaoChangeLog.all_objects.filter(organizacao=organizacao)
-                .order_by("-created_at")[:10]
-            )
-            atividade_logs = (
-                OrganizacaoAtividadeLog.all_objects.filter(organizacao=organizacao)
-                .order_by("-created_at")[:10]
-            )
+            change_logs = OrganizacaoChangeLog.all_objects.filter(organizacao=organizacao).order_by("-created_at")[:10]
+            atividade_logs = OrganizacaoAtividadeLog.all_objects.filter(organizacao=organizacao).order_by(
+                "-created_at"
+            )[:10]
             change_ser = OrganizacaoChangeLogSerializer(change_logs, many=True)
             atividade_ser = OrganizacaoAtividadeLogSerializer(atividade_logs, many=True)
             return Response({"changes": change_ser.data, "activities": atividade_ser.data})
@@ -339,9 +317,7 @@ class OrganizacaoUserViewSet(OrganizacaoRelatedModelViewSet):
         search = request.query_params.get("search")
         if search:
             qs = qs.filter(
-                Q(first_name__icontains=search)
-                | Q(last_name__icontains=search)
-                | Q(username__icontains=search)
+                Q(first_name__icontains=search) | Q(last_name__icontains=search) | Q(username__icontains=search)
             )
         page = self.paginate_queryset(qs)
         if page is not None:

--- a/organizacoes/signals.py
+++ b/organizacoes/signals.py
@@ -1,19 +1,12 @@
-from django.core.cache import cache
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 
+from core.cache import bump_cache_version
+
 from .models import Organizacao
-
-
-def _delete_pattern(pattern: str) -> None:
-    if hasattr(cache, "delete_pattern"):
-        cache.delete_pattern(pattern)  # type: ignore[attr-defined]
-    else:  # pragma: no cover - backend sem suporte
-        cache.clear()
 
 
 @receiver([post_save, post_delete], sender=Organizacao)
 def invalidate_organizacao_list_cache(**_kwargs) -> None:
     """Limpa cache da listagem de organizações após alterações."""
-    _delete_pattern("organizacoes_list_*")
-
+    bump_cache_version("organizacoes_list")


### PR DESCRIPTION
## Summary
- add utilities to manage versioned cache keys
- replace cache clears with version bumps
- include cache versions in list view and API keys

## Testing
- `ruff format feed/api.py feed/signals.py feed/views.py nucleos/api.py nucleos/signals.py nucleos/views.py organizacoes/api.py organizacoes/signals.py organizacoes/views.py core/cache.py`
- `isort feed/api.py feed/signals.py feed/views.py nucleos/api.py nucleos/signals.py nucleos/views.py organizacoes/api.py organizacoes/signals.py organizacoes/views.py core/cache.py`
- `black feed/api.py feed/signals.py feed/views.py nucleos/api.py nucleos/signals.py nucleos/views.py organizacoes/api.py organizacoes/signals.py organizacoes/views.py core/cache.py`
- `ruff check feed/api.py feed/signals.py feed/views.py nucleos/api.py nucleos/signals.py nucleos/views.py organizacoes/api.py organizacoes/signals.py organizacoes/views.py core/cache.py`
- `pytest -m "not slow"` (fails: tests/configuracoes/test_accessibility.py, tests/dashboard/test_notifications_htmx.py, tests/dashboard/test_views.py, tests/e2e/test_configuracoes_escopo_e2e.py, tests/e2e/test_notificacoes_e2e.py, tests/e2e/test_pwa_offline.py, tests/feed/test_services.py, tests/notificacoes/test_clients.py, tests/notificacoes/test_push_sender.py, tests/test_i18n_templates.py, tests/tokens/test_metrics.py)
- `bandit -r . --exclude .venv,migrations,static`

------
https://chatgpt.com/codex/tasks/task_e_68a8ba7b28a8832580f75631bfd1fee0