### PR TITLE
chore: clean up agenda templatetags

### DIFF
--- a/eventos/templatetags/__init__.py
+++ b/eventos/templatetags/__init__.py
@@ -1,0 +1,6 @@
+"""
+Custom template tags for the eventos app.
+
+No tags were migrated from the agenda app, but this module is kept
+for future extensions.
+"""


### PR DESCRIPTION
## Summary
- Remove unused `agenda/templatetags` directory
- Add stub `eventos` templatetags module for future custom tags

## Testing
- `pytest eventos/tests -q` *(fails: ModuleNotFoundError: No module named 'silk')*

------
https://chatgpt.com/codex/tasks/task_e_68baea1afa2c8325b8e625d3c44b3634