### PR TITLE
Remove search field from organizations list

### DIFF
--- a/organizacoes/templates/organizacoes/partials/list_section.html
+++ b/organizacoes/templates/organizacoes/partials/list_section.html
@@ -14,8 +14,7 @@
   </a>
 </div>
 
-<form hx-get="{% url 'organizacoes:list' %}" hx-target="#org-list" hx-push-url="true" class="mb-6 grid md:grid-cols-6 gap-2">
-  <input type="text" name="search" value="{{ request.GET.search }}" placeholder="{% trans 'Buscar por nome ou slug' %}" class="w-full p-2 border rounded-lg" />
+<form hx-get="{% url 'organizacoes:list' %}" hx-target="#org-list" hx-push-url="true" class="mb-6 grid md:grid-cols-5 gap-2">
   <select name="tipo" class="w-full p-2 border rounded-lg">
     <option value="">{% trans 'Tipo' %}</option>
     {% for value, label in tipos %}
@@ -45,7 +44,7 @@
     <option value="cidade" {% if request.GET.ordering == 'cidade' %}selected{% endif %}>{% trans 'Localização' %}</option>
     <option value="created_at" {% if request.GET.ordering == 'created_at' %}selected{% endif %}>{% trans 'Data' %}</option>
   </select>
-  <div class="md:col-span-6 flex justify-end">
+  <div class="md:col-span-5 flex justify-end">
     <button type="submit" class="px-4 py-2 bg-primary-600 text-white rounded-lg">{% trans 'Filtrar' %}</button>
   </div>
 </form>


### PR DESCRIPTION
## Summary
- remove unused search input from organizations listing filters
- adjust grid columns to keep layout

## Testing
- `pytest tests/organizacoes/test_views.py::test_list_view_superadmin tests/organizacoes/test_views.py::test_list_view_admin_access --override-ini="addopts=" -q`

------
https://chatgpt.com/codex/tasks/task_e_68af84648de483258b705371a608b8e4