### PR TITLE
feat: introduce reusable hero component

### DIFF
--- a/eventos/templates/eventos/evento_list.html
+++ b/eventos/templates/eventos/evento_list.html
@@ -4,14 +4,12 @@
 {% block title %}{% trans 'Meus Eventos' %}{% endblock %}
 
 {% block content %}
+{% if is_admin_org %}
+{% include 'components/hero.html' with title=_('Eventos da Organização') action_template='eventos/hero_evento_list_action.html' %}
+{% else %}
+{% include 'components/hero.html' with title=_('Meus Eventos') action_template='eventos/hero_evento_list_action.html' %}
+{% endif %}
 <section class="max-w-6xl mx-auto mt-8 px-4">
-  <div class="flex items-center justify-between mb-6">
-    <h1 class="text-2xl font-bold">{% if is_admin_org %}{% trans 'Eventos da Organização' %}{% else %}{% trans 'Meus Eventos' %}{% endif %}</h1>
-    {% if is_admin_org %}
-      <a href="{% url 'eventos:evento_novo' %}" class="btn-primary">{% trans 'Novo evento' %}</a>
-    {% endif %}
-  </div>
-
   <form method="get" class="mb-6 flex gap-2">
     <label for="q" class="sr-only">{% trans 'Buscar' %}</label>
     <input id="q" name="q" value="{{ q }}" class="border rounded px-3 py-2 flex-grow" placeholder="{% trans 'Buscar' %}" />

--- a/eventos/templates/eventos/hero_evento_list_action.html
+++ b/eventos/templates/eventos/hero_evento_list_action.html
@@ -1,0 +1,4 @@
+{% load i18n %}
+{% if is_admin_org %}
+<a href="{% url 'eventos:evento_novo' %}" class="btn-primary">{% trans 'Novo evento' %}</a>
+{% endif %}

--- a/feed/templates/feed/bookmarks.html
+++ b/feed/templates/feed/bookmarks.html
@@ -6,13 +6,8 @@
 {% if request.user.user_type == 'root' %}
   <p class="text-center text-neutral-500">{% trans "Usuário root não tem acesso ao feed." %}</p>
 {% else %}
+{% include 'components/hero.html' with title=_('Meus Favoritos') action_template='feed/hero_actions_bookmarks.html' %}
 <section class="max-w-6xl mx-auto px-4 py-10">
-  <div class="flex items-center justify-between mb-6">
-    <h1 class="text-2xl font-bold text-neutral-900">{% trans "Meus Favoritos" %}</h1>
-    <div class="flex gap-2">
-      <a href="{% url 'feed:listar' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100 focus:outline-none focus:ring-2 focus:ring-indigo-500" aria-label="{% trans 'Voltar ao feed' %}">{% trans "Voltar ao feed" %}</a>
-    </div>
-  </div>
   {% include "feed/_grid.html" with posts=posts %}
 </section>
 {% endif %}

--- a/feed/templates/feed/feed.html
+++ b/feed/templates/feed/feed.html
@@ -7,23 +7,8 @@
 {% if request.user.user_type == 'root' %}
   <p class="text-center text-neutral-500">{% trans "Usuário root não tem acesso ao feed." %}</p>
 {% else %}
+{% include 'components/hero.html' with title=_('Feed de Postagens') action_template='feed/hero_actions.html' %}
 <section class="max-w-7xl mx-auto px-4 py-10">
-
-  <!-- Cabeçalho -->
-  <div class="flex items-center justify-between mb-6">
-    <h1 class="text-2xl font-bold text-neutral-900">{% trans "Feed de Postagens" %}</h1>
-    <div class="flex gap-2">
-      <a href="{% url 'feed:meu_mural' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100 focus:outline-none focus:ring-2 focus:ring-indigo-500" aria-label="{% trans 'Mural' %}">{% trans "Mural" %}</a>
-      <a href="{% url 'feed:bookmarks' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100 focus:outline-none focus:ring-2 focus:ring-indigo-500" aria-label="{% trans 'Favoritos' %}">{% trans "Favoritos" %}</a>
-      {% if request.user.user_type != 'root' %}
-      <a href="{% url 'feed:nova_postagem' %}" target="_blank" class="inline-flex items-center gap-2 px-4 py-2 rounded-md bg-blue-500 hover:bg-blue-600 text-white text-sm font-medium shadow-sm transition focus:outline-none focus:ring-2 focus:ring-blue-500" aria-label="{% trans 'Nova postagem' %}">
-        <i class="fa-solid fa-circle-plus"></i>
-        {% trans "Nova postagem" %}
-      </a>
-      {% endif %}
-    </div>
-  </div>
-
 
   <!-- Busca simples -->
   <form id="feed-search-form" class="flex items-center gap-2 mb-6" hx-get="{% url 'feed:listar' %}" hx-target="#feed-grid" hx-indicator="#feed-loading">

