### PR TITLE
Fix profile navigation check to avoid template error

### DIFF
--- a/accounts/templates/perfil/perfil.html
+++ b/accounts/templates/perfil/perfil.html
@@ -32,7 +32,7 @@
       </div>
 
       <!-- Abas de navegação -->
-      {% if request.resolver_match.url_name in ['informacoes_pessoais', 'seguranca', 'redes_sociais'] %}
+      {% if request.resolver_match.url_name == 'informacoes_pessoais' or request.resolver_match.url_name == 'seguranca' or request.resolver_match.url_name == 'redes_sociais' %}
       <nav class="mt-6 border-b flex space-x-4 text-sm font-medium text-gray-600" role="tablist">
         <a href="{% url 'accounts:informacoes_pessoais' %}"
            class="px-3 py-2 -mb-px border-b-2 {% if request.resolver_match.url_name == 'informacoes_pessoais' %}border-primary text-primary{% else %}border-transparent hover:text-primary{% endif %}"


### PR DESCRIPTION
## Summary
- avoid TemplateSyntaxError by using explicit URL name checks for profile navigation tabs

## Testing
- `python manage.py shell -c "from django.test import Client; from django.contrib.auth import get_user_model; User=get_user_model(); u=User.objects.create_user(username='tmp3', email='tmp3@example.com', password='tmp123'); c=Client(); c.force_login(u); resp=c.get('/accounts/perfil/'); print(resp.status_code)"`
- `pytest tests/test_accounts_auth.py::AuthTests::test_email_login_success -q` *(fails: Required test coverage of 90% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c81465948325a2dfb9b183b47957