### PR TITLE
refactor: handle boto3 absence in feed

### DIFF
--- a/feed/tests/test_presigned.py
+++ b/feed/tests/test_presigned.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from django.test import TestCase, override_settings
+from unittest.mock import patch
+import builtins
+
+from feed.api import PostSerializer
+
+
+class PresignedURLTest(TestCase):
+    @override_settings(AWS_STORAGE_BUCKET_NAME="bucket")
+    def test_fallback_without_boto3(self):
+        original_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "boto3":
+                raise ImportError()
+            return original_import(name, *args, **kwargs)
+
+        with (
+            patch("feed.api.default_storage.url", return_value="fallback") as mock_url,
+            patch("builtins.__import__", side_effect=fake_import),
+        ):
+            serializer = PostSerializer()
+            result = serializer._generate_presigned("file")
+        self.assertEqual(result, "fallback")
+        mock_url.assert_called_once_with("file")


### PR DESCRIPTION
## Summary
- lazily import boto3 in PostSerializer and fall back to default storage when missing
- add regression test ensuring presigned URLs work without boto3

## Testing
- `python -m pytest feed/tests/test_presigned.py::PresignedURLTest::test_fallback_without_boto3 -q --no-cov`
- `python -m pytest feed/tests/test_post_api.py::PostAPITest::test_create_text_post -q --no-cov` *(fails: 404 != 201)*

------
https://chatgpt.com/codex/tasks/task_e_68af6ced25a88325bc618c6e2f9db4d0