### PR TITLE
Add confirmation prompt to Nucleo delete link

### DIFF
--- a/nucleos/templates/nucleos/detail.html
+++ b/nucleos/templates/nucleos/detail.html
@@ -121,6 +121,17 @@
     <div id="modal"></div>
   </div>
 
+  <div class="flex justify-end mt-4">
+    {% if perms.nucleos.delete_nucleo %}
+    <a
+      href="{% url 'nucleos:delete' object.pk %}"
+      class="text-sm px-4 py-2 rounded-xl bg-red-100 text-red-700 hover:bg-red-200"
+      hx-confirm="Deseja realmente excluir?"
+      >{% trans "Excluir" %}</a
+    >
+    {% endif %}
+  </div>
+
   <script>
     // Tabs simples em JS vanilla
     const tabButtons = document.querySelectorAll('.tab-btn');


### PR DESCRIPTION
## Summary
- Add delete action with hx-confirm to Nucleo detail page

## Testing
- `pytest tests/nucleos/test_views.py::test_nucleo_create_and_soft_delete -q` *(fails: Required test coverage of 90% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0c7b994c83258a762752ae80bcda