### PR TITLE
Use empresa avatar in list view test

### DIFF
--- a/empresas/templates/empresas/partials/card.html
+++ b/empresas/templates/empresas/partials/card.html
@@ -1,6 +1,8 @@
 {% load i18n %}
 <div class="bg-white rounded-lg shadow p-4 flex flex-col items-center text-center hover:shadow-md transition">
-  {% if empresa.usuario.avatar %}
+  {% if empresa.avatar %}
+    <img src="{{ empresa.avatar.url }}" alt="{{ empresa.nome }}" class="w-24 h-24 rounded-full object-cover mb-2" />
+  {% elif empresa.usuario.avatar %}
     <img src="{{ empresa.usuario.avatar.url }}" alt="{{ empresa.usuario.username }}" class="w-24 h-24 rounded-full object-cover mb-2" />
   {% else %}
     <div class="w-24 h-24 rounded-full bg-neutral-200 flex items-center justify-center text-2xl font-semibold text-primary mb-2">

--- a/empresas/tests/test_list_view.py
+++ b/empresas/tests/test_list_view.py
@@ -15,10 +15,10 @@ def test_admin_list_empresas_cards(client, settings, tmp_path):
     admin.save()
 
     owner = UserFactory(organizacao=admin.organizacao)
-    owner.avatar = SimpleUploadedFile("a.png", b"a", content_type="image/png")
-    owner.save()
 
     empresa = EmpresaFactory(organizacao=admin.organizacao, usuario=owner, nome="Empresa X")
+    empresa.avatar = SimpleUploadedFile("a.png", b"a", content_type="image/png")
+    empresa.save()
     EmpresaFactory()  # Empresa de outra organização
 
     client.force_login(admin)
@@ -28,4 +28,4 @@ def test_admin_list_empresas_cards(client, settings, tmp_path):
     assert "Empresa X" in content
     assert owner.username in content
     assert reverse("empresas:detail", args=[empresa.pk]) in content
-    assert "<img" in content
+    assert f'<img src="{empresa.avatar.url}"' in content


### PR DESCRIPTION
## Summary
- test: assign avatar to empresa instead of owner and check rendering
- template: render company avatar when available

## Testing
- `pytest --no-cov --nomigrations empresas/tests/test_list_view.py::test_admin_list_empresas_cards -q`

------
https://chatgpt.com/codex/tasks/task_e_68b5e418d18083259cada2188ceb511f