### PR TITLE
Restrict user queryset to asociados only

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -807,6 +807,12 @@ class UserViewSet(viewsets.ModelViewSet):
     serializer_class = UserSerializer
     permission_classes = [IsAuthenticated]
 
+    def get_queryset(self):
+        organizacao = getattr(self.request.user, "organizacao", None)
+        if not organizacao:
+            return User.objects.none()
+        return User.objects.filter(organizacao=organizacao, is_associado=True)
+
     def get_permission_classes(self):
         """Retorna lista de classes de permissão baseadas na ação atual."""
         permission_classes = [IsAuthenticated]


### PR DESCRIPTION
## Summary
- Filter user queryset by organization and associated status
- Safeguard against missing organization when listing users

## Testing
- `pytest accounts -q` *(fails: Required test coverage of 90% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_68b23c4fd2948325a3f43d07bb32b795