### PR TITLE
Restrict root user actions in discussao module

### DIFF
--- a/discussao/services/__init__.py
+++ b/discussao/services/__init__.py
@@ -84,7 +84,7 @@ def votar_interacao(*, user: User, obj: models.Model, valor: int) -> InteracaoDi
 
 
 def marcar_resolucao(*, topico: TopicoDiscussao, resposta: RespostaDiscussao, user: User) -> TopicoDiscussao:
-    if user != topico.autor and user.user_type not in {"admin", "root"}:
+    if user != topico.autor and user.user_type != UserType.ADMIN:
         raise PermissionDenied
     with transaction.atomic():
         topico.melhor_resposta = resposta
@@ -118,14 +118,14 @@ def verificar_prazo_edicao(
 ) -> bool:
     """Retorna se ``user`` pode editar ou excluir ``obj``.
 
-    Usuários administradores e root podem sempre editar. Outros usuários só
+    Usuários administradores podem sempre editar. Outros usuários só
     podem editar se forem autores e estiverem dentro do prazo definido. Tipos
     adicionais podem ser informados através de ``tipos_extras``.
     """
 
     tipos_extras = tipos_extras or set()
     tipo_usuario = getattr(user, "user_type", None) or getattr(user, "get_tipo_usuario", None)
-    if tipo_usuario in {UserType.ADMIN, UserType.ROOT}:
+    if tipo_usuario == UserType.ADMIN:
         return True
     if obj.autor != user and tipo_usuario not in tipos_extras:
         return False

--- a/discussao/templates/discussao/_categorias_lista.html
+++ b/discussao/templates/discussao/_categorias_lista.html
@@ -13,13 +13,13 @@
         {% endif %}
       </div>
     </div>
-    <div class="flex items-center gap-4">
-      <span class="text-sm text-neutral-600">{{ categoria.num_topicos }}</span>
-      {% if user.user_type == 'admin' or user.user_type == 'coordenador' or user.user_type == 'root' %}
-      <a href="{% url 'discussao:categoria_editar' categoria.slug %}" class="text-sm text-neutral-600">{% trans 'Editar' %}</a>
-      <a href="{% url 'discussao:categoria_remover' categoria.slug %}" class="text-sm text-red-600">{% trans 'Remover' %}</a>
-      {% endif %}
-    </div>
+      <div class="flex items-center gap-4">
+        <span class="text-sm text-neutral-600">{{ categoria.num_topicos }}</span>
+        {% if user.user_type == 'admin' or user.user_type == 'coordenador' %}
+        <a href="{% url 'discussao:categoria_editar' categoria.slug %}" class="text-sm text-neutral-600">{% trans 'Editar' %}</a>
+        <a href="{% url 'discussao:categoria_remover' categoria.slug %}" class="text-sm text-red-600">{% trans 'Remover' %}</a>
+        {% endif %}
+      </div>
   </li>
   {% empty %}
   <li class="text-neutral-600">{% trans 'Nenhuma categoria cadastrada.' %}</li>

--- a/discussao/templates/discussao/categorias.html
+++ b/discussao/templates/discussao/categorias.html
@@ -3,22 +3,14 @@
 {% block title %}{% trans 'Categorias' %} | HubX{% endblock %}
 {% block content %}
   <div class="max-w-4xl mx-auto px-4 py-10">
-    <div class="flex items-center mb-6">
-      <h1 class="text-2xl font-bold text-neutral-900">{% trans 'Categorias' %}</h1>
-      {% if user.user_type == 'admin' or user.user_type == 'coordenador' or user.user_type == 'root' %}
-      <a href="{% url 'discussao:categoria_criar' %}" class="ml-auto bg-primary-600 hover:bg-primary-700 text-white font-semibold py-2 px-4 rounded-xl">{% trans 'Novo' %}</a>
-      {% endif %}
-    </div>
-    <form id="filtros" class="mb-6 flex flex-col sm:flex-row gap-3">
-      {% if user.user_type == 'root' %}
-      <select name="organizacao" class="form-select" hx-get="?" hx-target="#lista-categorias" hx-include="#filtros">
-        <option value="">{% trans 'Organização' %}</option>
-        {% for o in organizacoes %}
-        <option value="{{ o.id }}" {% if organizacao_id == o.id %}selected{% endif %}>{{ o.nome }}</option>
-        {% endfor %}
-      </select>
-      {% endif %}
-      <select name="nucleo" class="form-select" hx-get="?" hx-target="#lista-categorias" hx-include="#filtros">
+      <div class="flex items-center mb-6">
+        <h1 class="text-2xl font-bold text-neutral-900">{% trans 'Categorias' %}</h1>
+        {% if user.user_type == 'admin' or user.user_type == 'coordenador' %}
+        <a href="{% url 'discussao:categoria_criar' %}" class="ml-auto bg-primary-600 hover:bg-primary-700 text-white font-semibold py-2 px-4 rounded-xl">{% trans 'Novo' %}</a>
+        {% endif %}
+      </div>
+      <form id="filtros" class="mb-6 flex flex-col sm:flex-row gap-3">
+        <select name="nucleo" class="form-select" hx-get="?" hx-target="#lista-categorias" hx-include="#filtros">
         <option value="">{% trans 'Núcleo' %}</option>
         {% for n in nucleos %}
         <option value="{{ n.id }}" {% if nucleo_id == n.id %}selected{% endif %}>{{ n.nome }}</option>

