### PR TITLE
feat: add cover image to user profile

### DIFF
--- a/accounts/templates/perfil/perfil.html
+++ b/accounts/templates/perfil/perfil.html
@@ -5,46 +5,55 @@
 
 {% block content %}
 <div class="max-w-5xl mx-auto mt-8 px-4">
-  <div class="bg-white rounded-2xl shadow p-6 flex flex-col min-h-[80vh]">
-
-    <!-- Avatar + Nome -->
-    <div class="flex flex-col items-center">
-      {% if user.avatar %}
-        <img src="{{ user.avatar.url }}" alt="{{ user.username }}"
-             class="w-28 h-28 rounded-full object-cover shadow mb-3">
+  <div class="bg-white rounded-2xl shadow overflow-hidden flex flex-col min-h-[80vh]">
+    <div class="profile-cover h-48 w-full">
+      {% if user.cover %}
+        <img src="{{ user.cover.url }}" alt="{% trans "Capa do usuário" %}" class="w-full h-full object-cover">
       {% else %}
-        <div class="w-28 h-28 rounded-full bg-gray-200 flex items-center justify-center text-2xl font-semibold text-primary shadow mb-3" role="img" aria-label="{{ user.username }}">
-          {{ user.username|first|upper }}
-        </div>
+        <div class="w-full h-full bg-gray-200" role="img" aria-label="{% trans "Capa padrão" %}"></div>
       {% endif %}
-
-      <h2 class="text-lg font-bold">{{ user.get_full_name }}</h2>
-      <p class="text-sm text-gray-500 mb-2">@{{ user.username }}</p>
-      <button class="text-sm text-primary hover:underline">{% trans "Alterar foto" %}</button>
     </div>
+    <div class="p-6 flex flex-col flex-grow">
 
-    <!-- Abas de navegação -->
-    <nav class="mt-6 border-b flex space-x-4 text-sm font-medium text-gray-600" role="tablist">
-      <a href="{% url 'accounts:informacoes_pessoais' %}"
-         class="px-3 py-2 -mb-px border-b-2 {% if request.resolver_match.url_name == 'informacoes_pessoais' %}border-primary text-primary{% else %}border-transparent hover:text-primary{% endif %}"
-         role="tab"
-         aria-selected="{% if request.resolver_match.url_name == 'informacoes_pessoais' %}true{% else %}false{% endif %}">{% trans "Informações Pessoais" %}</a>
-      <a href="{% url 'accounts:seguranca' %}"
-         class="px-3 py-2 -mb-px border-b-2 {% if request.resolver_match.url_name == 'seguranca' %}border-primary text-primary{% else %}border-transparent hover:text-primary{% endif %}"
-         role="tab"
-         aria-selected="{% if request.resolver_match.url_name == 'seguranca' %}true{% else %}false{% endif %}">{% trans "Segurança" %}</a>
-      <a href="{% url 'configuracoes' %}?tab=preferencias"
-         class="px-3 py-2 -mb-px border-b-2 border-transparent hover:text-primary"
-         role="tab"
-         aria-selected="false">{% trans "Notificações" %}</a>
-    </nav>
+      <!-- Avatar + Nome -->
+      <div class="flex flex-col items-center">
+        {% if user.avatar %}
+          <img src="{{ user.avatar.url }}" alt="{{ user.username }}"
+               class="w-28 h-28 rounded-full object-cover shadow mb-3">
+        {% else %}
+          <div class="w-28 h-28 rounded-full bg-gray-200 flex items-center justify-center text-2xl font-semibold text-primary shadow mb-3" role="img" aria-label="{{ user.username }}">
+            {{ user.username|first|upper }}
+          </div>
+        {% endif %}
 
