### PR TITLE
chore: remove associados test route

### DIFF
--- a/Hubx/urls.py
+++ b/Hubx/urls.py
@@ -35,6 +35,8 @@ urlpatterns = [
     path("notificacoes/", include(("notificacoes.urls", "notificacoes"), namespace="notificacoes")),
     path("configuracoes/", ConfiguracoesView.as_view(), name="configuracoes"),
     path("financeiro/", include(("financeiro.urls", "financeiro"), namespace="financeiro")),
+    # Rotas antes definidas em `associados.urls` foram migradas para `accounts.urls`;
+    # este include será removido futuramente
     path("associados/", include(("associados.urls", "associados"), namespace="associados")),
     path("jsi18n/", JavaScriptCatalog.as_view(), name="javascript-catalog"),
     path("select2/", include("django_select2.urls")),

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -21,7 +21,6 @@ urlpatterns = [
     path("nucleos/", include(("nucleos.urls", "nucleos"), namespace="nucleos")),
     path("organizacoes/", include(("organizacoes.urls", "organizacoes"), namespace="organizacoes")),
     path("tokens/", include(("tokens.urls", "tokens"), namespace="tokens")),
-    path("associados/", include(("associados.urls", "associados"), namespace="associados")),
     path("configuracoes/", ConfiguracoesView.as_view(), name="configuracoes"),
     path(
         "api/financeiro/",


### PR DESCRIPTION
## Summary
- remove deprecated associados path from test URL configuration
- document migration of associados URLs into accounts

## Testing
- `pytest tests/test_root_metrics.py::test_root_metrics_partial -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68b23c5cb85c83259f04da89bf0065d9