### PR TITLE
test: move agenda tests to eventos

### DIFF
--- a/eventos/factories.py
+++ b/eventos/factories.py
@@ -1,0 +1,2 @@
+"""Reexporta factories de agenda."""
+from agenda.factories import *  # noqa: F401,F403

--- a/eventos/models.py
+++ b/eventos/models.py
@@ -1,0 +1,2 @@
+"""Reexporta models de agenda."""
+from agenda.models import *  # noqa: F401,F403

--- a/eventos/tests/test_api_permissions.py
+++ b/eventos/tests/test_api_permissions.py
@@ -1,0 +1,66 @@
+import pytest
+from datetime import date
+from django.urls import reverse
+from rest_framework.test import APIClient
+from accounts.factories import UserFactory
+from eventos.factories import EventoFactory
+from empresas.factories import EmpresaFactory
+from eventos.models import ParceriaEvento
+from accounts.models import UserType
+
+
+@pytest.mark.django_db
+def test_non_admin_cannot_create_briefing():
+    evento = EventoFactory()
+    user = UserFactory(user_type=UserType.ASSOCIADO, organizacao=evento.organizacao, nucleo_obj=None)
+    client = APIClient()
+    client.force_authenticate(user=user)
+    url = reverse("eventos_api:briefing-list")
+    data = {"evento": evento.pk, "objetivos": "o", "publico_alvo": "p", "requisitos_tecnicos": "r"}
+    resp = client.post(url, data)
+    assert resp.status_code == 403
+
+
+@pytest.mark.django_db
+def test_admin_can_create_briefing():
+    evento = EventoFactory()
+    user = UserFactory(user_type=UserType.ADMIN, organizacao=evento.organizacao, nucleo_obj=None)
+    client = APIClient()
+    client.force_authenticate(user=user)
+    url = reverse("eventos_api:briefing-list")
+    data = {"evento": evento.pk, "objetivos": "o", "publico_alvo": "p", "requisitos_tecnicos": "r"}
+    resp = client.post(url, data)
+    assert resp.status_code == 201
+
+
+@pytest.mark.django_db
+def test_unauthenticated_request_denied():
+    evento = EventoFactory()
+    client = APIClient()
+    url = reverse("eventos_api:briefing-list")
+    resp = client.get(url)
+    assert resp.status_code == 401
+
+
+@pytest.mark.django_db
+def test_avaliar_parceria_ja_avaliada_retorna_erro():
+    evento = EventoFactory()
+    empresa = EmpresaFactory(organizacao=evento.organizacao)
+    parceria = ParceriaEvento.objects.create(
+        evento=evento,
+        empresa=empresa,
+        nucleo=evento.nucleo,
+        cnpj="12345678901234",
+        contato="Contato",
+        representante_legal="Rep",
+        data_inicio=date.today(),
+        data_fim=date.today(),
+        avaliacao=5,
+    )
+    user = UserFactory(user_type=UserType.ADMIN, organizacao=evento.organizacao, nucleo_obj=None)
+    client = APIClient()
+    client.force_authenticate(user=user)
+    url = reverse("eventos_api:parceria-avaliar", args=[parceria.pk])
+    resp = client.post(url, {"avaliacao": 4})
+    assert resp.status_code == 400
+    assert resp.json()["error"] == "Parceria já avaliada."

--- a/eventos/tests/test_briefing_views.py
+++ b/eventos/tests/test_briefing_views.py
@@ -1,0 +1,24 @@
+import pytest
+from django.urls import reverse
+from django.contrib.messages import get_messages
+from accounts.factories import UserFactory
+from eventos.factories import EventoFactory
+from accounts.models import UserType
+
+
+@pytest.mark.django_db
+def test_briefing_create_exibe_mensagem(client):
+    evento = EventoFactory()
+    user = UserFactory(user_type=UserType.ADMIN, organizacao=evento.organizacao, nucleo_obj=None)
+    client.force_login(user)
+    data = {
+        "evento": evento.pk,
+        "objetivos": "obj",
+        "publico_alvo": "pub",
+        "requisitos_tecnicos": "req",
+    }
+    resp = client.post(reverse("eventos:briefing_criar"), data, follow=True)
+    assert resp.status_code == 200
+    assert "agenda/briefing_list.html" in [t.name for t in resp.templates]
+    messages = list(get_messages(resp.wsgi_request))
+    assert any("Briefing criado com sucesso" in m.message for m in messages)

--- a/eventos/tests/test_material_views.py
+++ b/eventos/tests/test_material_views.py
@@ -1,0 +1,38 @@
+import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.urls import reverse
+from accounts.factories import UserFactory
+from eventos.factories import EventoFactory
+from eventos.models import MaterialDivulgacaoEvento
+from accounts.models import UserType
+
+
+@pytest.mark.django_db
+def test_material_list_shows_only_approved(client):
+    evento = EventoFactory()
+    arquivo1 = SimpleUploadedFile("file1.txt", b"x")
+    MaterialDivulgacaoEvento.objects.create(
+        evento=evento,
+        titulo="Aprovado",
+        descricao="",
+        tipo="banner",
+        arquivo=arquivo1,
+        status="aprovado",
+    )
+    arquivo2 = SimpleUploadedFile("file2.txt", b"x")
+    MaterialDivulgacaoEvento.objects.create(
+        evento=evento,
+        titulo="Rascunho",
+        descricao="",
+        tipo="banner",
+        arquivo=arquivo2,
+        status="criado",
+    )
+    user = UserFactory(user_type=UserType.ASSOCIADO, organizacao=evento.organizacao, nucleo_obj=None)
+    client.force_login(user)
+    resp = client.get(reverse("eventos:material_list"))
+    assert resp.status_code == 200
+    assert "agenda/material_list.html" in [t.name for t in resp.templates]
+    materiais = list(resp.context["materiais"])
+    assert len(materiais) == 1
+    assert materiais[0].titulo == "Aprovado"

