### PR TITLE
Handle cache backends missing delete_pattern

### DIFF
--- a/nucleos/tasks.py
+++ b/nucleos/tasks.py
@@ -75,7 +75,32 @@ def expirar_solicitacoes_pendentes() -> None:
 
 @shared_task
 def limpar_contadores_convites() -> None:
-    cache.delete_pattern("convites_nucleo:*")  # type: ignore[attr-defined]
+    """Limpa contadores de convites de núcleo do cache.
+
+    Tenta usar ``delete_pattern`` quando disponível. Para backends que não
+    oferecem esse método (como ``LocMemCache``), itera manualmente pelas chaves
+    armazenadas e remove aquelas que iniciam com o prefixo esperado.
+    """
+
+    prefix = "convites_nucleo:"
+    pattern = f"{prefix}*"
+    if hasattr(cache, "delete_pattern"):
+        cache.delete_pattern(pattern)  # type: ignore[attr-defined]
+        return
+
+    version = getattr(cache, "version", 1)
+    internal_prefix = f":{version}:{prefix}"
+    try:
+        keys = [
+            k.split(f":{version}:", 1)[1]
+            for k in getattr(cache, "_cache").keys()
+            if isinstance(k, str) and k.startswith(internal_prefix)
+        ]
+    except AttributeError:
+        keys = []
+
+    if keys:
+        cache.delete_many(keys)
 
 
 @shared_task

--- a/tests/nucleos/test_tasks.py
+++ b/tests/nucleos/test_tasks.py
@@ -1,0 +1,22 @@
+import pytest
+from django.core.cache import cache
+
+from nucleos.tasks import limpar_contadores_convites
+
+pytestmark = pytest.mark.django_db
+
+
+def test_limpar_contadores_convites_without_delete_pattern(monkeypatch):
+    cache.clear()
+    cache.set("convites_nucleo:1", "a")
+    cache.set("convites_nucleo:2", "b")
+    cache.set("other", "c")
+
+    # Simula backend sem suporte a delete_pattern
+    monkeypatch.delattr(cache, "delete_pattern", raising=False)
+
+    limpar_contadores_convites()
+
+    assert cache.get("convites_nucleo:1") is None
+    assert cache.get("convites_nucleo:2") is None
+    assert cache.get("other") == "c"


### PR DESCRIPTION
## Summary
- Safely clear `convites_nucleo` cache keys even when the backend lacks `delete_pattern`
- Add regression test simulating a cache backend without `delete_pattern`

## Testing
- `pytest tests/nucleos/test_tasks.py::test_limpar_contadores_convites_without_delete_pattern -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68af68df16e08325aeb60151b59ede97