### PR TITLE
Log token validation errors

### DIFF
--- a/tests/tokens/test_validate_token_logs.py
+++ b/tests/tokens/test_validate_token_logs.py
@@ -1,0 +1,72 @@
+import pytest
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from accounts.factories import UserFactory
+from tokens.factories import TokenAcessoFactory
+from tokens.models import TokenAcesso, TokenUsoLog
+
+pytestmark = [pytest.mark.django_db, pytest.mark.urls("tests.urls_tokens")]
+
+
+def _validate(client, code, ip="1.1.1.1", ua="test-agent"):
+    url = reverse("tokens_api:token-validate") + f"?codigo={code}"
+    return client.get(url, REMOTE_ADDR=ip, HTTP_USER_AGENT=ua)
+
+
+def _setup_client(user=None):
+    client = APIClient()
+    if user is None:
+        user = UserFactory()
+    client.force_authenticate(user=user)
+    return client
+
+
+def test_log_on_invalid_code():
+    client = _setup_client()
+    invalid_code = TokenAcesso.generate_code()
+    resp = _validate(client, invalid_code)
+    assert resp.status_code == 404
+    log = TokenUsoLog.objects.get()
+    assert log.acao == TokenUsoLog.Acao.VALIDACAO
+    assert log.token is None
+    assert log.ip == "1.1.1.1"
+    assert log.user_agent == "test-agent"
+
+
+def test_log_on_revoked_token():
+    token = TokenAcessoFactory(estado=TokenAcesso.Estado.REVOGADO)
+    client = _setup_client()
+    resp = _validate(client, token.codigo)
+    assert resp.status_code == 409
+    log = TokenUsoLog.objects.get()
+    assert log.token == token
+    assert log.acao == TokenUsoLog.Acao.VALIDACAO
+    assert log.ip == "1.1.1.1"
+    assert log.user_agent == "test-agent"
+
+
+def test_log_on_invalid_state_token():
+    token = TokenAcessoFactory(estado=TokenAcesso.Estado.USADO)
+    client = _setup_client()
+    resp = _validate(client, token.codigo)
+    assert resp.status_code == 409
+    log = TokenUsoLog.objects.get()
+    assert log.token == token
+    assert log.acao == TokenUsoLog.Acao.VALIDACAO
+
+
+def test_log_on_expired_token():
+    token = TokenAcessoFactory(
+        estado=TokenAcesso.Estado.NOVO,
+        data_expiracao=timezone.now() - timezone.timedelta(days=1),
+    )
+    client = _setup_client()
+    resp = _validate(client, token.codigo)
+    assert resp.status_code == 409
+    token.refresh_from_db()
+    assert token.estado == TokenAcesso.Estado.EXPIRADO
+    log = TokenUsoLog.objects.get()
+    assert log.token == token
+    assert log.acao == TokenUsoLog.Acao.VALIDACAO

--- a/tests/urls_tokens.py
+++ b/tests/urls_tokens.py
@@ -1,0 +1,5 @@
+from django.urls import include, path
+
+urlpatterns = [
+    path("api/tokens/", include(("tokens.api_urls", "tokens_api"), namespace="tokens_api")),
+]

--- a/tokens/migrations/0013_alter_tokenusolog_token.py
+++ b/tokens/migrations/0013_alter_tokenusolog_token.py
@@ -1,0 +1,22 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("tokens", "0012_merge_20250821_1829"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="tokenusolog",
+            name="token",
+            field=models.ForeignKey(
+                to="tokens.tokenacesso",
+                on_delete=models.CASCADE,
+                related_name="logs",
+                null=True,
+                blank=True,
+            ),
+        ),
+    ]

--- a/tokens/models.py
+++ b/tokens/models.py
@@ -222,6 +222,8 @@ class TokenUsoLog(TimeStampedModel, SoftDeleteModel):
         TokenAcesso,
         on_delete=models.CASCADE,
         related_name="logs",
+        null=True,
+        blank=True,
     )
     usuario = models.ForeignKey(
         get_user_model(),


### PR DESCRIPTION
## Summary
- log token validation errors with IP and user-agent
- allow TokenUsoLog without associated token
- test validation logging for invalid, revoked, used and expired tokens

## Testing
- `ruff check tokens/api.py tokens/models.py tokens/migrations/0013_alter_tokenusolog_token.py tests/tokens/test_validate_token_logs.py`
- `pytest --no-cov tests/tokens/test_validate_token_logs.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8d8452ef083259c6404418db98e41