### PR TITLE
Fix feed template reaction checks

### DIFF
--- a/feed/templates/feed/_grid.html
+++ b/feed/templates/feed/_grid.html
@@ -59,7 +59,7 @@
           <div id="like-btn-{{ post.id }}">
             {% include 'feed/_like_button.html' with post=post %}
           </div>
-          <button type="button" data-post-id="{{ post.id }}" class="share-btn inline-flex items-center gap-1 hover:text-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 rounded {% if post.reacoes.filter(vote='share', user=user).exists %}text-blue-600{% endif %}" aria-label="{% trans 'Compartilhar' %}">
+            <button type="button" data-post-id="{{ post.id }}" class="share-btn inline-flex items-center gap-1 hover:text-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 rounded {% if post.is_shared %}text-blue-600{% endif %}" aria-label="{% trans 'Compartilhar' %}">
             <i class="fa-solid fa-share" aria-hidden="true"></i>
             <span class="share-count">{{ post.share_count }}</span>
           </button>

--- a/feed/templates/feed/_like_button.html
+++ b/feed/templates/feed/_like_button.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-{% with liked=post.reacoes.filter(user=user, vote='like', deleted=False).exists count=post.like_count %}
+{% with liked=post.is_liked count=post.like_count %}
 <button
   hx-post="/api/feed/posts/{{ post.id }}/reacoes/"
   hx-ext="json-enc"

--- a/feed/templates/feed/post_detail.html
+++ b/feed/templates/feed/post_detail.html
@@ -58,14 +58,14 @@
       <div id="like-btn-{{ post.id }}">
         {% include 'feed/_like_button.html' with post=post %}
       </div>
-      <button type="button" data-post-id="{{ post.id }}" class="share-btn inline-flex items-center gap-1 hover:text-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 rounded {% if post.reacoes.filter(vote='share', user=user).exists %}text-blue-600{% endif %}" aria-label="{% trans 'Compartilhar' %}">
+      <button type="button" data-post-id="{{ post.id }}" class="share-btn inline-flex items-center gap-1 hover:text-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 rounded {% if post.is_shared %}text-blue-600{% endif %}" aria-label="{% trans 'Compartilhar' %}">
         <i class="fa-solid fa-share"></i>
         <span class="share-count">{{ post.share_count }}</span>
       </button>
-      <button type="button" data-post-id="{{ post.id }}" class="bookmark-btn hover:text-yellow-600 focus:outline-none focus:ring-2 focus:ring-yellow-500 rounded {% if post.bookmarks.filter(user=user).exists %}text-yellow-600{% endif %}" aria-label="{% trans 'Salvar' %}">
+      <button type="button" data-post-id="{{ post.id }}" class="bookmark-btn hover:text-yellow-600 focus:outline-none focus:ring-2 focus:ring-yellow-500 rounded {% if post.is_bookmarked %}text-yellow-600{% endif %}" aria-label="{% trans 'Salvar' %}">
         <i class="fa-solid fa-bookmark"></i>
       </button>
-      <button type="button" data-post-id="{{ post.id }}" class="flag-btn hover:text-red-600 focus:outline-none focus:ring-2 focus:ring-red-500 rounded {% if post.flags.filter(user=user).exists %}text-red-600 cursor-not-allowed{% endif %}" aria-label="{% trans 'Denunciar' %}" {% if post.flags.filter(user=user).exists %}disabled{% endif %}>
+      <button type="button" data-post-id="{{ post.id }}" class="flag-btn hover:text-red-600 focus:outline-none focus:ring-2 focus:ring-red-500 rounded {% if post.is_flagged %}text-red-600 cursor-not-allowed{% endif %}" aria-label="{% trans 'Denunciar' %}" {% if post.is_flagged %}disabled{% endif %}>
         <i class="fa-solid fa-flag"></i>
       </button>
 


### PR DESCRIPTION
## Summary
- Avoid calling queryset filters in templates by annotating reaction flags
- Highlight like/share buttons using `is_liked` and `is_shared`
- Simplify bookmark list to query posts with reaction annotations

## Testing
- `pytest feed/tests -q` *(fails: ModuleNotFoundError: No module named 'factory')*
- `pytest feed/tests/test_reactions.py tests/feed/test_models.py -q` *(fails: Required test coverage of 90% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_68af6e49eb7c83259c8de1b2b4ed6cb0