--- a/feed/templates/feed/hero_actions.html
+++ b/feed/templates/feed/hero_actions.html
@@ -1,0 +1,11 @@
+{% load i18n %}
+<div class="flex gap-2">
+  <a href="{% url 'feed:meu_mural' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100 focus:outline-none focus:ring-2 focus:ring-indigo-500" aria-label="{% trans 'Mural' %}">{% trans 'Mural' %}</a>
+  <a href="{% url 'feed:bookmarks' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100 focus:outline-none focus:ring-2 focus:ring-indigo-500" aria-label="{% trans 'Favoritos' %}">{% trans 'Favoritos' %}</a>
+  {% if request.user.user_type != 'root' %}
+  <a href="{% url 'feed:nova_postagem' %}" target="_blank" class="inline-flex items-center gap-2 px-4 py-2 rounded-md bg-blue-500 hover:bg-blue-600 text-white text-sm font-medium shadow-sm transition focus:outline-none focus:ring-2 focus:ring-blue-500" aria-label="{% trans 'Nova postagem' %}">
+    <i class="fa-solid fa-circle-plus"></i>
+    {% trans 'Nova postagem' %}
+  </a>
+  {% endif %}
+</div>

--- a/feed/templates/feed/hero_actions_bookmarks.html
+++ b/feed/templates/feed/hero_actions_bookmarks.html
@@ -1,0 +1,4 @@
+{% load i18n %}
+<div class="flex gap-2">
+  <a href="{% url 'feed:listar' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100 focus:outline-none focus:ring-2 focus:ring-indigo-500" aria-label="{% trans 'Voltar ao feed' %}">{% trans 'Voltar ao feed' %}</a>
+</div>

--- a/feed/templates/feed/hero_actions_mural.html
+++ b/feed/templates/feed/hero_actions_mural.html
@@ -1,0 +1,11 @@
+{% load i18n %}
+<div class="flex gap-2">
+  <a href="{% url 'feed:listar' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100 focus:outline-none focus:ring-2 focus:ring-indigo-500" aria-label="{% trans 'Ver Feed Global' %}">{% trans 'Ver Feed Global' %}</a>
+  <a href="{% url 'feed:bookmarks' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100 focus:outline-none focus:ring-2 focus:ring-indigo-500" aria-label="{% trans 'Favoritos' %}">{% trans 'Favoritos' %}</a>
+  {% if request.user.user_type != 'root' %}
+  <a href="{% url 'feed:nova_postagem' %}" target="_blank" class="inline-flex items-center gap-2 px-4 py-2 rounded-md bg-blue-500 hover:bg-blue-600 text-white text-sm font-medium shadow-sm transition focus:outline-none focus:ring-2 focus:ring-blue-500" aria-label="{% trans 'Nova postagem' %}">
+    <i class="fa-solid fa-circle-plus"></i>
+    {% trans 'Nova postagem' %}
+  </a>
+  {% endif %}
+</div>

--- a/feed/templates/feed/mural.html
+++ b/feed/templates/feed/mural.html
@@ -6,25 +6,9 @@
 {% if request.user.user_type == 'root' %}
   <p class="text-center text-neutral-500">{% trans "Usuário root não tem acesso ao feed." %}</p>
 {% else %}
+{% include 'components/hero.html' with title=_('Meu Mural') action_template='feed/hero_actions_mural.html' %}
 <section class="max-w-6xl mx-auto px-4 py-10">
