### PR TITLE
Remove CSV and XLS export features

### DIFF
--- a/chat/tasks.py
+++ b/chat/tasks.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import csv
 import json
 import re
 from collections import Counter
@@ -140,7 +139,7 @@ def exportar_historico_chat(
 
     Args:
         channel_id: ID do ``ChatChannel`` a ser exportado.
-        formato: ``"json"`` ou ``"csv"``.
+        formato: ``"json"``.
         inicio: filtro opcional de data inicial (ISO8601).
         fim: filtro opcional de data final (ISO8601).
         tipos: lista de tipos de mensagem a incluir.
@@ -173,17 +172,7 @@ def exportar_historico_chat(
     ]
     buffer = ""
     filename = f"chat_exports/{channel.id}.{formato}"
-    if formato == "csv":
-        from io import StringIO
-
-        sio = StringIO()
-        writer = csv.DictWriter(sio, fieldnames=["id", "remetente", "tipo", "conteudo", "created_at"])
-        writer.writeheader()
-        for row in data:
-            writer.writerow(row)
-        buffer = sio.getvalue()
-    else:
-        buffer = json.dumps(data)
+    buffer = json.dumps(data)
     path = default_storage.save(filename, ContentFile(buffer.encode()))
     rel.arquivo_path = path
     rel.arquivo_url = default_storage.url(path)

--- a/chat/templates/chat/historico_edicoes.html
+++ b/chat/templates/chat/historico_edicoes.html
@@ -14,7 +14,6 @@
     <input type="date" name="fim" id="fim" value="{{ request.GET.fim }}" class="border px-2 py-1 rounded" />
   </div>
   <button type="submit" class="px-3 py-1 bg-primary text-white rounded">{% trans "Filtrar" %}</button>
-  <button type="submit" name="export" value="csv" class="px-3 py-1 border rounded">{% trans "Exportar CSV" %}</button>
 </form>
 <div class="overflow-x-auto">
   <table class="min-w-full text-sm">

--- a/chat/templates/chat/partials/export_modal.html
+++ b/chat/templates/chat/partials/export_modal.html
@@ -4,7 +4,6 @@
     <label class="block mb-2">{% trans "Formato" %}
       <select name="formato" class="border rounded p-1">
         <option value="json">{% trans "JSON" %}</option>
-        <option value="csv">{% trans "CSV" %}</option>
       </select>
     </label>
     <label class="block mb-2">{% trans "Início" %}

--- a/chat/views.py
+++ b/chat/views.py
@@ -6,7 +6,6 @@ from django.contrib.auth.decorators import login_required, user_passes_test
 from django.core.paginator import Paginator
 from django.db.models import Case, Count, F, OuterRef, Subquery, TextField, UUIDField, When
 from django.http import HttpResponse
-import csv
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.dateparse import parse_date
 from django.utils.translation import gettext_lazy as _
@@ -177,14 +176,6 @@ def historico_edicoes(request, channel_id, message_id):
         dt = parse_date(fim)
         if dt:
             logs = logs.filter(created_at__date__lte=dt)
-    if request.GET.get("export") == "csv":
-        response = HttpResponse(content_type="text/csv")
-        response["Content-Disposition"] = "attachment; filename=historico_edicoes.csv"
-        writer = csv.writer(response)
-        writer.writerow(["created_at", "moderator", "previous_content"])
-        for log in logs:
-            writer.writerow([log.created_at.isoformat(), log.moderator.username, log.previous_content])
-        return response
     paginator = Paginator(logs, 20)
     page = paginator.get_page(request.GET.get("page"))
     return render(

--- a/dashboard/templates/dashboard/partials/filters_form.html
+++ b/dashboard/templates/dashboard/partials/filters_form.html
@@ -84,9 +84,7 @@
       {% if can_export %}
       <label for="formato" class="sr-only">{% trans 'Formato de exportação' %}</label>
       <select id="formato" name="formato" class="border-gray-300 rounded" aria-label="{% trans 'Formato de exportação' %}">
-        <option value="csv">{% trans 'CSV' %}</option>
         <option value="pdf">{% trans 'PDF' %}</option>
-        <option value="xlsx">{% trans 'Excel' %}</option>
         <option value="png">{% trans 'PNG' %}</option>
       </select>
     <button type="submit" formaction="{% url 'dashboard:export' %}" class="px-4 py-2 bg-neutral-200 text-neutral-800 rounded focus:outline-none focus:ring" aria-label="{% trans 'Exportar métricas' %}">{% trans 'Exportar' %}</button>

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -1,4 +1,3 @@
-import csv
 import io
 import json
 import logging
@@ -35,7 +34,6 @@ from django.views.generic import (
     UpdateView,
     View,
 )
-from openpyxl import Workbook
 
 from accounts.models import UserType
 from agenda.models import Evento
@@ -605,7 +603,7 @@ def eventos_partial(request):
 
 
 class DashboardExportView(LoginRequiredMixin, View):
-    """Exporta métricas em CSV ou PDF."""
+    """Exporta métricas em PDF ou PNG."""
 
     def get(self, request):
         user = request.user
@@ -622,7 +620,7 @@ class DashboardExportView(LoginRequiredMixin, View):
 
         periodo = request.GET.get("periodo", "mensal")
         escopo = request.GET.get("escopo", "auto")
-        formato = request.GET.get("formato", "csv")
+        formato = request.GET.get("formato", "pdf")
         audit_action = f"EXPORT_{formato.upper()}"
         inicio_str = request.GET.get("data_inicio")
         fim_str = request.GET.get("data_fim")
@@ -708,32 +706,6 @@ class DashboardExportView(LoginRequiredMixin, View):
             )
             return resp
 
-        if formato == "xlsx":
-            wb = Workbook()
-            ws = wb.active
-            ws.title = "Métricas"
-            ws.append(["Métrica", "Valor", "Variação (%)"])
-            for key, data in metrics.items():
-                ws.append([key, data["total"], data["crescimento"]])
-            output = io.BytesIO()
-            wb.save(output)
-            resp = HttpResponse(
-                output.getvalue(),
-                content_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-            )
-            filename = datetime.now().strftime("metrics_%Y%m%d_%H%M%S.xlsx")
-            resp["Content-Disposition"] = f"attachment; filename={filename}"
-            log_audit(
-                user=request.user,
-                action="EXPORT_XLSX",
-                object_type="DashboardMetrics",
-                object_id="",
-                ip_hash=hash_ip(get_client_ip(request)),
-                status="SUCCESS",
-                metadata={"formato": formato, **filters},
-            )
-            return resp
-
         if formato == "png":
             keys = list(metrics.keys())
             values = [data["total"] for data in metrics.values()]
@@ -756,24 +728,7 @@ class DashboardExportView(LoginRequiredMixin, View):
             )
             return FileResponse(open(filepath, "rb"), as_attachment=True, filename=filename)
 
