### PR TITLE
Redirect admins to API token list

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -144,10 +144,16 @@
           <i class="fas fa-sitemap"></i> {% trans "Organizações" %}
         </a>
         {% endif %}
-  {% if user.is_authenticated and user.user_type == 'root' or user.is_authenticated and user.user_type == 'admin' or user.is_authenticated and user.user_type == 'coordenador' %}
+  {% if user.is_authenticated and user.user_type in ('root', 'admin', 'coordenador') %}
+        {% if user.user_type in ('root', 'admin') %}
+        <a href="{% url 'tokens:listar_api_tokens' %}" class="flex items-center gap-x-2 hover:text-primary transition">
+          <i class="fas fa-key"></i> {% trans "Token" %}
+        </a>
+        {% else %}
         <a href="{% url 'tokens:gerar_convite' %}" class="flex items-center gap-x-2 hover:text-primary transition">
           <i class="fas fa-key"></i> {% trans "Token" %}
         </a>
+        {% endif %}
         {% endif %}
         {% if user.is_authenticated %}
           <span class="text-gray-600">{% blocktrans %}Olá, {{ user.username }}{% endblocktrans %}</span>

--- a/tests/tokens/test_token_redirect.py
+++ b/tests/tokens/test_token_redirect.py
@@ -1,0 +1,17 @@
+import pytest
+from django.urls import reverse
+
+from accounts.factories import UserFactory
+from accounts.models import UserType
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.mark.parametrize("user_type", [UserType.ROOT.value, UserType.ADMIN.value])
+def test_root_admin_redirect_to_listar_api_tokens(client, user_type):
+    user = UserFactory(user_type=user_type)
+    client.force_login(user)
+
+    resp = client.get(reverse("tokens:token"))
+    assert resp.status_code == 302
+    assert resp.url == reverse("tokens:listar_api_tokens")

--- a/tokens/views.py
+++ b/tokens/views.py
@@ -60,6 +60,12 @@ User = get_user_model()
 
 
 def token(request):
+    if request.user.is_authenticated and (
+        request.user.is_superuser
+        or request.user.user_type in [UserType.ROOT, UserType.ADMIN]
+    ):
+        return redirect("tokens:listar_api_tokens")
+
     if request.method == "POST":
         tkn = request.POST.get("token")
         if tkn:


### PR DESCRIPTION
## Summary
- Redirect root and admin users to API token list when opening Tokens
- Update menu to send root/admin to API token list and others to invite generation
- Test redirect behavior for root and admin users

## Testing
- `pytest --no-cov tests/tokens/test_token_redirect.py tests/tokens/test_root_api_token_generation.py -q` *(failed: KeyboardInterrupt during migrations)*

------
https://chatgpt.com/codex/tasks/task_e_68b089b99c6c83259d48dc7daaaf1799