### PR TITLE
Fix associate listing filter

### DIFF
--- a/associados/views.py
+++ b/associados/views.py
@@ -14,10 +14,14 @@ class AssociadoListView(NoSuperadminMixin, GerenteRequiredMixin, LoginRequiredMi
 
     def get_queryset(self):
         User = get_user_model()
-        qs = User.objects.filter(
-            Q(is_associado=True) | Q(user_type=UserType.ASSOCIADO),
-            organizacao=self.request.user.organizacao,
-        ).select_related("organizacao", "nucleo")
+        qs = (
+            User.objects.filter(
+                user_type=UserType.ASSOCIADO.value,
+                organizacao=self.request.user.organizacao,
+            )
+            .select_related("organizacao", "nucleo")
+        )
+        # TODO: unify "user_type" and "is_associado" fields to avoid duplicate state
         q = self.request.GET.get("q")
         if q:
             qs = qs.filter(Q(username__icontains=q) | Q(first_name__icontains=q) | Q(last_name__icontains=q))


### PR DESCRIPTION
## Summary
- fix associate listing to use `user_type=ASSOCIADO` filter
- note todo for consolidating user type vs is_associado

## Testing
- `pytest associados -q` *(fails: FAIL Required test coverage of 90% not reached. Total coverage: 7.54%)*

------
https://chatgpt.com/codex/tasks/task_e_68b2371cccb083259e317775e07bd5e0