### PR TITLE
Add aria-hidden to decorative SVG icons

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -78,21 +78,23 @@
             </button>
           </div>
           <a href="#" class="relative" aria-label="{% trans 'Notificações' %}">
-            <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <path d="M10 21a1 1 0 0 0 2 0" />
               <path d="M18 8a6 6 0 1 0-12 0c0 7-3 9-3 9h18s-3-2-3-9" />
             </svg>
+            <span class="sr-only">{% trans "Notificações" %}</span>
           </a>
           {% if request.user.is_authenticated %}
           <a href="{% url 'accounts:perfil' %}" class="block w-8 h-8 rounded-full overflow-hidden" aria-label="{% trans 'Perfil' %}">
             {% if request.user.avatar %}
             <img src="{{ request.user.avatar.url }}" alt="{{ request.user.username }}" class="w-full h-full object-cover" />
             {% else %}
-            <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2" />
               <circle cx="12" cy="7" r="4" />
             </svg>
             {% endif %}
+            <span class="sr-only">{% trans "Perfil" %}</span>
           </a>
           {% endif %}
         </div>

--- a/templates/components/nav_sidebar.html
+++ b/templates/components/nav_sidebar.html
@@ -3,7 +3,7 @@
   <div class="flex items-center justify-between p-4 border-b">
     <a href="/" class="text-2xl font-bold text-primary" aria-label="{% trans 'Página inicial' %}" aria-current="{% if request.path == '/' %}page{% endif %}"><span class="sidebar-label">HubX</span></a>
     <button id="sidebar-toggle" class="text-gray-800" aria-label="{% trans 'Alternar menu' %}" aria-controls="sidebar" aria-expanded="true">
-      <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
         <path d="M4 5h16" />
         <path d="M4 12h16" />
         <path d="M4 19h16" />
@@ -17,18 +17,19 @@
           {% if user.avatar %}
             <img src="{{ user.avatar.url }}" alt="{{ user.username }}" class="w-6 h-6 rounded-full object-cover" />
           {% else %}
-            <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2" />
               <circle cx="12" cy="7" r="4" />
             </svg>
           {% endif %}
+          <span class="sr-only">{% trans "Perfil" %}</span>
         </a>
         <span id="notif-count" class="hidden"></span>
       {% endif %}
 
       {% if user.user_type == 'admin' or user.user_type == 'coordenador' %}
         <a href="/" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Dashboard' %}" aria-current="{% if request.path == '/' %}page{% endif %}">
-          <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <rect width="7" height="9" x="3" y="3" rx="1" />
             <rect width="7" height="5" x="14" y="3" rx="1" />
             <rect width="7" height="9" x="14" y="12" rx="1" />
@@ -37,7 +38,7 @@
         </a>
         {% url 'associados_lista' as associados_lista_url %}
         <a href="{{ associados_lista_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Associados' %}" aria-current="{% if request.path == associados_lista_url %}page{% endif %}">
-          <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
             <path d="M16 3.128a4 4 0 0 1 0 7.744" />
             <path d="M22 21v-2a4 4 0 0 0-3-3.87" />
@@ -46,7 +47,7 @@
         </a>
         {% url 'empresas:lista' as empresas_lista_url %}
         <a href="{{ empresas_lista_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Empresas' %}" aria-current="{% if request.path == empresas_lista_url %}page{% endif %}">
-          <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <path d="M6 22V4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v18Z" />
             <path d="M6 12H4a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h2" />
             <path d="M18 9h2a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2h-2" />
@@ -58,7 +59,7 @@
         </a>
         {% url 'nucleos:list' as nucleos_list_url %}
         <a href="{{ nucleos_list_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Núcleos' %}" aria-current="{% if request.path == nucleos_list_url %}page{% endif %}">
-          <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
             <path d="M16 3.128a4 4 0 0 1 0 7.744" />
             <path d="M22 21v-2a4 4 0 0 0-3-3.87" />
