### PR TITLE
refactor: centralize token rotation utilities

### DIFF
--- a/tests/tokens/test_api_token_metrics.py
+++ b/tests/tokens/test_api_token_metrics.py
@@ -9,7 +9,8 @@ from rest_framework.test import APIClient
 from accounts.factories import UserFactory
 from tokens import metrics as m
 from tokens.models import ApiToken
-from tokens.services import generate_token, revoke_token, rotate_token
+from tokens.services import generate_token
+from tokens.utils import revoke_token, rotate_token
 
 pytestmark = pytest.mark.django_db
 

--- a/tests/tokens/test_api_tokens.py
+++ b/tests/tokens/test_api_tokens.py
@@ -13,8 +13,9 @@ from rest_framework.test import APIClient
 
 from accounts.factories import UserFactory
 from tokens.models import ApiToken, ApiTokenLog
-from tokens.services import generate_token, revoke_token, rotate_token
+from tokens.services import generate_token
 from tokens.tasks import revogar_tokens_expirados, rotacionar_tokens_proximos_da_expiracao
+from tokens.utils import revoke_token, rotate_token
 
 pytestmark = pytest.mark.django_db
 

--- a/tests/tokens/test_webhooks.py
+++ b/tests/tokens/test_webhooks.py
@@ -8,7 +8,8 @@ from django.test import override_settings
 
 from accounts.factories import UserFactory
 from tokens.models import ApiToken
-from tokens.services import generate_token, revoke_token, rotate_token
+from tokens.services import generate_token
+from tokens.utils import revoke_token, rotate_token
 
 
 pytestmark = pytest.mark.django_db

--- a/tokens/api_views.py
+++ b/tokens/api_views.py
@@ -12,9 +12,9 @@ from rest_framework.response import Response
 
 from .models import ApiToken, ApiTokenIp, ApiTokenLog
 from .serializers import ApiTokenIpSerializer, ApiTokenSerializer
-from .services import generate_token, list_tokens, revoke_token, rotate_token
+from .services import generate_token, list_tokens
 from .metrics import tokens_api_latency_seconds
-from .utils import get_client_ip
+from .utils import get_client_ip, revoke_token, rotate_token
 
 
 class ApiTokenViewSet(viewsets.ViewSet):

--- a/tokens/tasks.py
+++ b/tokens/tasks.py
@@ -11,7 +11,7 @@ from django.conf import settings
 from django.utils import timezone
 
 from .models import ApiToken, ApiTokenLog, TokenUsoLog, TokenWebhookEvent
-from .services import revoke_token, rotate_token
+from .utils import revoke_token, rotate_token
 from .metrics import (
     tokens_webhook_latency_seconds,
     tokens_webhooks_failed_total,

--- a/tokens/utils.py
+++ b/tokens/utils.py
@@ -1,6 +1,21 @@
 from __future__ import annotations
 
+import hashlib
+import uuid
+from datetime import timedelta
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.http import HttpRequest
+from django.utils import timezone
+
+from .metrics import (
+    tokens_api_tokens_revoked_total,
+    tokens_api_tokens_rotated_total,
+)
+from .models import ApiToken, ApiTokenLog
+
+User = get_user_model()
 
 
 def get_client_ip(request: HttpRequest) -> str:
@@ -15,4 +30,85 @@ def get_client_ip(request: HttpRequest) -> str:
     if x_forwarded_for:
         return x_forwarded_for.split(",")[0].strip()
     return request.META.get("REMOTE_ADDR", "")
+
+
+def _send_webhook(payload: dict[str, object]) -> None:
+    """Queue task to send ``payload`` to the configured webhook."""
+
+    url = getattr(settings, "TOKENS_WEBHOOK_URL", None)
+    if not url:
+        return
+
+    # Imported lazily to avoid circular import with tasks module
+    from .tasks import send_webhook
+
+    send_webhook.delay(payload)
+
+
+def revoke_token(
+    token_id: uuid.UUID,
+    revogado_por: User | None = None,
+    ip: str | None = None,
+    user_agent: str | None = None,
+    usuario_log: User | None = None,
+) -> bool:
+    """Revoga o token indicado e dispara webhook."""
+
+    token = ApiToken.all_objects.get(id=token_id)
+    if token.revoked_at:
+        return False
+
+    now = timezone.now()
+    token.revoked_at = now
+    token.revogado_por = revogado_por or token.user
+    token.deleted = True
+    token.deleted_at = now
+    token.save(update_fields=["revoked_at", "revogado_por", "deleted", "deleted_at"])
+
+    ApiTokenLog.objects.create(
+        token=token,
+        usuario=usuario_log or revogado_por,
+        acao=ApiTokenLog.Acao.REVOGACAO,
+        ip=ip,
+        user_agent=user_agent,
+    )
+
+    tokens_api_tokens_revoked_total.inc()
+    _send_webhook({"event": "revoked", "id": str(token.id)})
+    return True
+
+
+def rotate_token(
+    token_id: uuid.UUID,
+    revogado_por: User | None = None,
+    ip: str | None = None,
+    user_agent: str | None = None,
+) -> str:
+    """Gera novo token e revoga o anterior automaticamente."""
+
+    token = ApiToken.objects.get(id=token_id)
+    expires_in: timedelta | None = None
+    if token.expires_at:
+        delta = token.expires_at - timezone.now()
+        if delta.total_seconds() > 0:
+            expires_in = delta
+
+    from .services import generate_token  # Lazy import to avoid circular dependency
+
+    raw_token = generate_token(
+        token.user,
+        token.client_name,
+        token.scope,
+        expires_in,
+    )
+    token_hash = hashlib.sha256(raw_token.encode()).hexdigest()
+    novo_token = ApiToken.objects.get(token_hash=token_hash)
+    novo_token.anterior = token
+    novo_token.save(update_fields=["anterior"])
+
+    revoke_token(token.id, revogado_por, ip=ip, user_agent=user_agent)
+    _send_webhook({"event": "rotated", "id": str(token.id), "new_id": str(novo_token.id)})
+    tokens_api_tokens_rotated_total.inc()
+
+    return raw_token
 

--- a/tokens/views.py
+++ b/tokens/views.py
@@ -53,9 +53,8 @@ from .services import (
     invite_revoked,
     invite_used,
     list_tokens,
-    revoke_token,
 )
-from .utils import get_client_ip
+from .utils import get_client_ip, revoke_token
 
 User = get_user_model()
 


### PR DESCRIPTION
## Summary
- move token revocation and rotation helpers into `tokens.utils`
- update services, tasks, views and API views to import from new utils module
- adjust tests and other modules to use the new utility functions

## Testing
- `python manage.py check`

------
https://chatgpt.com/codex/tasks/task_e_68b06d5bfb688325aa35ffea046951dd