### PR TITLE
Evita duplicidade na notificação de suplente

### DIFF
--- a/nucleos/tasks.py
+++ b/nucleos/tasks.py
@@ -38,12 +38,14 @@ def notify_participacao_recusada(participacao_id: int) -> None:
 def notify_suplente_designado(nucleo_id: int, email: str) -> None:
     """Notifica apenas o suplente designado identificado pelo e-mail."""
     nucleo = Nucleo.objects.get(pk=nucleo_id)
-    participacoes = nucleo.participacoes.select_related("user").filter(
-        user__email=email
+    participacao = (
+        nucleo.participacoes.select_related("user")
+        .filter(user__email=email)
+        .first()
     )
-    for part in participacoes:
+    if participacao:
         enviar_para_usuario(
-            part.user,
+            participacao.user,
             "suplente_designado",
             {"nucleo": nucleo.nome},
         )

--- a/tests/nucleos/test_suplentes.py
+++ b/tests/nucleos/test_suplentes.py
@@ -38,3 +38,30 @@ def test_notify_suplente_designado_envia_somente_para_suplente(monkeypatch):
     notify_suplente_designado(nucleo.id, suplente.email)
 
     assert enviados == [suplente.email]
+
+
+@pytest.mark.django_db
+def test_notify_suplente_designado_sem_duplicidades_com_varias_participacoes(monkeypatch):
+    nucleo = NucleoFactory()
+    outro_nucleo = NucleoFactory(organizacao=nucleo.organizacao)
+    User = get_user_model()
+    suplente = User.objects.create_user(
+        username="suplente",
+        email="suplente@example.com",
+        password="pass",
+        user_type=UserType.NUCLEADO,
+        organizacao=nucleo.organizacao,
+    )
+    ParticipacaoNucleo.objects.create(user=suplente, nucleo=nucleo, status="ativo")
+    ParticipacaoNucleo.objects.create(user=suplente, nucleo=outro_nucleo, status="ativo")
+
+    enviados: list[str] = []
+
+    def fake_enviar_para_usuario(user, template, context):
+        enviados.append(user.email)
+
+    monkeypatch.setattr("nucleos.tasks.enviar_para_usuario", fake_enviar_para_usuario)
+
+    notify_suplente_designado(nucleo.id, suplente.email)
+
+    assert enviados == [suplente.email]


### PR DESCRIPTION
## Summary
- Notificar suplente designado apenas uma vez
- Adicionar teste garantindo ausência de notificações duplicadas

## Testing
- `pytest tests/nucleos/test_suplentes.py -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68af68e0aeb483259c81247aa2a213c1