### PR TITLE
Display organization stats on root dashboard

### DIFF
--- a/dashboard/templates/dashboard/partials/org_cards.html
+++ b/dashboard/templates/dashboard/partials/org_cards.html
@@ -1,0 +1,11 @@
+{% load i18n %}
+{% for org in organizacoes %}
+<div class="p-4 bg-white rounded-lg shadow" data-org="{{ org.slug }}">
+  <h3 class="text-lg font-semibold mb-2">{{ org.nome }}</h3>
+  <p class="text-sm">{% trans "Usuários" %}: {{ org.num_users }}</p>
+  <p class="text-sm">{% trans "Núcleos" %}: {{ org.num_nucleos }}</p>
+  <p class="text-sm">{% trans "Eventos" %}: {{ org.num_eventos }}</p>
+</div>
+{% empty %}
+<p class="text-center text-neutral-500">{% trans "Nenhuma organização encontrada" %}</p>
+{% endfor %}

--- a/dashboard/templates/dashboard/root.html
+++ b/dashboard/templates/dashboard/root.html
@@ -49,6 +49,13 @@
     </div>
   </section>
 
+  <section class="mb-8">
+    <h2 class="text-xl font-semibold mb-4">{% trans "Organizações" %}</h2>
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+      {% include 'dashboard/partials/org_cards.html' %}
+    </div>
+  </section>
+
   <section
     id="notifications"
     hx-get="{% url 'dashboard:notificacoes-partial' %}"

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -15,7 +15,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import get_user_model
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.db.models import Q
+from django.db.models import Q, Count
 from django.http import (
     FileResponse,
     HttpResponse,
@@ -359,6 +359,14 @@ class RootDashboardView(SuperadminRequiredMixin, DashboardBaseView):
             "disco": round(used / total * 100, 2),
         }
         context["security_metrics"] = {"login_bloqueados": 0}
+        context["organizacoes"] = (
+            Organizacao.objects.annotate(
+                num_users=Count("users", distinct=True),
+                num_nucleos=Count("nucleos", distinct=True),
+                num_eventos=Count("evento", distinct=True),
+            )
+            .all()
+        )
         return context
 
 


### PR DESCRIPTION
## Summary
- Annotate organizations with user, núcleo, and event counts on the root dashboard
- Show organizations in a responsive card grid via new partial template
- Test organization card renders correct counts

## Testing
- `pytest --override-ini="addopts=" tests/dashboard/test_views.py::test_root_dashboard_organizacao_counts -vv --disable-warnings` *(fails: ModuleNotFoundError: No module named 'django_extensions')*


------
https://chatgpt.com/codex/tasks/task_e_68af7f093e508325a1dbbbca2258ee82