### PR TITLE
chore: align color palette and cleanup tailwind

### DIFF
--- a/app/static/css/hubx.css
+++ b/app/static/css/hubx.css
@@ -9,16 +9,16 @@
 /* CSS Variables */
 :root {
   /* Light Theme Colors */
-  --color-primary-50: #e0f2ff;
-  --color-primary-100: #cce0ff;
-  --color-primary-200: #99c2ff;
-  --color-primary-300: #66a3ff;
-  --color-primary-400: #3385ff;
-  --color-primary-500: #0066ff;
-  --color-primary-600: #0052cc;
-  --color-primary-700: #003d99;
-  --color-primary-800: #002966;
-  --color-primary-900: #001433;
+  --color-primary-50: #eff6ff;
+  --color-primary-100: #dbeafe;
+  --color-primary-200: #bfdbfe;
+  --color-primary-300: #93c5fd;
+  --color-primary-400: #60a5fa;
+  --color-primary-500: #3b82f6;
+  --color-primary-600: #2563eb;
+  --color-primary-700: #1d4ed8;
+  --color-primary-800: #1e40af;
+  --color-primary-900: #1e3a8a;
 
   /* Neutral Colors - Light */
   --color-neutral-50: #f8fafc;
@@ -87,6 +87,7 @@
   /* Border Radius */
   --radius-sm: 0.375rem;
   --radius-md: 0.5rem;
+  --radius: 0.5rem;
   --radius-lg: 0.75rem;
   --radius-xl: 1rem;
   --radius-2xl: 1.5rem;
@@ -141,7 +142,7 @@
     --bg-primary: #0f172a;
     --bg-secondary: #1e293b;
     --bg-tertiary: #334155;
-    --bg-accent: #1e40af;
+    --bg-accent: var(--color-primary-800);
 
     --text-primary: var(--color-neutral-100);
     --text-secondary: var(--color-neutral-300);
@@ -175,7 +176,7 @@
   --bg-primary: #0f172a;
   --bg-secondary: #1e293b;
   --bg-tertiary: #334155;
-  --bg-accent: #1e40af;
+  --bg-accent: var(--color-primary-800);
 
   --text-primary: var(--color-neutral-100);
   --text-secondary: var(--color-neutral-300);

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -15,65 +15,19 @@ const config: Config = {
   theme: {
   	extend: {
                 colors: {
-                        background: 'hsl(var(--background))',
-                        foreground: 'hsl(var(--foreground))',
-                        card: {
-                                DEFAULT: 'hsl(var(--card))',
-                                foreground: 'hsl(var(--card-foreground))'
-                        },
-                        popover: {
-                                DEFAULT: 'hsl(var(--popover))',
-                                foreground: 'hsl(var(--popover-foreground))'
-                        },
                         primary: {
-                                50: '#e0f2ff',
-                                100: '#cce0ff',
-                                200: '#99c2ff',
-                                300: '#66a3ff',
-                                400: '#3385ff',
-                                500: '#0066ff',
-                                600: '#0052cc',
-                                700: '#003d99',
-                                800: '#002966',
-                                900: '#001433',
-                                DEFAULT: 'hsl(var(--primary))',
-                                foreground: 'hsl(var(--primary-foreground))'
-                        },
-                        secondary: {
-                                DEFAULT: 'hsl(var(--secondary))',
-                                foreground: 'hsl(var(--secondary-foreground))'
-                        },
-                        muted: {
-                                DEFAULT: 'hsl(var(--muted))',
-                                foreground: 'hsl(var(--muted-foreground))'
-                        },
-                        accent: {
-                                DEFAULT: 'hsl(var(--accent))',
-                                foreground: 'hsl(var(--accent-foreground))'
-                        },
-                        destructive: {
-                                DEFAULT: 'hsl(var(--destructive))',
-                                foreground: 'hsl(var(--destructive-foreground))'
-                        },
-                        border: 'hsl(var(--border))',
-                        input: 'hsl(var(--input))',
-                        ring: 'hsl(var(--ring))',
-                        chart: {
-                                '1': 'hsl(var(--chart-1))',
-                                '2': 'hsl(var(--chart-2))',
-                                '3': 'hsl(var(--chart-3))',
-                                '4': 'hsl(var(--chart-4))',
-                                '5': 'hsl(var(--chart-5))'
-                        },
-                        sidebar: {
-                                DEFAULT: 'hsl(var(--sidebar-background))',
-                                foreground: 'hsl(var(--sidebar-foreground))',
-                                primary: 'hsl(var(--sidebar-primary))',
-                                'primary-foreground': 'hsl(var(--sidebar-primary-foreground))',
-                                accent: 'hsl(var(--sidebar-accent))',
-                                'accent-foreground': 'hsl(var(--sidebar-accent-foreground))',
-                                border: 'hsl(var(--sidebar-border))',
-                                ring: 'hsl(var(--sidebar-ring))'
+                                50: '#eff6ff',
+                                100: '#dbeafe',
+                                200: '#bfdbfe',
+                                300: '#93c5fd',
+                                400: '#60a5fa',
+                                500: '#3b82f6',
+                                600: '#2563eb',
+                                700: '#1d4ed8',
+                                800: '#1e40af',
+                                900: '#1e3a8a',
+                                DEFAULT: '#3b82f6',
+                                foreground: '#ffffff'
                         }
                 },
                 fontFamily: {


### PR DESCRIPTION
## Summary
- streamline Tailwind config by dropping unused color tokens
- sync primary blue palette with CSS variables and gradient requirements

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run build:css`
- `pytest` *(fails: No module named 'silk')*

------
https://chatgpt.com/codex/tasks/task_e_68bb403e2bac83259e57eb9ec92adc8c