@@ -67,7 +68,7 @@
         </a>
         {% url 'eventos:lista' as eventos_lista_url %}
         <a href="{{ eventos_lista_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Eventos' %}" aria-current="{% if request.path == eventos_lista_url %}page{% endif %}">
-          <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <path d="M8 2v4" />
             <path d="M16 2v4" />
             <rect width="18" height="18" x="3" y="4" rx="2" />
@@ -82,7 +83,7 @@
         </a>
         {% url 'feed:listar' as feed_listar_url %}
         <a href="{{ feed_listar_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Feed' %}" aria-current="{% if request.path == feed_listar_url %}page{% endif %}">
-          <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <path d="M4 11a9 9 0 0 1 9 9" />
             <path d="M4 4a16 16 0 0 1 16 16" />
             <circle cx="5" cy="19" r="1" />
@@ -90,7 +91,7 @@
         </a>
         {% url 'financeiro:repasses' as financeiro_repasses_url %}
         <a href="{{ financeiro_repasses_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Financeiro' %}" aria-current="{% if request.path == financeiro_repasses_url %}page{% endif %}">
-          <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <path d="M11 15h2a2 2 0 1 0 0-4h-3c-.6 0-1.1.2-1.4.6L3 17" />
             <path d="m7 21 1.6-1.4c.3-.4.8-.6 1.4-.6h4c1.1 0 2.1-.4 2.8-1.2l4.6-4.4a2 2 0 0 0-2.75-2.91l-4.2 3.9" />
             <path d="m2 16 6 6" />
@@ -100,7 +101,7 @@
         </a>
         {% url 'tokens:listar_api_tokens' as listar_api_tokens_url %}
         <a href="{{ listar_api_tokens_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Tokens' %}" aria-current="{% if request.path == listar_api_tokens_url %}page{% endif %}">
-          <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <path d="m15.5 7.5 2.3 2.3a1 1 0 0 0 1.4 0l2.1-2.1a1 1 0 0 0 0-1.4L19 4" />
             <path d="m21 2-9.6 9.6" />
             <circle cx="7.5" cy="15.5" r="5.5" />
@@ -108,14 +109,14 @@
         </a>
         {% url 'configuracoes' as configuracoes_url %}
         <a href="{{ configuracoes_url }}" class="hover:text-primary transition" aria-label="{% trans 'Configurações' %}" aria-current="{% if request.path == configuracoes_url %}page{% endif %}">
-          <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <path d="M9.671 4.136a2.34 2.34 0 0 1 4.659 0 2.34 2.34 0 0 0 3.319 1.915 2.34 2.34 0 0 1 2.33 4.033 2.34 2.34 0 0 0 0 3.831 2.34 2.34 0 0 1-2.33 4.033 2.34 2.34 0 0 0-3.319 1.915 2.34 2.34 0 0 1-4.659 0 2.34 2.34 0 0 0-3.32-1.915 2.34 2.34 0 0 1-2.33-4.033 2.34 2.34 0 0 0 0-3.831A2.34 2.34 0 0 1 6.35 6.051a2.34 2.34 0 0 0 3.319-1.915" />
             <circle cx="12" cy="12" r="3" />
           </svg><span class="sidebar-label">{% trans "Configurações" %}</span>
         </a>
         {% url 'accounts:logout' as logout_url %}
         <a href="{{ logout_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Sair' %}" aria-current="{% if request.path == logout_url %}page{% endif %}">
-          <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <path d="m16 17 5-5-5-5" />
             <path d="M21 12H9" />
             <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
@@ -123,7 +124,7 @@
         </a>
       {% else %}
         <a href="/" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Dashboard' %}" aria-current="{% if request.path == '/' %}page{% endif %}">
-          <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <rect width="7" height="9" x="3" y="3" rx="1" />
             <rect width="7" height="5" x="14" y="3" rx="1" />
             <rect width="7" height="9" x="14" y="12" rx="1" />
