### PR TITLE
Render Nucleo members as card grid

### DIFF
--- a/nucleos/templates/nucleos/detail.html
+++ b/nucleos/templates/nucleos/detail.html
@@ -25,13 +25,13 @@
   <div id="membro-status" class="mt-2 text-sm text-gray-700"></div>
 
   <h2 class="mt-6 font-semibold">{% trans 'Membros' %}</h2>
-  <ul>
+  <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
     {% for part in membros_ativos %}
       {% include "nucleos/partials/membro.html" with part=part object=object %}
     {% empty %}
-      <li>{% trans 'Sem membros.' %}</li>
+      <p class="col-span-full text-center text-gray-500">{% trans 'Sem membros.' %}</p>
     {% endfor %}
-  </ul>
+  </div>
 
   {% if membros_pendentes %}
   <h2 class="mt-6 font-semibold">{% trans 'Pendentes' %}</h2>

--- a/nucleos/templates/nucleos/partials/membro.html
+++ b/nucleos/templates/nucleos/partials/membro.html
@@ -1,8 +1,25 @@
 {% load i18n %}
-<li id="membro-{{ part.id }}">
-  {{ part.user.get_full_name|default:part.user.username }}{% if part.papel == 'coordenador' %} - {% trans 'Coordenador' %}{% endif %}
-  {% if part.status_suspensao %}<span class="text-red-600">({% trans 'Suspenso' %})</span>{% endif %}
+<div id="membro-{{ part.id }}" class="p-4 bg-white border rounded shadow-sm flex flex-col gap-2">
+  <div class="flex items-center gap-4">
+    {% if part.user.avatar %}
+    <img src="{{ part.user.avatar.url }}" alt="{{ part.user.username }}" class="w-12 h-12 rounded-full object-cover" />
+    {% else %}
+    <div class="w-12 h-12 rounded-full bg-gray-200"></div>
+    {% endif %}
+    <div>
+      <a href="{% url 'accounts:perfil_publico' part.user.pk %}" class="font-medium text-gray-800">
+        {{ part.user.get_full_name|default:part.user.username }}
+      </a>
+      {% if part.papel == 'coordenador' %}
+        <span class="text-sm text-gray-500"> - {% trans 'Coordenador' %}</span>
+      {% endif %}
+      {% if part.status_suspensao %}
+        <span class="text-sm text-red-600">({% trans 'Suspenso' %})</span>
+      {% endif %}
+    </div>
+  </div>
   {% if request.user.user_type == 'admin' or request.user.user_type == 'coordenador' %}
+  <div class="mt-2 space-x-2">
     <button class="text-sm text-blue-600"
             hx-post="{% url 'nucleos:membro_promover' object.pk part.pk %}"
             hx-target="#membro-{{ part.id }}"
@@ -31,5 +48,7 @@
         <button class="text-sm text-yellow-600">{% trans 'Suspender' %}</button>
       </form>
     {% endif %}
+  </div>
   {% endif %}
-</li>
+</div>
+


### PR DESCRIPTION
## Summary
- Display active Núcleo members in a responsive grid of cards
- Create member card partial with avatar, profile link and admin actions

## Testing
- `pytest nucleos -q` *(fails: Required test coverage of 90% not reached. Total coverage: 7.72%)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e8b5b3f083259a2a5060487b6e21