### PR TITLE
Listar associados em grade

### DIFF
--- a/associados/templates/associados/lista.html
+++ b/associados/templates/associados/lista.html
@@ -4,21 +4,44 @@
 {% block title %}{% trans 'Associados' %}{% endblock %}
 
 {% block content %}
-<section class="container mx-auto p-4">
-  <h1 class="text-xl font-bold mb-4">{% trans 'Associados' %}</h1>
-  <form method="get" class="mb-4 flex gap-2">
+<section class="max-w-5xl mx-auto mt-8 px-4">
+  <h1 class="text-2xl font-bold mb-6">{% trans 'Associados' %}</h1>
+  <form method="get" class="mb-6 flex gap-2">
     <label for="q" class="sr-only">{% trans 'Buscar' %}</label>
-    <input id="q" name="q" value="{{ request.GET.q }}" class="border rounded px-2 py-1" placeholder="{% trans 'Buscar' %}" />
-    <button type="submit" class="bg-primary text-white px-3 py-1 rounded">{% trans 'Buscar' %}</button>
+    <input
+      id="q"
+      name="q"
+      value="{{ request.GET.q }}"
+      class="border rounded px-3 py-2 flex-grow"
+      placeholder="{% trans 'Buscar' %}"
+    />
+    <button type="submit" class="bg-primary text-white px-4 py-2 rounded">{% trans 'Buscar' %}</button>
   </form>
-  <ul class="space-y-2">
+  <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
     {% for associado in associados %}
-    <li class="p-2 border rounded">
-      {{ associado.get_full_name|default:associado.username }}
-    </li>
+      <a
+        href="{% url 'accounts:perfil_publico' associado.pk %}"
+        class="bg-white rounded-lg shadow p-4 flex flex-col items-center text-center hover:shadow-md transition"
+      >
+        {% if associado.avatar %}
+          <img
+            src="{{ associado.avatar.url }}"
+            alt="{{ associado.username }}"
+            class="w-24 h-24 rounded-full object-cover mb-2"
+          />
+        {% else %}
+          <div
+            class="w-24 h-24 rounded-full bg-gray-200 flex items-center justify-center text-2xl font-semibold text-primary mb-2"
+          >
+            {{ associado.username|first|upper }}
+          </div>
+        {% endif %}
+        <h2 class="font-medium">{{ associado.get_full_name|default:associado.username }}</h2>
+        <p class="text-sm text-gray-500">@{{ associado.username }}</p>
+      </a>
     {% empty %}
-    <li>{% trans 'Nenhum associado encontrado.' %}</li>
+      <p class="col-span-full text-center">{% trans 'Nenhum associado encontrado.' %}</p>
     {% endfor %}
-  </ul>
+  </div>
 </section>
 {% endblock %}

--- a/associados/views.py
+++ b/associados/views.py
@@ -14,9 +14,13 @@ class AssociadoListView(NoSuperadminMixin, AdminRequiredMixin, LoginRequiredMixi
 
     def get_queryset(self):
         User = get_user_model()
-        qs = User.objects.filter(
-            Q(is_associado=True) | Q(user_type=UserType.ASSOCIADO)
-        ).select_related("organizacao", "nucleo")
+        qs = (
+            User.objects.filter(
+                Q(is_associado=True) | Q(user_type=UserType.ASSOCIADO),
+                organizacao=self.request.user.organizacao,
+            )
+            .select_related("organizacao", "nucleo")
+        )
         q = self.request.GET.get("q")
         if q:
             qs = qs.filter(


### PR DESCRIPTION
## Sumário
- filtra associados pela organização do administrador
- exibe cards em grade com avatar, nome e usuário
- cada card direciona ao perfil público do associado

## Testes
- `pytest tests/associados -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68b21f3f52048325acc2e8d2d5fd3221