@@ -133,7 +134,7 @@
         {% if user.user_type != 'root' %}
           {% url 'empresas:lista' as empresas_lista_url %}
           <a href="{{ empresas_lista_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Empresas' %}" aria-current="{% if request.path == empresas_lista_url %}page{% endif %}">
-            <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <path d="M6 22V4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v18Z" />
               <path d="M6 12H4a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h2" />
               <path d="M18 9h2a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2h-2" />
@@ -147,7 +148,7 @@
         {% if user.user_type != 'root' %}
           {% url 'empresas:buscar' as empresas_buscar_url %}
           <a href="{{ empresas_buscar_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Buscar Empresas' %}" aria-current="{% if request.path == empresas_buscar_url %}page{% endif %}">
-            <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <path d="m21 21-4.34-4.34" />
               <circle cx="11" cy="11" r="8" />
             </svg><span class="sidebar-label">{% trans "Buscar Empresas" %}</span>
@@ -156,7 +157,7 @@
         {% if user.user_type != 'root' %}
           {% url 'eventos:lista' as eventos_lista_url %}
           <a href="{{ eventos_lista_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Eventos' %}" aria-current="{% if request.path == eventos_lista_url %}page{% endif %}">
-            <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <path d="M8 2v4" />
               <path d="M16 2v4" />
               <rect width="18" height="18" x="3" y="4" rx="2" />
@@ -173,7 +174,7 @@
         {% if user.user_type != 'root' %}
           {% url 'feed:listar' as feed_listar_url %}
           <a href="{{ feed_listar_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Feed' %}" aria-current="{% if request.path == feed_listar_url %}page{% endif %}">
-            <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <path d="M4 11a9 9 0 0 1 9 9" />
               <path d="M4 4a16 16 0 0 1 16 16" />
               <circle cx="5" cy="19" r="1" />
@@ -183,7 +184,7 @@
         {% if user.user_type != 'root' %}
           {% url 'nucleos:list' as nucleos_list_url %}
           <a href="{{ nucleos_list_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Núcleos' %}" aria-current="{% if request.path == nucleos_list_url %}page{% endif %}">
-            <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
               <path d="M16 3.128a4 4 0 0 1 0 7.744" />
               <path d="M22 21v-2a4 4 0 0 0-3-3.87" />
@@ -194,7 +195,7 @@
         {% if user.user_type != 'root' and user.user_type != 'admin' %}
           {% url 'nucleos:meus' as nucleos_meus_url %}
           <a href="{{ nucleos_meus_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Meus Núcleos' %}" aria-current="{% if request.path == nucleos_meus_url %}page{% endif %}">
-            <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
               <path d="M22 21v-2a4 4 0 0 0-3-3.87" />
               <circle cx="9" cy="7" r="4" />
@@ -205,7 +206,7 @@
           {% if user.user_type == 'financeiro' or user.user_type == 'admin' %}
             {% url 'financeiro:repasses' as financeiro_repasses_url %}
             <a href="{{ financeiro_repasses_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Financeiro' %}" aria-current="{% if request.path == financeiro_repasses_url %}page{% endif %}">
-              <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <path d="M11 15h2a2 2 0 1 0 0-4h-3c-.6 0-1.1.2-1.4.6L3 17" />
                 <path d="m7 21 1.6-1.4c.3-.4.8-.6 1.4-.6h4c1.1 0 2.1-.4 2.8-1.2l4.6-4.4a2 2 0 0 0-2.75-2.91l-4.2 3.9" />
                 <path d="m2 16 6 6" />
@@ -218,7 +219,7 @@
         {% if user.is_authenticated and user.user_type == 'root' %}
           {% url 'organizacoes:list' as organizacoes_list_url %}
           <a href="{{ organizacoes_list_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Organizações' %}" aria-current="{% if request.path == organizacoes_list_url %}page{% endif %}">
