### PR TITLE
Add accessible header and layout container to base template

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -58,7 +58,47 @@
   {% endif %}
 
   <div id="content" class="flex flex-col flex-1 ml-64 transition-all">
-    <main id="main-content" class="flex-grow">
+    <header class="bg-white border-b">
+      <div class="container mx-auto p-4 flex items-center gap-4 justify-between">
+        <a href="/" class="text-xl font-bold text-primary" aria-label="{% trans 'Página inicial' %}">HubX</a>
+        <form action="#" method="get" role="search" class="flex-1 max-w-md">
+          <label for="header-search" class="sr-only">{% trans 'Buscar' %}</label>
+          <input id="header-search" name="q" type="search" placeholder="{% trans 'Buscar' %}" class="w-full border rounded px-3 py-2" />
+        </form>
+        <div class="flex items-center gap-4">
+          <div class="flex items-center gap-2" role="group" aria-label="{% trans 'Tema' %}">
+            <button type="button" class="btn-secondary btn-sm aria-pressed:bg-primary aria-pressed:text-white aria-pressed:border-primary" data-theme-option="claro" aria-pressed="false">
+              {% trans "Claro" %}
+            </button>
+            <button type="button" class="btn-secondary btn-sm aria-pressed:bg-primary aria-pressed:text-white aria-pressed:border-primary" data-theme-option="escuro" aria-pressed="false">
+              {% trans "Escuro" %}
+            </button>
+            <button type="button" class="btn-secondary btn-sm aria-pressed:bg-primary aria-pressed:text-white aria-pressed:border-primary" data-theme-option="automatico" aria-pressed="false">
+              {% trans "Automático" %}
+            </button>
+          </div>
+          <a href="#" class="relative" aria-label="{% trans 'Notificações' %}">
+            <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M10 21a1 1 0 0 0 2 0" />
+              <path d="M18 8a6 6 0 1 0-12 0c0 7-3 9-3 9h18s-3-2-3-9" />
+            </svg>
+          </a>
+          {% if request.user.is_authenticated %}
+          <a href="{% url 'accounts:perfil' %}" class="block w-8 h-8 rounded-full overflow-hidden" aria-label="{% trans 'Perfil' %}">
+            {% if request.user.avatar %}
+            <img src="{{ request.user.avatar.url }}" alt="{{ request.user.username }}" class="w-full h-full object-cover" />
+            {% else %}
+            <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2" />
+              <circle cx="12" cy="7" r="4" />
+            </svg>
+            {% endif %}
+          </a>
+          {% endif %}
+        </div>
+      </div>
+    </header>
+    <main id="main-content" class="container mx-auto p-6 flex-grow">
       {% block content %}{% endblock %}
     </main>
 


### PR DESCRIPTION
## Summary
- add top header with logo, search, theme selector, notifications icon, and user avatar
- wrap main content in responsive container spacing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'freezegun'; No module named 'axe_core_python'; No module named 'discussao'; No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_68bb36000c908325a2b739b4fe2d27a5