### PR TITLE
Add Font Awesome icons to navigation and fix settings gear

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -119,10 +119,12 @@
         <a href="{% url 'tokens:listar_api_tokens' %}" class="flex items-center gap-x-2 hover:text-primary transition">
           <i class="fas fa-key"></i> {% trans "Tokens" %}
         </a>
-        <a href="{% url 'configuracoes' %}" class="hover:text-primary transition">
-          <i class="fa-solid fa-gear" aria-hidden="true"></i><span class="sr-only">{% trans "Configurações" %}</span>
-        </a>
-        <a href="{% url 'accounts:logout' %}" class="hover:text-primary transition">{% trans "Sair" %}</a>
+          <a href="{% url 'configuracoes' %}" class="hover:text-primary transition" aria-label="{% trans 'Configurações' %}">
+            <i class="fas fa-cog"></i>
+          </a>
+          <a href="{% url 'accounts:logout' %}" class="flex items-center gap-x-2 hover:text-primary transition">
+            <i class="fas fa-right-from-bracket"></i> {% trans "Sair" %}
+          </a>
         {% else %}
         <a href="/" class="flex items-center gap-x-2 hover:text-primary transition">
           <i class="fas fa-tachometer-alt"></i> {% trans "Dashboard" %}
@@ -185,18 +187,21 @@
         </a>
         {% endif %}
         {% endif %}
-        {% if user.is_authenticated %}
-          <a href="{% url 'configuracoes' %}" class="hover:text-primary transition">
-            <i class="fas fa-cog"></i>
-            <span class="sr-only">{% trans "Configurações" %}</span>
-          </a>
-          <a href="{% url 'accounts:logout' %}" class="hover:text-primary transition">{% trans "Sair" %}</a>
-        {% else %}
-          <a href="{% url 'accounts:login' %}" class="hover:text-primary transition">{% trans "Entrar" %}</a>
-          <a href="{% url 'accounts:onboarding' %}" class="bg-primary text-white py-2 px-4 rounded-xl hover:bg-primary/90 transition">
-            {% trans "Cadastrar" %}
-          </a>
-        {% endif %}
+          {% if user.is_authenticated %}
+            <a href="{% url 'configuracoes' %}" class="hover:text-primary transition" aria-label="{% trans 'Configurações' %}">
+              <i class="fas fa-cog"></i>
+            </a>
+            <a href="{% url 'accounts:logout' %}" class="flex items-center gap-x-2 hover:text-primary transition">
+              <i class="fas fa-right-from-bracket"></i> {% trans "Sair" %}
+            </a>
+          {% else %}
+            <a href="{% url 'accounts:login' %}" class="flex items-center gap-x-2 hover:text-primary transition">
+              <i class="fas fa-right-to-bracket"></i> {% trans "Entrar" %}
+            </a>
+            <a href="{% url 'accounts:onboarding' %}" class="flex items-center gap-x-2 bg-primary text-white py-2 px-4 rounded-xl hover:bg-primary/90 transition">
+              <i class="fas fa-user-plus"></i> {% trans "Cadastrar" %}
+            </a>
+          {% endif %}
         {% endif %}
       </nav>
     </div>


### PR DESCRIPTION
## Summary
- use Font Awesome for settings and authentication links in main menu
- display gear icon properly by switching to `fas fa-cog`

## Testing
- `pytest tests/test_i18n_templates.py -q` *(fails: many translation errors)*
- `pytest tests/test_model_inheritance.py -q` *(fails: coverage threshold not met)*

------
https://chatgpt.com/codex/tasks/task_e_68b212840c1c8325b7307ef742763d54