--- a/discussao/templates/discussao/comentario_item.html
+++ b/discussao/templates/discussao/comentario_item.html
@@ -12,13 +12,13 @@
     {% if comentario.pode_editar %}
       <a href="{% url 'discussao:resposta_editar' comentario.id %}" class="text-blue-600 text-xs">{% trans "Editar" %}</a>
     {% endif %}
-    {% if comentario.pode_editar or user.get_tipo_usuario in ['admin', 'coordenador', 'root'] %}
+    {% if comentario.pode_editar or user.get_tipo_usuario in ['admin', 'coordenador'] %}
       <form method="post" hx-delete="{% url 'discussao:delete_comment' comentario.id %}" hx-target="#coment-{{ comentario.id }}" hx-swap="delete">
         {% csrf_token %}
         <button type="submit" class="text-red-600 text-xs">{% trans "Remover" %}</button>
       </form>
     {% endif %}
-    {% if not topico.melhor_resposta and (user == topico.autor or user.get_tipo_usuario in ['admin','root']) %}
+    {% if not topico.melhor_resposta and (user == topico.autor or user.get_tipo_usuario == 'admin') %}
       <form method="post" hx-post="{% url 'discussao:topico_resolver' topico.categoria.slug topico.slug %}" hx-target="#topico-container" hx-swap="outerHTML">
         {% csrf_token %}
         <input type="hidden" name="melhor_resposta" value="{{ comentario.id }}" />

--- a/discussao/templates/discussao/topico_detail.html
+++ b/discussao/templates/discussao/topico_detail.html
@@ -22,7 +22,7 @@
     {% if pode_editar_topico %}
       <a href="{% url 'discussao:topico_editar' topico.categoria.slug topico.slug %}" class="text-sm text-blue-600">{% trans "Editar" %}</a>
     {% endif %}
-    {% if user == topico.autor or user.get_tipo_usuario in ['admin','root'] %}
+    {% if user == topico.autor or user.get_tipo_usuario == 'admin' %}
     <form method="post" hx-post="{% url 'discussao:topico_resolver' topico.categoria.slug topico.slug %}" hx-target="#topico-container" hx-swap="outerHTML" class="mt-2">
       {% csrf_token %}
       {% if topico.resolvido %}
@@ -92,13 +92,13 @@
       <input type="file" name="arquivo" />
       <button type="submit" class="bg-primary-600 hover:bg-primary-700 text-white font-semibold py-2 px-4 rounded-xl">{% trans "Comentar" %}</button>
     </form>
-    {% if user == topico.autor or user.get_tipo_usuario in ['admin','root'] %}
+    {% if user == topico.autor or user.get_tipo_usuario == 'admin' %}
       <form method="post" action="{% url 'discussao:topico_toggle_fechado' topico.categoria.slug topico.slug %}" class="mt-4">
         {% csrf_token %}
         <button type="submit" class="text-sm text-red-600">{% trans "Fechar tópico" %}</button>
       </form>
     {% endif %}
-    {% elif user.get_tipo_usuario in ['admin','root'] %}
+    {% elif user.get_tipo_usuario == 'admin' %}
       <form method="post" action="{% url 'discussao:topico_toggle_fechado' topico.categoria.slug topico.slug %}">
         {% csrf_token %}
         <button type="submit" class="bg-primary-600 text-white font-semibold py-2 px-4 rounded-xl">{% trans "Reabrir tópico" %}</button>


### PR DESCRIPTION
## Summary
- block ROOT user from public discussion views using `NoSuperadminMixin`
- remove ROOT authorization logic from discussion services and templates

## Testing
- `pytest tests/discussao -q` *(fails: ModuleNotFoundError: coverage can't parse or many errors; required coverage not reached)*

------
https://chatgpt.com/codex/tasks/task_e_68af78b2b3f4832585f2e5cb209c969b