### PR TITLE
Rename agenda namespace to eventos

### DIFF
--- a/Hubx/settings.py
+++ b/Hubx/settings.py
@@ -86,11 +86,7 @@ INSTALLED_APPS = [
     "organizacoes",
     "tokens.apps.TokensConfig",
     "nucleos",
-<<<<<<< HEAD
-    # App de eventos (mantém label antigo 'agenda' para compatibilidade)
-=======
-    # App legado (mantém label e migrações)
->>>>>>> main
+    # App de eventos
     "eventos.apps.EventosConfig",
     "feed",
     "configuracoes",

--- a/Hubx/urls.py
+++ b/Hubx/urls.py
@@ -26,10 +26,8 @@ urlpatterns = [
     path("organizacoes/", include(("organizacoes.urls", "organizacoes"), namespace="organizacoes")),
     path("nucleos/", include(("nucleos.urls", "nucleos"), namespace="nucleos")),
     path("eventos/", include(("eventos.urls", "eventos"), namespace="eventos")),
-    # Rotas legadas ainda funcionam apontando para o mesmo conjunto
-    path("agenda/", include(("eventos.urls", "agenda"), namespace="agenda")),
-    # Redireciona /agenda para /eventos no futuro (mantido por enquanto)
-    # path("eventos/<path:rest>/", RedirectView.as_view(url="/eventos/%(rest)s", permanent=True)),
+    path("agenda/<path:rest>/", RedirectView.as_view(url="/eventos/%(rest)s", permanent=True)),
+    path("agenda/", RedirectView.as_view(url="/eventos/", permanent=True)),
     # Discussão e Feed (web)
     path("feed/", include(("feed.urls", "feed"), namespace="feed")),
     path("notificacoes/", include(("notificacoes.urls", "notificacoes"), namespace="notificacoes")),
@@ -87,12 +85,6 @@ urlpatterns = [
     path(
         "api/eventos/",
         include(("eventos.api_urls", "eventos_api"), namespace="eventos_api"),
-    ),
-
-    # Mantém API antiga
-    path(
-        "api/agenda/",
-        include(("eventos.api_urls", "agenda_api"), namespace="agenda_api"),
     ),
 
     path("", include("django_prometheus.urls")),

--- a/core/management/commands/seed_data.py
+++ b/core/management/commands/seed_data.py
@@ -5,7 +5,7 @@ from django.utils import timezone
 from faker import Faker
 
 from accounts.factories import UserFactory
-from agenda.factories import EventoFactory
+from eventos.factories import EventoFactory
 from eventos.models import FeedbackNota, InscricaoEvento, ParceriaEvento
 # O app 'discussao' foi removido; factories opcionais
 try:  # pragma: no cover

--- a/eventos/README.md
+++ b/eventos/README.md
@@ -1,7 +1,6 @@
 # Eventos
 
-Este app substitui o antigo módulo **Agenda**, mantendo o label `agenda`
-para compatibilidade com migrations e chaves estrangeiras existentes.
+Este app substitui o antigo módulo **Agenda**.
 
 Todos os modelos deste app herdam de `core.models.TimeStampedModel`,
 disponibilizando os campos `created_at` e `updated_at` para registro de

--- a/eventos/__init__.py
+++ b/eventos/__init__.py
@@ -1,8 +1,6 @@
 """Configuração inicial do app ``eventos``.
 
-O aplicativo substitui o antigo ``agenda`` mantendo o mesmo *label*
-para garantir compatibilidade com migrações e chaves estrangeiras
-existentes.
+Este aplicativo substitui o antigo ``agenda``.
 """
 
 __all__ = ["apps"]

--- a/eventos/admin.py
+++ b/eventos/admin.py
@@ -1,3 +1,43 @@
-"""Reexporta configurações de admin do app legado `agenda`."""
-from agenda.admin import *  # noqa: F401,F403
+from django.contrib import admin
+
+from .forms import EventoForm
+from .models import (
+    BriefingEvento,
+    Evento,
+    InscricaoEvento,
+    MaterialDivulgacaoEvento,
+    ParceriaEvento,
+    Tarefa,
+)
+
+
+@admin.register(Evento)
+class EventoAdmin(admin.ModelAdmin):
+    form = EventoForm
+    list_display = ["titulo", "data_inicio", "data_fim", "cidade", "estado", "status"]
+
+
+@admin.register(InscricaoEvento)
+class InscricaoEventoAdmin(admin.ModelAdmin):
+    list_display = ["user", "evento", "presente"]
+
+
+@admin.register(ParceriaEvento)
+class ParceriaEventoAdmin(admin.ModelAdmin):
+    list_display = ["empresa", "evento", "tipo_parceria"]
+
+
+@admin.register(MaterialDivulgacaoEvento)
+class MaterialDivulgacaoEventoAdmin(admin.ModelAdmin):
+    list_display = ["evento", "descricao", "tags"]
+
+
+@admin.register(BriefingEvento)
+class BriefingEventoAdmin(admin.ModelAdmin):
+    list_display = ["evento", "objetivos"]
+
+
+@admin.register(Tarefa)
+class TarefaAdmin(admin.ModelAdmin):
+    list_display = ["titulo", "data_inicio", "data_fim", "status"]
 

--- a/eventos/api.py
+++ b/eventos/api.py
@@ -14,11 +14,7 @@ from rest_framework.exceptions import ValidationError
 
 from accounts.models import UserType
 
-<<<<<<< HEAD:agenda/api.py
-from eventos.models import (
-=======
-from agenda.models import (
->>>>>>> main:eventos/api.py
+from .models import (
     BriefingEvento,
     Evento,
     EventoLog,
@@ -29,8 +25,8 @@ from agenda.models import (
     Tarefa,
     TarefaLog,
 )
-from agenda.permissions import IsAdminOrCoordenadorOrReadOnly
-from agenda.serializers import (
+from .permissions import IsAdminOrCoordenadorOrReadOnly
+from .serializers import (
     BriefingEventoSerializer,
     EventoSerializer,
     InscricaoEventoSerializer,
@@ -38,7 +34,7 @@ from agenda.serializers import (
     ParceriaEventoSerializer,
     TarefaSerializer,
 )
-from agenda.tasks import notificar_briefing_status
+from .tasks import notificar_briefing_status
 
 
 class DefaultPagination(PageNumberPagination):

--- a/eventos/apps.py
+++ b/eventos/apps.py
@@ -3,18 +3,10 @@ from django.apps import AppConfig
 
 class EventosConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
-    # Mantém o label antigo para compatibilidade com ForeignKeys e migrações
-    label = "agenda"
-    # O app continua a utilizar os módulos do pacote legado ``agenda``
-    name = "agenda"
+    name = "eventos"
+    label = "eventos"
     verbose_name = "Eventos"
 
     def ready(self) -> None:  # pragma: no cover - configuração
-<<<<<<< HEAD
-        # Registra os sinais do app de eventos
-        from eventos import signals  # noqa: F401
-=======
-        # Carrega os sinais mantendo compatibilidade com o app legado
         from . import signals  # noqa: F401
 
->>>>>>> main

--- a/eventos/factories.py
+++ b/eventos/factories.py
@@ -1,2 +1,39 @@
-"""Reexporta factories de agenda."""
-from agenda.factories import *  # noqa: F401,F403
+from datetime import timedelta, timezone as dt_timezone
+
+import factory
+from factory.django import DjangoModelFactory
+
+from accounts.factories import UserFactory
+from nucleos.factories import NucleoFactory
+from organizacoes.factories import OrganizacaoFactory
+
+from .models import Evento
+
+
+class EventoFactory(DjangoModelFactory):
+    class Meta:
+        model = Evento
+
+    organizacao = factory.SubFactory(OrganizacaoFactory)
+    nucleo = factory.SubFactory(NucleoFactory, organizacao=factory.SelfAttribute("..organizacao"))
+    coordenador = factory.SubFactory(UserFactory)
+    titulo = factory.Faker("sentence", locale="pt_BR")
+    descricao = factory.Faker("paragraph", locale="pt_BR")
+    data_inicio = factory.Faker("future_datetime", tzinfo=dt_timezone.utc)
+    data_fim = factory.LazyAttribute(lambda o: o.data_inicio + timedelta(hours=1))
+    local = factory.Faker("street_address", locale="pt_BR")
+    cidade = factory.Faker("city", locale="pt_BR")
+    estado = factory.Faker("state_abbr", locale="pt_BR")
+    cep = factory.Faker("postcode", locale="pt_BR")
+    status = factory.Faker("random_element", elements=[0, 1, 2])
+    publico_alvo = factory.Faker("random_element", elements=[0, 1, 2])
+    numero_convidados = factory.Faker("pyint", min_value=10, max_value=100)
+    numero_presentes = factory.LazyAttribute(lambda o: o.numero_convidados // 2)
+    valor_ingresso = factory.Faker("pydecimal", left_digits=2, right_digits=2, positive=True)
+    orcamento = factory.Faker("pydecimal", left_digits=3, right_digits=2, positive=True)
+    cronograma = factory.Faker("paragraph", locale="pt_BR")
+    informacoes_adicionais = factory.Faker("paragraph", locale="pt_BR")
+    contato_nome = factory.Faker("name", locale="pt_BR")
+    contato_email = factory.Faker("email", locale="pt_BR")
+    contato_whatsapp = factory.Faker("msisdn")
+

--- a/eventos/forms.py
+++ b/eventos/forms.py
@@ -1,0 +1,208 @@
+import os
+
+from django import forms
+from django.forms import ClearableFileInput
+from django.utils.translation import gettext_lazy as _
+from django_select2 import forms as s2forms
+from validate_docbr import CNPJ
+
+from .validators import validate_uploaded_file
+from .models import (
+    BriefingEvento,
+    Evento,
+    FeedbackNota,
+    InscricaoEvento,
+    MaterialDivulgacaoEvento,
+    ParceriaEvento,
+    Tarefa,
+)
+
+
+class TarefaForm(forms.ModelForm):
+    class Meta:
+        model = Tarefa
+        fields = [
+            "titulo",
+            "descricao",
+            "data_inicio",
+            "data_fim",
+            "responsavel",
+            "status",
+        ]
+        widgets = {
+            "data_inicio": forms.DateTimeInput(attrs={"type": "datetime-local"}),
+            "data_fim": forms.DateTimeInput(attrs={"type": "datetime-local"}),
+            "descricao": forms.Textarea(attrs={"rows": 3}),
+        }
+
+
+class EventoForm(forms.ModelForm):
+    class Meta:
+        model = Evento
+        fields = [
+            "titulo",
+            "descricao",
+            "data_inicio",
+            "data_fim",
+            "local",
+            "cidade",
+            "estado",
+            "cep",
+            "coordenador",
+            "status",
+            "publico_alvo",
+            "numero_convidados",
+            "numero_presentes",
+            "participantes_maximo",
+            "espera_habilitada",
+            "valor_ingresso",
+            "orcamento",
+            "cronograma",
+            "informacoes_adicionais",
+            "contato_nome",
+            "contato_email",
+            "contato_whatsapp",
+            "avatar",
+            "cover",
+        ]
+        widgets = {
+            "data_inicio": forms.DateTimeInput(attrs={"type": "datetime-local"}),
+            "data_fim": forms.DateTimeInput(attrs={"type": "datetime-local"}),
+            "descricao": forms.Textarea(attrs={"rows": 3}),
+            "avatar": ClearableFileInput(),
+            "cover": ClearableFileInput(),
+        }
+
+
+class EventoWidget(s2forms.ModelSelect2Widget):
+    search_fields = ["titulo__icontains"]
+
+
+class EventoSearchForm(forms.Form):
+    evento = forms.ModelChoiceField(
+        queryset=Evento.objects.all(),
+        required=False,
+        label="",
+        widget=EventoWidget(
+            attrs={
+                "data-placeholder": "Buscar eventos...",
+                "data-minimum-input-length": 2,
+            }
+        ),
+    )
+
+
+class InscricaoEventoForm(forms.ModelForm):
+    class Meta:
+        model = InscricaoEvento
+        fields = [
+            "valor_pago",
+            "metodo_pagamento",
+            "comprovante_pagamento",
+            "observacao",
+        ]
+
+    def clean_valor_pago(self):
+        valor = self.cleaned_data.get("valor_pago")
+        if valor is not None and valor <= 0:
+            raise forms.ValidationError(_("O valor pago deve ser positivo."))
+        return valor
+
+    def clean_comprovante_pagamento(self):
+        arquivo = self.cleaned_data.get("comprovante_pagamento")
+        if not arquivo:
+            return arquivo
+        validate_uploaded_file(arquivo)
+        return arquivo
+
+
+class FeedbackForm(forms.ModelForm):
+    class Meta:
+        model = FeedbackNota
+        fields = ["nota", "comentario"]
+
+
+class MaterialDivulgacaoEventoForm(forms.ModelForm):
+    class Meta:
+        model = MaterialDivulgacaoEvento
+        fields = [
+            "evento",
+            "titulo",
+            "descricao",
+            "tipo",
+            "arquivo",
+            "imagem_thumb",
+            "tags",
+        ]
+
+    def clean_arquivo(self):
+        arquivo = self.cleaned_data.get("arquivo")
+        if not arquivo:
+            return arquivo
+        validate_uploaded_file(arquivo)
+        return arquivo
+
+    def clean_imagem_thumb(self):
+        img = self.cleaned_data.get("imagem_thumb")
+        if not img:
+            return img
+        ext = os.path.splitext(img.name)[1].lower()
+        if ext not in {".jpg", ".jpeg", ".png"}:
+            raise forms.ValidationError(_("Formato de imagem não permitido."))
+        if img.size > 10 * 1024 * 1024:
+            raise forms.ValidationError(_("Imagem excede o tamanho máximo de 10MB."))
+        return img
+
+
+class BriefingEventoForm(forms.ModelForm):
+    class Meta:
+        model = BriefingEvento
+        fields = [
+            "objetivos",
+            "publico_alvo",
+            "requisitos_tecnicos",
+            "cronograma_resumido",
+            "conteudo_programatico",
+            "observacoes",
+        ]
+
+
+class BriefingEventoCreateForm(BriefingEventoForm):
+    """Formulário de criação que inclui o evento associado."""
+
+    class Meta(BriefingEventoForm.Meta):
+        fields = ["evento", *BriefingEventoForm.Meta.fields]
+
+
+class ParceriaEventoForm(forms.ModelForm):
+    class Meta:
+        model = ParceriaEvento
+        fields = [
+            "evento",
+            "nucleo",
+            "empresa",
+            "cnpj",
+            "contato",
+            "representante_legal",
+            "data_inicio",
+            "data_fim",
+            "tipo_parceria",
+            "descricao",
+            "acordo",
+        ]
+
+    def clean_cnpj(self):
+        cnpj = self.cleaned_data.get("cnpj", "")
+        if not cnpj.isdigit() or len(cnpj) != 14:
+            raise forms.ValidationError(_("CNPJ deve conter 14 dígitos."))
+        if not CNPJ().validate(cnpj):
+            raise forms.ValidationError(_("CNPJ inválido."))
+        return cnpj
+
+    def clean_acordo(self):
+        arquivo = self.cleaned_data.get("acordo")
+        if not arquivo:
+            return arquivo
+        validate_uploaded_file(arquivo)
+        return arquivo
+

--- a/eventos/migrations/0001_initial.py
+++ b/eventos/migrations/0001_initial.py
@@ -171,7 +171,7 @@ class Migration(migrations.Migration):
                         to=settings.AUTH_USER_MODEL,
                     ),
                 ),
-                ("evento", models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to="agenda.evento")),
+                ("evento", models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to="eventos.evento")),
             ],
             options={
                 "verbose_name": "Briefing de Evento",
@@ -200,7 +200,7 @@ class Migration(migrations.Migration):
                 (
                     "evento",
                     models.ForeignKey(
-                        on_delete=django.db.models.deletion.CASCADE, related_name="logs", to="agenda.evento"
+                        on_delete=django.db.models.deletion.CASCADE, related_name="logs", to="eventos.evento"
                     ),
                 ),
                 (
@@ -254,7 +254,7 @@ class Migration(migrations.Migration):
                         null=True,
                         on_delete=django.db.models.deletion.DO_NOTHING,
                         related_name="+",
-                        to="agenda.evento",
+                        to="eventos.evento",
                     ),
                 ),
                 (
@@ -333,7 +333,7 @@ class Migration(migrations.Migration):
                         to=settings.AUTH_USER_MODEL,
                     ),
                 ),
-                ("evento", models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to="agenda.evento")),
+                ("evento", models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to="eventos.evento")),
             ],
             options={
                 "verbose_name": "Material de Divulgação de Evento",
@@ -397,7 +397,7 @@ class Migration(migrations.Migration):
                         on_delete=django.db.models.deletion.PROTECT, related_name="parcerias", to="empresas.empresa"
                     ),
                 ),
