### PR TITLE
Ajusta navegação do perfil e tema escuro

### DIFF
--- a/accounts/templates/perfil/informacoes_pessoais.html
+++ b/accounts/templates/perfil/informacoes_pessoais.html
@@ -1,5 +1,5 @@
 {% extends 'perfil/perfil.html' %}
-{% load static i18n %}
+{% load static i18n custom_filters %}
 
 {% block title %}{% trans "Informações Pessoais" %} | HubX{% endblock %}
 
@@ -71,7 +71,7 @@
 
     <div>
       {{ form.endereco.label_tag }}
-      {{ form.endereco }}
+      {{ form.endereco|add_class:'w-full' }}
       {{ form.endereco.errors }}
     </div>
 

--- a/accounts/templates/perfil/perfil.html
+++ b/accounts/templates/perfil/perfil.html
@@ -32,6 +32,7 @@
       </div>
 
       <!-- Abas de navegação -->
+      {% if request.resolver_match.url_name in ['informacoes_pessoais', 'seguranca', 'redes_sociais'] %}
       <nav class="mt-6 border-b flex space-x-4 text-sm font-medium text-gray-600" role="tablist">
         <a href="{% url 'accounts:informacoes_pessoais' %}"
            class="px-3 py-2 -mb-px border-b-2 {% if request.resolver_match.url_name == 'informacoes_pessoais' %}border-primary text-primary{% else %}border-transparent hover:text-primary{% endif %}"
@@ -41,11 +42,16 @@
            class="px-3 py-2 -mb-px border-b-2 {% if request.resolver_match.url_name == 'seguranca' %}border-primary text-primary{% else %}border-transparent hover:text-primary{% endif %}"
            role="tab"
            aria-selected="{% if request.resolver_match.url_name == 'seguranca' %}true{% else %}false{% endif %}">{% trans "Segurança" %}</a>
+        <a href="{% url 'accounts:redes_sociais' %}"
+           class="px-3 py-2 -mb-px border-b-2 {% if request.resolver_match.url_name == 'redes_sociais' %}border-primary text-primary{% else %}border-transparent hover:text-primary{% endif %}"
+           role="tab"
+           aria-selected="{% if request.resolver_match.url_name == 'redes_sociais' %}true{% else %}false{% endif %}">{% trans "Redes Sociais" %}</a>
         <a href="{% url 'configuracoes' %}?tab=preferencias"
            class="px-3 py-2 -mb-px border-b-2 border-transparent hover:text-primary"
            role="tab"
            aria-selected="false">{% trans "Notificações" %}</a>
       </nav>
+      {% endif %}
 
       <!-- Bloco dinâmico para subpáginas -->
       <div class="flex-grow mt-8">

--- a/accounts/templates/perfil/redes_sociais.html
+++ b/accounts/templates/perfil/redes_sociais.html
@@ -1,5 +1,5 @@
 {% extends 'perfil/perfil.html' %}
-{% load static i18n %}
+{% load static i18n custom_filters %}
 
 {% block title %}{% trans "Redes Sociais" %} | HubX{% endblock %}
 
@@ -11,16 +11,28 @@
   <form method="post" action="{% url 'accounts:redes_sociais' %}" class="space-y-6">
     {% csrf_token %}
 
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
       <div>
-        {{ form.redes_sociais.label_tag }}
-        {{ form.redes_sociais }}
-        {% if form.redes_sociais.errors %}
-          <p class="text-red-600 text-sm mt-1">{{ form.redes_sociais.errors }}</p>
-        {% endif %}
-        {% if form.non_field_errors %}
-          <p class="text-red-600 text-sm mt-1">{{ form.non_field_errors }}</p>
-        {% endif %}
+        {{ form.facebook.label_tag }}
+        {{ form.facebook|add_class:'w-full' }}
+        {{ form.facebook.errors }}
       </div>
+      <div>
+        {{ form.twitter.label_tag }}
+        {{ form.twitter|add_class:'w-full' }}
+        {{ form.twitter.errors }}
+      </div>
+      <div>
+        {{ form.instagram.label_tag }}
+        {{ form.instagram|add_class:'w-full' }}
+        {{ form.instagram.errors }}
+      </div>
+      <div>
+        {{ form.linkedin.label_tag }}
+        {{ form.linkedin|add_class:'w-full' }}
+        {{ form.linkedin.errors }}
+      </div>
+    </div>
 
     <div class="pt-4">
       <button type="submit"

--- a/static/configuracoes/preferencias.js
+++ b/static/configuracoes/preferencias.js
@@ -22,6 +22,7 @@ function initPreferencias() {
   const selEmailEl = document.getElementById(selEmail);
   const selWhatsEl = document.getElementById(selWhats);
   const selPushEl = document.getElementById(selPush);
+  const temaSelectEl = document.getElementById('id_tema');
 
   if (!chkEmailEl || !chkWhatsEl || !chkPushEl || !selEmailEl || !selWhatsEl || !selPushEl) {
     return;
@@ -71,6 +72,23 @@ function initPreferencias() {
   chkPushEl.addEventListener('change', toggleFields);
 
   toggleFields();
+
+  if (temaSelectEl) {
+    const applyTheme = () => {
+      const temaValue = temaSelectEl.value;
+      localStorage.setItem('tema', temaValue);
+      document.cookie = `tema=${temaValue};path=/`;
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      const theme =
+        temaValue === 'automatico'
+          ? prefersDark
+            ? 'escuro'
+            : 'claro'
+          : temaValue;
+      document.documentElement.classList.toggle('dark', theme === 'escuro');
+    };
+    temaSelectEl.addEventListener('change', applyTheme);
+  }
 
   if (updatedPreferences === 'true') {
     const temaValue = tema;


### PR DESCRIPTION
## Summary
- Exibe abas de edição apenas ao editar o perfil
- Amplia campo de endereço e adiciona edição de redes sociais
- Corrige troca imediata para tema escuro nas preferências

## Testing
- `pytest tests/accounts tests/configuracoes -q` *(fails: ModuleNotFoundError: No module named 'freezegun')*

------
https://chatgpt.com/codex/tasks/task_e_68b1c56671088325b12eccda333fc1c2