### PR TITLE
refactor: apply floating labels to account forms

### DIFF
--- a/accounts/templates/login/login.html
+++ b/accounts/templates/login/login.html
@@ -18,41 +18,50 @@
     <form method="post" action="{% url 'accounts:login' %}" class="space-y-5">
       {% csrf_token %}
       <div>
-        <label for="id_email" class="block mb-1 text-sm font-medium text-gray-700">{% trans "Email" %}</label>
-        <input type="email" id="id_email" name="email"
-               value="{{ form.email.value|default_if_none:'' }}"
-               placeholder="{% trans 'Digite seu e-mail' %}"
-               autocomplete="email"
-               class="w-full p-3 border border-gray-300 rounded-lg text-sm placeholder-gray-400 shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
-               required
-               aria-describedby="email-error"
-               {% if form.email.errors %}aria-invalid="true"{% endif %}>
+        <div class="relative">
+          <input type="email" id="id_email" name="email"
+                 value="{{ form.email.value|default_if_none:'' }}"
+                 autocomplete="email"
+                 class="peer w-full p-3 border border-gray-300 rounded-lg text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
+                 placeholder=" "
+                 required
+                 aria-describedby="email-error"
+                 {% if form.email.errors %}aria-invalid="true"{% endif %}>
+          <label for="id_email"
+                 class="absolute left-3 -top-2 text-xs text-gray-700 transition-all peer-placeholder-shown:top-3 peer-placeholder-shown:text-sm peer-placeholder-shown:text-gray-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary">{% trans "Email" %}</label>
+        </div>
         {% if form.email.errors %}
           <div id="email-error" class="text-red-600 text-xs mt-1" role="alert">{{ form.email.errors }}</div>
         {% endif %}
       </div>
       <div>
-        <label for="id_password" class="block mb-1 text-sm font-medium text-gray-700">{% trans "Senha" %}</label>
-        <input type="password" id="id_password" name="password"
-               placeholder="{% trans 'Digite sua senha' %}"
-               autocomplete="current-password"
-               class="w-full p-3 border border-gray-300 rounded-lg text-sm placeholder-gray-400 shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
-               required
-               aria-describedby="password-error"
-               {% if form.password.errors %}aria-invalid="true"{% endif %}>
+        <div class="relative">
+          <input type="password" id="id_password" name="password"
+                 autocomplete="current-password"
+                 class="peer w-full p-3 border border-gray-300 rounded-lg text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
+                 placeholder=" "
+                 required
+                 aria-describedby="password-error"
+                 {% if form.password.errors %}aria-invalid="true"{% endif %}>
+          <label for="id_password"
+                 class="absolute left-3 -top-2 text-xs text-gray-700 transition-all peer-placeholder-shown:top-3 peer-placeholder-shown:text-sm peer-placeholder-shown:text-gray-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary">{% trans "Senha" %}</label>
+        </div>
         {% if form.password.errors %}
           <div id="password-error" class="text-red-600 text-xs mt-1" role="alert">{{ form.password.errors }}</div>
         {% endif %}
       </div>
       <div id="totp-field">
-        <label for="id_totp" class="block mb-1 text-sm font-medium text-gray-700">{% trans "TOTP" %}</label>
-        <input type="text" id="id_totp" name="totp"
-               value="{{ form.totp.value|default_if_none:'' }}"
-               placeholder="{% trans 'Código 2FA' %}"
-               autocomplete="one-time-code"
-               class="w-full p-3 border border-gray-300 rounded-lg text-sm placeholder-gray-400 shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
-               aria-describedby="totp-error"
-               {% if form.totp.errors %}aria-invalid="true"{% endif %}>
+        <div class="relative">
+          <input type="text" id="id_totp" name="totp"
+                 value="{{ form.totp.value|default_if_none:'' }}"
+                 autocomplete="one-time-code"
+                 class="peer w-full p-3 border border-gray-300 rounded-lg text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
+                 placeholder=" "
+                 aria-describedby="totp-error"
+                 {% if form.totp.errors %}aria-invalid="true"{% endif %}>
+          <label for="id_totp"
+                 class="absolute left-3 -top-2 text-xs text-gray-700 transition-all peer-placeholder-shown:top-3 peer-placeholder-shown:text-sm peer-placeholder-shown:text-gray-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary">{% trans "TOTP" %}</label>
+        </div>
         <p class="text-xs text-gray-500 mt-1">{% trans "Deixe em branco se não tiver 2FA" %}</p>
         {% if form.totp.errors %}
           <div id="totp-error" class="text-red-600 text-xs mt-1" role="alert">{{ form.totp.errors }}</div>

--- a/accounts/templates/register/cpf.html
+++ b/accounts/templates/register/cpf.html
@@ -35,8 +35,23 @@
     <form id="cpfForm" method="post" action="{% url 'accounts:cpf' %}" class="space-y-6">
       {% csrf_token %}
       <div>
