### PR TITLE
Exibe cards de totais na visualização de organização

### DIFF
--- a/organizacoes/templates/organizacoes/detail.html
+++ b/organizacoes/templates/organizacoes/detail.html
@@ -60,6 +60,27 @@
     </dl>
   </section>
 
+  {% if request.user.user_type == 'root' %}
+  <section id="org-stats" class="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+    <div class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-4 text-center">
+      <p class="text-xs text-neutral-500">{% trans 'Usuários' %}</p>
+      <p class="text-lg font-semibold text-neutral-900">{{ usuarios|length }}</p>
+    </div>
+    <div class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-4 text-center">
+      <p class="text-xs text-neutral-500">{% trans 'Núcleos' %}</p>
+      <p class="text-lg font-semibold text-neutral-900">{{ nucleos|length }}</p>
+    </div>
+    <div class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-4 text-center">
+      <p class="text-xs text-neutral-500">{% trans 'Eventos' %}</p>
+      <p class="text-lg font-semibold text-neutral-900">{{ eventos|length }}</p>
+    </div>
+    <div class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-4 text-center">
+      <p class="text-xs text-neutral-500">{% trans 'Empresas' %}</p>
+      <p class="text-lg font-semibold text-neutral-900">{{ empresas|length }}</p>
+    </div>
+  </section>
+  {% endif %}
+
   {% if request.user.user_type != 'root' %}
   <section id="usuarios-section">
     {% include 'organizacoes/partials/usuarios_list.html' %}

--- a/organizacoes/tests/test_detail_root_cards.py
+++ b/organizacoes/tests/test_detail_root_cards.py
@@ -1,0 +1,41 @@
+import pytest
+from django.urls import reverse
+
+from accounts.factories import UserFactory
+from nucleos.factories import NucleoFactory
+from agenda.factories import EventoFactory
+from empresas.factories import EmpresaFactory
+from organizacoes.factories import OrganizacaoFactory
+
+
+@pytest.fixture
+def root_user(django_user_model):
+    return django_user_model.objects.create_superuser(
+        username="root",
+        email="root@example.com",
+        password="password",
+    )
+
+
+@pytest.mark.django_db
+def test_root_view_shows_summary_cards(client, root_user):
+    org = OrganizacaoFactory()
+    nucleo = NucleoFactory(organizacao=org)
+    user = UserFactory(organizacao=org, nucleo_obj=nucleo)
+    for _ in range(2):
+        EventoFactory(organizacao=org, nucleo=nucleo, coordenador=user)
+    EmpresaFactory(organizacao=org, usuario=user)
+
+    client.force_login(root_user)
+    response = client.get(reverse("organizacoes:detail", args=[org.id]))
+    content = response.content.decode()
+
+    assert 'id="org-stats"' in content
+    assert "Usuários" in content
+    assert "Núcleos" in content
+    assert "Eventos" in content
+    assert "Empresas" in content
+    assert len(response.context["usuarios"]) == 1
+    assert len(response.context["nucleos"]) == 1
+    assert len(response.context["eventos"]) == 2
+    assert len(response.context["empresas"]) == 1


### PR DESCRIPTION
## Summary
- mostra cards com totais de usuários, núcleos, eventos e empresas ao usuário root
- adiciona teste para validar a exibição dos cards e contagens

## Testing
- `pytest organizacoes/tests/test_detail_root_cards.py::test_root_view_shows_summary_cards -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68af881115808325a5cc7c6950d16771