### PR TITLE
Exibir eventos relacionados em detalhes do Núcleo

### DIFF
--- a/nucleos/templates/nucleos/detail.html
+++ b/nucleos/templates/nucleos/detail.html
@@ -87,6 +87,23 @@
   </div>
   {% endif %}
 
+  <h2 class="mt-6 font-semibold">{% trans 'Eventos' %}</h2>
+  <div class="mt-4 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+    {% for evento in eventos %}
+      <a href="{% url 'agenda:evento_detalhe' evento.pk %}" class="block bg-white rounded shadow p-4 hover:shadow-md">
+        {% if evento.avatar %}
+        <img src="{{ evento.avatar.url }}" alt="{{ evento.titulo }}" class="w-full h-32 object-cover rounded mb-4" />
+        {% endif %}
+        <h3 class="text-lg font-semibold">{{ evento.titulo }}</h3>
+        <p class="text-sm text-gray-500">{{ evento.data_inicio|date:'d/m/Y H:i' }}</p>
+        <p class="text-sm">{{ evento.num_inscritos }} {% trans 'inscritos' %}</p>
+        <p class="text-sm text-gray-600">{{ evento.get_status_display }}</p>
+      </a>
+    {% empty %}
+      <p class="text-sm text-gray-500">{% trans 'Sem eventos.' %}</p>
+    {% endfor %}
+  </div>
+
     <div class="mt-6 space-x-2">
       <div class="inline-block relative">
         <a

--- a/nucleos/views.py
+++ b/nucleos/views.py
@@ -25,6 +25,7 @@ from django.views.generic import (
 from accounts.models import UserType
 from core.cache import get_cache_version
 from core.permissions import AdminRequiredMixin, GerenteRequiredMixin, NoSuperadminMixin
+from agenda.models import Evento
 
 from .forms import NucleoForm, NucleoSearchForm, ParticipacaoDecisaoForm, SuplenteForm
 from .models import CoordenadorSuplente, Nucleo, ParticipacaoNucleo
@@ -230,6 +231,9 @@ class NucleoDetailView(NoSuperadminMixin, LoginRequiredMixin, DetailView):
         part = nucleo.participacoes.filter(user=self.request.user).first()
         ctx["mostrar_solicitar"] = not part or part.status == "inativo"
         ctx["pode_postar"] = bool(part and part.status == "ativo" and not part.status_suspensao)
+        ctx["eventos"] = Evento.objects.filter(nucleo=nucleo).annotate(
+            num_inscritos=Count("inscricoes")
+        )
         return ctx
 
 


### PR DESCRIPTION
## Summary
- List events with attendee counts in `NucleoDetailView`
- Show event cards in núcleo detail template
- Cover new behaviour with updated test

## Testing
- `pytest tests/nucleos/test_views.py::test_nucleo_detail_view_queries -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68b5e8c015a883259f557aa032044cb0