### PR TITLE
Restrict nucleus feed posting to active members

### DIFF
--- a/nucleos/views.py
+++ b/nucleos/views.py
@@ -267,7 +267,8 @@ class NucleoDetailView(NoSuperadminMixin, LoginRequiredMixin, DetailView):
         ctx["suplentes"] = nucleo.coordenadores_suplentes.all()
         part = nucleo.participacoes.filter(user=self.request.user).first()
         ctx["mostrar_solicitar"] = (not part) or part.status == "inativo"
-        ctx["pode_postar"] = bool(part and part.status == "ativo" and not part.status_suspensao)
+        if part and part.status == "ativo" and not part.status_suspensao:
+            ctx["pode_postar"] = True
 
         eventos_qs = Evento.objects.filter(nucleo=nucleo)
         ctx["eventos"] = eventos_qs.annotate(num_inscritos=Count("inscricoes", distinct=True))


### PR DESCRIPTION
## Summary
- Only expose `pode_postar` flag for active, unsuspended nucleus participants

## Testing
- `pytest tests/nucleos/test_posts.py::test_postar_no_feed -q --override-ini addopts="" -p no:warnings` *(fails: ModuleNotFoundError: No module named 'discussao')*


------
https://chatgpt.com/codex/tasks/task_e_68ba0c843ad4832581880e19617eff18