### PR TITLE
refactor: centralize hero actions

### DIFF
--- a/feed/templates/feed/feed.html
+++ b/feed/templates/feed/feed.html
@@ -10,20 +10,6 @@
 {% include 'components/hero.html' with title=_('Feed de Postagens') action_template='feed/hero_actions.html' %}
 <section class="max-w-7xl mx-auto px-4 py-10">
 
-  <!-- Cabeçalho -->
-  <div class="flex items-center justify-between mb-6">
-    <h1 class="text-2xl font-bold text-neutral-900">{% trans "Feed de Postagens" %}</h1>
-    <div class="flex gap-2">
-      <a href="{% url 'feed:meu_mural' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100 focus:outline-none focus:ring-2 focus:ring-indigo-500" aria-label="{% trans 'Mural' %}">{% trans "Mural" %}</a>
-      <a href="{% url 'feed:bookmarks' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100 focus:outline-none focus:ring-2 focus:ring-indigo-500" aria-label="{% trans 'Favoritos' %}">{% trans "Favoritos" %}</a>
-      {% if request.user.user_type != 'root' %}
-      <a href="{% url 'feed:nova_postagem' %}" target="_blank" class="inline-flex items-center gap-2 px-4 py-2 rounded-md bg-blue-500 hover:bg-blue-600 text-white text-sm font-medium shadow-sm transition focus:outline-none focus:ring-2 focus:ring-blue-500" aria-label="{% trans 'Nova postagem' %}">
-        {% lucide 'circle-plus' class='w-5 h-5' %}
-        {% trans "Nova postagem" %}
-      </a>
-      {% endif %}
-    </div>
-  </div>
 
   <!-- Busca simples -->
   <form id="feed-search-form" class="flex items-center gap-2 mb-6" hx-get="{% url 'feed:listar' %}" hx-target="#feed-grid" hx-indicator="#feed-loading">

--- a/feed/templates/feed/mural.html
+++ b/feed/templates/feed/mural.html
@@ -8,23 +8,7 @@
 {% else %}
 {% include 'components/hero.html' with title=_('Meu Mural') action_template='feed/hero_actions_mural.html' %}
 <section class="max-w-6xl mx-auto px-4 py-10">
-  <!-- Cabeçalho -->
-  <div class="flex items-center justify-between mb-6">
-    <h1 class="text-2xl font-bold text-neutral-900">{% trans "Meu Mural" %}</h1>
-    <div class="flex gap-2">
-      <a href="{% url 'feed:listar' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100 focus:outline-none focus:ring-2 focus:ring-indigo-500" aria-label="{% trans 'Ver Feed Global' %}">{% trans "Ver Feed Global" %}</a>
-      <a href="{% url 'feed:bookmarks' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100 focus:outline-none focus:ring-2 focus:ring-indigo-500" aria-label="{% trans 'Favoritos' %}">{% trans "Favoritos" %}</a>
-      {% if request.user.user_type != 'root' %}
-      <a href="{% url 'feed:nova_postagem' %}" target="_blank" class="inline-flex items-center gap-2 px-4 py-2 rounded-md bg-blue-500 hover:bg-blue-600 text-white text-sm font-medium shadow-sm transition focus:outline-none focus:ring-2 focus:ring-blue-500" aria-label="{% trans 'Nova postagem' %}">
-        {% lucide 'circle-plus' class='w-5 h-5' %}
-        {% trans "Nova postagem" %}
-      </a>
-      {% endif %}
-    </div>
-  </div>
-
-
-  {% include "feed/_grid.html" with posts=posts %}
+    {% include "feed/_grid.html" with posts=posts %}
 </section>
 {% endif %}
 {% endblock %}

--- a/nucleos/templates/nucleos/hero_meus_list_action.html
+++ b/nucleos/templates/nucleos/hero_meus_list_action.html
@@ -1,2 +1,7 @@
 {% load i18n %}
-<a href="{% url 'nucleos:list' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100" aria-label="{% trans 'Ver todos os núcleos' %}">{% trans 'Todos os Núcleos' %}</a>
+<div class="flex gap-2">
+  <a href="{% url 'nucleos:list' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100" aria-label="{% trans 'Ver todos os núcleos' %}">{% trans 'Todos os Núcleos' %}</a>
+  {% if request.user.user_type == 'admin' %}
+  <a href="{% url 'nucleos:create' %}" class="px-3 py-2 bg-green-600 text-white rounded" aria-label="{% trans 'Criar novo núcleo' %}">{% trans 'Novo' %}</a>
+  {% endif %}
+</div>

--- a/nucleos/templates/nucleos/meus_list.html
+++ b/nucleos/templates/nucleos/meus_list.html
@@ -10,12 +10,6 @@
     <input type="text" name="q" value="{{ form.q.value }}" placeholder="{% trans 'Buscar...' %}" class="border rounded px-2 py-1 flex-1" />
     <button class="px-3 py-1 bg-blue-600 text-white rounded" aria-label="{% trans 'Buscar núcleos' %}">{% trans 'Buscar' %}</button>
   </form>
-    {% if request.user.user_type == 'admin' %}
-  <div class="mb-4">
-    <a href="{% url 'nucleos:create' %}" class="px-3 py-2 bg-green-600 text-white rounded" aria-label="{% trans 'Criar novo núcleo' %}">{% trans 'Novo' %}</a>
-  </div>
-  {% endif %}
-
     <ul role="list" class="grid grid-cols-1 md:grid-cols-2 gap-4">
 
     {% for nucleo in object_list %}


### PR DESCRIPTION
## Summary
- remove duplicated feed and mural headers after hero component
- move núcleo creation link into hero action template
- keep hero-driven actions for feed and mural views

## Testing
- `pytest` *(fails: ModuleNotFoundError: missing dependencies then 81 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bb368fd5748325b6949fadb0e7f4ad