-        # default csv
-        resp = HttpResponse(content_type="text/csv")
-        filename = datetime.now().strftime("metrics_%Y%m%d_%H%M%S.csv")
-        resp["Content-Disposition"] = f"attachment; filename={filename}"
-        writer = csv.writer(resp)
-        writer.writerow(["Métrica", "Valor", "Variação (%)"])
-        for key, data in metrics.items():
-            writer.writerow([key, data["total"], data["crescimento"]])
-        log_audit(
-            user=request.user,
-            action="EXPORT_CSV",
-            object_type="DashboardMetrics",
-            object_id="",
-            ip_hash=hash_ip(get_client_ip(request)),
-            status="SUCCESS",
-            metadata={"formato": formato, **filters},
-        )
-        return resp
+        return _response_with_message(_("Formato inválido"), 400)
 
 
 class DashboardExportedImageView(LoginRequiredMixin, View):

--- a/financeiro/templates/financeiro/forecast.html
+++ b/financeiro/templates/financeiro/forecast.html
@@ -33,10 +33,6 @@
   <div id="forecast-result" class="mt-6">
     <!-- gráfico e tabela serão inseridos aqui -->
   </div>
-  <div class="mt-4 space-x-2">
-    <a href="#" onclick="exportData('csv');return false;" class="bg-gray-200 px-3 py-1 rounded">{% trans "Exportar CSV" %}</a>
-    <a href="#" onclick="exportData('xlsx');return false;" class="bg-gray-200 px-3 py-1 rounded">{% trans "Exportar XLSX" %}</a>
-  </div>
 </div>
 <script src="{% static 'js/vendor/chart-4.5.0.min.js' %}"></script>
 <script>
@@ -92,8 +88,4 @@ function renderForecast(xhr){
   }
 }
 
