### PR TITLE
refactor: apply hero and card layout to templates

### DIFF
--- a/eventos/templates/eventos/briefing_form.html
+++ b/eventos/templates/eventos/briefing_form.html
@@ -3,32 +3,43 @@
 {% block title %}{% if object %}{% trans "Editar Briefing" %}{% else %}{% trans "Novo Briefing" %}{% endif %} | Hubx{% endblock %}
 
 {% block content %}
-<section class="max-w-screen-xl mx-auto pt-8 px-6 lg:px-8">
-  <h1 class="text-2xl font-bold text-neutral-900 mb-6">
-    {% if object %}{% trans "Editar Briefing" %}{% else %}{% trans "Novo Briefing" %}{% endif %}
-  </h1>
-  <form method="post" class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 space-y-6">
-    {% csrf_token %}
-    {{ form.non_field_errors }}
-    {% for field in form %}
-    <div>
-      <label for="{{ field.id_for_label }}" class="block text-sm font-medium text-neutral-700 mb-1">
-        {{ field.label }}
-      </label>
-      {% if field.name == 'evento' %}
-        {{ field|add_class:'form-select' }}
-      {% else %}
-        {{ field|add_class:'form-textarea' }}
-      {% endif %}
-      {% if field.errors %}
-        <p class="text-sm text-red-600 mt-1">{{ field.errors }}</p>
-      {% endif %}
+{% if object %}
+  {% include 'components/hero.html' with title=_('Editar Briefing') %}
+{% else %}
+  {% include 'components/hero.html' with title=_('Novo Briefing') %}
+{% endif %}
+<section class="max-w-3xl mx-auto px-4 py-12 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+  <div class="card">
+    <div class="card-header">
+      <h2 class="text-xl font-semibold">
+        {% if object %}{% trans "Editar Briefing" %}{% else %}{% trans "Novo Briefing" %}{% endif %}
+      </h2>
     </div>
-    {% endfor %}
-    <div class="flex justify-end gap-3 pt-4 border-t border-neutral-100">
-      <a href="{% url 'eventos:briefing_list' %}" class="btn-secondary" aria-label="{% trans 'Cancelar' %}">{% trans 'Cancelar' %}</a>
-      <button type="submit" class="btn-primary" aria-label="{% trans 'Salvar' %}">{% trans 'Salvar' %}</button>
+    <div class="card-body">
+      <form method="post" class="space-y-6">
+        {% csrf_token %}
+        {{ form.non_field_errors }}
+        {% for field in form %}
+        <div>
+          <label for="{{ field.id_for_label }}" class="block text-sm font-medium text-neutral-700 mb-1">
+            {{ field.label }}
+          </label>
+          {% if field.name == 'evento' %}
+            {{ field|add_class:'form-select' }}
+          {% else %}
+            {{ field|add_class:'form-textarea' }}
+          {% endif %}
+          {% if field.errors %}
+            <p class="text-sm text-red-600 mt-1">{{ field.errors }}</p>
+          {% endif %}
+        </div>
+        {% endfor %}
+        <div class="flex justify-end gap-3 pt-4 border-t border-neutral-100">
+          <a href="{% url 'eventos:briefing_list' %}" class="btn-secondary" aria-label="{% trans 'Cancelar' %}">{% trans 'Cancelar' %}</a>
+          <button type="submit" class="btn-primary" aria-label="{% trans 'Salvar' %}">{% trans 'Salvar' %}</button>
+        </div>
+      </form>
     </div>
-  </form>
+  </div>
 </section>
 {% endblock %}

--- a/tokens/templates/tokens/api_tokens.html
+++ b/tokens/templates/tokens/api_tokens.html
@@ -3,70 +3,81 @@
 {% block title %}{% trans "Tokens de API" %} | HubX{% endblock %}
 
 {% block content %}