-
-  <!-- Cabeçalho -->
-  <div class="flex items-center justify-between mb-6">
-    <h1 class="text-2xl font-bold text-neutral-900">{% trans "Meu Mural" %}</h1>
-    <div class="flex gap-2">
-      <a href="{% url 'feed:listar' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100 focus:outline-none focus:ring-2 focus:ring-indigo-500" aria-label="{% trans 'Ver Feed Global' %}">{% trans "Ver Feed Global" %}</a>
-      <a href="{% url 'feed:bookmarks' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100 focus:outline-none focus:ring-2 focus:ring-indigo-500" aria-label="{% trans 'Favoritos' %}">{% trans "Favoritos" %}</a>
-      {% if request.user.user_type != 'root' %}
-      <a href="{% url 'feed:nova_postagem' %}" target="_blank" class="inline-flex items-center gap-2 px-4 py-2 rounded-md bg-blue-500 hover:bg-blue-600 text-white text-sm font-medium shadow-sm transition focus:outline-none focus:ring-2 focus:ring-blue-500" aria-label="{% trans 'Nova postagem' %}">
-        <i class="fa-solid fa-circle-plus"></i>
-        {% trans "Nova postagem" %}
-      </a>
-      {% endif %}
-    </div>
-  </div>
-
   {% include "feed/_grid.html" with posts=posts %}
-
 </section>
 {% endif %}
 {% endblock %}

--- a/financeiro/templates/financeiro/centros_list.html
+++ b/financeiro/templates/financeiro/centros_list.html
@@ -4,13 +4,8 @@
 {% block title %}{% trans "Centros de Custo" %}{% endblock %}
 
 {% block content %}
+{% include 'components/hero.html' with title=_('Centros de Custo') action_template='financeiro/hero_centros_action.html' %}
 <main class="p-4 max-w-5xl mx-auto">
-  <header class="flex items-center justify-between mb-4">
-    <h1 class="text-2xl font-semibold">{% trans "Centros de Custo" %}</h1>
-      <button class="bg-blue-600 text-white px-4 py-2 rounded" hx-get="/financeiro/centros/form/" hx-target="#modal" hx-trigger="click">
-        {% trans "Novo Centro" %}
-      </button>
-  </header>
   <section id="centros-list" class="overflow-x-auto" aria-live="polite">
     <table class="min-w-full divide-y divide-gray-200">
       <thead class="bg-gray-50">

--- a/financeiro/templates/financeiro/hero_centros_action.html
+++ b/financeiro/templates/financeiro/hero_centros_action.html
@@ -1,0 +1,2 @@
+{% load i18n %}
+<button class="bg-blue-600 text-white px-4 py-2 rounded" hx-get="/financeiro/centros/form/" hx-target="#modal" hx-trigger="click">{% trans "Novo Centro" %}</button>

--- a/financeiro/templates/financeiro/hero_integracoes_action.html
+++ b/financeiro/templates/financeiro/hero_integracoes_action.html
@@ -1,0 +1,2 @@
+{% load i18n %}
+<button class="bg-blue-600 text-white px-4 py-2 rounded" hx-get="{% url 'financeiro:integracao_form' %}" hx-target="#modal" hx-trigger="click">{% trans "Nova Configuração" %}</button>

--- a/financeiro/templates/financeiro/integracoes_list.html
+++ b/financeiro/templates/financeiro/integracoes_list.html
@@ -4,15 +4,8 @@
 {% block title %}{% trans "Integrações" %}{% endblock %}
 
 {% block content %}
+{% include 'components/hero.html' with title=_('Integrações') action_template='financeiro/hero_integracoes_action.html' %}
 <main class="p-4 max-w-5xl mx-auto">
-  <header class="flex items-center justify-between mb-4">
-    <h1 class="text-2xl font-semibold">{% trans "Integrações" %}</h1>
-    <button class="bg-blue-600 text-white px-4 py-2 rounded"
-            hx-get="{% url 'financeiro:integracao_form' %}"
-            hx-target="#modal" hx-trigger="click">
-      {% trans "Nova Configuração" %}
-    </button>
-  </header>
   <section id="integracoes-list" class="overflow-x-auto" aria-live="polite">
     <table class="min-w-full divide-y divide-gray-200">
       <thead class="bg-gray-50">

