### PR TITLE
Ocultar métricas e ações administrativas para root

### DIFF
--- a/organizacoes/templates/organizacoes/partials/list_section.html
+++ b/organizacoes/templates/organizacoes/partials/list_section.html
@@ -68,6 +68,7 @@
           {% endif %}
         </div>
       </div>
+      {% if request.user.user_type != 'root' %}
       <div class="grid grid-cols-3 gap-4 text-center mt-auto">
         <div>
           <p class="text-xs text-neutral-500">{% trans 'Usuários' %}</p>
@@ -82,23 +83,11 @@
           <p class="text-lg font-semibold text-neutral-900">{{ organizacao.events_count }}</p>
         </div>
       </div>
-      <div class="mt-4 flex gap-2 justify-center">
+      {% endif %}
+      <div class="flex gap-2 justify-center {% if request.user.user_type == 'root' %}mt-auto{% else %}mt-4{% endif %}">
         <a href="{% url 'organizacoes:detail' organizacao.id %}" class="text-blue-600 hover:underline" aria-label="{% trans 'Visualizar' %}">{% trans 'Visualizar' %}</a>
         {% if perms.organizacoes.change_organizacao %}
         <a href="{% url 'organizacoes:update' organizacao.id %}" class="text-yellow-700 hover:underline" aria-label="{% trans 'Editar' %}">{% trans 'Editar' %}</a>
-        {% endif %}
-        {% if request.user.user_type == 'root' %}
-          {% if perms.organizacoes.delete_organizacao %}
-          <a href="{% url 'organizacoes:delete' organizacao.id %}" class="text-red-700 hover:underline" aria-label="{% trans 'Remover' %}" hx-confirm="{% trans 'Confirmar remoção?' %}">{% trans 'Remover' %}</a>
-          {% endif %}
-          <form method="post" action="{% url 'organizacoes:toggle' organizacao.id %}" hx-confirm="{% trans 'Tem certeza?' %}">
-            {% csrf_token %}
-            {% if organizacao.inativa %}
-              <button type="submit" class="text-neutral-700 hover:underline" aria-label="{% trans 'Reativar' %}">{% trans 'Reativar' %}</button>
-            {% else %}
-              <button type="submit" class="text-neutral-700 hover:underline" aria-label="{% trans 'Inativar' %}">{% trans 'Inativar' %}</button>
-            {% endif %}
-          </form>
         {% endif %}
       </div>
     </div>

--- a/organizacoes/tests/test_list_cards.py
+++ b/organizacoes/tests/test_list_cards.py
@@ -2,8 +2,9 @@ import pytest
 from django.urls import reverse
 
 from accounts.factories import UserFactory
-from nucleos.factories import NucleoFactory
+from accounts.models import UserType
 from agenda.factories import EventoFactory
+from nucleos.factories import NucleoFactory
 from organizacoes.factories import OrganizacaoFactory
 
 
@@ -38,3 +39,18 @@ def test_list_template_renders_cards(client, admin_user):
     assert "Núcleos" in content
     assert "Eventos" in content
 
+
+@pytest.mark.django_db
+def test_list_template_root_hides_counts_and_actions(client):
+    OrganizacaoFactory()
+    user = UserFactory(user_type=UserType.ROOT)
+    client.force_login(user)
+    response = client.get(reverse("organizacoes:list"))
+    content = response.content.decode()
+
+    assert "Usuários" not in content
+    assert "Núcleos" not in content
+    assert "Eventos" not in content
+    assert "Remover" not in content
+    assert "Inativar" not in content
+    assert "Reativar" not in content


### PR DESCRIPTION
## Sumário
- omite estatísticas de usuários, núcleos e eventos para usuários root
- remove links de remoção/inativação no card de organizações
- garante via teste que root não vê métricas nem ações administrativas

## Testes
- `pytest organizacoes/tests/test_list_cards.py::test_list_template_root_hides_counts_and_actions --no-cov -q`
- `pytest organizacoes/tests/test_list_cards.py tests/organizacoes/test_views.py --no-cov -q` *(falhou: assert 'Usuários' in content, criação/edição de organização)*

------
https://chatgpt.com/codex/tasks/task_e_68af8a878a808325a792fd430d516d0f