### PR TITLE
Add aria-labels to dashboard links for accessibility

### DIFF
--- a/dashboard/templates/dashboard/admin.html
+++ b/dashboard/templates/dashboard/admin.html
@@ -55,19 +55,19 @@
   <section class="mb-8">
     <h2 class="text-xl font-semibold mb-4">{% trans "Ações Rápidas" %}</h2>
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-      <a href="{% url 'dashboard:custom-metrics' %}" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50">
+      <a href="{% url 'dashboard:custom-metrics' %}" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50" aria-label="{% trans 'Métricas Personalizadas' %}">
         <i class="fa-solid fa-chart-line mb-2"></i>
         <span class="block">{% trans "Métricas Personalizadas" %}</span>
       </a>
-      <a href="{% url 'admin:accounts_user_changelist' %}" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50">
+      <a href="{% url 'admin:accounts_user_changelist' %}" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50" aria-label="{% trans 'Administrar Usuários' %}">
         <i class="fa-solid fa-user-gear mb-2"></i>
         <span class="block">{% trans "Administrar Usuários" %}</span>
       </a>
-      <a href="{% url 'financeiro:relatorios' %}" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50">
+      <a href="{% url 'financeiro:relatorios' %}" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50" aria-label="{% trans 'Relatórios Financeiros' %}">
         <i class="fa-solid fa-file-invoice-dollar mb-2"></i>
         <span class="block">{% trans "Relatórios Financeiros" %}</span>
       </a>
-      <a href="{% url 'notificacoes:logs_list' %}" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50">
+      <a href="{% url 'notificacoes:logs_list' %}" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50" aria-label="{% trans 'Logs de Notificações' %}">
         <i class="fa-solid fa-bell mb-2"></i>
         <span class="block">{% trans "Logs de Notificações" %}</span>
       </a>

--- a/dashboard/templates/dashboard/cliente.html
+++ b/dashboard/templates/dashboard/cliente.html
@@ -42,11 +42,11 @@
   <section class="mb-8">
     <h2 class="text-xl font-semibold mb-4">{% trans "Atalhos" %}</h2>
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-      <a href="{% url 'agenda:calendario' %}" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50">
+      <a href="{% url 'agenda:calendario' %}" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50" aria-label="{% trans 'Inscrever-se em Eventos' %}">
         <i class="fa-solid fa-calendar-plus mb-2"></i>
         <span class="block">{% trans "Inscrever-se em Eventos" %}</span>
       </a>
-      <a href="{% url 'feed:listar' %}" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50">
+      <a href="{% url 'feed:listar' %}" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50" aria-label="{% trans 'Ver Feed' %}">
         <i class="fa-solid fa-rss mb-2"></i>
         <span class="block">{% trans "Ver Feed" %}</span>
       </a>

--- a/dashboard/templates/dashboard/layout_list.html
+++ b/dashboard/templates/dashboard/layout_list.html
@@ -19,6 +19,6 @@
       <li>{% trans "Nenhum layout" %}</li>
     {% endfor %}
   </ul>
-  <a href="{% url 'dashboard:layout-create' %}" class="btn btn-primary">{% trans "Novo Layout" %}</a>
+  <a href="{% url 'dashboard:layout-create' %}" class="btn btn-primary" aria-label="{% trans 'Novo Layout' %}">{% trans "Novo Layout" %}</a>
 </main>
 {% endblock %}

--- a/dashboard/templates/dashboard/root.html
+++ b/dashboard/templates/dashboard/root.html
@@ -65,11 +65,11 @@
   <section class="mb-8">
     <h2 class="text-xl font-semibold mb-4">{% trans "Ações Rápidas" %}</h2>
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-        <a href="{% url 'admin:index' %}" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50">
+        <a href="{% url 'admin:index' %}" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50" aria-label="{% trans 'Django Admin' %}">
           <i class="fa-solid fa-wrench mb-2" aria-hidden="true"></i>
           <span class="block">{% trans "Django Admin" %}</span>
         </a>
-        <a href="{% url 'dashboard:custom-metrics' %}" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50">
+        <a href="{% url 'dashboard:custom-metrics' %}" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50" aria-label="{% trans 'Métricas Personalizadas' %}">
           <i class="fa-solid fa-chart-line mb-2" aria-hidden="true"></i>
           <span class="block">{% trans "Métricas Personalizadas" %}</span>
         </a>


### PR DESCRIPTION
## Summary
- add `aria-label` attributes to dashboard shortcut links

## Testing
- `pytest` *(fails: 89 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b05dcb9bcc8325a246ffe31a4af443