### PR TITLE
fix: allow superuser dashboard

### DIFF
--- a/core/permissions.py
+++ b/core/permissions.py
@@ -11,7 +11,12 @@ class SuperadminRequiredMixin(UserPassesTestMixin):
     """Permite acesso apenas a superadministradores."""
 
     def test_func(self):
-        return self.request.user.user_type == UserType.ROOT
+        user = self.request.user
+        return (
+            getattr(user, "user_type", None) == UserType.ROOT
+            or getattr(user, "is_superuser", False)
+            or getattr(user, "get_tipo_usuario", None) == UserType.ROOT.value
+        )
 
 
 class AdminRequiredMixin(UserPassesTestMixin):

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -388,13 +388,20 @@ def dashboard_redirect(request):
     if not user.is_authenticated:
         return redirect("accounts:login")
 
-    if user.user_type == UserType.ROOT:
+    user_type = getattr(user, "user_type", None) or getattr(user, "get_tipo_usuario", None)
+
+    if user.is_superuser or user_type in {UserType.ROOT, UserType.ROOT.value}:
         return redirect("dashboard:root")
-    if user.user_type == UserType.ADMIN:
+    if user_type in {UserType.ADMIN, UserType.ADMIN.value}:
         return redirect("dashboard:admin")
-    if user.user_type == UserType.COORDENADOR:
+    if user_type in {UserType.COORDENADOR, UserType.COORDENADOR.value}:
         return redirect("dashboard:coordenador")
-    if user.user_type in {UserType.ASSOCIADO, UserType.NUCLEADO}:
+    if user_type in {
+        UserType.ASSOCIADO,
+        UserType.ASSOCIADO.value,
+        UserType.NUCLEADO,
+        UserType.NUCLEADO.value,
+    }:
         return redirect("dashboard:cliente")
     return redirect("accounts:perfil")
 


### PR DESCRIPTION
## Summary
- allow superusers to access root dashboard
- route dashboard based on effective user type

## Testing
- `pytest --cov=. --cov-report=term --cov-fail-under=0 tests/dashboard/test_redirect.py::test_dashboard_redirect_root -vv`


------
https://chatgpt.com/codex/tasks/task_e_68af8d3a3b6483258ab1d2db71805dc5