### PR TITLE
Fix message styling conditional in registration templates

### DIFF
--- a/accounts/templates/register/cpf.html
+++ b/accounts/templates/register/cpf.html
@@ -27,7 +27,7 @@
     {% if messages %}
     <div class="mb-4 space-y-2">
       {% for message in messages %}
-        <p class="rounded-xl px-4 py-2 text-sm {{ message.tags == 'success'|yesno:'bg-green-100 text-green-700,bg-red-100 text-red-700' }}">{{ message }}</p>
+        <p class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-green-100 text-green-700{% else %}bg-red-100 text-red-700{% endif %}">{{ message }}</p>
       {% endfor %}
     </div>
     {% endif %}

--- a/accounts/templates/register/email.html
+++ b/accounts/templates/register/email.html
@@ -27,7 +27,7 @@
     {% if messages %}
     <div class="mb-4 space-y-2">
       {% for message in messages %}
-        <p class="rounded-xl px-4 py-2 text-sm {{ message.tags == 'success'|yesno:'bg-green-100 text-green-700,bg-red-100 text-red-700' }}">{{ message }}</p>
+        <p class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-green-100 text-green-700{% else %}bg-red-100 text-red-700{% endif %}">{{ message }}</p>
       {% endfor %}
     </div>
     {% endif %}

--- a/accounts/templates/register/foto.html
+++ b/accounts/templates/register/foto.html
@@ -27,7 +27,7 @@
     {% if messages %}
     <div class="mb-4 space-y-2">
       {% for message in messages %}
-        <p class="rounded-xl px-4 py-2 text-sm {{ message.tags == 'success'|yesno:'bg-green-100 text-green-700,bg-red-100 text-red-700' }}">{{ message }}</p>
+        <p class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-green-100 text-green-700{% else %}bg-red-100 text-red-700{% endif %}">{{ message }}</p>
       {% endfor %}
     </div>
     {% endif %}

--- a/accounts/templates/register/nome.html
+++ b/accounts/templates/register/nome.html
@@ -27,7 +27,7 @@
     {% if messages %}
     <div class="mb-4 space-y-2">
       {% for message in messages %}
-        <p class="rounded-xl px-4 py-2 text-sm {{ message.tags == 'success'|yesno:'bg-green-100 text-green-700,bg-red-100 text-red-700' }}">{{ message }}</p>
+        <p class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-green-100 text-green-700{% else %}bg-red-100 text-red-700{% endif %}">{{ message }}</p>
       {% endfor %}
     </div>
     {% endif %}

--- a/accounts/templates/register/onboarding.html
+++ b/accounts/templates/register/onboarding.html
@@ -26,7 +26,7 @@
         {% if messages %}
         <div class="mb-4 space-y-2">
             {% for message in messages %}
-            <p class="rounded-xl px-4 py-2 text-sm {{ message.tags == 'success'|yesno:'bg-green-100 text-green-700,bg-red-100 text-red-700' }}">{{ message }}</p>
+            <p class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-green-100 text-green-700{% else %}bg-red-100 text-red-700{% endif %}">{{ message }}</p>
             {% endfor %}
         </div>
         {% endif %}

--- a/accounts/templates/register/registro_sucesso.html
+++ b/accounts/templates/register/registro_sucesso.html
@@ -9,7 +9,7 @@
     {% if messages %}
     <div class="mb-4 space-y-2">
       {% for message in messages %}
-        <p class="rounded-xl px-4 py-2 text-sm {{ message.tags == 'success'|yesno:'bg-green-100 text-green-700,bg-red-100 text-red-700' }}">{{ message }}</p>
+        <p class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-green-100 text-green-700{% else %}bg-red-100 text-red-700{% endif %}">{{ message }}</p>
       {% endfor %}
     </div>
     {% endif %}

--- a/accounts/templates/register/senha.html
+++ b/accounts/templates/register/senha.html
@@ -27,7 +27,7 @@
     {% if messages %}
     <div class="mb-4 space-y-2">
       {% for message in messages %}
-        <p class="rounded-xl px-4 py-2 text-sm {{ message.tags == 'success'|yesno:'bg-green-100 text-green-700,bg-red-100 text-red-700' }}">{{ message }}</p>
+        <p class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-green-100 text-green-700{% else %}bg-red-100 text-red-700{% endif %}">{{ message }}</p>
       {% endfor %}
     </div>
     {% endif %}

--- a/accounts/templates/register/termos.html
+++ b/accounts/templates/register/termos.html
@@ -27,7 +27,7 @@
     {% if messages %}
     <div class="mb-4 space-y-2">
       {% for message in messages %}
-        <p class="rounded-xl px-4 py-2 text-sm {{ message.tags == 'success'|yesno:'bg-green-100 text-green-700,bg-red-100 text-red-700' }}">{{ message }}</p>
+        <p class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-green-100 text-green-700{% else %}bg-red-100 text-red-700{% endif %}">{{ message }}</p>
       {% endfor %}
     </div>
     {% endif %}

--- a/accounts/templates/register/token.html
+++ b/accounts/templates/register/token.html
@@ -34,7 +34,7 @@
     {% if messages %}
     <div class="mb-4 space-y-2">
       {% for message in messages %}
-        <p class="rounded-xl px-4 py-2 text-sm {{ message.tags == 'success'|yesno:'bg-green-100 text-green-700,bg-red-100 text-red-700' }}">{{ message }}</p>
+        <p class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-green-100 text-green-700{% else %}bg-red-100 text-red-700{% endif %}">{{ message }}</p>
       {% endfor %}
     </div>
     {% endif %}


### PR DESCRIPTION
## Summary
- replace `yesno` filter with explicit success/error conditional in registration templates

## Testing
- `python - <<'PY'
from django.template import Engine
engine = Engine(dirs=['accounts/templates','templates'], libraries={'i18n':'django.templatetags.i18n','static':'django.templatetags.static','tz':'django.templatetags.tz'})
files=[
    'accounts/templates/register/onboarding.html',
    'accounts/templates/register/senha.html',
    'accounts/templates/register/nome.html',
    'accounts/templates/register/email.html',
    'accounts/templates/register/cpf.html',
    'accounts/templates/register/token.html',
    'accounts/templates/register/foto.html',
    'accounts/templates/register/registro_sucesso.html',
    'accounts/templates/register/termos.html',
]
for f in files:
    with open(f) as fh:
        engine.from_string(fh.read())
print('Template compilation succeeded for', len(files), 'files')
PY`
- ⚠️ `python manage.py runserver 0.0.0.0:8000` (ModuleNotFoundError: No module named 'silk' -> installed, then SyntaxError in tokens views)

------
https://chatgpt.com/codex/tasks/task_e_68aa5343c8788325a017a75c4ff969d0