### PR TITLE
Use conditional styling for message tags

### DIFF
--- a/agenda/templates/agenda/_messages.html
+++ b/agenda/templates/agenda/_messages.html
@@ -3,7 +3,7 @@
   {% if messages %}
     <div class="mb-4 space-y-2">
       {% for message in messages %}
-        <p class="rounded-xl px-4 py-2 text-sm {{ message.tags|yesno:'bg-green-100 text-green-700,bg-red-100 text-red-700' }}">{{ message }}</p>
+        <p class="rounded-xl px-4 py-2 text-sm {% if 'success' in message.tags %}bg-green-100 text-green-700{% else %}bg-red-100 text-red-700{% endif %}">{{ message }}</p>
       {% endfor %}
     </div>
   {% endif %}

--- a/agenda/templates/agenda/briefing_list.html
+++ b/agenda/templates/agenda/briefing_list.html
@@ -16,7 +16,7 @@
   {% if messages %}
     <div class="mb-4 space-y-2">
       {% for message in messages %}
-        <p class="rounded-xl px-4 py-2 text-sm {{ message.tags|yesno:'bg-green-100 text-green-700,bg-red-100 text-red-700' }}">{{ message }}</p>
+        <p class="rounded-xl px-4 py-2 text-sm {% if 'success' in message.tags %}bg-green-100 text-green-700{% else %}bg-red-100 text-red-700{% endif %}">{{ message }}</p>
       {% endfor %}
     </div>
   {% endif %}

--- a/agenda/templates/agenda/inscricao_list.html
+++ b/agenda/templates/agenda/inscricao_list.html
@@ -11,9 +11,9 @@
 
   {% if messages %}
     <div class="mb-4 space-y-2">
-      {% for message in messages %}
-        <p class="rounded-xl px-4 py-2 text-sm {{ message.tags|yesno:'bg-green-100 text-green-700,bg-red-100 text-red-700' }}">{{ message }}</p>
-      {% endfor %}
+        {% for message in messages %}
+          <p class="rounded-xl px-4 py-2 text-sm {% if 'success' in message.tags %}bg-green-100 text-green-700{% else %}bg-red-100 text-red-700{% endif %}">{{ message }}</p>
+        {% endfor %}
     </div>
   {% endif %}
 

--- a/discussao/templates/discussao/topico_novo.html
+++ b/discussao/templates/discussao/topico_novo.html
@@ -8,9 +8,9 @@
   <h1 class="text-2xl font-bold text-neutral-900 mb-6">{% trans "Criar T\u00f3pico" %}</h1>
   {% if messages %}
   <div class="mb-4 space-y-2">
-    {% for message in messages %}
-      <p class="rounded-xl px-4 py-2 text-sm {{ message.tags == 'success'|yesno:'bg-green-100 text-green-700,bg-red-100 text-red-700' }}">{{ message }}</p>
-    {% endfor %}
+      {% for message in messages %}
+        <p class="rounded-xl px-4 py-2 text-sm {% if 'success' in message.tags %}bg-green-100 text-green-700{% else %}bg-red-100 text-red-700{% endif %}">{{ message }}</p>
+      {% endfor %}
   </div>
   {% endif %}
   <form method="post" class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 space-y-6">

--- a/notificacoes/templates/notificacoes/template_form.html
+++ b/notificacoes/templates/notificacoes/template_form.html
@@ -9,9 +9,9 @@
   </div>
   {% if messages %}
   <div class="mb-4 space-y-2" aria-live="polite">
-    {% for message in messages %}
-      <p role="alert" class="rounded-xl px-4 py-2 text-sm {{ message.tags == 'success'|yesno:'bg-green-600 text-white,bg-red-600 text-white' }}">{{ message }}</p>
-    {% endfor %}
+      {% for message in messages %}
+        <p role="alert" class="rounded-xl px-4 py-2 text-sm {% if 'success' in message.tags %}bg-green-100 text-green-700{% else %}bg-red-100 text-red-700{% endif %}">{{ message }}</p>
+      {% endfor %}
   </div>
   {% endif %}
   <form method="post" class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 space-y-6">

--- a/notificacoes/templates/notificacoes/templates_list.html
+++ b/notificacoes/templates/notificacoes/templates_list.html
@@ -14,9 +14,9 @@
   </div>
   {% if messages %}
   <div class="mb-4 space-y-2" aria-live="polite">
-    {% for message in messages %}
-      <p role="alert" class="rounded-xl px-4 py-2 text-sm {{ message.tags == 'success'|yesno:'bg-green-100 text-green-700,bg-red-100 text-red-700' }}">{{ message }}</p>
-    {% endfor %}
+      {% for message in messages %}
+        <p role="alert" class="rounded-xl px-4 py-2 text-sm {% if 'success' in message.tags %}bg-green-100 text-green-700{% else %}bg-red-100 text-red-700{% endif %}">{{ message }}</p>
+      {% endfor %}
   </div>
   {% endif %}
   {% if templates %}

--- a/organizacoes/templates/organizacoes/update.html
+++ b/organizacoes/templates/organizacoes/update.html
@@ -18,7 +18,7 @@
   {% if messages %}
   <div class="mb-4 space-y-2">
     {% for message in messages %}
-      <p class="rounded-xl px-4 py-2 text-sm {{ message.tags == 'success'|yesno:'bg-green-100 text-green-700,bg-red-100 text-red-700' }}">{{ message }}</p>
+      <p class="rounded-xl px-4 py-2 text-sm {% if 'success' in message.tags %}bg-green-100 text-green-700{% else %}bg-red-100 text-red-700{% endif %}">{{ message }}</p>
     {% endfor %}
   </div>
   {% endif %}


### PR DESCRIPTION
## Summary
- Replace `yesno` filters with explicit success/error class check in flash message templates

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'factory')*

------
https://chatgpt.com/codex/tasks/task_e_68aa53460cc483259b5ee496360b0417