-        <label for="cpf" class="mb-1 block text-sm font-medium text-neutral-700">{% trans "CPF" %}</label>
-        <input type="text" id="cpf" name="cpf" maxlength="14" class="w-full rounded-lg border border-neutral-300 px-4 py-2 placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder="{% trans '000.000.000-00' %}" required autofocus aria-describedby="cpf_help cpf_validation">
+        <div class="relative">
+          <input
+            type="text"
+            id="cpf"
+            name="cpf"
+            maxlength="14"
+            class="peer w-full rounded-lg border border-neutral-300 px-4 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500"
+            placeholder=" "
+            required
+            autofocus
+            aria-describedby="cpf_help cpf_validation"
+          />
+          <label
+            for="cpf"
+            class="absolute left-4 -top-2 text-xs text-neutral-700 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600"
+          >{% trans "CPF" %}</label>
+        </div>
         <div class="text-sm text-red-600" id="cpf_validation"></div>
         <small id="cpf_help" class="text-sm text-neutral-500">{% trans "Formato 000.000.000-00" %}</small>
       </div>

--- a/accounts/templates/register/email.html
+++ b/accounts/templates/register/email.html
@@ -35,8 +35,22 @@
     <form id="emailForm" method="post" action="{% url 'accounts:email' %}" class="space-y-6">
       {% csrf_token %}
       <div>
-        <label for="email" class="mb-1 block text-sm font-medium text-neutral-700">{% trans "Email" %}</label>
-        <input type="email" id="email" name="email" class="w-full rounded-lg border border-neutral-300 px-4 py-2 placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder="{% trans 'Digite seu email' %}" required autofocus aria-describedby="email_help email_validation">
+        <div class="relative">
+          <input
+            type="email"
+            id="email"
+            name="email"
+            class="peer w-full rounded-lg border border-neutral-300 px-4 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500"
+            placeholder=" "
+            required
+            autofocus
+            aria-describedby="email_help email_validation"
+          />
+          <label
+            for="email"
+            class="absolute left-4 -top-2 text-xs text-neutral-700 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600"
+          >{% trans "Email" %}</label>
+        </div>
         <div class="text-sm text-red-600" id="email_validation"></div>
         <small id="email_help" class="text-sm text-neutral-500">{% trans "Enviaremos um link de confirmação" %}</small>
       </div>

--- a/accounts/templates/register/foto.html
+++ b/accounts/templates/register/foto.html
@@ -35,8 +35,20 @@
     <form id="fotoForm" method="post" action="{% url 'accounts:foto' %}" enctype="multipart/form-data" class="space-y-6">
       {% csrf_token %}
       <div>
-        <label for="foto" class="mb-1 block text-sm font-medium text-neutral-700">{% trans "Escolher Foto" %}</label>
-        <input type="file" id="foto" name="foto" accept="image/*" class="w-full rounded-lg border border-neutral-300 px-4 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500">
+        <div class="relative">
+          <input
+            type="file"
+            id="foto"
+            name="foto"
+            accept="image/*"
+            class="peer w-full rounded-lg border border-neutral-300 px-4 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500"
+            placeholder=" "
+          />
+          <label
+            for="foto"
+            class="absolute left-4 -top-2 text-xs text-neutral-700 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600"
+          >{% trans "Escolher Foto" %}</label>
+        </div>
         <div class="text-sm text-red-600" id="foto_validation"></div>
         <small class="text-sm text-neutral-500">{% trans "Formatos aceitos: JPG, PNG. Tamanho máximo: 5MB" %}</small>
       </div>

--- a/accounts/templates/register/nome.html
+++ b/accounts/templates/register/nome.html
@@ -35,8 +35,21 @@
     <form id="nomeForm" method="post" action="{% url 'accounts:nome' %}" class="space-y-6">
       {% csrf_token %}
       <div>
-        <label for="nome" class="mb-1 block text-sm font-medium text-neutral-700">{% trans "Nome Completo" %}</label>
-        <input type="text" id="nome" name="nome" class="w-full rounded-lg border border-neutral-300 px-4 py-2 placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder="{% trans 'Digite seu nome completo' %}" required autofocus>
+        <div class="relative">
+          <input
+            type="text"
+            id="nome"
+            name="nome"
+            class="peer w-full rounded-lg border border-neutral-300 px-4 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500"
+            placeholder=" "
+            required
+            autofocus
+          />
+          <label
+            for="nome"
+            class="absolute left-4 -top-2 text-xs text-neutral-700 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600"
+          >{% trans "Nome Completo" %}</label>
+        </div>
         <div class="text-sm text-red-600" id="nome_validation"></div>
       </div>
 

--- a/accounts/templates/register/senha.html
+++ b/accounts/templates/register/senha.html
@@ -35,15 +35,42 @@
     <form id="senhaForm" method="post" action="{% url 'accounts:senha' %}" class="space-y-6">
       {% csrf_token %}
       <div>
