### PR TITLE
Respect OneSignal setting when sending push notifications

### DIFF
--- a/notificacoes/services/notificacoes.py
+++ b/notificacoes/services/notificacoes.py
@@ -76,7 +76,7 @@ def enviar_para_usuario(
             canais_desabilitados.append(Canal.EMAIL)
 
     if template.canal in {Canal.PUSH, Canal.TODOS}:
-        if prefs.push:
+        if prefs.push and getattr(settings, "ONESIGNAL_ENABLED", False):
             canais.append(Canal.PUSH)
         else:
             canais_desabilitados.append(Canal.PUSH)

--- a/tests/notificacoes/test_clients.py
+++ b/tests/notificacoes/test_clients.py
@@ -67,6 +67,7 @@ def test_send_push_success(monkeypatch, settings, caplog):
     user = UserFactory()
     settings.ONESIGNAL_APP_ID = "app"
     settings.ONESIGNAL_API_KEY = "key"
+    settings.ONESIGNAL_ENABLED = True
 
     class FakeClient:
         def __init__(self, app_id, rest_api_key):
@@ -86,6 +87,7 @@ def test_send_push_invalida_inscricao(monkeypatch, settings, caplog):
     user = UserFactory()
     settings.ONESIGNAL_APP_ID = "app"
     settings.ONESIGNAL_API_KEY = "key"
+    settings.ONESIGNAL_ENABLED = True
     sub = PushSubscription.objects.create(
         user=user,
         device_id="d1",

--- a/tests/notificacoes/test_services.py
+++ b/tests/notificacoes/test_services.py
@@ -65,7 +65,8 @@ def test_template_inexistente() -> None:
         svc.enviar_para_usuario(user, "x", {})
 
 
-def test_enviar_multiplos_canais(monkeypatch) -> None:
+def test_enviar_multiplos_canais(monkeypatch, settings) -> None:
+    settings.ONESIGNAL_ENABLED = True
     user = UserFactory()
     NotificationTemplate.objects.create(codigo="t", assunto="Oi", corpo="C", canal="todos")
     called = {}
@@ -84,7 +85,8 @@ def test_enviar_multiplos_canais(monkeypatch) -> None:
     assert NotificationLog.objects.count() == 3
 
 
-def test_enviar_todos_sem_canais() -> None:
+def test_enviar_todos_sem_canais(settings) -> None:
+    settings.ONESIGNAL_ENABLED = True
     user = UserFactory()
     NotificationTemplate.objects.create(codigo="t", assunto="Oi", corpo="C", canal="todos")
     prefs = UserNotificationPreference.objects.get(user=user)
@@ -120,7 +122,8 @@ def test_enviar_todos_sem_canais() -> None:
     assert dest_por_canal[Canal.PUSH] == "dev1"
 
 
-def test_enviar_todos_com_canais_desativados(monkeypatch) -> None:
+def test_enviar_todos_com_canais_desativados(monkeypatch, settings) -> None:
+    settings.ONESIGNAL_ENABLED = True
     user = UserFactory()
     NotificationTemplate.objects.create(codigo="t", assunto="Oi", corpo="C", canal="todos")
     prefs = UserNotificationPreference.objects.get(user=user)
@@ -166,7 +169,8 @@ def test_enviar_todos_com_canais_desativados(monkeypatch) -> None:
     assert whatsapp_log.destinatario == user.whatsapp
 
 
-def test_enviar_para_usuario_respeita_push(monkeypatch) -> None:
+def test_enviar_para_usuario_respeita_push(monkeypatch, settings) -> None:
+    settings.ONESIGNAL_ENABLED = True
     user = UserFactory()
     NotificationTemplate.objects.create(codigo="p", assunto="Oi", corpo="C", canal="push")
     prefs = UserNotificationPreference.objects.get(user=user)


### PR DESCRIPTION
## Summary
- Avoid registering push channel when OneSignal integration is disabled
- Ensure feed notifications don't trigger push when OneSignal is off
- Update notification tests to account for OneSignal flag

## Testing
- `pytest feed/tests/test_notifications.py::test_notify_new_post_uses_template feed/tests/test_notifications.py::test_notify_new_post_without_push_when_disabled tests/notificacoes/test_services.py::test_enviar_multiplos_canais tests/notificacoes/test_services.py::test_enviar_todos_sem_canais tests/notificacoes/test_services.py::test_enviar_todos_com_canais_desativados tests/notificacoes/test_services.py::test_enviar_para_usuario_respeita_push tests/notificacoes/test_clients.py::test_send_push_success tests/notificacoes/test_clients.py::test_send_push_invalida_inscricao --no-cov -q`

------
https://chatgpt.com/codex/tasks/task_e_68b9e4c567e483259afb6fd6ce56e423