### PR TITLE
Add HTMX json-enc extension

### DIFF
--- a/static/js/vendor/README.md
+++ b/static/js/vendor/README.md
@@ -6,3 +6,4 @@ These libraries are stored locally to avoid relying on external CDNs. Replace th
 - **Chart.js 4.5.0** – <https://cdn.jsdelivr.net/npm/chart.js@4.5.0/dist/chart.umd.min.js>
 - **jQuery 3.7.1** – <https://code.jquery.com/jquery-3.7.1.min.js>
 - **Select2 4.1.0-rc.0** – <https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js>
+- **HTMX json-enc extension** – <https://raw.githubusercontent.com/bigskysoftware/htmx/master/dist/ext/json-enc.js>

--- a/static/js/vendor/json-enc.js
+++ b/static/js/vendor/json-enc.js
@@ -1,0 +1,16 @@
+if (htmx.version && !htmx.version.startsWith("1.")) {
+    console.warn("WARNING: You are using an htmx 1 extension with htmx " + htmx.version +
+        ".  It is recommended that you move to the version of this extension found on https://htmx.org/extensions")
+}
+htmx.defineExtension('json-enc', {
+    onEvent: function (name, evt) {
+        if (name === "htmx:configRequest") {
+            evt.detail.headers['Content-Type'] = "application/json";
+        }
+    },
+
+    encodeParameters : function(xhr, parameters, elt) {
+        xhr.overrideMimeType('text/json');
+        return (JSON.stringify(parameters));
+    }
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -215,6 +215,7 @@
   <script src="{% static 'notificacoes/js/push_socket.js' %}"></script>
   {% endif %}
   <script src="{% static 'js/vendor/htmx-1.9.12.min.js' %}"></script>
+  <script src="{% static 'js/vendor/json-enc.js' %}"></script>
   <script src="{% static 'js/dashboard.js' %}"></script>
   <script>
     document.body.addEventListener('htmx:responseError', function (evt) {


### PR DESCRIPTION
## Summary
- vendored HTMX json-enc extension
- include json-enc script in base template after htmx
- document json-enc in vendored JS README

## Testing
- `pytest feed/tests/test_reactions.py::ReactionToggleAPITest::test_toggle_reaction -q --no-cov`

------
https://chatgpt.com/codex/tasks/task_e_68ba1e580324832583aa409eb45a55bc