### PR TITLE
feat(feed): reuse plugin configs

### DIFF
--- a/feed/application/plugins_loader.py
+++ b/feed/application/plugins_loader.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from importlib import import_module
-from typing import List
+from typing import Iterable, List, Tuple
 
 import logging
 from django.db import models
@@ -11,11 +11,23 @@ from feed.models import FeedPluginConfig
 
 logger = logging.getLogger(__name__)
 
+def load_plugins_for(
+    organizacao: models.Model,
+    configs: Iterable[FeedPluginConfig] | None = None,
+) -> Tuple[List[FeedPlugin], List[FeedPluginConfig]]:
+    """Carrega instâncias de plugins registrados para uma organização.
 
-def load_plugins_for(organizacao: models.Model) -> List[FeedPlugin]:
-    """Carrega instâncias de plugins registrados para uma organização."""
+    Aceita configurações previamente consultadas ou retorna-as junto com as
+    instâncias carregadas.
+    """
+
+    if configs is None:
+        configs_list = list(FeedPluginConfig.objects.filter(organizacao=organizacao))
+    else:
+        configs_list = list(configs)
+
     plugins: List[FeedPlugin] = []
-    for config in FeedPluginConfig.objects.filter(organizacao=organizacao):
+    for config in configs_list:
         try:
             module_name, class_name = config.module_path.rsplit(".", 1)
             module = import_module(module_name)
@@ -26,4 +38,4 @@ def load_plugins_for(organizacao: models.Model) -> List[FeedPlugin]:
             # Falha ao carregar plugin não deve interromper feed
             logger.exception("Falha ao carregar plugin %s", config.module_path)
             continue
-    return plugins
+    return plugins, configs_list

--- a/feed/tasks.py
+++ b/feed/tasks.py
@@ -156,10 +156,10 @@ def executar_plugins() -> None:
         user = User.objects.filter(organizacao=org).first()
         if not user:
             continue
-        configs = {
-            c.module_path: c for c in FeedPluginConfig.objects.filter(organizacao=org)
-        }
-        for plugin in load_plugins_for(org):
+        configs_list = list(FeedPluginConfig.objects.filter(organizacao=org))
+        plugins, configs_list = load_plugins_for(org, configs_list)
+        configs = {c.module_path: c for c in configs_list}
+        for plugin in plugins:
             module_path = f"{plugin.__class__.__module__}.{plugin.__class__.__name__}"
             config = configs.get(module_path)
             if not config:

--- a/feed/tests/test_plugins.py
+++ b/feed/tests/test_plugins.py
@@ -17,7 +17,7 @@ def test_load_plugins_for(db):
         module_path="feed.tests.sample_plugin.DummyPlugin",
         frequency=1,
     )
-    plugins = load_plugins_for(org)
+    plugins, _ = load_plugins_for(org)
     assert len(plugins) == 1
     plugin = plugins[0]
     User = get_user_model()
@@ -55,7 +55,7 @@ def test_load_plugins_logs_failure(caplog, db):
         frequency=1,
     )
     with caplog.at_level(logging.ERROR):
-        plugins = load_plugins_for(org)
+        plugins, _ = load_plugins_for(org)
     assert plugins == []
     assert "Falha ao carregar plugin feed.tests.sample_plugin.MissingPlugin" in caplog.text
 


### PR DESCRIPTION
## Summary
- load_plugins_for accepts optional configs and returns them
- executar_plugins reuses pre-fetched plugin configs
- update plugin loader tests for new return signature

## Testing
- `pytest feed/tests/test_plugins.py -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68af6cf699c483258bd60fa251bfeb81