-                ("evento", models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to="agenda.evento")),
+                ("evento", models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to="eventos.evento")),
                 (
                     "nucleo",
                     models.ForeignKey(
@@ -483,7 +483,7 @@ class Migration(migrations.Migration):
                 (
                     "tarefa",
                     models.ForeignKey(
-                        on_delete=django.db.models.deletion.CASCADE, related_name="logs", to="agenda.tarefa"
+                        on_delete=django.db.models.deletion.CASCADE, related_name="logs", to="eventos.tarefa"
                     ),
                 ),
                 (
@@ -527,7 +527,7 @@ class Migration(migrations.Migration):
                 (
                     "evento",
                     models.ForeignKey(
-                        on_delete=django.db.models.deletion.CASCADE, related_name="feedbacks", to="agenda.evento"
+                        on_delete=django.db.models.deletion.CASCADE, related_name="feedbacks", to="eventos.evento"
                     ),
                 ),
                 (
@@ -595,7 +595,7 @@ class Migration(migrations.Migration):
                 (
                     "evento",
                     models.ForeignKey(
-                        on_delete=django.db.models.deletion.CASCADE, related_name="inscricoes", to="agenda.evento"
+                        on_delete=django.db.models.deletion.CASCADE, related_name="inscricoes", to="eventos.evento"
                     ),
                 ),
                 (

--- a/eventos/migrations/0002_rename_timestamp_fields.py
+++ b/eventos/migrations/0002_rename_timestamp_fields.py
@@ -6,7 +6,7 @@ from django.db import migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("agenda", "0001_initial"),
+        ("eventos", "0001_initial"),
     ]
 
     operations = [

--- a/eventos/migrations/0003_alter_eventolog_options_alter_tarefalog_options_and_more.py
+++ b/eventos/migrations/0003_alter_eventolog_options_alter_tarefalog_options_and_more.py
@@ -7,7 +7,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("agenda", "0002_rename_timestamp_fields"),
+        ("eventos", "0002_rename_timestamp_fields"),
     ]
 
     operations = [

--- a/eventos/migrations/0004_inscricao_avaliacao_constraint.py
+++ b/eventos/migrations/0004_inscricao_avaliacao_constraint.py
@@ -3,7 +3,7 @@ from django.db.models import Q
 
 
 def limpar_avaliacoes_invalidas(apps, schema_editor):
-    InscricaoEvento = apps.get_model('agenda', 'InscricaoEvento')
+    InscricaoEvento = apps.get_model('eventos', 'InscricaoEvento')
     InscricaoEvento.objects.filter(
         avaliacao__isnull=False
     ).exclude(avaliacao__gte=1, avaliacao__lte=5).update(avaliacao=None)
@@ -12,7 +12,7 @@ def limpar_avaliacoes_invalidas(apps, schema_editor):
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("agenda", "0003_alter_eventolog_options_alter_tarefalog_options_and_more"),
+        ("eventos", "0003_alter_eventolog_options_alter_tarefalog_options_and_more"),
     ]
 
     operations = [

--- a/eventos/migrations/0005_remove_avaliacao_feedback_from_inscricao.py
+++ b/eventos/migrations/0005_remove_avaliacao_feedback_from_inscricao.py
@@ -3,7 +3,7 @@ from django.db import migrations
 
 class Migration(migrations.Migration):
     dependencies = [
-        ("agenda", "0004_inscricao_avaliacao_constraint"),
+        ("eventos", "0004_inscricao_avaliacao_constraint"),
     ]
 
     operations = [

--- a/eventos/migrations/0006_evento_slug.py
+++ b/eventos/migrations/0006_evento_slug.py
@@ -6,7 +6,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("agenda", "0005_remove_avaliacao_feedback_from_inscricao"),
+        ("eventos", "0005_remove_avaliacao_feedback_from_inscricao"),
     ]
 
     operations = [

--- a/eventos/migrations/0007_alter_evento_avatar_cover.py
+++ b/eventos/migrations/0007_alter_evento_avatar_cover.py
@@ -6,7 +6,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("agenda", "0006_evento_slug"),
+        ("eventos", "0006_evento_slug"),
     ]
 
     operations = [

--- a/eventos/models.py
+++ b/eventos/models.py
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 from __future__ import annotations
 
 # ruff: noqa: I001
@@ -544,9 +543,3 @@ class EventoLog(TimeStampedModel, SoftDeleteModel):
 
     class Meta:
         ordering = ["-created_at"]
-=======
-"""Reexporta modelos do app legado 'agenda'."""
-from agenda.models import *  # noqa: F401,F403
-
-
->>>>>>> main

--- a/eventos/permissions.py
+++ b/eventos/permissions.py
@@ -1,0 +1,19 @@
+from rest_framework import permissions
+
+from accounts.models import UserType
+
+
+class IsAdminOrCoordenadorOrReadOnly(permissions.IsAuthenticated):
+    """Allow write actions only to admins or coordinators."""
+
+    def has_permission(self, request, view) -> bool:  # type: ignore[override]
+        if not super().has_permission(request, view):
+            return False
+        if request.method in permissions.SAFE_METHODS:
+            return True
+        return request.user.user_type in {
+            UserType.ADMIN,
+            UserType.COORDENADOR,
+            UserType.ROOT,
+        }
+

--- a/eventos/serializers.py
+++ b/eventos/serializers.py
@@ -1,0 +1,304 @@
+from __future__ import annotations
+
+import os
+
+from rest_framework import serializers
+from rest_framework.exceptions import PermissionDenied
+from validate_docbr import CNPJ
+from typing import Any, Dict
+from django.core.exceptions import ValidationError as DjangoValidationError
+from accounts.models import UserType
+
+from .validators import validate_uploaded_file
+
+from .models import (
+    BriefingEvento,
+    Evento,
+    EventoLog,
+    InscricaoEvento,
+    MaterialDivulgacaoEvento,
+    ParceriaEvento,
+    Tarefa,
+    TarefaLog,
+)
+from .tasks import upload_material_divulgacao
+
+
+class TarefaSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Tarefa
+        exclude = ("deleted", "deleted_at")
+        read_only_fields = (
+            "id",
+            "organizacao",
+            "responsavel",
+            "status",
+            "created_at",
+            "updated_at",
+        )
+
+    def create(self, validated_data):
+        request = self.context["request"]
+        validated_data["organizacao"] = request.user.organizacao
+        validated_data["responsavel"] = request.user
+        instance = super().create(validated_data)
+        TarefaLog.objects.create(
+            tarefa=instance, usuario=request.user, acao="tarefa_criada"
+        )
+        return instance
+
+    def update(self, instance, validated_data):
+        request = self.context["request"]
+        old_instance = Tarefa.objects.get(pk=instance.pk)
+        instance = super().update(instance, validated_data)
+        changes: Dict[str, Dict[str, Any]] = {}
+        for field in validated_data:
+            before = getattr(old_instance, field)
+            after = getattr(instance, field)
+            if before != after:
+                changes[field] = {"antes": before, "depois": after}
+        TarefaLog.objects.create(
+            tarefa=instance,
+            usuario=request.user,
+            acao="tarefa_atualizada",
+            detalhes=changes,
+        )
+        return instance
+
+
+class EventoSerializer(serializers.ModelSerializer):
+    nota_media = serializers.SerializerMethodField()
+    distribuicao_notas = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Evento
+        exclude = ("deleted", "deleted_at")
+        read_only_fields = (
+            "id",
+            "organizacao",
+            "coordenador",
+            "created_at",
+            "updated_at",
+            "nota_media",
+            "distribuicao_notas",
+        )
+        extra_kwargs = {
+            "avatar": {"required": False, "allow_null": True},
+            "cover": {"required": False, "allow_null": True},
+        }
+
+    def get_nota_media(self, obj: Evento):
+        media = obj.calcular_media_feedback()
+        return round(media, 2) if media else None
+
+    def get_distribuicao_notas(self, obj: Evento):
+        dist = {str(i): 0 for i in range(1, 6)}
+        for nota in obj.feedbacks.values_list("nota", flat=True):
+            dist[str(nota)] += 1
+        return dist
+
+    def create(self, validated_data):
+        request = self.context["request"]
+        validated_data["organizacao"] = request.user.organizacao
+        validated_data["coordenador"] = request.user
+        instance = super().create(validated_data)
+        EventoLog.objects.create(evento=instance, usuario=request.user, acao="evento_criado")
+        return instance
+
+    def update(self, instance, validated_data):
+        request = self.context["request"]
+        old_instance = Evento.objects.get(pk=instance.pk)
+        instance = super().update(instance, validated_data)
+        changes: Dict[str, Dict[str, Any]] = {}
+        for field in validated_data:
+            before = getattr(old_instance, field)
+            after = getattr(instance, field)
+            if before != after:
+                changes[field] = {"antes": before, "depois": after}
+        EventoLog.objects.create(
+            evento=instance,
+            usuario=request.user,
+            acao="evento_atualizado",
+            detalhes=changes,
+        )
+        return instance
+
+
+class InscricaoEventoSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = InscricaoEvento
+        exclude = ("deleted", "deleted_at")
+        read_only_fields = (
+            "id",
+            "user",
+            "status",
+            "data_confirmacao",
+            "qrcode_url",
+            "check_in_realizado_em",
+            "posicao_espera",
+            "created_at",
+            "updated_at",
+        )
+
+    def validate_comprovante_pagamento(self, arquivo):
+        if not arquivo:
+            return arquivo
+        try:
+            validate_uploaded_file(arquivo)
+        except DjangoValidationError as e:
+            raise serializers.ValidationError(e.messages)
+        return arquivo
+
+    def create(self, validated_data):
+        request = self.context["request"]
+        evento = validated_data["evento"]
+        if evento.organizacao != request.user.organizacao:
+            raise PermissionDenied("Evento de outra organização")
+        if InscricaoEvento.objects.filter(user=request.user, evento=evento, deleted=False).exists():
+            raise serializers.ValidationError("Usuário já inscrito neste evento.")
+        validated_data["user"] = request.user
+        instance = super().create(validated_data)
+        instance.confirmar_inscricao()
+        return instance
+
+
+class MaterialDivulgacaoEventoSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = MaterialDivulgacaoEvento
+        exclude = ("deleted", "deleted_at")
+        read_only_fields = (
+            "id",
+            "status",
+            "avaliado_por",
+            "avaliado_em",
+            "imagem_thumb",
+            "created_at",
+            "updated_at",
+        )
+
+    def validate_arquivo(self, arquivo):
+        if not arquivo:
+            return arquivo
+        try:
+            validate_uploaded_file(arquivo)
+        except DjangoValidationError as e:
+            raise serializers.ValidationError(e.messages)
+        return arquivo
+
+
+    def create(self, validated_data):
+        request = self.context["request"]
+        evento = validated_data["evento"]
+        user = request.user
+        if user.user_type != UserType.ROOT:
+            if evento.organizacao != user.organizacao:
+                raise PermissionDenied("Evento de outra organização")
+            if not user.nucleos.filter(id=evento.nucleo_id).exists():
+                raise PermissionDenied("Evento de outro núcleo")
+        instance = super().create(validated_data)
+        upload_material_divulgacao.delay(instance.pk)
+        return instance
+
+    def update(self, instance, validated_data):
+        request = self.context["request"]
+        old_instance = MaterialDivulgacaoEvento.objects.get(pk=instance.pk)
+        instance = super().update(instance, validated_data)
+        if "arquivo" in validated_data:
+            upload_material_divulgacao.delay(instance.pk)
+        changes: Dict[str, Dict[str, Any]] = {}
+        for field in validated_data:
+            before = getattr(old_instance, field)
+            after = getattr(instance, field)
+            if before != after:
+                changes[field] = {"antes": before, "depois": after}
+        EventoLog.objects.create(
+            evento=instance.evento,
+            usuario=request.user,
+            acao="material_atualizado",
+            detalhes=changes,
+        )
+        return instance
+
+
+class ParceriaEventoSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ParceriaEvento
+        exclude = ("deleted", "deleted_at")
+        read_only_fields = (
+            "id",
+            "avaliacao",
+            "comentario",
+            "created_at",
+            "updated_at",
+        )
+
+    def validate_acordo(self, arquivo):
+        if not arquivo:
+            return arquivo
+        try:
+            validate_uploaded_file(arquivo)
+        except DjangoValidationError as e:
+            raise serializers.ValidationError(e.messages)
+        return arquivo
+
+    def validate_cnpj(self, value: str) -> str:
+        if not CNPJ().validate(value):
+            raise serializers.ValidationError("CNPJ inválido")
+        return value
+
+    def validate(self, attrs):
+        if attrs.get("data_fim") and attrs.get("data_inicio") and attrs["data_fim"] < attrs["data_inicio"]:
+            raise serializers.ValidationError({"data_fim": "Data final deve ser posterior à inicial"})
+        return attrs
+
+    def create(self, validated_data):
+        request = self.context["request"]
+        evento = validated_data["evento"]
+        if evento.organizacao != request.user.organizacao:
+            raise PermissionDenied("Evento de outra organização")
+        return super().create(validated_data)
+
+
+class BriefingEventoSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = BriefingEvento
+        exclude = ("deleted", "deleted_at")
+        read_only_fields = (
+            "id",
+            "status",
+            "orcamento_enviado_em",
+            "aprovado_em",
+            "recusado_em",
+            "coordenadora_aprovou",
+            "recusado_por",
+            "prazo_limite_resposta",
+            "avaliado_por",
+            "avaliado_em",
+            "created_at",
+            "updated_at",
+        )
+
+    def create(self, validated_data):
+        request = self.context["request"]
+        evento = validated_data["evento"]
+        if evento.organizacao != request.user.organizacao:
+            raise PermissionDenied("Evento de outra organização")
+        return super().create(validated_data)
+
+    def update(self, instance, validated_data):
+        request = self.context["request"]
+        old_instance = BriefingEvento.objects.get(pk=instance.pk)
+        instance = super().update(instance, validated_data)
+        changes: Dict[str, Dict[str, Any]] = {}
+        for field in validated_data:
+            before = getattr(old_instance, field)
+            after = getattr(instance, field)
+            if before != after:
+                changes[field] = {"antes": before, "depois": after}
+        EventoLog.objects.create(
+            evento=instance.evento,
+            usuario=request.user,
+            acao="briefing_atualizado",
+            detalhes=changes,
+        )
+        return instance

--- a/eventos/signals.py
+++ b/eventos/signals.py
@@ -1,11 +1,10 @@
-<<<<<<< HEAD
 from __future__ import annotations
 
 from django.db.models.signals import pre_save, post_save
 from django.dispatch import receiver
 
-from eventos.models import Evento, InscricaoEvento
-from agenda.tasks import promover_lista_espera
+from .models import Evento, InscricaoEvento
+from .tasks import promover_lista_espera
 
 
 @receiver(pre_save, sender=InscricaoEvento)
@@ -50,8 +49,4 @@ def _evento_trigger_waitlist(sender, instance, created, **kwargs):
     new = instance.participantes_maximo
     if new is not None and (old is None or new > old):
         promover_lista_espera.delay(str(instance.pk))
-=======
-"""Reexporta sinais do app legado `agenda`."""
-from agenda.signals import *  # noqa: F401,F403
 
->>>>>>> main

--- a/eventos/tasks.py
+++ b/eventos/tasks.py
@@ -1,0 +1,94 @@
+import logging
+
+from celery import shared_task
+from django.contrib.auth import get_user_model
+from django.core.files.storage import default_storage
+from django.utils import timezone
+
+from notificacoes.services.notificacoes import enviar_para_usuario
+
+from .models import (
+    BriefingEvento,
+    Evento,
+    EventoLog,
+    MaterialDivulgacaoEvento,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+@shared_task
+def promover_lista_espera(evento_id: int) -> None:
+    evento = Evento.objects.filter(pk=evento_id).first()
+    if not evento or not evento.participantes_maximo:
+        return
+    vagas = evento.participantes_maximo - evento.inscricoes.filter(status="confirmada").count()
+    if vagas <= 0:
+        return
+    pendentes = evento.inscricoes.filter(status="pendente").order_by("posicao_espera")[:vagas]
+    for ins in pendentes:
+        ins.status = "confirmada"
+        ins.posicao_espera = None
+        ins.data_confirmacao = timezone.now()
+        ins.gerar_qrcode()
+        ins.save(update_fields=["status", "posicao_espera", "data_confirmacao", "qrcode_url", "updated_at"])
+
+        enviar_para_usuario(
+            ins.user,
+            "evento_lista_espera_promovido",
+            {"evento": {"id": evento.pk, "titulo": evento.titulo}},
+            escopo_tipo="eventos.Evento",
+            escopo_id=str(evento.pk),
+        )
+        EventoLog.objects.create(
+            evento=evento,
+            usuario=ins.user,
+            acao="inscricao_promovida",
+            detalhes={"notificacao": True},
+        )
+
+
+@shared_task(bind=True, autoretry_for=(Exception,), retry_backoff=True, retry_kwargs={"max_retries": 3})
+def upload_material_divulgacao(self, material_id: int) -> None:
+    """Realiza upload assíncrono do material para o storage padrão."""
+
+    material = MaterialDivulgacaoEvento.objects.filter(pk=material_id).first()
+    if not material or not material.arquivo:
+        return
+    try:
+        default_storage.save(material.arquivo.name, material.arquivo.file)
+    except Exception as exc:  # pragma: no cover - rede/storage
+        logger.exception("Falha no upload do material %s", material_id)
+        raise exc
+    logger.info("Upload do material %s concluído", material_id)
+
+
+@shared_task
+def notificar_briefing_status(
+    briefing_id: int,
+    status: str,
+    destinatarios: list[int] | None = None,
+    corpo: str | None = None,
+) -> None:
+    """Notifica mudança de status do briefing."""
+
+    briefing = BriefingEvento.objects.filter(pk=briefing_id).select_related("evento__coordenador").first()
+    if not briefing:
+        return
+
+    usuarios: list = []
+    if briefing.evento.coordenador:
+        usuarios.append(briefing.evento.coordenador)
+
+    if destinatarios:
+        User = get_user_model()
+        extras = User.objects.filter(pk__in=destinatarios)
+        usuarios.extend(extras)
+
+    contexto = {"status": status, "mensagem": corpo or ""}
+    for user in usuarios:
+        enviar_para_usuario(user, "eventos_briefing_status", contexto)
+
+    logger.info("Briefing %s mudou para %s", briefing_id, status)
+

--- a/eventos/templates/eventos/_material_row.html
+++ b/eventos/templates/eventos/_material_row.html
@@ -11,7 +11,7 @@
       </a>
       {% if user.user_type == 'admin' or user.user_type == 'coordenador' %}
       <form
-        hx-post="{% url 'agenda_api:material-aprovar' material.pk %}"
+        hx-post="{% url 'eventos_api:material-aprovar' material.pk %}"
         hx-target="closest tr"
         hx-swap="outerHTML"
         class="inline"
@@ -20,7 +20,7 @@
         <button type="submit" class="text-green-600 hover:underline">{% trans "Aprovar" %}</button>
       </form>
       <form
-        hx-post="{% url 'agenda_api:material-devolver' material.pk %}"
+        hx-post="{% url 'eventos_api:material-devolver' material.pk %}"
         hx-target="closest tr"
         hx-swap="outerHTML"
         class="inline-flex items-center gap-1"

--- a/eventos/templates/eventos/briefing_form.html
+++ b/eventos/templates/eventos/briefing_form.html
@@ -26,7 +26,7 @@
     </div>
     {% endfor %}
     <div class="flex justify-end gap-3 pt-4 border-t border-neutral-100">
-      <a href="{% url 'agenda:briefing_list' %}" class="btn-secondary" aria-label="{% trans 'Cancelar' %}">{% trans 'Cancelar' %}</a>
+      <a href="{% url 'eventos:briefing_list' %}" class="btn-secondary" aria-label="{% trans 'Cancelar' %}">{% trans 'Cancelar' %}</a>
       <button type="submit" class="btn-primary" aria-label="{% trans 'Salvar' %}">{% trans 'Salvar' %}</button>
     </div>
   </form>

--- a/eventos/templates/eventos/briefing_list.html
+++ b/eventos/templates/eventos/briefing_list.html
@@ -8,7 +8,7 @@
   <header class="mb-6 flex items-center justify-between">
     <h1 class="text-2xl font-bold text-neutral-900">{% trans "Briefings de Eventos" %}</h1>
     <a
-      href="{% url 'agenda:briefing_criar' %}"
+      href="{% url 'eventos:briefing_criar' %}"
       class="btn-primary"
     >{% trans "Novo Briefing" %}</a>
   </header>
@@ -22,7 +22,7 @@
   {% endif %}
 
   <form
-    hx-get="{% url 'agenda:briefing_list' %}"
+    hx-get="{% url 'eventos:briefing_list' %}"
     hx-target="#briefing-container"
     hx-push-url="true"
     class="mb-6 flex gap-2"
@@ -69,12 +69,12 @@
               <td class="px-4 py-2">{{ briefing.observacoes }}</td>
               <td class="px-4 py-2 space-x-2">
                 <a
-                  href="{% url 'agenda:briefing_editar' briefing.pk %}"
+                  href="{% url 'eventos:briefing_editar' briefing.pk %}"
                   class="text-blue-600 hover:underline"
                 >{% trans "Editar" %}</a>
                 <form
                   method="post"
-                  action="{% url 'agenda:briefing_status' briefing.pk 'orcamentado' %}"
+                  action="{% url 'eventos:briefing_status' briefing.pk 'orcamentado' %}"
                   class="inline space-x-1"
                 >
                   {% csrf_token %}
@@ -90,7 +90,7 @@
                 </form>
                 <form
                   method="post"
-                  action="{% url 'agenda:briefing_status' briefing.pk 'aprovado' %}"
+                  action="{% url 'eventos:briefing_status' briefing.pk 'aprovado' %}"
                   class="inline"
                 >
                   {% csrf_token %}
@@ -100,7 +100,7 @@
                 </form>
                 <form
                   method="post"
-                  action="{% url 'agenda:briefing_status' briefing.pk 'recusado' %}"
+                  action="{% url 'eventos:briefing_status' briefing.pk 'recusado' %}"
                   class="inline space-x-1"
                 >
                   {% csrf_token %}
@@ -128,7 +128,7 @@
   </main>
 
   <footer class="mt-6 text-right">
-    <a href="{% url 'agenda:calendario' %}" class="text-sm text-blue-600 hover:underline">{% trans "Voltar à agenda" %}</a>
+    <a href="{% url 'eventos:calendario' %}" class="text-sm text-blue-600 hover:underline">{% trans "Voltar aos eventos" %}</a>
   </footer>
 </section>
 {% endblock %}

--- a/eventos/templates/eventos/calendario.html
+++ b/eventos/templates/eventos/calendario.html
@@ -5,12 +5,12 @@
 <section class="max-w-screen-xl mx-auto pt-8 px-6 lg:px-8">
   <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
     <h2 class="font-semibold text-2xl mb-4 flex items-center justify-between">
-      <a href="{% url 'agenda:calendario_mes' prev_ano prev_mes %}" class="px-2 py-1 rounded hover:bg-gray-100">&laquo;</a>
+      <a href="{% url 'eventos:calendario_mes' prev_ano prev_mes %}" class="px-2 py-1 rounded hover:bg-gray-100">&laquo;</a>
       <span>{{ data_atual|date:'YEAR_MONTH_FORMAT' }}</span>
-      <a href="{% url 'agenda:calendario_mes' next_ano next_mes %}" class="px-2 py-1 rounded hover:bg-gray-100">&raquo;</a>
+      <a href="{% url 'eventos:calendario_mes' next_ano next_mes %}" class="px-2 py-1 rounded hover:bg-gray-100">&raquo;</a>
     </h2>
-    {% if perms.agenda.add_evento %}
-    <a href="{% url 'agenda:evento_novo' %}"
+    {% if perms.eventos.add_evento %}
+    <a href="{% url 'eventos:evento_novo' %}"
        class="btn-primary inline-flex items-center gap-2 px-4 py-2 bg-primary-600 text-white rounded-md hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-600 sm:ml-auto sm:order-last mt-4 sm:mt-0"
        aria-label="{% trans 'Novo Evento' %}">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -25,7 +25,7 @@
     <div class="grid grid-cols-7 gap-px bg-gray-200 rounded-lg overflow-hidden text-sm leading-tight select-none">
       {% for dia in dias_mes %}
         <div class="relative bg-white p-4 h-28 align-top {% if not dia.mes_atual %}text-gray-400{% else %}text-gray-900{% endif %}"
-             hx-get="{% url 'agenda:lista_eventos' dia.data|date:'Y-m-d' %}"
+             hx-get="{% url 'eventos:lista_eventos' dia.data|date:'Y-m-d' %}"
              hx-target="#eventos-dia" hx-trigger="click">
           <div class="flex items-center justify-between mb-2">
             <span class="{% if dia.hoje %}ring-2 ring-primary-600 rounded-full{% endif %} inline-block w-6 h-6 leading-6 text-center">
@@ -38,9 +38,9 @@
           <ul class="space-y-1">
             {% for ev in dia.eventos|slice:":3" %}
               <li>
-                <a href="{% url 'agenda:evento_detalhe' ev.id %}"
+                <a href="{% url 'eventos:evento_detalhe' ev.id %}"
                    class="block bg-emerald-50 border border-emerald-200 text-emerald-800 rounded px-1.5 py-0.5 text-xs leading-tight hover:bg-emerald-100 transition line-clamp-3"
-                   hx-get="{% url 'agenda:evento_detalhe' ev.id %}"
+                   hx-get="{% url 'eventos:evento_detalhe' ev.id %}"
                    hx-target="#modal" hx-trigger="click" hx-stop-propagation="click">
                   {{ ev.titulo }}
                 </a>

--- a/eventos/templates/eventos/checkin_form.html
+++ b/eventos/templates/eventos/checkin_form.html
@@ -5,7 +5,7 @@
 {% block content %}
 <main class="max-w-md mx-auto py-8 px-4">
   <h1 class="text-xl font-semibold mb-4">{% trans "Check-in do evento" %}</h1>
-  <form method="post" action="{% url 'agenda:inscricao_checkin' inscricao.id %}" id="checkin-form" class="space-y-4">
+  <form method="post" action="{% url 'eventos:inscricao_checkin' inscricao.id %}" id="checkin-form" class="space-y-4">
     {% csrf_token %}
     <label for="codigo" class="block text-sm font-medium">{% trans "Código do check-in" %}</label>
     <input type="text" id="codigo" name="codigo" class="form-input w-full" placeholder="{% trans 'Escaneie ou digite o código' %}" required>

--- a/eventos/templates/eventos/create.html
+++ b/eventos/templates/eventos/create.html
@@ -49,7 +49,7 @@
     </div>
 
     <div class="flex justify-end gap-3 pt-4 border-t border-neutral-100">
-      <a href="{% url 'agenda:calendario' %}" class="btn-secondary" aria-label="{% trans 'Cancelar' %}">{% trans "Cancelar" %}</a>
+      <a href="{% url 'eventos:calendario' %}" class="btn-secondary" aria-label="{% trans 'Cancelar' %}">{% trans "Cancelar" %}</a>
       <button type="submit" class="btn-primary" aria-label="{% trans 'Salvar' %}">{% trans "Salvar" %}</button>
     </div>
   </form>

--- a/eventos/templates/eventos/delete.html
+++ b/eventos/templates/eventos/delete.html
@@ -10,7 +10,7 @@
 
     <form method="post" class="mt-6 flex justify-center gap-3">
       {% csrf_token %}
-      <a href="{% url 'agenda:calendario' %}" class="btn-secondary" aria-label="{% trans 'Cancelar' %}">{% trans "Cancelar" %}</a>
+      <a href="{% url 'eventos:calendario' %}" class="btn-secondary" aria-label="{% trans 'Cancelar' %}">{% trans "Cancelar" %}</a>
       <button type="submit" class="btn-danger" aria-label="{% trans 'Remover' %}">{% trans "Remover" %}</button>
     </form>
   </div>

--- a/eventos/templates/eventos/detail.html
+++ b/eventos/templates/eventos/detail.html
@@ -60,7 +60,7 @@
       <div class="mb-10 space-y-4">
         <img src="{{ inscricao.qrcode_url }}" alt="{% trans 'QR Code da inscrição' %}" class="mx-auto h-48 w-48" />
         {% if avaliacao_permitida %}
-          <form method="post" action="{% url 'agenda:evento_feedback' object.pk %}" class="space-y-4">
+          <form method="post" action="{% url 'eventos:evento_feedback' object.pk %}" class="space-y-4">
             {% csrf_token %}
             <div>
               <label for="nota" class="block text-sm font-medium">{% trans "Nota" %}</label>
@@ -79,7 +79,7 @@
             </div>
           </form>
         {% else %}
-          <form method="post" action="{% url 'agenda:evento_subscribe' object.pk %}">
+          <form method="post" action="{% url 'eventos:evento_subscribe' object.pk %}">
             {% csrf_token %}
             <button type="submit" class="btn-secondary" aria-label="{% trans 'Cancelar inscrição' %}">{% trans "Cancelar inscrição" %}</button>
           </form>
@@ -87,7 +87,7 @@
       </div>
     {% else %}
       <div class="mb-10">
-        <a href="{% url 'agenda:inscricao_criar' object.pk %}" class="btn-primary" aria-label="{% trans 'Inscrever-se' %}">{% trans "Inscrever-se" %}</a>
+        <a href="{% url 'eventos:inscricao_criar' object.pk %}" class="btn-primary" aria-label="{% trans 'Inscrever-se' %}">{% trans "Inscrever-se" %}</a>
       </div>
     {% endif %}
   {% endif %}
@@ -121,7 +121,7 @@
 
   <!-- Voltar -->
   <div class="flex justify-end mt-10">
-    <a href="{% url 'agenda:calendario' %}" class="btn-secondary" aria-label="{% trans 'Voltar' %}">{% trans "Voltar" %}</a>
+    <a href="{% url 'eventos:calendario' %}" class="btn-secondary" aria-label="{% trans 'Voltar' %}">{% trans "Voltar" %}</a>
   </div>
 </section>
 {% endblock %}

--- a/eventos/templates/eventos/evento_list.html
+++ b/eventos/templates/eventos/evento_list.html
@@ -8,7 +8,7 @@
   <div class="flex items-center justify-between mb-6">
     <h1 class="text-2xl font-bold">{% if is_admin_org %}{% trans 'Eventos da Organização' %}{% else %}{% trans 'Meus Eventos' %}{% endif %}</h1>
     {% if is_admin_org %}
-      <a href="{% url 'agenda:evento_novo' %}" class="btn-primary">{% trans 'Novo evento' %}</a>
+      <a href="{% url 'eventos:evento_novo' %}" class="btn-primary">{% trans 'Novo evento' %}</a>
     {% endif %}
   </div>
 

--- a/eventos/templates/eventos/inscricao_form.html
+++ b/eventos/templates/eventos/inscricao_form.html
@@ -30,7 +30,7 @@
       {{ form.observacao.errors }}
     </div>
     <div class="flex justify-end gap-3 pt-4 border-t border-neutral-100">
-      <a href="{% url 'agenda:evento_detalhe' evento.pk %}" class="btn-secondary" aria-label="{% trans 'Cancelar' %}">{% trans "Cancelar" %}</a>
+      <a href="{% url 'eventos:evento_detalhe' evento.pk %}" class="btn-secondary" aria-label="{% trans 'Cancelar' %}">{% trans "Cancelar" %}</a>
       <button type="submit" class="btn-primary" aria-label="{% trans 'Salvar' %}">{% trans "Salvar" %}</button>
     </div>
   </form>

--- a/eventos/templates/eventos/inscricao_list.html
+++ b/eventos/templates/eventos/inscricao_list.html
@@ -18,7 +18,7 @@
   {% endif %}
 
   <form
-    hx-get="{% url 'agenda:inscricao_list' %}"
+    hx-get="{% url 'eventos:inscricao_list' %}"
     hx-target="#inscricao-container"
     hx-push-url="true"
     class="mb-6 flex gap-2"
@@ -81,14 +81,14 @@
               <td class="px-4 py-2">{{ inscricao.observacao }}</td>
               <td class="px-4 py-2">
                 <a
-                  href="{% url 'agenda:evento_detalhe' inscricao.evento.pk %}"
+                  href="{% url 'eventos:evento_detalhe' inscricao.evento.pk %}"
                   class="text-blue-600 hover:underline"
                 >
                   {% trans "Ver" %}
                 </a>
                 |
                 <a
-                  href="{% url 'agenda:inscricao_checkin_form' inscricao.pk %}"
+                  href="{% url 'eventos:inscricao_checkin_form' inscricao.pk %}"
                   class="text-blue-600 hover:underline"
                 >
                   {% trans "Check-in" %}
@@ -106,7 +106,7 @@
   </main>
 
   <footer class="mt-6 text-right">
-    <a href="{% url 'agenda:calendario' %}" class="text-sm text-blue-600 hover:underline">{% trans "Voltar à agenda" %}</a>
+    <a href="{% url 'eventos:calendario' %}" class="text-sm text-blue-600 hover:underline">{% trans "Voltar aos eventos" %}</a>
   </footer>
 </section>
 {% endblock %}

--- a/eventos/templates/eventos/material_form.html
+++ b/eventos/templates/eventos/material_form.html
@@ -24,7 +24,7 @@
     </div>
     {% endfor %}
     <div class="flex justify-end gap-3 pt-4 border-t border-neutral-100">
-      <a href="{% url 'agenda:material_list' %}" class="btn-secondary" aria-label="{% trans 'Cancelar' %}">{% trans "Cancelar" %}</a>
+      <a href="{% url 'eventos:material_list' %}" class="btn-secondary" aria-label="{% trans 'Cancelar' %}">{% trans "Cancelar" %}</a>
       <button type="submit" class="btn-primary" aria-label="{% trans 'Salvar' %}">{% trans "Salvar" %}</button>
     </div>
   </form>

--- a/eventos/templates/eventos/material_list.html
+++ b/eventos/templates/eventos/material_list.html
@@ -7,13 +7,13 @@
 <section id="material-container" class="max-w-7xl mx-auto px-4 py-10">
   <header class="mb-6 flex items-center justify-between">
     <h1 class="text-2xl font-bold text-neutral-900">{% trans "Materiais de Divulgação" %}</h1>
-    <a href="{% url 'agenda:material_criar' %}" class="btn-primary">{% trans "Novo Material" %}</a>
+    <a href="{% url 'eventos:material_criar' %}" class="btn-primary">{% trans "Novo Material" %}</a>
   </header>
 
 {% include "eventos/_messages.html" %}
 
   <form
-    hx-get="{% url 'agenda:material_list' %}"
+    hx-get="{% url 'eventos:material_list' %}"
     hx-target="#material-container"
     hx-push-url="true"
     class="mb-6 flex gap-2"
@@ -59,7 +59,7 @@
   </main>
 
   <footer class="mt-6 text-right">
-    <a href="{% url 'agenda:calendario' %}" class="text-sm text-blue-600 hover:underline">{% trans "Voltar à agenda" %}</a>
+    <a href="{% url 'eventos:calendario' %}" class="text-sm text-blue-600 hover:underline">{% trans "Voltar aos eventos" %}</a>
   </footer>
 </section>
 {% endblock %}

--- a/eventos/templates/eventos/parceria_avaliar.html
+++ b/eventos/templates/eventos/parceria_avaliar.html
@@ -8,7 +8,7 @@
   <form
     id="avaliacao-form"
     method="post"
-    action="{% url 'agenda_api:parceria-avaliar' parceria.pk %}"
+    action="{% url 'eventos_api:parceria-avaliar' parceria.pk %}"
     class="space-y-4"
   >
     {% csrf_token %}

--- a/eventos/templates/eventos/parceria_confirm_delete.html
+++ b/eventos/templates/eventos/parceria_confirm_delete.html
@@ -10,7 +10,7 @@
     <p class="text-sm text-neutral-700">{% blocktrans %}Tem certeza que deseja remover <strong>{{ object.empresa.nome }}</strong>?{% endblocktrans %}</p>
     <form method="post" class="mt-6 flex justify-center gap-3">
       {% csrf_token %}
-      <a href="{% url 'agenda:parceria_list' %}" class="btn-secondary" aria-label="{% trans 'Cancelar' %}">{% trans 'Cancelar' %}</a>
+      <a href="{% url 'eventos:parceria_list' %}" class="btn-secondary" aria-label="{% trans 'Cancelar' %}">{% trans 'Cancelar' %}</a>
       <button type="submit" class="btn-danger" aria-label="{% trans 'Remover' %}">{% trans 'Remover' %}</button>
     </form>
   </div>

--- a/eventos/templates/eventos/parceria_form.html
+++ b/eventos/templates/eventos/parceria_form.html
@@ -21,7 +21,7 @@
     </div>
     {% endfor %}
     <div class="flex justify-end gap-3 pt-4 border-t border-neutral-100">
-      <a href="{% url 'agenda:parceria_list' %}" class="btn-secondary" aria-label="{% trans 'Cancelar' %}">{% trans "Cancelar" %}</a>
+      <a href="{% url 'eventos:parceria_list' %}" class="btn-secondary" aria-label="{% trans 'Cancelar' %}">{% trans "Cancelar" %}</a>
       <button type="submit" class="btn-primary" aria-label="{% trans 'Salvar' %}">{% trans "Salvar" %}</button>
     </div>
   </form>

--- a/eventos/templates/eventos/parceria_list.html
+++ b/eventos/templates/eventos/parceria_list.html
@@ -7,7 +7,7 @@
 <section class="max-w-7xl mx-auto px-4 py-10">
   <header class="mb-6 flex items-center justify-between">
     <h1 class="text-2xl font-bold text-neutral-900">{% trans "Parcerias" %}</h1>
-    <a href="{% url 'agenda:parceria_criar' %}" class="btn-primary">{% trans "Nova Parceria" %}</a>
+    <a href="{% url 'eventos:parceria_criar' %}" class="btn-primary">{% trans "Nova Parceria" %}</a>
   </header>
 
   <main>
@@ -39,18 +39,18 @@
               <td class="px-4 py-2 space-x-2">
                 {% if parceria.avaliacao is None %}
                   <a
-                    href="{% url 'agenda:parceria_avaliar' parceria.pk %}"
+                    href="{% url 'eventos:parceria_avaliar' parceria.pk %}"
                     class="text-green-600 hover:underline"
                     >{% trans "Avaliar" %}</a
                   >
                 {% endif %}
                 <a
-                  href="{% url 'agenda:parceria_editar' parceria.pk %}"
+                  href="{% url 'eventos:parceria_editar' parceria.pk %}"
                   class="text-blue-600 hover:underline"
                   >{% trans "Editar" %}</a
                 >
                 <a
-                  href="{% url 'agenda:parceria_excluir' parceria.pk %}"
+                  href="{% url 'eventos:parceria_excluir' parceria.pk %}"
                   class="text-red-600 hover:underline"
                   >{% trans "Excluir" %}</a
                 >

--- a/eventos/templates/eventos/partials/card.html
+++ b/eventos/templates/eventos/partials/card.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 {# Card de Evento: cover, avatar, nome, inscritos, núcleo, coordenador, status #}
-<a href="{% url 'agenda:evento_detalhe' evento.pk %}"
+<a href="{% url 'eventos:evento_detalhe' evento.pk %}"
    class="group block rounded-2xl border border-neutral-200 bg-white shadow-sm hover:shadow-lg hover:scale-[1.01] transition-transform focus:outline-none focus:ring-2 focus:ring-primary/40"
    aria-label="{{ evento.titulo }}">
   <article class="overflow-hidden rounded-2xl" role="article">

--- a/eventos/templates/eventos/tarefa_detail.html
+++ b/eventos/templates/eventos/tarefa_detail.html
@@ -6,7 +6,7 @@
 <section class="max-w-screen-xl mx-auto pt-8 px-6 lg:px-8">
   <header class="mb-6 flex items-center justify-between">
     <h1 class="text-2xl font-bold text-neutral-900">{{ object.titulo }}</h1>
-    <a href="{% url 'agenda:tarefa_list' %}" class="btn-secondary" aria-label="{% trans 'Voltar' %}">{% trans "Voltar" %}</a>
+    <a href="{% url 'eventos:tarefa_list' %}" class="btn-secondary" aria-label="{% trans 'Voltar' %}">{% trans "Voltar" %}</a>
   </header>
 
   {% if object.descricao %}

--- a/eventos/templates/eventos/tarefa_form.html
+++ b/eventos/templates/eventos/tarefa_form.html
@@ -41,7 +41,7 @@
       {{ form.status.errors }}
     </div>
     <div class="flex justify-end gap-3 pt-4 border-t border-neutral-100">
-      <a href="{% url 'agenda:tarefa_list' %}" class="btn-secondary" aria-label="{% trans 'Cancelar' %}">{% trans "Cancelar" %}</a>
+      <a href="{% url 'eventos:tarefa_list' %}" class="btn-secondary" aria-label="{% trans 'Cancelar' %}">{% trans "Cancelar" %}</a>
       <button type="submit" class="btn-primary" aria-label="{% trans 'Salvar' %}">{% trans "Salvar" %}</button>
     </div>
   </form>

--- a/eventos/templates/eventos/tarefa_list.html
+++ b/eventos/templates/eventos/tarefa_list.html
@@ -6,12 +6,12 @@
 <section class="max-w-screen-xl mx-auto pt-8 px-6 lg:px-8">
   <header class="mb-6 flex items-center justify-between">
     <h1 class="text-2xl font-bold text-neutral-900">{% trans "Tarefas" %}</h1>
-    <a href="{% url 'agenda:tarefa_criar' %}" class="btn-primary">{% trans "Nova Tarefa" %}</a>
+    <a href="{% url 'eventos:tarefa_criar' %}" class="btn-primary">{% trans "Nova Tarefa" %}</a>
   </header>
   <ul class="space-y-2">
     {% for tarefa in tarefas %}
       <li class="p-4 bg-white border border-neutral-200 rounded-2xl shadow-sm">
-        <a href="{% url 'agenda:tarefa_detalhe' tarefa.pk %}" class="font-semibold">{{ tarefa.titulo }}</a>
+        <a href="{% url 'eventos:tarefa_detalhe' tarefa.pk %}" class="font-semibold">{{ tarefa.titulo }}</a>
         <div class="text-sm text-neutral-600">{{ tarefa.responsavel }} - {{ tarefa.status }}</div>
       </li>
     {% empty %}

--- a/eventos/templates/eventos/update.html
+++ b/eventos/templates/eventos/update.html
@@ -50,7 +50,7 @@
     </div>
 
     <div class="flex justify-end gap-3 pt-4 border-t border-neutral-100">
-      <a href="{% url 'agenda:calendario' %}" class="btn-secondary" aria-label="{% trans 'Cancelar' %}">{% trans "Cancelar" %}</a>
+      <a href="{% url 'eventos:calendario' %}" class="btn-secondary" aria-label="{% trans 'Cancelar' %}">{% trans "Cancelar" %}</a>
       <button type="submit" class="btn-primary" aria-label="{% trans 'Salvar' %}">{% trans "Salvar" %}</button>
     </div>
   </form>
@@ -58,7 +58,7 @@
   <!-- Orçamento -->
   <div class="mt-10">
     <h2 class="text-lg font-semibold text-neutral-900 mb-4">{% trans "Orçamento" %}</h2>
-    <form id="orcamento-form" method="post" action="{% url 'agenda:evento_orcamento' object.pk %}" class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 space-y-6">
+    <form id="orcamento-form" method="post" action="{% url 'eventos:evento_orcamento' object.pk %}" class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 space-y-6">
       {% csrf_token %}
       <div>
         <label for="id_orcamento_estimado" class="block text-sm font-medium text-neutral-700 mb-1">{% trans "Orçamento estimado" %}</label>
@@ -87,7 +87,7 @@
             <p class="text-xs text-neutral-500">{{ inscrito.email }}</p>
           </div>
           {% if user.user_type == "admin" or user.user_type == "gerente" %}
-          <form method="post" action="{% url 'agenda:evento_remover_inscrito' object.pk inscrito.pk %}">
+          <form method="post" action="{% url 'eventos:evento_remover_inscrito' object.pk inscrito.pk %}">
             {% csrf_token %}
             <button type="submit" class="text-sm text-red-600 hover:underline" aria-label="{% trans 'Remover' %}">{% trans "Remover" %}</button>
           </form>

--- a/eventos/tests/test_briefing_views.py
+++ b/eventos/tests/test_briefing_views.py
@@ -19,6 +19,6 @@ def test_briefing_create_exibe_mensagem(client):
     }
     resp = client.post(reverse("eventos:briefing_criar"), data, follow=True)
     assert resp.status_code == 200
-    assert "agenda/briefing_list.html" in [t.name for t in resp.templates]
+    assert "eventos/briefing_list.html" in [t.name for t in resp.templates]
     messages = list(get_messages(resp.wsgi_request))
     assert any("Briefing criado com sucesso" in m.message for m in messages)

--- a/eventos/tests/test_material_views.py
+++ b/eventos/tests/test_material_views.py
@@ -32,7 +32,7 @@ def test_material_list_shows_only_approved(client):
     client.force_login(user)
     resp = client.get(reverse("eventos:material_list"))
     assert resp.status_code == 200
-    assert "agenda/material_list.html" in [t.name for t in resp.templates]
+    assert "eventos/material_list.html" in [t.name for t in resp.templates]
     materiais = list(resp.context["materiais"])
     assert len(materiais) == 1
     assert materiais[0].titulo == "Aprovado"

--- a/eventos/tests/test_parceria_views.py
+++ b/eventos/tests/test_parceria_views.py
@@ -35,7 +35,7 @@ def test_parceria_list_template(client):
     client.force_login(user)
     resp = client.get(reverse("eventos:parceria_list"))
     assert resp.status_code == 200
-    assert "agenda/parceria_list.html" in [t.name for t in resp.templates]
+    assert "eventos/parceria_list.html" in [t.name for t in resp.templates]
 
 
 @pytest.mark.django_db

--- a/eventos/validators.py
+++ b/eventos/validators.py
@@ -1,0 +1,31 @@
+import mimetypes
+import os
+
+from django.core.exceptions import ValidationError
+from django.utils.translation import gettext_lazy as _
+
+
+SAFE_MIME_TYPES = {
+    "image/jpeg": {".jpg", ".jpeg"},
+    "image/png": {".png"},
+    "application/pdf": {".pdf"},
+}
+
+
+def validate_uploaded_file(f):
+    """Valida tipo, extensão e tamanho de arquivos de upload."""
+
+    ext = os.path.splitext(f.name)[1].lower()
+    content_type = getattr(f, "content_type", "") or mimetypes.guess_type(f.name)[0] or ""
+    allowed_exts = SAFE_MIME_TYPES.get(content_type)
+    if not allowed_exts:
+        raise ValidationError(_("Tipo de arquivo não permitido."))
+    if ext not in allowed_exts:
+        raise ValidationError(_("Extensão do arquivo não corresponde ao tipo MIME."))
+    if content_type == "application/pdf":
+        max_size = 20 * 1024 * 1024
+    else:
+        max_size = 10 * 1024 * 1024
+    if f.size > max_size:
+        raise ValidationError(_("Arquivo excede o tamanho máximo permitido."))
+

--- a/eventos/views.py
+++ b/eventos/views.py
@@ -44,7 +44,7 @@ from core.permissions import (
     no_superadmin_required,
 )
 
-from agenda.forms import (
+from .forms import (
     BriefingEventoCreateForm,
     BriefingEventoForm,
     EventoForm,
@@ -53,11 +53,7 @@ from agenda.forms import (
     ParceriaEventoForm,
     TarefaForm,
 )
-<<<<<<< HEAD:agenda/views.py
-from eventos.models import (
-=======
-from agenda.models import (
->>>>>>> main:eventos/views.py
+from .models import (
     BriefingEvento,
     Evento,
     EventoLog,
@@ -68,7 +64,7 @@ from agenda.models import (
     MaterialDivulgacaoEvento,
     ParceriaEvento,
 )
-from agenda.tasks import notificar_briefing_status, upload_material_divulgacao
+from .tasks import notificar_briefing_status, upload_material_divulgacao
 
 User = get_user_model()
 
@@ -206,9 +202,9 @@ class EventoCreateView(
     model = Evento
     form_class = EventoForm
     template_name = "eventos/create.html"
-    success_url = reverse_lazy("agenda:calendario")
+    success_url = reverse_lazy("eventos:calendario")
 
-    permission_required = "agenda.add_evento"
+    permission_required = "eventos.add_evento"
 
     def dispatch(self, request, *args, **kwargs):
         if request.user.username == "root":
@@ -237,9 +233,9 @@ class EventoUpdateView(
     model = Evento
     form_class = EventoForm
     template_name = "eventos/update.html"
-    success_url = reverse_lazy("agenda:calendario")
+    success_url = reverse_lazy("eventos:calendario")
 
-    permission_required = "agenda.change_evento"
+    permission_required = "eventos.change_evento"
 
     def get_queryset(self):  # pragma: no cover
         return _queryset_por_organizacao(self.request)
@@ -275,9 +271,9 @@ class EventoDeleteView(
 ):
     model = Evento
     template_name = "eventos/delete.html"
-    success_url = reverse_lazy("agenda:calendario")
+    success_url = reverse_lazy("eventos:calendario")
 
-    permission_required = "agenda.delete_evento"
+    permission_required = "eventos.delete_evento"
 
     def get_queryset(self):  # pragma: no cover
         return _queryset_por_organizacao(self.request)
@@ -419,7 +415,7 @@ class TarefaCreateView(LoginRequiredMixin, NoSuperadminMixin, GerenteRequiredMix
     model = Tarefa
     form_class = TarefaForm
     template_name = "eventos/tarefa_form.html"
-    success_url = reverse_lazy("agenda:tarefa_list")
+    success_url = reverse_lazy("eventos:tarefa_list")
 
     def get_form(self, form_class=None):
         form = super().get_form(form_class)
@@ -442,7 +438,7 @@ class TarefaUpdateView(LoginRequiredMixin, NoSuperadminMixin, GerenteRequiredMix
     model = Tarefa
     form_class = TarefaForm
     template_name = "eventos/tarefa_form.html"
-    success_url = reverse_lazy("agenda:tarefa_list")
+    success_url = reverse_lazy("eventos:tarefa_list")
 
     def get_queryset(self):
         qs = Tarefa.objects.select_related("organizacao")
@@ -490,7 +486,7 @@ class EventoSubscribeView(LoginRequiredMixin, NoSuperadminMixin, View):
             messages.error(
                 request, _("Administradores não podem se inscrever em eventos.")
             )  # pragma: no cover
-            return redirect("agenda:evento_detalhe", pk=pk)
+            return redirect("eventos:evento_detalhe", pk=pk)
 
         inscricao, created = InscricaoEvento.objects.get_or_create(
             user=request.user, evento=evento
@@ -507,7 +503,7 @@ class EventoSubscribeView(LoginRequiredMixin, NoSuperadminMixin, View):
                 messages.success(request, _("Inscrição realizada."))  # pragma: no cover
             else:
                 messages.success(request, _("Você está na lista de espera."))  # pragma: no cover
-        return redirect("agenda:evento_detalhe", pk=pk)
+        return redirect("eventos:evento_detalhe", pk=pk)
 
 
 class EventoRemoveInscritoView(LoginRequiredMixin, NoSuperadminMixin, GerenteRequiredMixin, View):
@@ -520,7 +516,7 @@ class EventoRemoveInscritoView(LoginRequiredMixin, NoSuperadminMixin, GerenteReq
             and evento.organizacao != request.user.organizacao
         ):
             messages.error(request, _("Acesso negado."))  # pragma: no cover
-            return redirect("agenda:calendario")
+            return redirect("eventos:calendario")
         inscrito = get_object_or_404(User, pk=user_id)
         inscricao = get_object_or_404(InscricaoEvento, user=inscrito, evento=evento)
         inscricao.cancelar_inscricao()
@@ -531,7 +527,7 @@ class EventoRemoveInscritoView(LoginRequiredMixin, NoSuperadminMixin, GerenteReq
             detalhes={"inscrito_id": inscrito.id},
         )
         messages.success(request, _("Inscrito removido."))  # pragma: no cover
-        return redirect("agenda:evento_editar", pk=pk)
+        return redirect("eventos:evento_editar", pk=pk)
 
 
 class EventoFeedbackView(LoginRequiredMixin, NoSuperadminMixin, View):
@@ -585,11 +581,11 @@ class EventoFeedbackView(LoginRequiredMixin, NoSuperadminMixin, View):
             detalhes={"nota": nota},
         )
         messages.success(request, _("Feedback registrado com sucesso."))
-        return redirect("agenda:evento_detalhe", pk=pk)
+        return redirect("eventos:evento_detalhe", pk=pk)
 
 
 def eventos_por_dia(request):
-    """Compatível com reverse('agenda:eventos_por_dia') via ?dia=YYYY-MM-DD"""
+    """Compatível com reverse('eventos:eventos_por_dia') via ?dia=YYYY-MM-DD"""
     dia_iso = request.GET.get("dia")
     if not dia_iso:
         raise Http404("Parâmetro 'dia' ausente.")
@@ -742,7 +738,7 @@ class InscricaoEventoCreateView(LoginRequiredMixin, NoSuperadminMixin, CreateVie
             messages.error(
                 request, _("Administradores não podem se inscrever em eventos.")
             )
-            return redirect("agenda:evento_detalhe", pk=kwargs["pk"])
+            return redirect("eventos:evento_detalhe", pk=kwargs["pk"])
         return super().dispatch(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):
@@ -759,7 +755,7 @@ class InscricaoEventoCreateView(LoginRequiredMixin, NoSuperadminMixin, CreateVie
         return response
 
     def get_success_url(self):
-        return reverse_lazy("agenda:evento_detalhe", kwargs={"pk": self.evento.pk})
+        return reverse_lazy("eventos:evento_detalhe", kwargs={"pk": self.evento.pk})
 
 
 class MaterialDivulgacaoEventoListView(LoginRequiredMixin, NoSuperadminMixin, ListView):
@@ -793,7 +789,7 @@ class MaterialDivulgacaoEventoCreateView(
     model = MaterialDivulgacaoEvento
     form_class = MaterialDivulgacaoEventoForm
     template_name = "eventos/material_form.html"
-    success_url = reverse_lazy("agenda:material_list")
+    success_url = reverse_lazy("eventos:material_list")
 
 
     def get_form(self, form_class=None):
@@ -806,7 +802,7 @@ class MaterialDivulgacaoEventoCreateView(
             )
         return form
 
-    permission_required = "agenda.add_materialdivulgacaoevento"
+    permission_required = "eventos.add_materialdivulgacaoevento"
 
 
     def form_valid(self, form):
@@ -835,9 +831,9 @@ class MaterialDivulgacaoEventoUpdateView(
     model = MaterialDivulgacaoEvento
     form_class = MaterialDivulgacaoEventoForm
     template_name = "eventos/material_form.html"
-    success_url = reverse_lazy("agenda:material_list")
+    success_url = reverse_lazy("eventos:material_list")
 
-    permission_required = "agenda.change_materialdivulgacaoevento"
+    permission_required = "eventos.change_materialdivulgacaoevento"
 
     def get_queryset(self):  # pragma: no cover - simples
         qs = MaterialDivulgacaoEvento.objects.all()
@@ -906,7 +902,7 @@ class ParceriaEventoCreateView(LoginRequiredMixin, NoSuperadminMixin, ParceriaPe
     model = ParceriaEvento
     form_class = ParceriaEventoForm
     template_name = "eventos/parceria_form.html"
-    success_url = reverse_lazy("agenda:parceria_list")
+    success_url = reverse_lazy("eventos:parceria_list")
 
     def get_form(self, form_class=None):
         form = super().get_form(form_class)
@@ -935,7 +931,7 @@ class ParceriaEventoUpdateView(LoginRequiredMixin, NoSuperadminMixin, ParceriaPe
     model = ParceriaEvento
     form_class = ParceriaEventoForm
     template_name = "eventos/parceria_form.html"
-    success_url = reverse_lazy("agenda:parceria_list")
+    success_url = reverse_lazy("eventos:parceria_list")
 
     def get_queryset(self):
         qs = ParceriaEvento.objects.all()
@@ -973,7 +969,7 @@ class ParceriaEventoUpdateView(LoginRequiredMixin, NoSuperadminMixin, ParceriaPe
 class ParceriaEventoDeleteView(LoginRequiredMixin, NoSuperadminMixin, ParceriaPermissionMixin, DeleteView):
     model = ParceriaEvento
     template_name = "eventos/parceria_confirm_delete.html"
-    success_url = reverse_lazy("agenda:parceria_list")
+    success_url = reverse_lazy("eventos:parceria_list")
 
     def get_queryset(self):
         qs = ParceriaEvento.objects.all()
@@ -1089,7 +1085,7 @@ class BriefingEventoStatusView(LoginRequiredMixin, NoSuperadminMixin, View):
         )
         if not briefing.can_transition_to(status):
             messages.error(request, _("Transição de status inválida."))
-            return redirect("agenda:briefing_list")
+            return redirect("eventos:briefing_list")
         now = timezone.now()
         update_fields = ["status", "avaliado_por", "avaliado_em", "updated_at"]
         briefing.avaliado_por = request.user
@@ -1099,11 +1095,11 @@ class BriefingEventoStatusView(LoginRequiredMixin, NoSuperadminMixin, View):
             prazo_str = request.POST.get("prazo_limite_resposta")
             if not prazo_str:
                 messages.error(request, _("Informe o prazo limite de resposta."))
-                return redirect("agenda:briefing_list")
+                return redirect("eventos:briefing_list")
             prazo = parse_datetime(prazo_str)
             if prazo is None:
                 messages.error(request, _("Prazo limite inválido."))
-                return redirect("agenda:briefing_list")
+                return redirect("eventos:briefing_list")
             if timezone.is_naive(prazo):
                 prazo = timezone.make_aware(prazo)
             briefing.status = "orcamentado"
@@ -1119,7 +1115,7 @@ class BriefingEventoStatusView(LoginRequiredMixin, NoSuperadminMixin, View):
             motivo = request.POST.get("motivo_recusa", "").strip()
             if not motivo:
                 messages.error(request, _("Informe o motivo da recusa."))
-                return redirect("agenda:briefing_list")
+                return redirect("eventos:briefing_list")
             briefing.status = "recusado"
             briefing.recusado_em = now
             briefing.recusado_por = request.user
@@ -1137,4 +1133,4 @@ class BriefingEventoStatusView(LoginRequiredMixin, NoSuperadminMixin, View):
         )
         notificar_briefing_status.delay(briefing.pk, briefing.status)
         messages.success(request, _("Status do briefing atualizado."))
-        return redirect("agenda:briefing_list")
+        return redirect("eventos:briefing_list")

--- a/feed/migrations/0001_initial.py
+++ b/feed/migrations/0001_initial.py
@@ -13,7 +13,7 @@ class Migration(migrations.Migration):
     initial = True
 
     dependencies = [
-        ("agenda", "0001_initial"),
+        ("eventos", "0001_initial"),
         ("nucleos", "0001_initial"),
         ("organizacoes", "0001_initial"),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
@@ -89,7 +89,7 @@ class Migration(migrations.Migration):
                 (
                     "evento",
                     models.ForeignKey(
-                        blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, to="agenda.evento"
+                        blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, to="eventos.evento"
                     ),
                 ),
                 (

--- a/feed/models.py
+++ b/feed/models.py
@@ -69,7 +69,7 @@ class Post(TimeStampedModel, SoftDeleteModel):
     video = models.FileField(upload_to="videos/", null=True, blank=True)
     video_preview = models.ImageField(upload_to="video_previews/", null=True, blank=True)
     nucleo = models.ForeignKey("nucleos.Nucleo", null=True, blank=True, on_delete=models.SET_NULL)
-    evento = models.ForeignKey("agenda.Evento", null=True, blank=True, on_delete=models.SET_NULL)
+    evento = models.ForeignKey("eventos.Evento", null=True, blank=True, on_delete=models.SET_NULL)
     tags = models.ManyToManyField(Tag, related_name="posts", blank=True)
 
     objects = SoftDeleteManager()

--- a/financeiro/migrations/0001_initial.py
+++ b/financeiro/migrations/0001_initial.py
@@ -14,7 +14,7 @@ class Migration(migrations.Migration):
     initial = True
 
     dependencies = [
-        ("agenda", "0001_initial"),
+        ("eventos", "0001_initial"),
         ("nucleos", "0001_initial"),
         ("organizacoes", "0001_initial"),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
@@ -108,7 +108,7 @@ class Migration(migrations.Migration):
                         null=True,
                         on_delete=django.db.models.deletion.SET_NULL,
                         related_name="centros_custo",
-                        to="agenda.evento",
+                        to="eventos.evento",
                     ),
                 ),
                 (

--- a/financeiro/models/__init__.py
+++ b/financeiro/models/__init__.py
@@ -39,7 +39,7 @@ class CentroCusto(TimeStampedModel, SoftDeleteModel):
         related_name="centros_custo",
     )
     evento = models.ForeignKey(
-        "agenda.Evento",
+        "eventos.Evento",
         on_delete=models.SET_NULL,
         null=True,
         blank=True,

--- a/financeiro/tests/test_distribuicao_participantes.py
+++ b/financeiro/tests/test_distribuicao_participantes.py
@@ -2,7 +2,7 @@ import pytest
 from decimal import Decimal
 
 from accounts.factories import UserFactory
-from agenda.factories import EventoFactory
+from eventos.factories import EventoFactory
 from financeiro.models import CentroCusto, ContaAssociado, LancamentoFinanceiro
 from financeiro.services.distribuicao import distribuir_receita_evento
 from nucleos.factories import NucleoFactory

--- a/financeiro/tests/test_quitar.py
+++ b/financeiro/tests/test_quitar.py
@@ -5,7 +5,7 @@ from rest_framework.test import APIClient
 
 from accounts.factories import UserFactory
 from accounts.models import UserType
-from agenda.factories import EventoFactory
+from eventos.factories import EventoFactory
 from financeiro.models import CentroCusto, LancamentoFinanceiro, FinanceiroLog
 from financeiro.serializers import LancamentoFinanceiroSerializer
 from nucleos.factories import NucleoFactory

--- a/nucleos/templates/nucleos/detail.html
+++ b/nucleos/templates/nucleos/detail.html
@@ -106,7 +106,7 @@
       <div class="tab-panel hidden" data-tab="eventos">
         <div class="mt-2 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
           {% for evento in eventos %}
-            {% include 'agenda/partials/card.html' with evento=evento %}
+            {% include 'eventos/partials/card.html' with evento=evento %}
           {% empty %}
             <p class="text-sm text-gray-500">{% trans 'Sem eventos.' %}</p>
           {% endfor %}

--- a/organizacoes/api.py
+++ b/organizacoes/api.py
@@ -15,7 +15,7 @@ from sentry_sdk import capture_exception
 from accounts.models import UserType
 from accounts.serializers import UserSerializer
 from eventos.models import Evento
-from agenda.serializers import EventoSerializer
+from eventos.serializers import EventoSerializer
 from core.cache import get_cache_version
 from core.permissions import IsOrgAdminOrSuperuser, IsRoot
 from empresas.models import Empresa

--- a/organizacoes/tests/test_detail_root_cards.py
+++ b/organizacoes/tests/test_detail_root_cards.py
@@ -3,7 +3,7 @@ from django.urls import reverse
 
 from accounts.factories import UserFactory
 from nucleos.factories import NucleoFactory
-from agenda.factories import EventoFactory
+from eventos.factories import EventoFactory
 from empresas.factories import EmpresaFactory
 from organizacoes.factories import OrganizacaoFactory
 

--- a/organizacoes/tests/test_list_cards.py
+++ b/organizacoes/tests/test_list_cards.py
@@ -3,7 +3,7 @@ from django.urls import reverse
 
 from accounts.factories import UserFactory
 from accounts.models import UserType
-from agenda.factories import EventoFactory
+from eventos.factories import EventoFactory
 from nucleos.factories import NucleoFactory
 from organizacoes.factories import OrganizacaoFactory
 

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,4 +1,5 @@
 from django.urls import include, path
+from django.views.generic import RedirectView
 from django.contrib import admin
 from django.views.i18n import JavaScriptCatalog
 
@@ -15,7 +16,9 @@ urlpatterns = [
     path("accounts/", include(("accounts.urls", "accounts"), namespace="accounts")),
     path("dashboard/", include(("dashboard.urls", "dashboard"), namespace="dashboard")),
     path("empresas/", include(("empresas.urls", "empresas"), namespace="empresas")),
-    path("agenda/", include(("eventos.urls", "agenda"), namespace="agenda")),
+    path("eventos/", include(("eventos.urls", "eventos"), namespace="eventos")),
+    path("agenda/<path:rest>/", RedirectView.as_view(url="/eventos/%(rest)s", permanent=True)),
+    path("agenda/", RedirectView.as_view(url="/eventos/", permanent=True)),
     path("discussao/", include(("discussao.urls", "discussao"), namespace="discussao")),
     path("feed/", include(("feed.urls", "feed"), namespace="feed")),
     path("nucleos/", include(("nucleos.urls", "nucleos"), namespace="nucleos")),
@@ -50,8 +53,8 @@ urlpatterns = [
         include(("accounts.api_urls", "accounts_api"), namespace="accounts_api"),
     ),
     path(
-        "api/agenda/",
-        include(("eventos.api_urls", "agenda_api"), namespace="agenda_api"),
+        "api/eventos/",
+        include(("eventos.api_urls", "eventos_api"), namespace="eventos_api"),
     ),
     path(
         "api/dashboard/",

--- a/tests/urls_accounts_plus.py
+++ b/tests/urls_accounts_plus.py
@@ -1,10 +1,13 @@
 from django.urls import include, path
+from django.views.generic import RedirectView
 from django.views.i18n import JavaScriptCatalog
 
 urlpatterns = [
     path('', include(('accounts.urls', 'accounts'), namespace='accounts')),
     path('api/accounts/', include(('accounts.api_urls', 'accounts_api'), namespace='accounts_api')),
     path('empresas/', include(('empresas.urls', 'empresas'), namespace='empresas')),
-    path('agenda/', include(('eventos.urls', 'agenda'), namespace='agenda')),
+    path('eventos/', include(('eventos.urls', 'eventos'), namespace='eventos')),
+    path('agenda/<path:rest>/', RedirectView.as_view(url='/eventos/%(rest)s', permanent=True)),
+    path('agenda/', RedirectView.as_view(url='/eventos/', permanent=True)),
     path('jsi18n/', JavaScriptCatalog.as_view(), name='javascript-catalog'),
 ]


### PR DESCRIPTION
## Summary
- replace legacy agenda namespace with eventos across settings and URLs
- migrate agenda forms, serializers, tasks, and permissions into eventos app
- adjust templates, models, and migrations to reference eventos

## Testing
- `pytest eventos/tests/test_briefing_views.py::test_briefing_create_exibe_mensagem -q -p no:cov --override-ini addopts=` *(fails: No module named 'discussao')*


------
https://chatgpt.com/codex/tasks/task_e_68ba25a8f8d0832599a099d16913da77