### PR TITLE
Exibir dados do proprietário e participações da empresa

### DIFF
--- a/empresas/templates/empresas/detail.html
+++ b/empresas/templates/empresas/detail.html
@@ -110,15 +110,65 @@
     </div>
   {% endif %}
 
+  {% if empresa.usuario %}
+    <h2 class="mt-8 text-lg font-semibold text-neutral-900">{% trans "Proprietário" %}</h2>
+    <div class="flex items-center gap-4 mt-4">
+      {% with dono=empresa.usuario %}
+        {% if dono.avatar %}
+          <img src="{{ dono.avatar.url }}" alt="{{ dono.username }}" class="w-12 h-12 rounded-full object-cover" />
+        {% else %}
+          <div class="w-12 h-12 rounded-full bg-neutral-100 flex items-center justify-center text-sm font-semibold text-neutral-700" role="img" aria-label="{{ dono.username }}">
+            {{ dono.username|make_list|first|upper }}
+          </div>
+        {% endif %}
+        <div>
+          <p class="text-sm font-medium text-neutral-800">{{ dono.get_full_name|default:dono.username }}</p>
+          <p class="text-xs text-neutral-600">{{ dono.email }}</p>
+        </div>
+      {% endwith %}
+    </div>
+  {% endif %}
+
+  {% if nucleos_dono %}
+    <h2 class="mt-8 text-lg font-semibold text-neutral-900">{% trans "Núcleos" %}</h2>
+    <div class="grid gap-6 sm:grid-cols-2 md:grid-cols-3 mt-4">
+      {% for nucleo in nucleos_dono %}
+        <div class="bg-white border border-neutral-200 rounded-2xl p-4 shadow-sm text-center">
+          {% if nucleo.avatar %}
+            <img src="{{ nucleo.avatar.url }}" alt="{{ nucleo.nome }}" class="w-16 h-16 rounded-full object-cover mx-auto mb-2" />
+          {% else %}
+            <div class="w-16 h-16 rounded-full bg-neutral-100 flex items-center justify-center text-sm font-medium text-neutral-700 mx-auto mb-2" role="img" aria-label="{{ nucleo.nome }}">
+              {{ nucleo.nome|make_list|first|upper }}
+            </div>
+          {% endif %}
+          <h3 class="text-sm font-medium text-neutral-800">{{ nucleo.nome }}</h3>
+        </div>
+      {% empty %}
+        <p class="text-sm text-neutral-500">{% trans "Nenhum núcleo." %}</p>
+      {% endfor %}
+    </div>
+  {% endif %}
+
+  {% if eventos_dono %}
+    <h2 class="mt-8 text-lg font-semibold text-neutral-900">{% trans "Eventos" %}</h2>
+    <div class="grid gap-6 sm:grid-cols-2 md:grid-cols-3 mt-4">
+      {% for evento in eventos_dono %}
+        <div class="bg-white border border-neutral-200 rounded-2xl p-4 shadow-sm">
+          <h3 class="text-base font-medium text-neutral-800">{{ evento.titulo }}</h3>
+          <p class="text-sm text-neutral-600">{{ evento.data_inicio|date:"SHORT_DATE_FORMAT" }}</p>
+        </div>
+      {% empty %}
+        <p class="text-sm text-neutral-500">{% trans "Nenhum evento." %}</p>
+      {% endfor %}
+    </div>
+  {% endif %}
+
   <div class="mt-8">
     {% include "empresas/includes/avaliacoes.html" %}
   </div>
 
   <div class="flex justify-end gap-3 mt-8">
     <a href="{% url 'empresas:lista' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100">{% trans "Voltar" %}</a>
-    {% if request.user == empresa.usuario or request.user.is_staff %}
-    <a href="{% url 'empresas:historico' empresa.id %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100">{% trans "Histórico" %}</a>
-    {% endif %}
     {% translate "Favoritar" as txt_favoritar %}
     {% translate "Desfavoritar" as txt_desfavoritar %}
     <button

--- a/empresas/views.py
+++ b/empresas/views.py
@@ -19,6 +19,7 @@ from core.permissions import (
 )
 from empresas.tasks import nova_avaliacao
 from organizacoes.models import Organizacao
+from agenda.models import Evento
 
 from .forms import AvaliacaoForm, ContatoEmpresaForm, EmpresaForm, TagForm, TagSearchForm
 from .models import (
@@ -335,6 +336,14 @@ def detalhes_empresa(request, pk):
     contatos = []
     if pode_visualizar_contatos:
         contatos = list(empresa.contatos.filter(deleted=False))
+    nucleos_dono = empresa.usuario.nucleos
+    eventos_dono = (
+        Evento.objects.filter(
+            inscricoes__user=empresa.usuario,
+            inscricoes__status="confirmada",
+        )
+        .distinct()
+    )
     context = {
         "empresa": empresa,
         "empresa_tags": empresa.tags.all(),
@@ -345,6 +354,8 @@ def detalhes_empresa(request, pk):
         "avaliacao_usuario": avaliacao_usuario,
         "contatos": contatos,
         "pode_visualizar_contatos": pode_visualizar_contatos,
+        "nucleos_dono": nucleos_dono,
+        "eventos_dono": eventos_dono,
     }
     return render(request, "empresas/detail.html", context)
 


### PR DESCRIPTION
## Summary
- Exibe dados do usuário proprietário da empresa
- Lista núcleos e eventos do proprietário em formato de cards
- Remove botão de histórico da página da empresa

## Testing
- `pytest empresas -q` *(fails: Required test coverage of 90% not reached, multiple test errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e9c511348325be29ef52920c8e43