### PR TITLE
Replace Font Awesome circle-plus icons with Lucide

### DIFF
--- a/feed/templates/feed/hero_actions.html
+++ b/feed/templates/feed/hero_actions.html
@@ -1,10 +1,10 @@
-{% load i18n %}
+{% load i18n lucide_icons %}
 <div class="flex gap-2">
   <a href="{% url 'feed:meu_mural' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100 focus:outline-none focus:ring-2 focus:ring-indigo-500" aria-label="{% trans 'Mural' %}">{% trans 'Mural' %}</a>
   <a href="{% url 'feed:bookmarks' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100 focus:outline-none focus:ring-2 focus:ring-indigo-500" aria-label="{% trans 'Favoritos' %}">{% trans 'Favoritos' %}</a>
   {% if request.user.user_type != 'root' %}
   <a href="{% url 'feed:nova_postagem' %}" target="_blank" class="inline-flex items-center gap-2 px-4 py-2 rounded-md bg-blue-500 hover:bg-blue-600 text-white text-sm font-medium shadow-sm transition focus:outline-none focus:ring-2 focus:ring-blue-500" aria-label="{% trans 'Nova postagem' %}">
-    <i class="fa-solid fa-circle-plus"></i>
+    {% lucide 'circle-plus' class='w-4 h-4' %}
     {% trans 'Nova postagem' %}
   </a>
   {% endif %}

--- a/feed/templates/feed/hero_actions_mural.html
+++ b/feed/templates/feed/hero_actions_mural.html
@@ -1,10 +1,10 @@
-{% load i18n %}
+{% load i18n lucide_icons %}
 <div class="flex gap-2">
   <a href="{% url 'feed:listar' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100 focus:outline-none focus:ring-2 focus:ring-indigo-500" aria-label="{% trans 'Ver Feed Global' %}">{% trans 'Ver Feed Global' %}</a>
   <a href="{% url 'feed:bookmarks' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100 focus:outline-none focus:ring-2 focus:ring-indigo-500" aria-label="{% trans 'Favoritos' %}">{% trans 'Favoritos' %}</a>
   {% if request.user.user_type != 'root' %}
   <a href="{% url 'feed:nova_postagem' %}" target="_blank" class="inline-flex items-center gap-2 px-4 py-2 rounded-md bg-blue-500 hover:bg-blue-600 text-white text-sm font-medium shadow-sm transition focus:outline-none focus:ring-2 focus:ring-blue-500" aria-label="{% trans 'Nova postagem' %}">
-    <i class="fa-solid fa-circle-plus"></i>
+    {% lucide 'circle-plus' class='w-4 h-4' %}
     {% trans 'Nova postagem' %}
   </a>
   {% endif %}


### PR DESCRIPTION
## Summary
- replace Font Awesome circle-plus icons in feed hero templates with inline Lucide SVG

## Testing
- `pytest` *(fails: 14 errors during collection, see log)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3abf10e08325a759beb5a9405b6b