### PR TITLE
refactor: centralize share button logic

### DIFF
--- a/feed/static/feed/js/share.js
+++ b/feed/static/feed/js/share.js
@@ -1,0 +1,39 @@
+export async function handleShare(event) {
+  const btn = event.target.closest('.share-btn');
+  if (!btn) return;
+
+  event.preventDefault();
+  const postId = btn.dataset.postId;
+  if (!postId) return;
+
+  const countSpan = btn.querySelector('.share-count');
+  const csrfToken = document.cookie.match(/(?:^|; )csrftoken=([^;]+)/)?.[1] || '';
+
+  try {
+    const res = await fetch(`/api/feed/posts/${postId}/reacoes/`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRFToken': csrfToken
+      },
+      body: JSON.stringify({ vote: 'share' })
+    });
+
+    if (res.status === 201) {
+      btn.classList.add('text-blue-600');
+      if (countSpan) {
+        countSpan.textContent = String(parseInt(countSpan.textContent || '0') + 1);
+      }
+    } else if (res.status === 204) {
+      btn.classList.remove('text-blue-600');
+      if (countSpan) {
+        const newValue = Math.max(parseInt(countSpan.textContent || '0') - 1, 0);
+        countSpan.textContent = String(newValue);
+      }
+    }
+  } catch (err) {
+    console.error('Erro ao compartilhar', err);
+  }
+}
+
+document.addEventListener('click', handleShare);

--- a/feed/templates/feed/_grid.html
+++ b/feed/templates/feed/_grid.html
@@ -106,27 +106,5 @@
       btn.setAttribute('disabled', 'disabled');
     });
   });
-  document.querySelectorAll('.share-btn').forEach(btn => {
-    btn.addEventListener('click', async () => {
-      const postId = btn.dataset.postId;
-      const countSpan = btn.querySelector('.share-count');
-      const res = await fetch(`/api/feed/posts/${postId}/reacoes/`, {
-        method: 'POST',
-        headers: {'Content-Type': 'application/json', 'X-CSRFToken': csrfToken},
-        body: JSON.stringify({vote: 'share'})
-      });
-      if (!res.ok) {
-        alert('{% trans "Erro ao compartilhar" %}');
-        return;
-      }
-      if (res.status === 201) {
-        btn.classList.add('text-blue-600');
-        countSpan.textContent = parseInt(countSpan.textContent || '0') + 1;
-      } else if (res.status === 204) {
-        btn.classList.remove('text-blue-600');
-        countSpan.textContent = Math.max(parseInt(countSpan.textContent || '0') - 1, 0);
-      }
-    });
-  });
 </script>
 {% endif %}

--- a/feed/templates/feed/post_detail.html
+++ b/feed/templates/feed/post_detail.html
@@ -137,24 +137,6 @@
       }
     });
   });
-  document.querySelectorAll('.share-btn').forEach(btn => {
-    btn.addEventListener('click', async () => {
-      const postId = btn.dataset.postId;
-      const countSpan = btn.querySelector('.share-count');
-      const res = await fetch(`/api/feed/posts/${postId}/reacoes/`, {
-        method: 'POST',
-        headers: {'Content-Type': 'application/json', 'X-CSRFToken': csrfToken},
-        body: JSON.stringify({vote: 'share'})
-      });
-      if (res.status === 201) {
-        btn.classList.add('text-blue-600');
-        countSpan.textContent = parseInt(countSpan.textContent || '0') + 1;
-      } else if (res.status === 204) {
-        btn.classList.remove('text-blue-600');
-        countSpan.textContent = Math.max(parseInt(countSpan.textContent || '0') - 1, 0);
-      }
-    });
-  });
 
 
   function setReplyTo(commentId) {

--- a/templates/base.html
+++ b/templates/base.html
@@ -216,6 +216,7 @@
   {% endif %}
   <script src="{% static 'js/vendor/htmx-1.9.12.min.js' %}"></script>
   <script src="{% static 'js/dashboard.js' %}"></script>
+  <script type="module" src="{% static 'feed/js/share.js' %}"></script>
   <script>
     document.body.addEventListener('htmx:responseError', function (evt) {
       if (evt.detail.xhr.status === 403) {


### PR DESCRIPTION
## Summary
- add delegated share handler module
- load share handler globally
- drop duplicated share scripts from templates

## Testing
- `pytest feed/tests` *(fails: 18 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1e5d05a08325a87508db3072887b