### PR TITLE
Corrige comentário de organização no CSV de usuários

### DIFF
--- a/core/management/commands/generate_test_data.py
+++ b/core/management/commands/generate_test_data.py
@@ -259,7 +259,7 @@ class Command(BaseCommand):
                         user.username,
                         user.email,
                         user.tipo.descricao,
-                        user.organizacao.nome,  # Corrigido para usar 'organization'
+                        user.organizacao.nome,  # Corrigido para usar 'organizacao'
                     ]
                 )
 


### PR DESCRIPTION
## Summary
- Corrige comentário na geração do CSV para refletir o campo `organizacao`

## Testing
- `pytest tests/tokens/test_models.py -q` *(falha: ModuleNotFoundError: No module named 'factory')*

------
https://chatgpt.com/codex/tasks/task_e_68b231ffd0488325b525e68737d4d0fb