--- a/notificacoes/templates/notificacoes/hero_action.html
+++ b/notificacoes/templates/notificacoes/hero_action.html
@@ -1,0 +1,4 @@
+{% load i18n %}
+<a href="{% url 'notificacoes:template_create' %}" class="inline-flex items-center gap-2 bg-primary-600 text-white text-sm px-4 py-2 rounded-xl hover:bg-primary-700">
+  <span class="text-xl leading-none">+</span> {% trans 'Novo Template' %}
+</a>

--- a/notificacoes/templates/notificacoes/templates_list.html
+++ b/notificacoes/templates/notificacoes/templates_list.html
@@ -2,16 +2,8 @@
 {% load i18n %}
 {% block title %}{% trans 'Templates de Notificação' %} | HubX{% endblock %}
 {% block content %}
+{% include 'components/hero.html' with title=_('Templates de Notificação') subtitle=_('Gerencie as mensagens utilizadas nos envios.') action_template='notificacoes/hero_action.html' %}
 <div class="max-w-6xl mx-auto px-4 py-10">
-  <div class="flex items-center justify-between mb-8">
-    <div>
-      <h1 class="text-2xl font-bold text-neutral-900">{% trans 'Templates de Notificação' %}</h1>
-      <p class="text-sm text-neutral-600">{% trans 'Gerencie as mensagens utilizadas nos envios.' %}</p>
-    </div>
-    <a href="{% url 'notificacoes:template_create' %}" class="inline-flex items-center gap-2 bg-primary-600 text-white text-sm px-4 py-2 rounded-xl hover:bg-primary-700">
-      <span class="text-xl leading-none">+</span> {% trans 'Novo Template' %}
-    </a>
-  </div>
   {% if messages %}
   <div class="mb-4 space-y-2" aria-live="polite">
       {% for message in messages %}

--- a/nucleos/templates/nucleos/hero_meus_list_action.html
+++ b/nucleos/templates/nucleos/hero_meus_list_action.html
@@ -1,0 +1,2 @@
+{% load i18n %}
+<a href="{% url 'nucleos:list' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100" aria-label="{% trans 'Ver todos os núcleos' %}">{% trans 'Todos os Núcleos' %}</a>

--- a/nucleos/templates/nucleos/meus_list.html
+++ b/nucleos/templates/nucleos/meus_list.html
@@ -4,11 +4,8 @@
 {% block title %}{% trans "Meus Núcleos" %}{% endblock %}
 
 {% block content %}
+{% include 'components/hero.html' with title=_('Meus Núcleos') action_template='nucleos/hero_meus_list_action.html' %}
 <section class="max-w-5xl mx-auto py-8">
-  <div class="flex items-center justify-between mb-4">
-    <h1 class="text-2xl font-bold">{% trans "Meus Núcleos" %}</h1>
-    <a href="{% url 'nucleos:list' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100" aria-label="{% trans 'Ver todos os núcleos' %}">{% trans "Todos os Núcleos" %}</a>
-  </div>
   <form method="get" class="mb-4 flex gap-2">
     <input type="text" name="q" value="{{ form.q.value }}" placeholder="{% trans 'Buscar...' %}" class="border rounded px-2 py-1 flex-1" />
     <button class="px-3 py-1 bg-blue-600 text-white rounded" aria-label="{% trans 'Buscar núcleos' %}">{% trans 'Buscar' %}</button>

--- a/organizacoes/templates/organizacoes/list.html
+++ b/organizacoes/templates/organizacoes/list.html
@@ -4,6 +4,7 @@
 {% block title %}{% trans 'Organizações' %} | Hubx{% endblock %}
 
 {% block content %}
+{% include 'components/hero.html' with title=_('Organizações') subtitle=_('Gerencie as organizações cadastradas') action_template='organizacoes/partials/hero_action.html' %}
 <section class="max-w-6xl mx-auto px-4 py-10" id="org-list">
   {% include 'organizacoes/partials/list_section.html' %}
 </section>

