### PR TITLE
Ocultar listagens de associações para usuário root

### DIFF
--- a/organizacoes/templates/organizacoes/detail.html
+++ b/organizacoes/templates/organizacoes/detail.html
@@ -60,6 +60,7 @@
     </dl>
   </section>
 
+  {% if request.user.user_type != 'root' %}
   <section id="usuarios-section">
     {% include 'organizacoes/partials/usuarios_list.html' %}
   </section>
@@ -79,6 +80,7 @@
   <section id="posts-section">
     {% include 'organizacoes/partials/posts_list.html' %}
   </section>
+  {% endif %}
 
   <div class="flex justify-end gap-3">
     {% if perms.organizacoes.change_organizacao %}


### PR DESCRIPTION
## Summary
- Restringe a exibição de membros, núcleos, eventos, empresas e posts para usuários root
- Adiciona testes garantindo visibilidade apenas para admins e ocultação para root

## Testing
- `pytest tests/organizacoes/test_views.py::test_detail_view_lists_associations_admin_user tests/organizacoes/test_views.py::test_detail_view_lists_hidden_for_root --no-cov -q`


------
https://chatgpt.com/codex/tasks/task_e_68af845930648325a8ea415f886eb471