### PR TITLE
Fix associates menu route

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -98,7 +98,7 @@
         <a href="/" class="flex items-center gap-x-2 hover:text-primary transition">
           <i class="fa-solid fa-gauge"></i> {% trans "Dashboard" %}
         </a>
-        <a href="{% url 'accounts:associados_lista' %}" class="flex items-center gap-x-2 hover:text-primary transition">
+        <a href="{% url 'associados_lista' %}" class="flex items-center gap-x-2 hover:text-primary transition">
           <i class="fa-solid fa-users"></i> {% trans "Associados" %}
         </a>
         <a href="{% url 'empresas:lista' %}" class="flex items-center gap-x-2 hover:text-primary transition">


### PR DESCRIPTION
## Summary
- point "Associados" menu item to root-level associates list route

## Testing
- `pytest --no-cov tests/accounts/test_associados.py::test_admin_list_associados -q` *(fails: django.template.exceptions.TemplateSyntaxError: Could not parse the remainder: '('admin',' from '('admin',)*

------
https://chatgpt.com/codex/tasks/task_e_68b23f6ca5648325935742fee2da9aa3