### PR TITLE
feat(agenda): enforce no-superadmin and simplify templates

### DIFF
--- a/agenda/templates/agenda/_material_row.html
+++ b/agenda/templates/agenda/_material_row.html
@@ -9,7 +9,7 @@
       <a href="{{ material.arquivo.url }}" class="text-blue-600 hover:underline">
         {% trans "Download" %}
       </a>
-      {% if user.user_type == 'admin' or user.user_type == 'coordenador' or user.user_type == 'root' %}
+      {% if user.user_type == 'admin' or user.user_type == 'coordenador' %}
       <form
         hx-post="{% url 'agenda_api:material-aprovar' material.pk %}"
         hx-target="closest tr"

--- a/agenda/templates/agenda/calendario.html
+++ b/agenda/templates/agenda/calendario.html
@@ -9,7 +9,7 @@
       <span>{{ data_atual|date:'YEAR_MONTH_FORMAT' }}</span>
       <a href="{% url 'agenda:calendario_mes' next_ano next_mes %}" class="px-2 py-1 rounded hover:bg-gray-100">&raquo;</a>
     </h2>
-    {% if request.user.username != 'root' and perms.agenda.add_evento %}
+    {% if perms.agenda.add_evento %}
     <a href="{% url 'agenda:evento_novo' %}"
        class="btn-primary inline-flex items-center gap-2 px-4 py-2 bg-primary-600 text-white rounded-md hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-600 sm:ml-auto sm:order-last mt-4 sm:mt-0"
        aria-label="{% trans 'Novo Evento' %}">

--- a/agenda/templates/agenda/detail.html
+++ b/agenda/templates/agenda/detail.html
@@ -55,7 +55,7 @@
   </div>
 
   <!-- Inscrição -->
-  {% if user.is_authenticated and user.user_type != 'admin' and user.user_type != 'root' %}
+  {% if user.is_authenticated and user.user_type != 'admin' %}
     {% with inscricao=object.inscricoes.filter(user=user, status='confirmada').first %}
       {% if inscricao %}
         <div class="mb-10 space-y-4">

--- a/agenda/templates/agenda/update.html
+++ b/agenda/templates/agenda/update.html
@@ -83,7 +83,7 @@
             <h3 class="text-sm font-medium text-neutral-800">{{ inscrito.get_full_name|default:inscrito.username }}</h3>
             <p class="text-xs text-neutral-500">{{ inscrito.email }}</p>
           </div>
-          {% if user.user_type in ("admin","gerente","root") %}
+          {% if user.user_type in ("admin","gerente") %}
           <form method="post" action="{% url 'agenda:evento_remover_inscrito' object.pk inscrito.pk %}">
             {% csrf_token %}
             <button type="submit" class="text-sm text-red-600 hover:underline" aria-label="{% trans 'Remover' %}">{% trans "Remover" %}</button>


### PR DESCRIPTION
## Summary
- block root user across agenda views using NoSuperadminMixin or equivalent
- drop root-specific conditionals from agenda templates

## Testing
- `pytest` *(fails: ModuleNotFoundError / token tests)*

------
https://chatgpt.com/codex/tasks/task_e_68af78b6fac88325b1e2ed4ff1146781