--- a/organizacoes/templates/organizacoes/partials/hero_action.html
+++ b/organizacoes/templates/organizacoes/partials/hero_action.html
@@ -1,0 +1,8 @@
+{% load i18n %}
+<a href="{% url 'organizacoes:create' %}" class="inline-flex items-center gap-2 bg-primary-600 text-white text-sm px-4 py-2 rounded-xl hover:bg-primary-700">
+  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+    <line x1="12" y1="5" x2="12" y2="19"/>
+    <line x1="5" y1="12" x2="19" y2="12"/>
+  </svg>
+  {% trans 'Nova Organização' %}
+</a>

--- a/organizacoes/templates/organizacoes/partials/list_section.html
+++ b/organizacoes/templates/organizacoes/partials/list_section.html
@@ -1,19 +1,4 @@
 {% load i18n %}
-<!-- Cabeçalho -->
-<div class="flex items-center justify-between mb-8">
-  <div>
-    <h1 class="text-2xl font-bold text-neutral-900">{% trans 'Organizações' %}</h1>
-    <p class="text-neutral-600 text-sm">{% trans 'Gerencie as organizações cadastradas' %}</p>
-  </div>
-  <a href="{% url 'organizacoes:create' %}" class="inline-flex items-center gap-2 bg-primary-600 text-white text-sm px-4 py-2 rounded-xl hover:bg-primary-700">
-    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-      <line x1="12" y1="5" x2="12" y2="19"/>
-      <line x1="5" y1="12" x2="19" y2="12"/>
-    </svg>
-    {% trans 'Nova Organização' %}
-  </a>
-</div>
-
 <form hx-get="{% url 'organizacoes:list' %}" hx-target="#org-list" hx-push-url="true" class="mb-6 grid md:grid-cols-5 gap-2">
   <select name="tipo" class="w-full p-2 border rounded-lg">
     <option value="">{% trans 'Tipo' %}</option>

--- a/templates/components/hero.html
+++ b/templates/components/hero.html
@@ -1,0 +1,18 @@
+<section class="bg-gradient-to-r from-[#3b82f6] to-[#1e40af] text-white">
+  <div class="max-w-7xl mx-auto px-4 py-10">
+    {% if breadcrumb_template %}
+      <div class="mb-4">{% include breadcrumb_template %}</div>
+    {% endif %}
+    <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+      <div>
+        <h1 class="text-4xl font-bold">{{ title }}</h1>
+        {% if subtitle %}
+          <p class="text-base text-secondary">{{ subtitle }}</p>
+        {% endif %}
+      </div>
+      {% if action_template %}
+      <div>{% include action_template %}</div>
+      {% endif %}
+    </div>
+  </div>
+</section>

--- a/tokens/templates/tokens/hero_action.html
+++ b/tokens/templates/tokens/hero_action.html
@@ -1,0 +1,2 @@
+{% load i18n %}
+<a href="{% url 'tokens:gerar_convite' %}" class="text-sm px-4 py-2 rounded-xl bg-primary-600 text-white hover:bg-primary-700">{% trans 'Gerar Token' %}</a>

--- a/tokens/templates/tokens/listar_convites.html
+++ b/tokens/templates/tokens/listar_convites.html
@@ -3,11 +3,8 @@
 {% block title %}{% trans "Convites Emitidos" %} | HubX{% endblock %}
 
 {% block content %}
+{% include 'components/hero.html' with title=_('Convites Emitidos') action_template='tokens/hero_action.html' %}
 <section class="max-w-3xl mx-auto px-4 py-10">
-  <div class="flex items-center justify-between mb-6">
-    <h1 class="text-2xl font-bold">{% trans "Convites Emitidos" %}</h1>
-    <a href="{% url 'tokens:gerar_convite' %}" class="text-sm px-4 py-2 rounded-xl bg-primary-600 text-white hover:bg-primary-700">{% trans "Gerar Token" %}</a>
-  </div>
   {% if convites %}
   <div class="overflow-x-auto">
     <table class="min-w-full divide-y divide-neutral-200 bg-white shadow-sm rounded-2xl">


### PR DESCRIPTION
## Summary
- add gradient hero template with slots for title, subtitle and actions
- replace page headers with new hero include and action partials

## Testing
- `pytest` *(fails: 81 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bb291379208325a267b5415265eee8