### PR TITLE
Ensure root dashboard redirect resolves to 200

### DIFF
--- a/tests/dashboard/test_redirect.py
+++ b/tests/dashboard/test_redirect.py
@@ -11,6 +11,14 @@ def test_dashboard_redirect_root(client, root_user):
     assert resp.url == reverse("dashboard:root")
 
 
+def test_dashboard_redirect_root_follow(client, root_user):
+    """Root user should be redirected to the root dashboard and receive 200."""
+    client.force_login(root_user)
+    resp = client.get(reverse("dashboard:dashboard"), follow=True)
+    assert resp.status_code == 200
+    assert resp.wsgi_request.path == reverse("dashboard:root")
+
+
 def test_dashboard_redirect_admin(client, admin_user):
     client.force_login(admin_user)
     resp = client.get(reverse("dashboard:dashboard"))


### PR DESCRIPTION
## Summary
- test that root users hitting `/dashboard/` are redirected to `/dashboard/root/` and receive 200

## Testing
- `pytest tests/dashboard/test_redirect.py::test_dashboard_redirect_root_follow -q --no-cov`

------
https://chatgpt.com/codex/tasks/task_e_68af7ef8586c8325ab9144ef63e32364