### PR TITLE
Restringe convites root a admins e oculta núcleos

### DIFF
--- a/tokens/templates/tokens/gerar_token.html
+++ b/tokens/templates/tokens/gerar_token.html
@@ -17,21 +17,23 @@
 
     <div class="space-y-4">
       {% for field in form %}
-        <div>
-          <label for="{{ field.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ field.label }}</label>
-          {% if field.field.widget.input_type == 'select' %}
-            {{ field|add_class:"form-select"|attr:"required" }}
-          {% else %}
-            {% if forloop.first %}
-              {{ field|add_class:"form-input"|attr:"autofocus required" }}
+        {% if user.user_type != 'root' or field.name != 'nucleos' %}
+          <div>
+            <label for="{{ field.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ field.label }}</label>
+            {% if field.field.widget.input_type == 'select' %}
+              {{ field|add_class:"form-select"|attr:"required" }}
             {% else %}
-              {{ field|add_class:"form-input"|attr:"required" }}
+              {% if forloop.first %}
+                {{ field|add_class:"form-input"|attr:"autofocus required" }}
+              {% else %}
+                {{ field|add_class:"form-input"|attr:"required" }}
+              {% endif %}
             {% endif %}
-          {% endif %}
-          {% if field.errors %}
-            <p class="text-red-500 text-xs mt-1">{{ field.errors }}</p>
-          {% endif %}
-        </div>
+            {% if field.errors %}
+              <p class="text-red-500 text-xs mt-1">{{ field.errors }}</p>
+            {% endif %}
+          </div>
+        {% endif %}
       {% endfor %}
     </div>
 

--- a/tokens/views.py
+++ b/tokens/views.py
@@ -314,7 +314,7 @@ class GerarTokenConviteView(LoginRequiredMixin, View):
                 tipo_destino=target_role,
                 data_expiracao=timezone.now() + timezone.timedelta(days=30),
                 organizacao=form.cleaned_data.get("organizacao"),
-                nucleos=form.cleaned_data["nucleos"],
+                nucleos=form.cleaned_data.get("nucleos"),
             )
 
             ip = get_client_ip(request)


### PR DESCRIPTION
## Resumo
- Ajusta formulário de convites para mostrar todas organizações ao root e ocultar núcleos
- Filtra opções de tipo de destino conforme permissões de convite
- Atualiza template e view para comportamento de root
- Garante cobertura de testes para cenário de root

## Testes
- `pytest --no-cov tests/tokens/test_invite_view_permissions.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af78c19d4483258ad83a02289272e3