--- a/eventos/tests/test_parceria_views.py
+++ b/eventos/tests/test_parceria_views.py
@@ -1,0 +1,60 @@
+import pytest
+from django.urls import reverse
+from accounts.factories import UserFactory
+from eventos.factories import EventoFactory
+from empresas.factories import EmpresaFactory
+from eventos.models import ParceriaEvento
+from accounts.models import UserType
+from datetime import date
+
+
+@pytest.mark.django_db
+def test_parceria_list_requires_admin(client):
+    evento = EventoFactory()
+    user = UserFactory(user_type=UserType.ASSOCIADO, organizacao=evento.organizacao, nucleo_obj=None)
+    client.force_login(user)
+    resp = client.get(reverse("eventos:parceria_list"))
+    assert resp.status_code == 403
+
+
+@pytest.mark.django_db
+def test_parceria_list_template(client):
+    evento = EventoFactory()
+    empresa = EmpresaFactory(organizacao=evento.organizacao)
+    ParceriaEvento.objects.create(
+        evento=evento,
+        empresa=empresa,
+        nucleo=evento.nucleo,
+        cnpj="12345678901234",
+        contato="Contato",
+        representante_legal="Rep",
+        data_inicio=date.today(),
+        data_fim=date.today(),
+    )
+    user = UserFactory(user_type=UserType.ADMIN, organizacao=evento.organizacao, nucleo_obj=None)
+    client.force_login(user)
+    resp = client.get(reverse("eventos:parceria_list"))
+    assert resp.status_code == 200
+    assert "agenda/parceria_list.html" in [t.name for t in resp.templates]
+
+
+@pytest.mark.django_db
+def test_parceria_create_evento_outra_org_mostra_erro(client):
+    evento_own = EventoFactory()
+    evento_other = EventoFactory()
+    empresa = EmpresaFactory(organizacao=evento_own.organizacao)
+    user = UserFactory(user_type=UserType.ADMIN, organizacao=evento_own.organizacao, nucleo_obj=None)
+    client.force_login(user)
+    data = {
+        "evento": evento_other.pk,
+        "empresa": empresa.pk,
+        "cnpj": "12345678901234",
+        "contato": "Contato",
+        "representante_legal": "Rep",
+        "data_inicio": date.today(),
+        "data_fim": date.today(),
+        "descricao": "",
+    }
+    resp = client.post(reverse("eventos:parceria_criar"), data)
+    assert resp.status_code == 200
+    assert "Evento de outra organização" in resp.content.decode()

--- a/eventos/tests/test_qrcode.py
+++ b/eventos/tests/test_qrcode.py
@@ -1,0 +1,64 @@
+import pytest
+from datetime import datetime, timedelta
+from django.urls import reverse, path, include
+from django.utils.timezone import make_aware
+from django.test import override_settings
+
+from accounts.models import User, UserType
+from eventos.models import Evento, InscricaoEvento
+from organizacoes.models import Organizacao
+
+
+urlpatterns = [
+    path("", include(("core.urls", "core"), namespace="core")),
+    path("eventos/", include(("eventos.urls", "eventos"), namespace="eventos")),
+]
+
+pytestmark = pytest.mark.django_db
+
+
+@override_settings(ROOT_URLCONF="eventos.tests.test_qrcode")
+def test_usuario_ve_qrcode_apos_inscricao(client, monkeypatch):
+    monkeypatch.setattr(
+        InscricaoEvento,
+        "gerar_qrcode",
+        lambda self: setattr(self, "qrcode_url", "/fake-qrcode.png"),
+    )
+    organizacao = Organizacao.objects.create(
+        nome="Org Teste", cnpj="00000000000191"
+    )
+    usuario = User.objects.create_user(
+        username="usuario",
+        email="u@example.com",
+        password="12345",
+        organizacao=organizacao,
+        user_type=UserType.NUCLEADO,
+    )
+    client.force_login(usuario)
+
+    evento = Evento.objects.create(
+        titulo="Evento",
+        descricao="Desc",
+        data_inicio=make_aware(datetime.now() + timedelta(days=1)),
+        data_fim=make_aware(datetime.now() + timedelta(days=2)),
+        local="Rua 1",
+        cidade="Cidade",
+        estado="ST",
+        cep="12345-678",
+        coordenador=usuario,
+        organizacao=organizacao,
+        status=0,
+        publico_alvo=0,
+        numero_convidados=10,
+        numero_presentes=0,
+    )
+
+    url = reverse("eventos:evento_subscribe", args=[evento.pk])
+    response = client.post(url, follow=True)
+
+    assert response.status_code == 200
+    inscricao = InscricaoEvento.objects.get(user=usuario, evento=evento)
+    assert inscricao.status == "confirmada"
+    assert inscricao.qrcode_url
+    assert inscricao.qrcode_url in response.content.decode()
+


### PR DESCRIPTION
## Summary
- add eventos test suite based on agenda tests
- proxy agenda factories and models in eventos

## Testing
- `pytest --no-cov eventos/tests` *(fails: ModuleNotFoundError: No module named 'discussao')*

------
https://chatgpt.com/codex/tasks/task_e_68ba1f260ddc8325b575216f94cd5210