-        <label for="senha" class="mb-1 block text-sm font-medium text-neutral-700">{% trans "Senha" %}</label>
-        <input type="password" id="senha" name="senha" class="w-full rounded-lg border border-neutral-300 px-4 py-2 placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder="{% trans 'Digite sua senha' %}" required autofocus aria-describedby="senha_help senha_validation">
+        <div class="relative">
+          <input
+            type="password"
+            id="senha"
+            name="senha"
+            class="peer w-full rounded-lg border border-neutral-300 px-4 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500"
+            placeholder=" "
+            required
+            autofocus
+            aria-describedby="senha_help senha_validation"
+          />
+          <label
+            for="senha"
+            class="absolute left-4 -top-2 text-xs text-neutral-700 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600"
+          >{% trans "Senha" %}</label>
+        </div>
         <div class="text-sm text-red-600" id="senha_validation"></div>
         <small id="senha_help" class="text-sm text-neutral-500">{% trans "Use ao menos 8 caracteres com letras e números" %}</small>
       </div>
 
       <div>
-        <label for="confirmar_senha" class="mb-1 block text-sm font-medium text-neutral-700">{% trans "Confirmar Senha" %}</label>
-        <input type="password" id="confirmar_senha" name="confirmar_senha" class="w-full rounded-lg border border-neutral-300 px-4 py-2 placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder="{% trans 'Confirme sua senha' %}" required aria-describedby="confirmar_senha_help confirmar_senha_validation">
+        <div class="relative">
+          <input
+            type="password"
+            id="confirmar_senha"
+            name="confirmar_senha"
+            class="peer w-full rounded-lg border border-neutral-300 px-4 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500"
+            placeholder=" "
+            required
+            aria-describedby="confirmar_senha_help confirmar_senha_validation"
+          />
+          <label
+            for="confirmar_senha"
+            class="absolute left-4 -top-2 text-xs text-neutral-700 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600"
+          >{% trans "Confirmar Senha" %}</label>
+        </div>
         <div class="text-sm text-red-600" id="confirmar_senha_validation"></div>
         <small id="confirmar_senha_help" class="text-sm text-neutral-500">{% trans "Repita a senha para confirmação" %}</small>
       </div>

--- a/accounts/templates/register/token.html
+++ b/accounts/templates/register/token.html
@@ -42,8 +42,21 @@
     <form method="post" action="{% url 'tokens:token' %}" class="space-y-6">
       {% csrf_token %}
       <div>
-        <label for="token" class="mb-1 block text-sm font-medium text-neutral-700">{% trans "Token de Convite" %}</label>
-        <input type="text" id="token" name="token" class="w-full rounded-lg border border-neutral-300 px-4 py-2 text-center font-mono tracking-widest placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder="{% trans 'Digite seu token de convite' %}" required autofocus>
+        <div class="relative">
+          <input
+            type="text"
+            id="token"
+            name="token"
+            class="peer w-full rounded-lg border border-neutral-300 px-4 py-2 text-center font-mono tracking-widest focus:outline-none focus:ring-2 focus:ring-primary-500"
+            placeholder=" "
+            required
+            autofocus
+          />
+          <label
+            for="token"
+            class="absolute left-4 -top-2 text-xs text-neutral-700 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600"
+          >{% trans "Token de Convite" %}</label>
+        </div>
         <p class="mt-1 text-sm text-neutral-500">{% trans "O token é necessário para continuar o cadastro na plataforma" %}</p>
       </div>
 

--- a/accounts/templates/register/usuario.html
+++ b/accounts/templates/register/usuario.html
@@ -39,8 +39,22 @@
     <form id="usuarioForm" method="post" action="{% url 'accounts:usuario' %}" class="space-y-6">
       {% csrf_token %}
       <div>
-        <label for="usuario" class="mb-1 block text-sm font-medium text-neutral-700">{% trans "Nome de Usuário" %}</label>
-        <input type="text" id="usuario" name="usuario" class="w-full rounded-lg border border-neutral-300 px-4 py-2 placeholder-neutral-400 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder="{% trans 'Digite seu nome de usuário' %}" required autofocus aria-describedby="usuario_help usuario_validation">
+        <div class="relative">
+          <input
+            type="text"
+            id="usuario"
+            name="usuario"
+            class="peer w-full rounded-lg border border-neutral-300 px-4 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500"
+            placeholder=" "
+            required
+            autofocus
+            aria-describedby="usuario_help usuario_validation"
+          />
+          <label
+            for="usuario"
+            class="absolute left-4 -top-2 text-xs text-neutral-700 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600"
+          >{% trans "Nome de Usuário" %}</label>
+        </div>
         <div class="text-sm text-red-600" id="usuario_validation"></div>
         <small id="usuario_help" class="text-sm text-neutral-500">{% trans "Use apenas letras, números e underscore (_)" %}</small>
       </div>


### PR DESCRIPTION
## Summary
- adopt floating label pattern across account registration and login templates
- use peer + placeholder trick to position labels with Tailwind utilities

## Testing
- `pytest` *(fails: ModuleNotFoundError: silk; after installing django-silk and pytest-cov, 81 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bb40e418c483259c50c62ea706c92e