### PR TITLE
Fix tuple membership in templates to avoid TemplateSyntaxError

### DIFF
--- a/agenda/templates/agenda/_material_row.html
+++ b/agenda/templates/agenda/_material_row.html
@@ -9,7 +9,7 @@
       <a href="{{ material.arquivo.url }}" class="text-blue-600 hover:underline">
         {% trans "Download" %}
       </a>
-      {% if user.user_type in ('admin','coordenador','root') %}
+      {% if user.user_type == 'admin' or user.user_type == 'coordenador' or user.user_type == 'root' %}
       <form
         hx-post="{% url 'agenda_api:material-aprovar' material.pk %}"
         hx-target="closest tr"

--- a/agenda/templates/agenda/create.html
+++ b/agenda/templates/agenda/create.html
@@ -11,7 +11,7 @@
 
     {{ form.non_field_errors }}
     {% for field in form %}
-      {% if field.name not in ('participantes_maximo','espera_habilitada') %}
+      {% if field.name != 'participantes_maximo' and field.name != 'espera_habilitada' %}
         <div>
           <label for="{{ field.id_for_label }}" class="block text-sm font-medium text-neutral-700 mb-1">
             {{ field.label }}

--- a/agenda/templates/agenda/update.html
+++ b/agenda/templates/agenda/update.html
@@ -9,7 +9,7 @@
   <form method="post" enctype="multipart/form-data" class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 space-y-6">
     {% csrf_token %}
     {% for field in form %}
-      {% if field.name not in ('inscricoes','participantes_maximo','espera_habilitada') %}
+      {% if field.name != 'inscricoes' and field.name != 'participantes_maximo' and field.name != 'espera_habilitada' %}
         <div>
           <label for="{{ field.id_for_label }}" class="block text-sm font-medium text-neutral-700 mb-1">
             {{ field.label }}

--- a/nucleos/templates/nucleos/detail.html
+++ b/nucleos/templates/nucleos/detail.html
@@ -62,7 +62,7 @@
       {{ s.usuario.get_full_name|default:s.usuario.username }} -
       {{ s.periodo_inicio|date:'d/m/Y' }} a {{ s.periodo_fim|date:'d/m/Y' }} -
       {% if s.ativo %}{% trans 'Ativo' %}{% else %}{% trans 'Inativo' %}{% endif %}
-      {% if request.user.user_type in ('admin','coordenador') %}
+      {% if request.user.user_type == 'admin' or request.user.user_type == 'coordenador' %}
       <form method="post" action="{% url 'nucleos:suplente_remover' object.pk s.id %}" class="inline">
         {% csrf_token %}
         <button class="text-sm text-red-600">{% trans 'Remover' %}</button>
@@ -72,7 +72,7 @@
     {% endfor %}
   </ul>
   {% endif %}
-  {% if request.user.user_type in ('admin','coordenador') %}
+  {% if request.user.user_type == 'admin' or request.user.user_type == 'coordenador' %}
   <div class="mt-4">
     <a href="{% url 'nucleos:suplente_adicionar' object.pk %}" class="text-blue-600">{% trans 'Adicionar Suplente' %}</a>
   </div>
@@ -102,14 +102,14 @@
         download="nucleo-{{ object.pk }}-membros.xlsx"
       >{% trans 'Exportar XLS' %}</a>
     </div>
-    {% if request.user.user_type in ('admin','coordenador','root') %}
+    {% if request.user.user_type == 'admin' or request.user.user_type == 'coordenador' or request.user.user_type == 'root' %}
     <form method="post" action="{% url 'nucleos:toggle_active' object.pk %}" class="inline">{% csrf_token %}
       <button class="ml-2 text-orange-600">{% if object.deleted %}{% trans 'Reativar' %}{% else %}{% trans 'Inativar' %}{% endif %}</button>
     </form>
     {% endif %}
   </div>
 
-    {% if mostrar_solicitar and request.user.user_type not in ('admin','coordenador') %}
+    {% if mostrar_solicitar and request.user.user_type != 'admin' and request.user.user_type != 'coordenador' %}
     <div class="mt-4">
       <button id="solicitar-btn" type="button" class="px-4 py-2 bg-blue-600 text-white rounded" hx-get="{% url 'nucleos:solicitar_modal' object.pk %}" hx-target="#modal">{% trans 'Solicitar participação' %}</button>
     </div>

--- a/nucleos/templates/nucleos/list.html
+++ b/nucleos/templates/nucleos/list.html
@@ -13,7 +13,7 @@
   <div class="mb-4">
     <a href="{% url 'nucleos:meus' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100" aria-label="{% trans 'Ver meus núcleos' %}">{% trans 'Meus Núcleos' %}</a>
   </div>
-  {% if request.user.user_type in ('admin', 'root') %}
+  {% if request.user.user_type == 'admin' or request.user.user_type == 'root' %}
   <div class="mb-4">
     <a href="{% url 'nucleos:create' %}" class="px-3 py-2 bg-green-600 text-white rounded" aria-label="{% trans 'Criar novo núcleo' %}">{% trans 'Novo' %}</a>
   </div>
@@ -38,7 +38,7 @@
       <p class="text-sm">{% trans "Mensalidade" %}: {{ nucleo.mensalidade|localize }}</p>
       <div class="mt-2">
         <a href="{% url 'nucleos:detail' nucleo.pk %}" class="text-blue-600" aria-label="{% blocktrans with nome=nucleo.nome %}Ver detalhes do núcleo {{ nome }}{% endblocktrans %}">{% trans 'Detalhes' %}</a>
-        {% if request.user.user_type in ('admin', 'root') %}
+        {% if request.user.user_type == 'admin' or request.user.user_type == 'root' %}
         <a href="{% url 'nucleos:delete' nucleo.pk %}" class="text-red-600 ml-2" aria-label="{% blocktrans with nome=nucleo.nome %}Excluir núcleo {{ nome }}{% endblocktrans %}">{% trans 'Excluir' %}</a>
         {% endif %}
       </div>


### PR DESCRIPTION
## Summary
- replace tuple-based user type checks with explicit comparisons in nucleos templates
- adjust agenda templates to use explicit comparisons instead of tuple membership

## Testing
- `python manage.py check`
- `pytest --override-ini="addopts=" -q` *(fails: ModuleNotFoundError: No module named 'factory')*

------
https://chatgpt.com/codex/tasks/task_e_68af73adb7208325ae2428ef8706fb42