### PR TITLE
docs: fix organization attribute name

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ export NOTIFICATIONS_WHATSAPP_API_KEY=token
 - Consultas filtram dados via:
 
 ```python
-User.objects.filter_current_org(request.user.organization)
+User.objects.filter_current_org(request.user.organizacao)
 ```
 
 - Superusuários não possuem organização associada e visualizam todos os dados.


### PR DESCRIPTION
## Summary
- replace deprecated `organization` attribute with `organizacao` in README example

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'silk')*

------
https://chatgpt.com/codex/tasks/task_e_68b231fa52408325bb642ca52c5d211c