### PR TITLE
fix: update font awesome link integrity

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -31,7 +31,7 @@
   <link rel="preconnect" href="https://rsms.me/">
   <link rel="stylesheet" href="https://rsms.me/inter/inter.css">
   <link rel="stylesheet" href="{% static 'tailwind.css' %}">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha384-pYTNyE466+vWXTjhBMWrMOL3pvN8MPmMXxMvmP0xSg6uSPRqCMgfHdCqkfNNPJBW" crossorigin="anonymous" referrerpolicy="no-referrer">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer">
   {% block extra_css %}{% endblock %}
 </head>
 


### PR DESCRIPTION
## Summary
- update font awesome CDN link to use official SRI hash

## Testing
- `curl -I https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css` *(403 Forbidden)*
- `pytest -m "not slow"` *(failed: No module named 'silk')*


------
https://chatgpt.com/codex/tasks/task_e_68b216eb2f3883259f4bd7a02a9c63c1