### PR TITLE
fix misnamed organizacao viewsets

### DIFF
--- a/organizacoes/api.py
+++ b/organizacoes/api.py
@@ -354,8 +354,7 @@ class OrganizacaoNucleoViewSet(OrganizacaoRelatedModelViewSet):
         nucleo = get_object_or_404(Nucleo, pk=pk, organizacao=org)
         nucleo.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)
-
-
+class OrganizacaoRelatedAssociationViewSet(OrganizacaoRelatedModelViewSet):
     model = None  # type: ignore[assignment]
     serializer_class = None  # type: ignore[assignment]
     search_field = "nome"
@@ -366,10 +365,7 @@ class OrganizacaoNucleoViewSet(OrganizacaoRelatedModelViewSet):
         return self.model.objects.filter(organizacao=org, deleted=False)
 
     def list(self, request, *args, **kwargs):  # type: ignore[override]
-        org = self.get_organizacao()
-
-        qs = Evento.objects.filter(deleted=False, organizacao__isnull=True)
-
+        qs = self.model.objects.filter(deleted=False, organizacao__isnull=True)
         search = request.query_params.get("search")
         if search:
             qs = qs.filter(**{f"{self.search_field}__icontains": search})
@@ -385,15 +381,13 @@ class OrganizacaoNucleoViewSet(OrganizacaoRelatedModelViewSet):
 
     def create(self, request, *args, **kwargs):  # type: ignore[override]
         org = self.get_organizacao()
-
-        evento_id = request.data.get("evento_id")
-        evento = get_object_or_404(Evento, pk=evento_id)
-        if evento.organizacao_id is not None:
+        pk_value = request.data.get(self._get_id_field())
+        obj = get_object_or_404(self.model, pk=pk_value)
+        if obj.organizacao_id is not None:
             return Response(status=status.HTTP_409_CONFLICT)
-        evento.organizacao = org
-        evento.save(update_fields=["organizacao"])
-        serializer = self.get_serializer(evento)
-
+        obj.organizacao = org
+        obj.save(update_fields=["organizacao"])
+        serializer = self.get_serializer(obj)
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
     def destroy(self, request, pk=None, organizacao_pk=None):  # type: ignore[override]
@@ -403,35 +397,9 @@ class OrganizacaoNucleoViewSet(OrganizacaoRelatedModelViewSet):
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
-class OrganizacaoNucleoViewSet(OrganizacaoRelatedAssociationViewSet):
-    model = Nucleo
-    serializer_class = NucleoSerializer
-
-
-
-    def list(self, request, *args, **kwargs):  # type: ignore[override]
-        org = self.get_organizacao()
-        qs = Empresa.objects.filter(deleted=False, organizacao__isnull=True)
-        search = request.query_params.get("search")
-        if search:
-            qs = qs.filter(nome__icontains=search)
-        page = self.paginate_queryset(qs)
-        if page is not None:
-            serializer = self.get_serializer(page, many=True)
-            return self.get_paginated_response(serializer.data)
-        serializer = self.get_serializer(qs, many=True)
-        return Response(serializer.data)
-
-    def create(self, request, *args, **kwargs):  # type: ignore[override]
-        org = self.get_organizacao()
-        empresa_id = request.data.get("empresa_id")
-        empresa = get_object_or_404(Empresa, pk=empresa_id)
-        if empresa.organizacao_id is not None:
-            return Response(status=status.HTTP_409_CONFLICT)
-        empresa.organizacao = org
-        empresa.save(update_fields=["organizacao"])
-        serializer = self.get_serializer(empresa)
-        return Response(serializer.data, status=status.HTTP_201_CREATED)
+class OrganizacaoEventoViewSet(OrganizacaoRelatedAssociationViewSet):
+    model = Evento
+    serializer_class = EventoSerializer
 
 
 class OrganizacaoEmpresaViewSet(OrganizacaoRelatedAssociationViewSet):


### PR DESCRIPTION
## Summary
- add generic viewset to handle associating models to an organization
- fix duplicate OrganizacaoNucleoViewSet by creating OrganizacaoEmpresaViewSet
- expose OrganizacaoEventoViewSet

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'silk')*


------
https://chatgpt.com/codex/tasks/task_e_68ac7a5248dc8325ae81a70218bd3f90