-function exportData(fmt){
-  const params = lastParams ? new URLSearchParams(lastParams) : new URLSearchParams(new FormData(document.getElementById('filters')));
-  window.location = '{% url 'financeiro_api:forecast-list' %}?'+params.toString()+'&format='+fmt;
-}
 </script>

--- a/financeiro/templates/financeiro/inadimplencias.html
+++ b/financeiro/templates/financeiro/inadimplencias.html
@@ -52,18 +52,11 @@
       <tbody></tbody>
     </table>
   </div>
-  <div class="mt-4 flex gap-4">
-    <a href="#" id="inad-export-csv" class="text-primary underline" hx-boost="false" aria-label="{% trans 'Exportar inadimplências em CSV' %}">{% trans "Exportar CSV" %}</a>
-    <a href="#" id="inad-export-xlsx" class="text-primary underline" hx-boost="false" aria-label="{% trans 'Exportar inadimplências em XLSX' %}">{% trans "Exportar XLSX" %}</a>
-  </div>
   <script>
     function renderInadimplencias(evt) {
       const data = JSON.parse(evt.detail.xhr.response);
       const tbody = document.querySelector('#lista tbody');
       tbody.innerHTML = data.map(r => `<tr><td class=\"px-3 py-2\">${r.id}</td><td class=\"px-3 py-2\">${r.centro || ''}</td><td class=\"px-3 py-2\">${r.conta || ''}</td><td class=\"px-3 py-2\">${r.valor}</td><td class=\"px-3 py-2\">${r.data_vencimento}</td><td class=\"px-3 py-2\">${r.dias_atraso}</td></tr>`).join('');
-      const params = new URLSearchParams(new FormData(document.getElementById('inad-form')));
-      document.getElementById('inad-export-csv').href = '/api/financeiro/inadimplencias/?' + params.toString() + '&format=csv';
-      document.getElementById('inad-export-xlsx').href = '/api/financeiro/inadimplencias/?' + params.toString() + '&format=xlsx';
     }
   </script>
 </section>

--- a/financeiro/templates/financeiro/relatorios.html
+++ b/financeiro/templates/financeiro/relatorios.html
@@ -67,10 +67,6 @@
   </form>
 
   <div id="relatorio" class="mt-6" aria-live="polite"></div>
-  <div class="mt-4 flex gap-4">
-    <a href="#" id="export-csv" class="text-primary underline" hx-boost="false" aria-label="{% trans 'Exportar relatório em CSV' %}">{% trans "Exportar CSV" %}</a>
-    <a href="#" id="export-xlsx" class="text-primary underline" hx-boost="false" aria-label="{% trans 'Exportar relatório em XLSX' %}">{% trans "Exportar XLSX" %}</a>
-    </div>
     <script src="{% url 'javascript-catalog' %}"></script>
     <script>
     function renderRelatorio(evt) {
@@ -85,13 +81,6 @@
           <p class=\"mb-2 font-medium\">{% trans "Saldo atual" %}: ${data.saldo_atual}</p>
           <p class=\"mb-2 font-medium\">{% trans "Total inadimplentes" %}: ${data.total_inadimplentes}</p>
           <table class=\"min-w-full divide-y divide-gray-200\"><thead><tr><th class=\"px-2 py-1 text-left text-xs font-medium text-gray-500\">{% trans "Mês" %}</th><th class=\"px-2 py-1 text-left text-xs font-medium text-gray-500\">{% trans "Receitas" %}</th><th class=\"px-2 py-1 text-left text-xs font-medium text-gray-500\">{% trans "Despesas" %}</th><th class=\"px-2 py-1 text-left text-xs font-medium text-gray-500\">{% trans "Saldo" %}</th></tr></thead><tbody>${rows}</tbody></table>`;
-        const form = document.getElementById('relatorio-form');
-        const params = new URLSearchParams(new FormData(form));
-        params.set('tipo', form.querySelector('[name="tipo"]').value);
-        params.set('status', form.querySelector('[name="status"]').value);
-        const query = params.toString();
-        document.getElementById('export-csv').href = `/api/financeiro/relatorios/?${query}&format=csv`;
-        document.getElementById('export-xlsx').href = `/api/financeiro/relatorios/?${query}&format=xlsx`;
       } catch (e) {
         container.textContent = gettext('Erro ao gerar relatório');
       }

--- a/financeiro/templates/financeiro/repasses.html
+++ b/financeiro/templates/financeiro/repasses.html
@@ -17,10 +17,7 @@
       </select>
     </div>
   </form>