-            <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <rect x="16" y="16" width="6" height="6" rx="1" />
               <rect x="2" y="16" width="6" height="6" rx="1" />
               <rect x="9" y="2" width="6" height="6" rx="1" />
@@ -232,7 +233,7 @@
             {% if user.user_type == 'root' or user.user_type == 'admin' %}
               {% url 'tokens:listar_api_tokens' as listar_api_tokens_url %}
               <a href="{{ listar_api_tokens_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Token' %}" aria-current="{% if request.path == listar_api_tokens_url %}page{% endif %}">
-                <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                   <path d="m15.5 7.5 2.3 2.3a1 1 0 0 0 1.4 0l2.1-2.1a1 1 0 0 0 0-1.4L19 4" />
                   <path d="m21 2-9.6 9.6" />
                   <circle cx="7.5" cy="15.5" r="5.5" />
@@ -241,7 +242,7 @@
             {% else %}
               {% url 'tokens:gerar_convite' as gerar_convite_url %}
               <a href="{{ gerar_convite_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Token' %}" aria-current="{% if request.path == gerar_convite_url %}page{% endif %}">
-                <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                   <path d="m15.5 7.5 2.3 2.3a1 1 0 0 0 1.4 0l2.1-2.1a1 1 0 0 0 0-1.4L19 4" />
                   <path d="m21 2-9.6 9.6" />
                   <circle cx="7.5" cy="15.5" r="5.5" />
@@ -253,14 +254,14 @@
         {% if user.is_authenticated %}
           {% url 'configuracoes' as configuracoes_url %}
           <a href="{{ configuracoes_url }}" class="hover:text-primary transition" aria-label="{% trans 'Configurações' %}" aria-current="{% if request.path == configuracoes_url %}page{% endif %}">
-            <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <path d="M9.671 4.136a2.34 2.34 0 0 1 4.659 0 2.34 2.34 0 0 0 3.319 1.915 2.34 2.34 0 0 1 2.33 4.033 2.34 2.34 0 0 0 0 3.831 2.34 2.34 0 0 1-2.33 4.033 2.34 2.34 0 0 0-3.319 1.915 2.34 2.34 0 0 1-4.659 0 2.34 2.34 0 0 0-3.32-1.915 2.34 2.34 0 0 1-2.33-4.033 2.34 2.34 0 0 0 0-3.831A2.34 2.34 0 0 1 6.35 6.051a2.34 2.34 0 0 0 3.319-1.915" />
               <circle cx="12" cy="12" r="3" />
             </svg><span class="sidebar-label">{% trans "Configurações" %}</span>
           </a>
           {% url 'accounts:logout' as logout_url %}
           <a href="{{ logout_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Sair' %}" aria-current="{% if request.path == logout_url %}page{% endif %}">
-            <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <path d="m16 17 5-5-5-5" />
               <path d="M21 12H9" />
               <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
@@ -269,7 +270,7 @@
         {% else %}
           {% url 'accounts:login' as login_url %}
           <a href="{{ login_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Entrar' %}" aria-current="{% if request.path == login_url %}page{% endif %}">
-            <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <path d="m10 17 5-5-5-5" />
               <path d="M15 12H3" />
               <path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4" />
@@ -277,7 +278,7 @@
           </a>
           {% url 'accounts:onboarding' as onboarding_url %}
           <a href="{{ onboarding_url }}" class="flex items-center gap-x-2 bg-primary text-white py-2 px-4 rounded-xl hover:bg-primary/90 transition" aria-label="{% trans 'Cadastrar' %}" aria-current="{% if request.path == onboarding_url %}page{% endif %}">
-            <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
               <circle cx="9" cy="7" r="4" />
               <line x1="19" x2="19" y1="8" y2="14" />


### PR DESCRIPTION
## Summary
- add `aria-hidden="true"` to decorative icons in sidebar navigation
- expose screen reader text for icon-only profile and notification links

## Testing
- `pytest -m "not slow"` *(fails: 81 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4ae770cc832580f29e7d9eb802da