### PR TITLE
Fix invalid membership checks in templates causing syntax error

### DIFF
--- a/agenda/templates/agenda/update.html
+++ b/agenda/templates/agenda/update.html
@@ -83,7 +83,7 @@
             <h3 class="text-sm font-medium text-neutral-800">{{ inscrito.get_full_name|default:inscrito.username }}</h3>
             <p class="text-xs text-neutral-500">{{ inscrito.email }}</p>
           </div>
-          {% if user.user_type in ("admin","gerente") %}
+          {% if user.user_type == "admin" or user.user_type == "gerente" %}
           <form method="post" action="{% url 'agenda:evento_remover_inscrito' object.pk inscrito.pk %}">
             {% csrf_token %}
             <button type="submit" class="text-sm text-red-600 hover:underline" aria-label="{% trans 'Remover' %}">{% trans "Remover" %}</button>

--- a/templates/base.html
+++ b/templates/base.html
@@ -94,7 +94,7 @@
           </div>
         </div>
         {% endif %}
-        {% if user.user_type in ('admin', 'coordenador') %}
+        {% if user.user_type == 'admin' or user.user_type == 'coordenador' %}
         <a href="/" class="flex items-center gap-x-2 hover:text-primary transition">
           <i class="fa-solid fa-gauge"></i> {% trans "Dashboard" %}
         </a>


### PR DESCRIPTION
## Summary
- Avoid tuple membership in base template navigation to prevent TemplateSyntaxError
- Use explicit user type comparisons in agenda update template

## Testing
- `pytest tests/test_i18n_templates.py` *(fails: 229 errors in 4.20s)*

------
https://chatgpt.com/codex/tasks/task_e_68b23f4df9e88325a9970b97121078f3