-  <div class="mb-4 flex gap-4">
-    <a href="#" id="export-csv" class="text-primary underline" hx-boost="false" aria-label="{% trans 'Exportar repasses em CSV' %}">{% trans "Exportar CSV" %}</a>
-    <a href="#" id="export-xlsx" class="text-primary underline" hx-boost="false" aria-label="{% trans 'Exportar repasses em XLSX' %}">{% trans "Exportar XLSX" %}</a>
-  </div>
+  <div class="mb-4 flex gap-4"></div>
   <div id="lista" aria-live="polite">
     <table class="min-w-full divide-y divide-gray-200">
       <thead>
@@ -53,9 +50,6 @@
           </tr>
         `).join('');
         tbody.innerHTML = rows || `<tr><td colspan=\"5\" class=\"px-3 py-2 text-center\">${gettext('Nenhum repasse')}</td></tr>`;
-        const params = new URLSearchParams(new FormData(document.getElementById('filtros')));
-        document.getElementById('export-csv').href = '/api/financeiro/repasses/?' + params.toString() + '&format=csv';
-        document.getElementById('export-xlsx').href = '/api/financeiro/repasses/?' + params.toString() + '&format=xlsx';
       } catch (e) {
         tbody.innerHTML = `<tr><td colspan=\"5\" class=\"px-3 py-2 text-center\">${gettext('Erro ao carregar')}</td></tr>`;
       }

--- a/notificacoes/admin.py
+++ b/notificacoes/admin.py
@@ -1,9 +1,6 @@
-import csv
 import logging
 
 from django.contrib import admin
-from django.core.exceptions import PermissionDenied
-from django.http import HttpResponse
 from django.utils.translation import gettext_lazy as _
 
 from .models import NotificationLog, NotificationTemplate, UserNotificationPreference
@@ -37,7 +34,7 @@ class NotificationLogAdmin(admin.ModelAdmin):
     search_fields = ("user__email", "template__codigo")
     list_filter = ("status", "canal")
     readonly_fields = ("user", "template", "canal", "status", "data_envio", "erro")
-    actions = ["exportar_csv"]
+    actions: list[str] = []
 
     def has_add_permission(self, request):  # pragma: no cover - admin
         return False
@@ -48,24 +45,3 @@ class NotificationLogAdmin(admin.ModelAdmin):
     def has_delete_permission(self, request, obj=None):  # pragma: no cover - admin
         return False
 
-    def exportar_csv(self, request, queryset):
-        if not request.user.is_staff:
-            logger.info("export_logs_denied", extra={"user": request.user.id})
-            raise PermissionDenied
-        logger.info("export_logs_admin", extra={"user": request.user.id, "count": queryset.count()})
-        response = HttpResponse(content_type="text/csv")
-        response["Content-Disposition"] = "attachment; filename=notification_logs.csv"
-        writer = csv.writer(response)
-        writer.writerow(["data_envio", "user", "template", "canal", "status", "erro"])
-        for log in queryset:
-            writer.writerow([
-                log.data_envio,
-                log.user_id,
-                log.template.codigo,
-                log.canal,
-                log.status,
-                log.erro,
-            ])
-        return response
-
-    exportar_csv.short_description = _("Exportar CSV")

--- a/notificacoes/templates/notificacoes/logs_list.html
+++ b/notificacoes/templates/notificacoes/logs_list.html
@@ -5,7 +5,7 @@
 <div class="max-w-6xl mx-auto px-4 py-10">
   <div class="mb-8">
     <h1 class="text-2xl font-bold text-neutral-900">{% trans 'Logs de Notificação' %}</h1>
-    <a href="?export=csv" class="text-blue-500 underline mt-2 inline-block">{% trans 'Baixar CSV completo' %}</a>
+    
   </div>
   <form method="get" class="bg-white border border-neutral-200 p-6 rounded-2xl shadow-sm mb-6 flex flex-col sm:flex-row gap-4 sm:items-end">
     <div>

--- a/nucleos/api.py
+++ b/nucleos/api.py
@@ -1,12 +1,7 @@
 from __future__ import annotations
 
-import csv
-import io
 import logging
-
-import tablib
 from django.core.cache import cache
-from django.http import HttpResponse
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
@@ -38,7 +33,6 @@ from .serializers import (
 )
 from .services import gerar_convite_nucleo, registrar_uso_convite
 from .tasks import (
-    notify_exportacao_membros,
     notify_participacao_aprovada,
     notify_participacao_recusada,
     notify_suplente_designado,
@@ -622,62 +616,6 @@ class NucleoViewSet(viewsets.ModelViewSet):
         ]
         return self.get_paginated_response(data)
 
