### PR TITLE
Redireciona usuário autenticado para página de perfil

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -57,7 +57,8 @@ User = get_user_model()
 
 @login_required
 def perfil_home(request):
-    return redirect("accounts:informacoes_pessoais")
+    """Exibe a página de detalhes do perfil do usuário."""
+    return render(request, "perfil/detail.html")
 
 
 def perfil_publico(request, pk):

--- a/core/views.py
+++ b/core/views.py
@@ -1,11 +1,13 @@
 from django.contrib.auth.decorators import login_required
-from django.shortcuts import render
+from django.shortcuts import redirect, render
 from django.views.generic import TemplateView
 
 from feed.models import Post
 
 
 def home(request):
+    if request.user.is_authenticated:
+        return redirect("accounts:perfil")
     return render(request, "core/home.html")
 
 

--- a/tests/core/test_home.py
+++ b/tests/core/test_home.py
@@ -19,9 +19,8 @@ def test_home_authenticated(client):
     user = User.objects.create_user(username="u", email="u@example.com", password="pass")
     client.force_login(user)
     response = client.get(reverse("core:home"))
-    assert response.status_code == 200
-    html = response.content.decode()
-    assert "Dashboard" in html or "Ir para Dashboard" in html
+    assert response.status_code == 302
+    assert response.url == reverse("accounts:perfil")
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Resumo
- Exibe página de detalhes do perfil ao acessar `/accounts/perfil/`
- Redireciona usuários autenticados que acessam a página inicial para seu perfil
- Ajusta testes do core para refletir novo comportamento

## Testes
- `pytest --cov=accounts --cov=core --cov-fail-under=0 tests/core/test_home.py tests/accounts/test_perfil_publico.py tests/accounts/test_email_change_requires_confirmation.py`


------
https://chatgpt.com/codex/tasks/task_e_68b08092cb18832580c2abeef602d4d5