### PR TITLE
fix(nav-sidebar): correct closing tags

### DIFF
--- a/templates/components/nav_sidebar.html
+++ b/templates/components/nav_sidebar.html
@@ -311,9 +311,5 @@
         </button>
       </div>
     </nav>
-  </div>
-</header>
-
-  </nav>
-</aside>
+  </aside>
 


### PR DESCRIPTION
## Summary
- remove stray `</header>` and duplicate `</nav>` from nav sidebar template
- ensure sidebar structure is `<aside> <div> <nav> ... </nav> </aside>`

## Testing
- `pytest` *(fails: 81 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3ac5891883259287a75376a08c62