-    @action(
-        detail=True,
-        methods=["get"],
-        url_path="membros/exportar",
-        permission_classes=[IsAdminOrCoordenador],
-    )
-    def exportar_membros(self, request, pk: str | None = None):
-        nucleo = self.get_object()
-        formato = request.query_params.get("formato", "csv")
-        membros = nucleo.participacoes.select_related("user").all()
-        now = timezone.now()
-        suplentes = set(
-            CoordenadorSuplente.objects.filter(
-                nucleo=nucleo,
-                periodo_inicio__lte=now,
-                periodo_fim__gte=now,
-                deleted=False,
-            ).values_list("usuario_id", flat=True)
-        )
-        data = tablib.Dataset(
-            headers=[
-                "Nome",
-                "Email",
-                "Status",
-                "papel",
-                "is_suplente",
-                "data_ingresso",
-            ]
-        )
-        for p in membros:
-            nome = p.user.get_full_name() or p.user.username
-            data.append(
-                [
-                    nome,
-                    p.user.email,
-                    p.status,
-                    p.papel,
-                    p.user_id in suplentes,
-                    (p.data_decisao or p.data_solicitacao).isoformat(),
-                ]
-            )
-        notify_exportacao_membros.delay(nucleo.id)
-        logger.info(
-            "Exportação de membros",
-            extra={"nucleo_id": nucleo.id, "user_id": request.user.id, "formato": formato},
-        )
-        if formato == "xls":
-            resp = HttpResponse(
-                data.export("xlsx"),
-                content_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-            )
-            resp["Content-Disposition"] = f"attachment; filename=nucleo-{nucleo.id}-membros.xlsx"
-            return resp
-        resp = HttpResponse(data.export("csv"), content_type="text/csv")
-        resp["Content-Disposition"] = f"attachment; filename=nucleo-{nucleo.id}-membros.csv"
-        return resp
 
     @action(detail=True, methods=["get"], url_path="metrics", permission_classes=[IsAuthenticated])
     def metrics(self, request, pk: str | None = None):

--- a/nucleos/templates/nucleos/detail.html
+++ b/nucleos/templates/nucleos/detail.html
@@ -103,22 +103,7 @@
     {% endfor %}
   </div>
 
-    <div class="mt-6 space-x-2">
-      <div class="inline-block relative">
-        <a
-          href="{% url 'nucleos_api:nucleo-exportar-membros' object.pk %}?formato=csv"
-          class="text-blue-600"
-          hx-boost="false"
-          download="nucleo-{{ object.pk }}-membros.csv"
-        >{% trans 'Exportar CSV' %}</a>
-        <a
-          href="{% url 'nucleos_api:nucleo-exportar-membros' object.pk %}?formato=xls"
-          class="text-blue-600"
-          hx-boost="false"
-          download="nucleo-{{ object.pk }}-membros.xlsx"
-        >{% trans 'Exportar XLS' %}</a>
-      </div>
-    </div>
+    <div class="mt-6 space-x-2"></div>
 
 
     {% if mostrar_solicitar and request.user.user_type != 'admin' and request.user.user_type != 'coordenador' %}

--- a/organizacoes/templates/organizacoes/history.html
+++ b/organizacoes/templates/organizacoes/history.html
@@ -4,7 +4,7 @@
 {% block content %}
 <section class="max-w-4xl mx-auto px-4 py-10">
   <h1 class="text-2xl font-bold mb-4">{% trans 'Histórico' %}</h1>
-  <a href="?export=csv" class="text-blue-500 underline mb-4 inline-block">{% trans 'Baixar CSV completo' %}</a>
+  
 
   <h2 class="text-xl font-semibold mt-4">{% trans 'Alterações' %}</h2>
   <table class="min-w-full bg-white border border-neutral-200 rounded-2xl shadow-sm mb-8">


### PR DESCRIPTION
## Summary
- Drop CSV/XLS export options from dashboard filters and restrict API export to PDF
- Remove CSV export code across chat, financeiro, nucleos and notifications modules
- Eliminate admin bulk CSV download and related UI links

## Testing
- `pytest` *(fails: Module tests/tokens/... missing dependencies; 88 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ee4d0a088325a6944cecd3548942