### PR TITLE
Include organization-wide search for admins

### DIFF
--- a/empresas/services.py
+++ b/empresas/services.py
@@ -38,8 +38,10 @@ def search_empresas(user, params):
     if user.is_superuser:
         pass
     elif user.user_type == UserType.ADMIN:
+        # Admins have visibility over all companies in their organization
         qs = qs.filter(organizacao=user.organizacao)
     elif user.user_type in {UserType.COORDENADOR, UserType.NUCLEADO}:
+        # Coordinators and nucleados are limited to companies they created
         qs = qs.filter(usuario=user)
     else:
         return Empresa.objects.none()

--- a/empresas/tests/test_search.py
+++ b/empresas/tests/test_search.py
@@ -15,3 +15,21 @@ def test_search_empresas_by_cnpj():
     params["q"] = empresa.cnpj
     qs = search_empresas(user, params)
     assert list(qs) == [empresa]
+
+
+@pytest.mark.django_db
+def test_search_empresas_admin_by_organizacao():
+    admin = UserFactory(user_type=UserType.ADMIN)
+    admin.organizacao = admin.nucleo.organizacao
+    admin.save()
+    outro_usuario = UserFactory(
+        user_type=UserType.COORDENADOR,
+        organizacao=admin.organizacao,
+        nucleo_obj=admin.nucleo,
+    )
+    emp1 = EmpresaFactory(organizacao=admin.organizacao, usuario=admin)
+    emp2 = EmpresaFactory(organizacao=admin.organizacao, usuario=outro_usuario)
+    EmpresaFactory()  # empresa de outra organização
+    params = QueryDict(mutable=True)
+    qs = search_empresas(admin, params)
+    assert set(qs) == {emp1, emp2}

--- a/tests/empresas/test_viewset_permissions.py
+++ b/tests/empresas/test_viewset_permissions.py
@@ -28,7 +28,7 @@ def _criar_empresa(usuario, organizacao, nome="Empresa"):
     )
 
 
-def test_admin_filtra_por_organizacao(api_client, admin_user):
+def test_admin_filtra_por_organizacao(api_client, admin_user, gerente_user, nucleado_user):
     org2 = OrganizacaoFactory()
     User = get_user_model()
     outro_admin = User.objects.create_user(
@@ -39,12 +39,14 @@ def test_admin_filtra_por_organizacao(api_client, admin_user):
         organizacao=org2,
     )
     emp1 = _criar_empresa(admin_user, admin_user.organizacao, "A")
-    _criar_empresa(outro_admin, org2, "B")
+    emp2 = _criar_empresa(gerente_user, admin_user.organizacao, "B")
+    emp3 = _criar_empresa(nucleado_user, admin_user.organizacao, "C")
+    _criar_empresa(outro_admin, org2, "D")
     url = reverse("empresas_api:empresa-list")
     api_client.force_authenticate(admin_user)
     resp = api_client.get(url)
     ids = {e["id"] for e in resp.data}
-    assert ids == {str(emp1.id)}
+    assert ids == {str(emp1.id), str(emp2.id), str(emp3.id)}
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- ensure admin users fetch all companies within their organization
- cover organization-wide visibility in API permissions tests
- verify service-level search returns all companies for admin's organization

## Testing
- `pytest tests/empresas/test_viewset_permissions.py empresas/tests/test_search.py -q --no-cov`

------
https://chatgpt.com/codex/tasks/task_e_68b24eba9098832585614da87af01d80