### PR TITLE
docs: expand frontend layout guide and component docs

### DIFF
--- a/docs/style_guide_frontend.md
+++ b/docs/style_guide_frontend.md
@@ -36,3 +36,53 @@ Aplique utilitários Tailwind diretamente nas tags para garantir consistência e
 - Utilize ícones [Lucide](https://lucide.dev) embutidos como SVG diretamente nos templates ou componentes.
 - Ícones meramente decorativos devem incluir `aria-hidden="true"`.
 - Quando o ícone transmitir significado, forneça um `aria-label` no elemento ou um texto auxiliar escondido com `sr-only`.
+
+## Estrutura de layout
+
+### Sidebar
+
+Use a partial `nav_sidebar.html` para menus de navegação fixos e responsivos.
+Ela traz links contextualizados pelo tipo de usuário e alterna entre visual
+mobile e desktop automaticamente.
+
+```django
+{% include "components/nav_sidebar.html" %}
+```
+
+### Hero
+
+Seções de destaque devem ocupar a área inicial da página com uma mensagem
+principal e call to action opcional. Utilize a partial `hero.html` para manter
+consistência de espaçamento e tipografia.
+
+```django
+{% include "components/hero.html" with title="Bem-vindo" subtitle="Resumo do app" %}
+```
+
+### Cartões
+
+Agrupe informações em cartões usando contêineres com borda suave e sombra
+leve.
+
+```html
+<div class="p-4 bg-white rounded-lg shadow">
+  <h3 class="font-semibold">Título</h3>
+  <p class="text-sm text-gray-600">Descrição ou conteúdo.</p>
+</div>
+```
+
+### Formulários
+
+Formulários devem ser compostos por `label`, `input` ou componentes do
+Tailwind, sempre com `aria-label` ou `aria-describedby` quando necessário.
+Botões primários usam `btn btn-primary` e ações secundárias `btn btn-secondary`.
+
+```html
+<form hx-post="/salvar" class="space-y-4">
+  <label class="block">
+    <span class="text-sm">Nome</span>
+    <input type="text" name="nome" class="mt-1 block w-full" />
+  </label>
+  <button type="submit" class="btn btn-primary">Enviar</button>
+</form>
+```

--- a/templates/components/README.md
+++ b/templates/components/README.md
@@ -1,0 +1,30 @@
+# Componentes de templates
+
+Os arquivos deste diretório servem como partes reutilizáveis em páginas do Hubx.
+Cada componente deve manter semântica HTML, classes do Tailwind e suporte a
+tradução.
+
+## nav_sidebar.html
+Barra de navegação responsiva que alterna entre menu superior e sidebar.
+Todos os links utilizam `{% trans %}` para i18n e incluem atributos de
+acessibilidade como `aria-label` e `aria-current`.
+
+```django
+{% include "components/nav_sidebar.html" %}
+```
+
+## hero.html
+Seção de destaque para cabeçalhos de páginas. Aceita variáveis `title`,
+`subtitle` e `cta` para botões de ação. Os valores devem ser textos já
+traduzidos ou envolvidos por `{% trans %}` dentro da partial.
+
+```django
+{% include "components/hero.html" with title=_("Título") %}
+```
+
+## Convenções de i18n
+
+- Todo texto visível deve estar dentro de `{% trans %}` ou `{% blocktrans %}`.
+- Atributos como `aria-label`, `alt` e placeholders precisam ser traduzíveis.
+- Componentes adicionais (cards, formulários, etc.) devem seguir as mesmas
+  regras ao serem criados.


### PR DESCRIPTION
## Summary
- document layout structures (sidebar, hero, cards, forms) in frontend style guide
- add README for template components with i18n expectations

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'factory')*

------
https://chatgpt.com/codex/tasks/task_e_68bb2922149c832596579f574da86e90