### PR TITLE
Replace Font Awesome with inline Lucide icons

### DIFF
--- a/docs/style_guide_frontend.md
+++ b/docs/style_guide_frontend.md
@@ -30,3 +30,9 @@ Evite JavaScript customizado sempre que possível. Utilize `hx-get` e `hx-post` 
 ```
 
 Aplique utilitários Tailwind diretamente nas tags para garantir consistência entre páginas.
+
+## Ícones
+
+- Utilize ícones [Lucide](https://lucide.dev) embutidos como SVG diretamente nos templates ou componentes.
+- Ícones meramente decorativos devem incluir `aria-hidden="true"`.
+- Quando o ícone transmitir significado, forneça um `aria-label` no elemento ou um texto auxiliar escondido com `sr-only`.

--- a/templates/base.html
+++ b/templates/base.html
@@ -31,7 +31,7 @@
   <link rel="preconnect" href="https://rsms.me/">
   <link rel="stylesheet" href="https://rsms.me/inter/inter.css">
   <link rel="stylesheet" href="{% static 'tailwind.css' %}">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer">
+  <!-- Font Awesome removed: icons are now inline SVGs -->
   {% block extra_css %}{% endblock %}
 </head>
 
@@ -66,7 +66,11 @@
         aria-controls="menu"
         aria-expanded="false"
       >
-        <i class="fa-solid fa-bars"></i>
+        <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M4 5h16" />
+          <path d="M4 12h16" />
+          <path d="M4 19h16" />
+        </svg>
       </button>
       <nav
         id="menu"
@@ -78,113 +82,265 @@
           {% if user.avatar %}
             <img src="{{ user.avatar.url }}" alt="{{ user.username }}" class="w-6 h-6 rounded-full object-cover" />
           {% else %}
-            <i class="fa-solid fa-user"></i>
+            <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2" />
+              <circle cx="12" cy="7" r="4" />
+            </svg>
           {% endif %}
         </a>
         <span id="notif-count" class="hidden"></span>
         {% endif %}
         {% if user.user_type == 'admin' or user.user_type == 'coordenador' %}
         <a href="/" class="flex items-center gap-x-2 hover:text-primary transition">
-          <i class="fa-solid fa-gauge"></i> {% trans "Dashboard" %}
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="m12 14 4-4" />
+            <path d="M3.34 19a10 10 0 1 1 17.32 0" />
+          </svg>
+          {% trans "Dashboard" %}
         </a>
         <a href="{% url 'associados_lista' %}" class="flex items-center gap-x-2 hover:text-primary transition">
-          <i class="fa-solid fa-users"></i> {% trans "Associados" %}
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+            <path d="M16 3.128a4 4 0 0 1 0 7.744" />
+            <path d="M22 21v-2a4 4 0 0 0-3-3.87" />
+            <circle cx="9" cy="7" r="4" />
+          </svg>
+          {% trans "Associados" %}
         </a>
         <a href="{% url 'empresas:lista' %}" class="flex items-center gap-x-2 hover:text-primary transition">
-          <i class="fa-solid fa-building"></i> {% trans "Empresas" %}
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M6 22V4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v18Z" />
+            <path d="M6 12H4a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h2" />
+            <path d="M18 9h2a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2h-2" />
+            <path d="M10 6h4" />
+            <path d="M10 10h4" />
+            <path d="M10 14h4" />
+            <path d="M10 18h4" />
+          </svg>
+          {% trans "Empresas" %}
         </a>
         <a href="{% url 'nucleos:list' %}" class="flex items-center gap-x-2 hover:text-primary transition">
-          <i class="fa-solid fa-users"></i> {% trans "Núcleos" %}
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+            <path d="M16 3.128a4 4 0 0 1 0 7.744" />
+            <path d="M22 21v-2a4 4 0 0 0-3-3.87" />
+            <circle cx="9" cy="7" r="4" />
+          </svg>
+          {% trans "Núcleos" %}
         </a>
-  <a href="{% url 'eventos:lista' %}" class="flex items-center gap-x-2 hover:text-primary transition">
-          <i class="fa-solid fa-calendar-days"></i> {% trans "Eventos" %}
+        <a href="{% url 'eventos:lista' %}" class="flex items-center gap-x-2 hover:text-primary transition">
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M8 2v4" />
+            <path d="M16 2v4" />
+            <rect width="18" height="18" x="3" y="4" rx="2" />
+            <path d="M3 10h18" />
+            <path d="M8 14h.01" />
+            <path d="M12 14h.01" />
+            <path d="M16 14h.01" />
+            <path d="M8 18h.01" />
+            <path d="M12 18h.01" />
+            <path d="M16 18h.01" />
+          </svg>
+          {% trans "Eventos" %}
         </a>
         <a href="{% url 'feed:listar' %}" class="flex items-center gap-x-2 hover:text-primary transition">
-          <i class="fa-solid fa-rss"></i> {% trans "Feed" %}
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M4 11a9 9 0 0 1 9 9" />
+            <path d="M4 4a16 16 0 0 1 16 16" />
+            <circle cx="5" cy="19" r="1" />
+          </svg>
+          {% trans "Feed" %}
         </a>
         <a href="{% url 'financeiro:repasses' %}" class="flex items-center gap-x-2 hover:text-primary transition">
-          <i class="fa-solid fa-hand-holding-dollar"></i> {% trans "Financeiro" %}
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M11 15h2a2 2 0 1 0 0-4h-3c-.6 0-1.1.2-1.4.6L3 17" />
+            <path d="m7 21 1.6-1.4c.3-.4.8-.6 1.4-.6h4c1.1 0 2.1-.4 2.8-1.2l4.6-4.4a2 2 0 0 0-2.75-2.91l-4.2 3.9" />
+            <path d="m2 16 6 6" />
+            <circle cx="16" cy="9" r="2.9" />
+            <circle cx="6" cy="5" r="3" />
+          </svg>
+          {% trans "Financeiro" %}
         </a>
         <a href="{% url 'tokens:listar_api_tokens' %}" class="flex items-center gap-x-2 hover:text-primary transition">
-          <i class="fa-solid fa-key"></i> {% trans "Tokens" %}
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="m15.5 7.5 2.3 2.3a1 1 0 0 0 1.4 0l2.1-2.1a1 1 0 0 0 0-1.4L19 4" />
+            <path d="m21 2-9.6 9.6" />
+            <circle cx="7.5" cy="15.5" r="5.5" />
+          </svg>
+          {% trans "Tokens" %}
         </a>
           <a href="{% url 'configuracoes' %}" class="hover:text-primary transition" aria-label="{% trans 'Configurações' %}">
-            <i class="fa-solid fa-gear"></i>
+            <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M9.671 4.136a2.34 2.34 0 0 1 4.659 0 2.34 2.34 0 0 0 3.319 1.915 2.34 2.34 0 0 1 2.33 4.033 2.34 2.34 0 0 0 0 3.831 2.34 2.34 0 0 1-2.33 4.033 2.34 2.34 0 0 0-3.319 1.915 2.34 2.34 0 0 1-4.659 0 2.34 2.34 0 0 0-3.32-1.915 2.34 2.34 0 0 1-2.33-4.033 2.34 2.34 0 0 0 0-3.831A2.34 2.34 0 0 1 6.35 6.051a2.34 2.34 0 0 0 3.319-1.915" />
+              <circle cx="12" cy="12" r="3" />
+            </svg>
           </a>
           <a href="{% url 'accounts:logout' %}" class="flex items-center gap-x-2 hover:text-primary transition">
-            <i class="fa-solid fa-right-from-bracket"></i> {% trans "Sair" %}
+            <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="m16 17 5-5-5-5" />
+              <path d="M21 12H9" />
+              <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+            </svg>
+            {% trans "Sair" %}
           </a>
         {% else %}
         <a href="/" class="flex items-center gap-x-2 hover:text-primary transition">
-          <i class="fa-solid fa-gauge"></i> {% trans "Dashboard" %}
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="m12 14 4-4" />
+            <path d="M3.34 19a10 10 0 1 1 17.32 0" />
+          </svg>
+          {% trans "Dashboard" %}
         </a>
         {% if user.user_type != 'root' %}
         <a href="{% url 'empresas:lista' %}" class="flex items-center gap-x-2 hover:text-primary transition">
-          <i class="fa-solid fa-building"></i> {% trans "Empresas" %}
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M6 22V4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v18Z" />
+            <path d="M6 12H4a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h2" />
+            <path d="M18 9h2a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2h-2" />
+            <path d="M10 6h4" />
+            <path d="M10 10h4" />
+            <path d="M10 14h4" />
+            <path d="M10 18h4" />
+          </svg>
+          {% trans "Empresas" %}
         </a>
         {% endif %}
         {% if user.user_type != 'root' %}
         <a href="{% url 'empresas:buscar' %}" class="flex items-center gap-x-2 hover:text-primary transition">
-          <i class="fa-solid fa-magnifying-glass"></i> {% trans "Buscar Empresas" %}
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="m21 21-4.34-4.34" />
+            <circle cx="11" cy="11" r="8" />
+          </svg>
+          {% trans "Buscar Empresas" %}
         </a>
         {% endif %}
         {% if user.user_type != 'root' %}
-  <a href="{% url 'eventos:lista' %}" class="flex items-center gap-x-2 hover:text-primary transition">
-          <i class="fa-solid fa-calendar-days"></i> {% trans "Eventos" %}
+        <a href="{% url 'eventos:lista' %}" class="flex items-center gap-x-2 hover:text-primary transition">
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M8 2v4" />
+            <path d="M16 2v4" />
+            <rect width="18" height="18" x="3" y="4" rx="2" />
+            <path d="M3 10h18" />
+            <path d="M8 14h.01" />
+            <path d="M12 14h.01" />
+            <path d="M16 14h.01" />
+            <path d="M8 18h.01" />
+            <path d="M12 18h.01" />
+            <path d="M16 18h.01" />
+          </svg>
+          {% trans "Eventos" %}
         </a>
         {% endif %}
   {# App Discussão removido: link ocultado #}
         {% if user.user_type != 'root' %}
         <a href="{% url 'feed:listar' %}" class="flex items-center gap-x-2 hover:text-primary transition">
-          <i class="fa-solid fa-rss"></i> {% trans "Feed" %}
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M4 11a9 9 0 0 1 9 9" />
+            <path d="M4 4a16 16 0 0 1 16 16" />
+            <circle cx="5" cy="19" r="1" />
+          </svg>
+          {% trans "Feed" %}
         </a>
         {% endif %}
         {% if user.user_type != 'root' %}
         <a href="{% url 'nucleos:list' %}" class="flex items-center gap-x-2 hover:text-primary transition">
-          <i class="fa-solid fa-users"></i> {% trans "Núcleos" %}
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+            <path d="M16 3.128a4 4 0 0 1 0 7.744" />
+            <path d="M22 21v-2a4 4 0 0 0-3-3.87" />
+            <circle cx="9" cy="7" r="4" />
+          </svg>
+          {% trans "Núcleos" %}
         </a>
         {% endif %}
         {% if user.user_type != 'root' and user.user_type != 'admin' %}
         <a href="{% url 'nucleos:meus' %}" class="flex items-center gap-x-2 hover:text-primary transition">
-          <i class="fa-solid fa-user-group"></i> {% trans "Meus Núcleos" %}
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M18 21a8 8 0 0 0-16 0" />
+            <circle cx="10" cy="8" r="5" />
+            <path d="M22 20c0-3.37-2-6.5-4-8a5 5 0 0 0-.45-8.3" />
+          </svg>
+          {% trans "Meus Núcleos" %}
         </a>
         {% endif %}
         {% if user.is_authenticated %}
         {% if user.user_type == 'financeiro' or user.user_type == 'admin' %}
         <a href="{% url 'financeiro:repasses' %}" class="flex items-center gap-x-2 hover:text-primary transition">
-          <i class="fa-solid fa-hand-holding-dollar"></i> {% trans "Financeiro" %}
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M11 15h2a2 2 0 1 0 0-4h-3c-.6 0-1.1.2-1.4.6L3 17" />
+            <path d="m7 21 1.6-1.4c.3-.4.8-.6 1.4-.6h4c1.1 0 2.1-.4 2.8-1.2l4.6-4.4a2 2 0 0 0-2.75-2.91l-4.2 3.9" />
+            <path d="m2 16 6 6" />
+            <circle cx="16" cy="9" r="2.9" />
+            <circle cx="6" cy="5" r="3" />
+          </svg>
+          {% trans "Financeiro" %}
         </a>
         {% endif %}
         {% endif %}
         {% if user.is_authenticated and user.user_type == 'root' %}
         <a href="{% url 'organizacoes:list' %}" class="flex items-center gap-x-2 hover:text-primary transition">
-          <i class="fa-solid fa-sitemap"></i> {% trans "Organizações" %}
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <line x1="6" x2="6" y1="3" y2="15" />
+            <circle cx="18" cy="6" r="3" />
+            <circle cx="6" cy="18" r="3" />
+            <path d="M18 9a9 9 0 0 1-9 9" />
+          </svg>
+          {% trans "Organizações" %}
         </a>
         {% endif %}
   {% if user.is_authenticated and user.user_type in 'root,admin,coordenador' %}
         {% if user.user_type in 'root,admin' %}
         <a href="{% url 'tokens:listar_api_tokens' %}" class="flex items-center gap-x-2 hover:text-primary transition">
-          <i class="fa-solid fa-key"></i> {% trans "Token" %}
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="m15.5 7.5 2.3 2.3a1 1 0 0 0 1.4 0l2.1-2.1a1 1 0 0 0 0-1.4L19 4" />
+            <path d="m21 2-9.6 9.6" />
+            <circle cx="7.5" cy="15.5" r="5.5" />
+          </svg>
+          {% trans "Token" %}
         </a>
         {% else %}
         <a href="{% url 'tokens:gerar_convite' %}" class="flex items-center gap-x-2 hover:text-primary transition">
-          <i class="fa-solid fa-key"></i> {% trans "Token" %}
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="m15.5 7.5 2.3 2.3a1 1 0 0 0 1.4 0l2.1-2.1a1 1 0 0 0 0-1.4L19 4" />
+            <path d="m21 2-9.6 9.6" />
+            <circle cx="7.5" cy="15.5" r="5.5" />
+          </svg>
+          {% trans "Token" %}
         </a>
         {% endif %}
         {% endif %}
           {% if user.is_authenticated %}
             <a href="{% url 'configuracoes' %}" class="hover:text-primary transition" aria-label="{% trans 'Configurações' %}">
-              <i class="fa-solid fa-gear"></i>
+              <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M9.671 4.136a2.34 2.34 0 0 1 4.659 0 2.34 2.34 0 0 0 3.319 1.915 2.34 2.34 0 0 1 2.33 4.033 2.34 2.34 0 0 0 0 3.831 2.34 2.34 0 0 1-2.33 4.033 2.34 2.34 0 0 0-3.319 1.915 2.34 2.34 0 0 1-4.659 0 2.34 2.34 0 0 0-3.32-1.915 2.34 2.34 0 0 1-2.33-4.033 2.34 2.34 0 0 0 0-3.831A2.34 2.34 0 0 1 6.35 6.051a2.34 2.34 0 0 0 3.319-1.915" />
+                <circle cx="12" cy="12" r="3" />
+              </svg>
             </a>
             <a href="{% url 'accounts:logout' %}" class="flex items-center gap-x-2 hover:text-primary transition">
-              <i class="fa-solid fa-right-from-bracket"></i> {% trans "Sair" %}
+              <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="m16 17 5-5-5-5" />
+                <path d="M21 12H9" />
+                <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+              </svg>
+              {% trans "Sair" %}
             </a>
           {% else %}
             <a href="{% url 'accounts:login' %}" class="flex items-center gap-x-2 hover:text-primary transition">
-              <i class="fa-solid fa-right-to-bracket"></i> {% trans "Entrar" %}
+              <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="m10 17 5-5-5-5" />
+                <path d="M15 12H3" />
+                <path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4" />
+              </svg>
+              {% trans "Entrar" %}
             </a>
             <a href="{% url 'accounts:onboarding' %}" class="flex items-center gap-x-2 bg-primary text-white py-2 px-4 rounded-xl hover:bg-primary/90 transition">
-              <i class="fa-solid fa-user-plus"></i> {% trans "Cadastrar" %}
+              <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+                <circle cx="9" cy="7" r="4" />
+                <line x1="19" x2="19" y1="8" y2="14" />
+                <line x1="22" x2="16" y1="11" y2="11" />
+              </svg>
+              {% trans "Cadastrar" %}
             </a>
           {% endif %}
         {% endif %}


### PR DESCRIPTION
## Summary
- remove Font Awesome CDN and inline Lucide SVG icons in base layout
- document icon guidelines in frontend style guide

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'silk')*


------
https://chatgpt.com/codex/tasks/task_e_68bb1f14c4708325b27b8a19a11660ec