### PR TITLE
Check root by user type when creating events

### DIFF
--- a/eventos/views.py
+++ b/eventos/views.py
@@ -207,7 +207,7 @@ class EventoCreateView(
     permission_required = "eventos.add_evento"
 
     def dispatch(self, request, *args, **kwargs):
-        if request.user.username == "root":
+        if request.user.user_type == UserType.ROOT:
             raise PermissionDenied("Usuário root não pode criar eventos.")
         return super().dispatch(request, *args, **kwargs)
 


### PR DESCRIPTION
## Summary
- Ensure `EventoCreateView` denies creation for ROOT users by checking `user_type` instead of username

## Testing
- `pytest eventos/tests/test_api_permissions.py::test_non_admin_cannot_create_briefing -q 2>&1 | tail -n 5` *(fails: ModuleNotFoundError: No module named 'django_extensions')*

------
https://chatgpt.com/codex/tasks/task_e_68baf89cafe483259004f7202d6e38b6