### PR TITLE
Allow coordinators to access admin menu

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -94,11 +94,11 @@
           </div>
         </div>
         {% endif %}
-        {% if user.user_type == 'admin' %}
+        {% if user.user_type in ('admin', 'coordenador') %}
         <a href="/" class="flex items-center gap-x-2 hover:text-primary transition">
           <i class="fa-solid fa-gauge"></i> {% trans "Dashboard" %}
         </a>
-        <a href="{% url 'associados:lista' %}" class="flex items-center gap-x-2 hover:text-primary transition">
+        <a href="{% url 'accounts:associados_lista' %}" class="flex items-center gap-x-2 hover:text-primary transition">
           <i class="fa-solid fa-users"></i> {% trans "Associados" %}
         </a>
         <a href="{% url 'empresas:lista' %}" class="flex items-center gap-x-2 hover:text-primary transition">


### PR DESCRIPTION
## Summary
- Show admin navigation for coordinators and admins
- Keep associates list link within this restricted block

## Testing
- `pytest -m "not slow"` *(fails: ModuleNotFoundError: No module named 'factory'; 16 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b23c43794083259116455b7b34b0be