### PR TITLE
Restrict admin access to "Meus Núcleos"

### DIFF
--- a/nucleos/README.md
+++ b/nucleos/README.md
@@ -3,7 +3,7 @@
 Views principais:
 
 - `nucleos:list` – lista núcleos ativos com busca por nome ou *slug*.
-- `nucleos:meus` – exibe apenas os núcleos dos quais o usuário participa.
+- `nucleos:meus` – exibe apenas os núcleos dos quais o usuário participa; indisponível para administradores.
 - `nucleos:create` – criação de núcleo vinculado à organização do usuário.
 - `nucleos:update` – edição de dados básicos do núcleo.
 - `nucleos:toggle_active` – inativa ou reativa um núcleo.

--- a/nucleos/templates/nucleos/list.html
+++ b/nucleos/templates/nucleos/list.html
@@ -10,9 +10,11 @@
       <input type="text" name="q" value="{{ form.q.value|default:'' }}" placeholder="{% trans 'Buscar...' %}" class="border rounded px-2 py-1 flex-1" />
     <button class="px-3 py-1 bg-blue-600 text-white rounded" aria-label="{% trans 'Buscar núcleos' %}">{% trans 'Buscar' %}</button>
   </form>
+  {% if request.user.user_type != 'admin' %}
   <div class="mb-4">
     <a href="{% url 'nucleos:meus' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100" aria-label="{% trans 'Ver meus núcleos' %}">{% trans 'Meus Núcleos' %}</a>
   </div>
+  {% endif %}
   {% if request.user.user_type == 'admin' %}
   <div class="mb-4">
     <a href="{% url 'nucleos:create' %}" class="px-3 py-2 bg-green-600 text-white rounded" aria-label="{% trans 'Criar novo núcleo' %}">{% trans 'Novo' %}</a>

--- a/nucleos/views.py
+++ b/nucleos/views.py
@@ -98,6 +98,11 @@ class NucleoMeusView(NoSuperadminMixin, LoginRequiredMixin, ListView):
     template_name = "nucleos/meus_list.html"
     paginate_by = 10
 
+    def dispatch(self, request, *args, **kwargs):
+        if request.user.user_type == UserType.ADMIN:
+            return redirect("nucleos:list")
+        return super().dispatch(request, *args, **kwargs)
+
     def get_queryset(self):
         user = self.request.user
         q = self.request.GET.get("q", "")

--- a/templates/base.html
+++ b/templates/base.html
@@ -159,7 +159,7 @@
           <i class="fa-solid fa-users"></i> {% trans "Núcleos" %}
         </a>
         {% endif %}
-        {% if user.user_type != 'root' %}
+        {% if user.user_type != 'root' and user.user_type != 'admin' %}
         <a href="{% url 'nucleos:meus' %}" class="flex items-center gap-x-2 hover:text-primary transition">
           <i class="fa-solid fa-user-group"></i> {% trans "Meus Núcleos" %}
         </a>

--- a/tests/nucleos/test_views.py
+++ b/tests/nucleos/test_views.py
@@ -242,6 +242,14 @@ def test_meus_nucleos_view(client, membro_user, organizacao):
     assert list(resp.context["object_list"]) == [nucleo1]
 
 
+def test_meus_nucleos_view_admin_redirect(client, admin_user):
+    client.force_login(admin_user)
+    resp = client.get(reverse("nucleos:meus"))
+    assert resp.status_code in (302, 403)
+    if resp.status_code == 302:
+        assert resp.url == reverse("nucleos:list")
+
+
 def test_nucleo_detail_view_queries(admin_user, organizacao, django_assert_num_queries):
     User = get_user_model()
     nucleo = Nucleo.objects.create(nome="NQ", slug="nq", organizacao=organizacao)


### PR DESCRIPTION
## Summary
- hide "Meus Núcleos" links for admin users
- redirect admins from NucleoMeusView to nucleo list
- document and test admin behaviour

## Testing
- `pytest tests/nucleos/test_views.py::test_meus_nucleos_view tests/nucleos/test_views.py::test_meus_nucleos_view_admin_redirect -q -p no:cov -o addopts=''`

------
https://chatgpt.com/codex/tasks/task_e_68b2489df28883258eebd65fde07ba56