### PR TITLE
Allow root users to generate API tokens

### DIFF
--- a/tests/tokens/test_root_api_token_generation.py
+++ b/tests/tokens/test_root_api_token_generation.py
@@ -1,0 +1,31 @@
+import re
+
+import pytest
+from django.urls import reverse
+
+from accounts.factories import UserFactory
+from accounts.models import UserType
+from tokens.models import ApiToken
+
+pytestmark = pytest.mark.django_db
+
+
+def test_root_user_can_generate_api_token(client):
+    user = UserFactory(user_type=UserType.ROOT.value)
+    client.force_login(user)
+
+    resp = client.get(reverse("tokens:listar_api_tokens"))
+    assert resp.status_code == 200
+    assert "Gerar Token" in resp.content.decode()
+
+    resp = client.post(
+        reverse("tokens:gerar_api_token"),
+        {"scope": "admin"},
+        HTTP_HX_REQUEST="true",
+    )
+    assert resp.status_code == 200
+    content = resp.content.decode()
+    assert "Token:" in content
+    match = re.search(r"<code[^>]*>([^<]+)</code>", content)
+    assert match and match.group(1)
+    assert ApiToken.objects.filter(user=user).exists()


### PR DESCRIPTION
## Summary
- Ensure root users can generate API tokens with admin scope
- Add regression test for root token generation

## Testing
- `pytest tests/tokens/test_root_api_token_generation.py::test_root_user_can_generate_api_token -q --override-ini=addopts=`


------
https://chatgpt.com/codex/tasks/task_e_68af7ee6c5ec8325b1a275f7c28a241d