### PR TITLE
Migrate agenda configuration to eventos app

### DIFF
--- a/Hubx/settings.py
+++ b/Hubx/settings.py
@@ -87,7 +87,7 @@ INSTALLED_APPS = [
     "tokens.apps.TokensConfig",
     "nucleos",
     # App legado (mantém label e migrações)
-    "agenda",
+    "eventos.apps.EventosConfig",
     "feed",
     "configuracoes",
     "financeiro.apps.FinanceiroConfig",

--- a/eventos/admin.py
+++ b/eventos/admin.py
@@ -1,0 +1,3 @@
+"""Reexporta configurações de admin do app legado `agenda`."""
+from agenda.admin import *  # noqa: F401,F403
+

--- a/eventos/apps.py
+++ b/eventos/apps.py
@@ -5,9 +5,11 @@ class EventosConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     # Mantém o label antigo para compatibilidade com ForeignKeys e migrações
     label = "agenda"
-    name = "eventos"
+    # O app continua a utilizar os módulos do pacote legado ``agenda``
+    name = "agenda"
     verbose_name = "Eventos"
 
     def ready(self) -> None:  # pragma: no cover - configuração
-        # Reutiliza os sinais do app legado
-        from agenda import signals  # noqa: F401
+        # Carrega os sinais mantendo compatibilidade com o app legado
+        from . import signals  # noqa: F401
+

--- a/eventos/signals.py
+++ b/eventos/signals.py
@@ -1,0 +1,3 @@
+"""Reexporta sinais do app legado `agenda`."""
+from agenda.signals import *  # noqa: F401,F403
+


### PR DESCRIPTION
## Summary
- replace legacy `agenda` entry in settings with `eventos.apps.EventosConfig`
- load signals under `eventos` and re-export admin and signals from the legacy app

## Testing
- `pytest tests/agenda -q` *(fails: ModuleNotFoundError: No module named 'factory')*

------
https://chatgpt.com/codex/tasks/task_e_68ba1f22d8b883259082e573be31fc2f