### PR TITLE
Fix missing static tag in feed template

### DIFF
--- a/feed/templates/feed/feed.html
+++ b/feed/templates/feed/feed.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load i18n %}
+{% load static i18n %}
 
 {% block title %}{% trans "Feed" %} | Hubx{% endblock %}
 


### PR DESCRIPTION
## Summary
- load static template tag in feed view

## Testing
- `pytest feed/tests` *(fails: 61 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68af6d4d9cc88325947442d008c7af4c