### PR TITLE
refactor: consolidate organization filters

### DIFF
--- a/organizacoes/api.py
+++ b/organizacoes/api.py
@@ -77,39 +77,36 @@ class OrganizacaoViewSet(viewsets.ModelViewSet):
             raise e
 
         params = self.request.query_params
-        search = params.get("search")
-        tipo = params.get("tipo")
-        cidade = params.get("cidade")
-        estado = params.get("estado")
-        inativa = params.get("inativa")
-        if inativa is not None:
-            qs = qs.filter(inativa=inativa.lower() == "true")
 
-        search = self.request.query_params.get("search")
-        if search:
-            qs = qs.filter(Q(nome__icontains=search) | Q(slug__icontains=search))
-        inativa = self.request.query_params.get("inativa")
-        if inativa not in (None, ""):
-            value = inativa.lower()
+        action = getattr(self, "action", "")
+
+        def _filter_inativa(queryset, value):
             truthy = {"1", "true", "t", "yes"}
             falsy = {"0", "false", "f", "no"}
-            if value in truthy:
-                qs = qs.filter(inativa=True)
-            elif value in falsy:
-                qs = qs.filter(inativa=False)
-            else:
-                qs = qs.filter(inativa=False)
+            if value not in (None, ""):
+                v = value.lower()
+                if v in truthy:
+                    return queryset.filter(inativa=True)
+                if v in falsy:
+                    return queryset.filter(inativa=False)
+            if action == "list":
+                return queryset.filter(inativa=False)
+            return queryset
 
-        else:
-            qs = qs.filter(inativa=False)
-        if search:
-            qs = qs.filter(Q(nome__icontains=search) | Q(slug__icontains=search))
-        if tipo:
-            qs = qs.filter(tipo=tipo)
-        if cidade:
-            qs = qs.filter(cidade=cidade)
-        if estado:
-            qs = qs.filter(estado=estado)
+        filters = {
+            "search": lambda q, v: q.filter(
+                Q(nome__icontains=v) | Q(slug__icontains=v)
+            ),
+            "tipo": lambda q, v: q.filter(tipo=v),
+            "cidade": lambda q, v: q.filter(cidade=v),
+            "estado": lambda q, v: q.filter(estado=v),
+            "inativa": _filter_inativa,
+        }
+
+        for key, func in filters.items():
+            value = params.get(key)
+            if value not in (None, "") or key == "inativa":
+                qs = func(qs, value)
         ordering = params.get("ordering")
         allowed = {"nome", "tipo", "cidade", "estado", "created_at"}
         if ordering and ordering.lstrip("-") in allowed:

--- a/tests/organizacoes/test_api.py
+++ b/tests/organizacoes/test_api.py
@@ -223,6 +223,47 @@ def test_filter_tipo_cidade_estado(api_client, root_user, faker_ptbr):
     assert str(o1.id) in ids and str(o2.id) not in ids
 
 
+def test_combined_filters(api_client, root_user, faker_ptbr):
+    auth(api_client, root_user)
+    o1 = Organizacao.objects.create(
+        nome="Org1",
+        cnpj=faker_ptbr.cnpj(),
+        slug="org1",
+        tipo="ong",
+        cidade="Cidade1",
+        estado="SP",
+    )
+    o2 = Organizacao.objects.create(
+        nome="Org2",
+        cnpj=faker_ptbr.cnpj(),
+        slug="org2",
+        tipo="ong",
+        cidade="Cidade1",
+        estado="SP",
+        inativa=True,
+    )
+    Organizacao.objects.create(
+        nome="Org3",
+        cnpj=faker_ptbr.cnpj(),
+        slug="org3",
+        tipo="empresa",
+        cidade="Cidade2",
+        estado="RJ",
+    )
+    url = reverse("organizacoes_api:organizacao-list")
+    resp = api_client.get(
+        url
+        + "?search=org2&tipo=ong&cidade=Cidade1&estado=SP&inativa=yes"
+    )
+    ids = [o["id"] for o in resp.data]
+    assert ids == [str(o2.id)]
+    resp = api_client.get(
+        url + "?search=org1&tipo=ong&cidade=Cidade1&estado=SP"
+    )
+    ids = [o["id"] for o in resp.data]
+    assert ids == [str(o1.id)]
+
+
 def test_invalid_cnpj_api(api_client, root_user):
     auth(api_client, root_user)
     url = reverse("organizacoes_api:organizacao-list")


### PR DESCRIPTION
## Summary
- centralize organization list filters into a single mapping
- regression test for combined API filters

## Testing
- `pytest --no-cov tests/organizacoes/test_api.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8ba769c0483259346f18dd4b72bff