### PR TITLE
Fix create Nucleo template widgets

### DIFF
--- a/nucleos/templates/nucleos/create.html
+++ b/nucleos/templates/nucleos/create.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load custom_filters i18n %}
+{% load i18n widget_tweaks %}
 
 {% block title %}{% trans 'Novo Núcleo' %}{% endblock %}
 


### PR DESCRIPTION
## Summary
- load `widget_tweaks` and `i18n` in Nucleo creation template

## Testing
- `pytest tests/nucleos/test_views.py::test_nucleo_create_and_soft_delete -q --cov=nucleos --cov-report=term --cov-fail-under=0` *(fails: ModuleNotFoundError: No module named 'discussao')*

------
https://chatgpt.com/codex/tasks/task_e_68ba0c6ef72c83258c50884088ab27e0