### PR TITLE
Avoid duplicate moderation records and update tests

### DIFF
--- a/feed/application/moderar_ai.py
+++ b/feed/application/moderar_ai.py
@@ -23,5 +23,10 @@ def aplicar_decisao(post: Post, decision: Decision) -> None:
     """Atualiza o status de moderação do ``post`` e registra em log."""
 
     status_map = {"aceito": "aprovado", "suspeito": "pendente", "rejeitado": "rejeitado"}
-    ModeracaoPost.objects.create(post=post, status=status_map[decision])
+    mod = post.moderacao
+    if mod:
+        mod.status = status_map[decision]
+        mod.save(update_fields=["status"])
+    else:
+        ModeracaoPost.objects.create(post=post, status=status_map[decision])
     logger.info("moderacao_ai", extra={"post_id": str(post.id), "decision": decision})

--- a/feed/models.py
+++ b/feed/models.py
@@ -88,10 +88,7 @@ class Post(TimeStampedModel, SoftDeleteModel):
             raise ValidationError({"evento": "Evento é obrigatório"})
 
     def save(self, *args, **kwargs):
-        is_new = self._state.adding
         super().save(*args, **kwargs)
-        if is_new:
-            ModeracaoPost.objects.create(post=self)
         banned = getattr(settings, "FEED_BAD_WORDS", [])
         if any(bad.lower() in (self.conteudo or "").lower() for bad in banned):
             mod = self.moderacao

--- a/feed/tests/test_ai_moderation.py
+++ b/feed/tests/test_ai_moderation.py
@@ -32,11 +32,13 @@ class AIModerationAPITest(TestCase):
         )
         self.assertEqual(post.moderacao.status, "pendente")
 
-    def test_multiple_ai_decisions_create_history(self):
-        post = Post.objects.create(autor=self.user, organizacao=self.user.organizacao, conteudo="ok")
+    def test_multiple_ai_decisions_update_status(self):
+        post = Post.objects.create(
+            autor=self.user, organizacao=self.user.organizacao, conteudo="ok"
+        )
         aplicar_decisao(post, "aceito")
         aplicar_decisao(post, "rejeitado")
-        self.assertEqual(ModeracaoPost.objects.filter(post=post).count(), 3)
+        self.assertEqual(ModeracaoPost.objects.filter(post=post).count(), 1)
         self.assertEqual(post.moderacao.status, "rejeitado")
 
 

--- a/tests/feed/test_feed.py
+++ b/tests/feed/test_feed.py
@@ -3,7 +3,7 @@ from django.test import TestCase
 from django.urls import reverse
 
 from accounts.models import UserType
-from feed.models import Post
+from feed.models import ModeracaoPost, Post
 from nucleos.models import Nucleo
 from organizacoes.models import Organizacao
 
@@ -40,8 +40,7 @@ class FeedPublicPrivateTests(TestCase):
             tipo_feed="global",
             organizacao=self.org,
         )
-        post.moderacao.status = "aprovado"
-        post.moderacao.save()
+        ModeracaoPost.objects.create(post=post, status="aprovado")
         resp = self.client.get(reverse("feed:listar"))
         self.assertIn("global", resp.content.decode())
 
@@ -52,8 +51,7 @@ class FeedPublicPrivateTests(TestCase):
             tipo_feed="nucleo",
             organizacao=self.org,
         )
-        post.moderacao.status = "aprovado"
-        post.moderacao.save()
+        ModeracaoPost.objects.create(post=post, status="aprovado")
         resp = self.client.get(reverse("feed:listar"))
         self.assertEqual(len(resp.context.get("posts", [])), 0)
 
@@ -65,8 +63,7 @@ class FeedPublicPrivateTests(TestCase):
             tipo_feed="nucleo",
             organizacao=self.org,
         )
-        post.moderacao.status = "aprovado"
-        post.moderacao.save()
+        ModeracaoPost.objects.create(post=post, status="aprovado")
         resp = self.client.get(reverse("feed:listar"))
         self.assertEqual(len(resp.context.get("posts", [])), 0)
 
@@ -79,9 +76,8 @@ class FeedPublicPrivateTests(TestCase):
     def test_search_returns_matching_posts(self):
         p1 = Post.objects.create(autor=self.user, conteudo="alpha bravo", organizacao=self.org)
         p2 = Post.objects.create(autor=self.user, conteudo="charlie delta", organizacao=self.org)
-        p1.moderacao.status = p2.moderacao.status = "aprovado"
-        p1.moderacao.save()
-        p2.moderacao.save()
+        ModeracaoPost.objects.create(post=p1, status="aprovado")
+        ModeracaoPost.objects.create(post=p2, status="aprovado")
         resp = self.client.get(reverse("feed:listar") + "?q=alpha")
         self.assertEqual(len(resp.context.get("posts", [])), 1)
         self.assertIn("alpha bravo", resp.content.decode())

--- a/tests/feed/test_moderation.py
+++ b/tests/feed/test_moderation.py
@@ -29,7 +29,7 @@ class ModerationTests(TestCase):
 
     def test_pending_visibility_and_approval(self):
         post = Post.objects.create(autor=self.author, organizacao=self.org, conteudo="hi")
-        self.assertEqual(post.moderacao.status, "pendente")
+        self.assertIsNone(post.moderacao)
 
         resp = self._list(self.other)
         data = resp.data if isinstance(resp.data, dict) else {"results": resp.data}
@@ -61,8 +61,7 @@ class ModerationTests(TestCase):
 
     def test_rejected_hidden(self):
         post = Post.objects.create(autor=self.author, organizacao=self.org, conteudo="hi")
-        post.moderacao.status = "rejeitado"
-        post.moderacao.save()
+        ModeracaoPost.objects.create(post=post, status="rejeitado")
 
         resp = self._list(self.author)
         data = resp.data if isinstance(resp.data, dict) else {"results": resp.data}
@@ -82,5 +81,5 @@ class ModerationTests(TestCase):
             format="json",
         )
         self.client.force_authenticate(user=None)
-        self.assertEqual(ModeracaoPost.objects.filter(post=post).count(), 3)
+        self.assertEqual(ModeracaoPost.objects.filter(post=post).count(), 2)
         self.assertEqual(post.moderacao.status, "rejeitado")


### PR DESCRIPTION
## Summary
- Stop creating `ModeracaoPost` automatically on `Post.save`
- Update AI moderation to update or create a single record
- Adapt moderation-related tests to new behavior

## Testing
- `pytest -o addopts='' --nomigrations tests/feed/test_moderation.py::ModerationTests::test_pending_visibility_and_approval -q` *(fails: HttpResponseNotFound)*

------
https://chatgpt.com/codex/tasks/task_e_68af6cea53a883258bbba16c094ecc57