### PR TITLE
Make content margin depend on navigation visibility

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -57,7 +57,7 @@
     {% include 'components/nav_sidebar.html' %}
   {% endif %}
 
-  <div id="content" class="flex flex-col flex-1 ml-64 transition-all">
+  <div id="content" class="flex flex-col flex-1 {% if not hide_nav %}ml-64{% else %}ml-0{% endif %} transition-all">
     <header class="bg-white border-b">
       <div class="container mx-auto p-4 flex items-center gap-4 justify-between">
         <a href="/" class="text-xl font-bold text-primary" aria-label="{% trans 'Página inicial' %}">HubX</a>
@@ -181,12 +181,13 @@
       const sidebar = document.getElementById('sidebar');
       const content = document.getElementById('content');
       if (sidebarToggle && sidebar && content) {
+        const baseMargin = '{% if hide_nav %}ml-0{% else %}ml-64{% endif %}';
         sidebarToggle.addEventListener('click', () => {
           const expanded = sidebarToggle.getAttribute('aria-expanded') === 'true';
           sidebarToggle.setAttribute('aria-expanded', String(!expanded));
           sidebar.classList.toggle('w-64');
           sidebar.classList.toggle('w-16');
-          content.classList.toggle('ml-64');
+          content.classList.toggle(baseMargin);
           content.classList.toggle('ml-16');
           document.querySelectorAll('#sidebar .sidebar-label').forEach(el => {
             el.classList.toggle('hidden');


### PR DESCRIPTION
## Summary
- Only apply left margin when navigation sidebar is visible
- Handle sidebar collapse script when navigation is hidden

## Testing
- `pytest -m "not slow"` *(fails: ModuleNotFoundError: No module named 'freezegun')*

------
https://chatgpt.com/codex/tasks/task_e_68bb4039cf448325bf5f8d409dce6530