-<section class="max-w-3xl mx-auto px-4 py-10">
-  <h1 class="text-2xl font-bold mb-6">{% trans "Tokens de API" %}</h1>
-  {% if tokens %}
-  <div class="overflow-x-auto">
-    <table class="min-w-full divide-y divide-neutral-200 bg-white shadow-sm rounded-2xl">
-      <thead class="bg-neutral-50">
-        <tr>
-          <th class="px-4 py-2 text-left text-sm font-medium text-neutral-700">{% trans "Cliente" %}</th>
-          <th class="px-4 py-2 text-left text-sm font-medium text-neutral-700">{% trans "Escopo" %}</th>
-          <th class="px-4 py-2 text-left text-sm font-medium text-neutral-700">{% trans "Ações" %}</th>
-        </tr>
-      </thead>
-      <tbody class="divide-y divide-neutral-200">
-        {% for token in tokens %}
-        <tr>
-          <td class="px-4 py-2 text-sm text-neutral-900">{{ token.client_name }}</td>
-          <td class="px-4 py-2 text-sm text-neutral-900">{{ token.get_scope_display }}</td>
-          <td class="px-4 py-2 text-sm">
-            {% if token.revoked_at %}
-              <span class="text-neutral-400">{% trans "Revogado" %}</span>
-            {% else %}
-            <form method="post" action="{% url 'tokens:revogar_api_token' token.id %}" hx-confirm="{% trans 'Confirmar revogação?' %}">
-              {% csrf_token %}
-              <button type="submit" class="text-red-600 hover:underline">{% trans "Revogar" %}</button>
-            </form>
-            {% endif %}
-          </td>
-        </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-  </div>
-  {% else %}
-    <p class="text-sm text-neutral-600">{% trans "Nenhum token de API encontrado." %}</p>
-  {% endif %}
-  <div class="mt-10">
-    <h2 class="text-xl font-bold mb-4">{% trans "Gerar novo token" %}</h2>
-    <form method="post" action="{% url 'tokens:gerar_api_token' %}" hx-post="{% url 'tokens:gerar_api_token' %}" hx-target="#resultado" hx-swap="innerHTML" class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 space-y-6">
-      {% csrf_token %}
-      <div class="space-y-4">
-        {% for field in form %}
-        <div>
-          <label for="{{ field.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ field.label }}</label>
-          {% if field.field.widget.input_type == 'select' %}
-            {{ field|add_class:"form-select" }}
-          {% else %}
-            {{ field|add_class:"form-input" }}
-          {% endif %}
-          {% if field.errors %}
-            <p class="text-red-500 text-xs mt-1">{{ field.errors }}</p>
-          {% endif %}
-        </div>
-        {% endfor %}
+{% include 'components/hero.html' with title=_('Tokens de API') %}
+<section class="max-w-3xl mx-auto px-4 py-12 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+  <div class="card">
+    <div class="card-header">
+      <h2 class="text-xl font-semibold">{% trans "Tokens de API" %}</h2>
+    </div>
+    <div class="card-body">
+      {% if tokens %}
+      <div class="overflow-x-auto">
+        <table class="min-w-full divide-y divide-neutral-200">
+          <thead class="bg-neutral-50">
+            <tr>
+              <th class="px-4 py-2 text-left text-sm font-medium text-neutral-700">{% trans "Cliente" %}</th>
+              <th class="px-4 py-2 text-left text-sm font-medium text-neutral-700">{% trans "Escopo" %}</th>
+              <th class="px-4 py-2 text-left text-sm font-medium text-neutral-700">{% trans "Ações" %}</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-neutral-200">
+            {% for token in tokens %}
+            <tr>
+              <td class="px-4 py-2 text-sm text-neutral-900">{{ token.client_name }}</td>
+              <td class="px-4 py-2 text-sm text-neutral-900">{{ token.get_scope_display }}</td>
+              <td class="px-4 py-2 text-sm">
+                {% if token.revoked_at %}
+                  <span class="text-neutral-400">{% trans "Revogado" %}</span>
+                {% else %}
+                <form method="post" action="{% url 'tokens:revogar_api_token' token.id %}" hx-confirm="{% trans 'Confirmar revogação?' %}">
+                  {% csrf_token %}
+                  <button type="submit" class="text-red-600 hover:underline">{% trans "Revogar" %}</button>
+                </form>
+                {% endif %}
+              </td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
       </div>
-      <div class="flex justify-end gap-3 pt-4 border-t border-neutral-100">
-        <button type="submit" class="text-sm px-4 py-2 rounded-xl bg-primary-600 text-white hover:bg-primary-700">{% trans "Gerar Token" %}</button>
-      </div>
-    </form>
-    <div id="resultado" class="mt-6 text-center" aria-live="polite">
-      {% include "tokens/_resultado.html" %}
+      {% else %}
+        <p class="text-sm text-neutral-600">{% trans "Nenhum token de API encontrado." %}</p>
+      {% endif %}
     </div>
   </div>
-  <div class="mt-6 text-center">
-    <a href="{% url 'configuracoes' %}" class="text-sm text-blue-600 hover:underline">{% trans "Voltar ao painel de segurança" %}</a>
+  <div class="card">
+    <div class="card-header">
+      <h2 class="text-xl font-semibold">{% trans "Gerar novo token" %}</h2>
+    </div>
+    <div class="card-body">
+      <form method="post" action="{% url 'tokens:gerar_api_token' %}" hx-post="{% url 'tokens:gerar_api_token' %}" hx-target="#resultado" hx-swap="innerHTML" class="space-y-6">
+        {% csrf_token %}
+        <div class="space-y-4">
+          {% for field in form %}
+          <div>
+            <label for="{{ field.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ field.label }}</label>
+            {% if field.field.widget.input_type == 'select' %}
+              {{ field|add_class:"form-select" }}
+            {% else %}
+              {{ field|add_class:"form-input" }}
+            {% endif %}
+            {% if field.errors %}
+              <p class="text-red-500 text-xs mt-1">{{ field.errors }}</p>
+            {% endif %}
+          </div>
+          {% endfor %}
+        </div>
+        <div class="flex justify-end gap-3 pt-4 border-t border-neutral-100">
+          <button type="submit" class="text-sm px-4 py-2 rounded-xl bg-primary-600 text-white hover:bg-primary-700">{% trans "Gerar Token" %}</button>
+        </div>
+      </form>
+      <div id="resultado" class="mt-6 text-center" aria-live="polite">
+        {% include "tokens/_resultado.html" %}
+      </div>
+      <div class="mt-6 text-center">
+        <a href="{% url 'configuracoes' %}" class="text-sm text-blue-600 hover:underline">{% trans "Voltar ao painel de segurança" %}</a>
+      </div>
+    </div>
   </div>
 </section>
 {% endblock %}


### PR DESCRIPTION
## Summary
- replace manual headings with hero component in briefing and API token templates
- wrap forms and tables in card layout with responsive grid

## Testing
- `pytest eventos tokens` *(fails: ModuleNotFoundError: No module named 'factory')*

------
https://chatgpt.com/codex/tasks/task_e_68bb4adc85388325a8d077b534958ccd