-    <!-- Bloco dinâmico para subpáginas -->
-    <div class="flex-grow mt-8">
-      {% block perfil_content %}
-      {% endblock %}
+        <h2 class="text-lg font-bold">{{ user.get_full_name }}</h2>
+        <p class="text-sm text-gray-500 mb-2">@{{ user.username }}</p>
+        <button class="text-sm text-primary hover:underline">{% trans "Alterar foto" %}</button>
+      </div>
+
+      <!-- Abas de navegação -->
+      <nav class="mt-6 border-b flex space-x-4 text-sm font-medium text-gray-600" role="tablist">
+        <a href="{% url 'accounts:informacoes_pessoais' %}"
+           class="px-3 py-2 -mb-px border-b-2 {% if request.resolver_match.url_name == 'informacoes_pessoais' %}border-primary text-primary{% else %}border-transparent hover:text-primary{% endif %}"
+           role="tab"
+           aria-selected="{% if request.resolver_match.url_name == 'informacoes_pessoais' %}true{% else %}false{% endif %}">{% trans "Informações Pessoais" %}</a>
+        <a href="{% url 'accounts:seguranca' %}"
+           class="px-3 py-2 -mb-px border-b-2 {% if request.resolver_match.url_name == 'seguranca' %}border-primary text-primary{% else %}border-transparent hover:text-primary{% endif %}"
+           role="tab"
+           aria-selected="{% if request.resolver_match.url_name == 'seguranca' %}true{% else %}false{% endif %}">{% trans "Segurança" %}</a>
+        <a href="{% url 'configuracoes' %}?tab=preferencias"
+           class="px-3 py-2 -mb-px border-b-2 border-transparent hover:text-primary"
+           role="tab"
+           aria-selected="false">{% trans "Notificações" %}</a>
+      </nav>
+
+      <!-- Bloco dinâmico para subpáginas -->
+      <div class="flex-grow mt-8">
+        {% block perfil_content %}
+        {% endblock %}
+      </div>
+
     </div>
-
   </div>
 </div>
 {% endblock %}

--- a/accounts/templates/perfil/publico.html
+++ b/accounts/templates/perfil/publico.html
@@ -1,25 +1,34 @@
 {% extends 'base.html' %}
-{% load i18n %}
+{% load static i18n %}
 {% block title %}{{ perfil.get_full_name|default:perfil.username }} | Hubx{% endblock %}
 {% block content %}
 <div class="max-w-3xl mx-auto mt-8 px-4">
-  <div class="bg-white rounded-2xl shadow p-6">
-    <div class="flex items-center gap-4">
-      {% if perfil.avatar %}
-        <img src="{{ perfil.avatar.url }}" alt="{{ perfil.username }}" class="w-20 h-20 rounded-full object-cover">
+  <div class="bg-white rounded-2xl shadow overflow-hidden">
+    <div class="profile-cover h-48 w-full">
+      {% if perfil.cover %}
+        <img src="{{ perfil.cover.url }}" alt="{% trans "Capa do usuário" %}" class="w-full h-full object-cover">
       {% else %}
-        <div class="w-20 h-20 rounded-full bg-gray-200 flex items-center justify-center text-xl font-semibold text-primary" role="img" aria-label="{{ perfil.username }}">
-          {{ perfil.username|first|upper }}
-        </div>
+        <div class="w-full h-full bg-gray-200" role="img" aria-label="{% trans "Capa padrão" %}"></div>
       {% endif %}
-      <div>
-        <h1 class="text-lg font-bold">{{ perfil.get_full_name|default:perfil.username }}</h1>
-        <p class="text-sm text-gray-500">@{{ perfil.username }}</p>
-      </div>
     </div>
-    {% if perfil.biografia %}
-      <p class="mt-4 text-gray-700 whitespace-pre-line">{{ perfil.biografia }}</p>
-    {% endif %}
+    <div class="p-6">
+      <div class="flex items-center gap-4">
+        {% if perfil.avatar %}
+          <img src="{{ perfil.avatar.url }}" alt="{{ perfil.username }}" class="w-20 h-20 rounded-full object-cover">
+        {% else %}
+          <div class="w-20 h-20 rounded-full bg-gray-200 flex items-center justify-center text-xl font-semibold text-primary" role="img" aria-label="{{ perfil.username }}">
+            {{ perfil.username|first|upper }}
+          </div>
+        {% endif %}
+        <div>
+          <h1 class="text-lg font-bold">{{ perfil.get_full_name|default:perfil.username }}</h1>
+          <p class="text-sm text-gray-500">@{{ perfil.username }}</p>
+        </div>
+      </div>
+      {% if perfil.biografia %}
+        <p class="mt-4 text-gray-700 whitespace-pre-line">{{ perfil.biografia }}</p>
+      {% endif %}
+    </div>
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- display user cover image on profile and public profile with gray fallback

## Testing
- `pytest tests/accounts -q` *(fails: ModuleNotFoundError: No module named 'freezegun')*
- `pytest tests/accounts/test_perfil_publico.py::test_perfil_publico_respects_privacy -q --no-cov` *(fails: fixture 'db' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c12426b88325ad183d338128cba1