### PR TITLE
Fix missing endif in profile template

### DIFF
--- a/accounts/templates/perfil/perfil.html
+++ b/accounts/templates/perfil/perfil.html
@@ -58,7 +58,9 @@
         {% endblock %}
       </div>
 
+      {% endif %}
+
+      </div>
     </div>
   </div>
-</div>
-{% endblock %}
+  {% endblock %}


### PR DESCRIPTION
## Summary
- close profile navigation conditional in `perfil.html`

## Testing
- `pytest -q` *(fails: No module named 'freezegun')*

------
https://chatgpt.com/codex/tasks/task_e_68b207a0e3f08325ae18de17d9e7164f