### PR TITLE
Wrap sidebar links in list

### DIFF
--- a/templates/components/nav_sidebar.html
+++ b/templates/components/nav_sidebar.html
@@ -10,10 +10,11 @@
       </svg>
     </button>
   </div>
-  <nav class="flex-1 overflow-y-auto px-4 py-4 flex flex-col gap-2 text-sm" role="navigation" aria-label="{% trans 'Menu' %}">
+  <nav class="flex-1 overflow-y-auto px-4 py-4" role="navigation" aria-label="{% trans 'Menu' %}">
+    <ul class="flex flex-col gap-2 text-sm">
       {% if user.is_authenticated %}
         {% url 'accounts:perfil' as perfil_url %}
-        <a href="{{ perfil_url }}" class="flex items-center hover:text-primary transition" aria-label="{% trans 'Perfil' %}" aria-current="{% if request.path == perfil_url %}page{% endif %}">
+        <li><a href="{{ perfil_url }}" class="flex items-center hover:text-primary transition" aria-label="{% trans 'Perfil' %}" aria-current="{% if request.path == perfil_url %}page{% endif %}">
           {% if user.avatar %}
             <img src="{{ user.avatar.url }}" alt="{{ user.username }}" class="w-6 h-6 rounded-full object-cover" />
           {% else %}
@@ -22,30 +23,29 @@
               <circle cx="12" cy="7" r="4" />
             </svg>
           {% endif %}
-        </a>
-        <span id="notif-count" class="hidden"></span>
+        </a><span id="notif-count" class="hidden"></span></li>
       {% endif %}
 
       {% if user.user_type == 'admin' or user.user_type == 'coordenador' %}
-        <a href="/" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Dashboard' %}" aria-current="{% if request.path == '/' %}page{% endif %}">
+        <li><a href="/" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Dashboard' %}" aria-current="{% if request.path == '/' %}page{% endif %}">
           <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <rect width="7" height="9" x="3" y="3" rx="1" />
             <rect width="7" height="5" x="14" y="3" rx="1" />
             <rect width="7" height="9" x="14" y="12" rx="1" />
             <rect width="7" height="5" x="3" y="16" rx="1" />
           </svg><span class="sidebar-label">{% trans "Dashboard" %}</span>
-        </a>
+        </a></li>
         {% url 'associados_lista' as associados_lista_url %}
-        <a href="{{ associados_lista_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Associados' %}" aria-current="{% if request.path == associados_lista_url %}page{% endif %}">
+        <li><a href="{{ associados_lista_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Associados' %}" aria-current="{% if request.path == associados_lista_url %}page{% endif %}">
           <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
             <path d="M16 3.128a4 4 0 0 1 0 7.744" />
             <path d="M22 21v-2a4 4 0 0 0-3-3.87" />
             <circle cx="9" cy="7" r="4" />
           </svg><span class="sidebar-label">{% trans "Associados" %}</span>
-        </a>
+        </a></li>
         {% url 'empresas:lista' as empresas_lista_url %}
-        <a href="{{ empresas_lista_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Empresas' %}" aria-current="{% if request.path == empresas_lista_url %}page{% endif %}">
+        <li><a href="{{ empresas_lista_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Empresas' %}" aria-current="{% if request.path == empresas_lista_url %}page{% endif %}">
           <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <path d="M6 22V4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v18Z" />
             <path d="M6 12H4a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h2" />
@@ -55,18 +55,18 @@
             <path d="M10 14h4" />
             <path d="M10 18h4" />
           </svg><span class="sidebar-label">{% trans "Empresas" %}</span>
-        </a>
+        </a></li>
         {% url 'nucleos:list' as nucleos_list_url %}
-        <a href="{{ nucleos_list_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Núcleos' %}" aria-current="{% if request.path == nucleos_list_url %}page{% endif %}">
+        <li><a href="{{ nucleos_list_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Núcleos' %}" aria-current="{% if request.path == nucleos_list_url %}page{% endif %}">
           <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
             <path d="M16 3.128a4 4 0 0 1 0 7.744" />
             <path d="M22 21v-2a4 4 0 0 0-3-3.87" />
             <circle cx="9" cy="7" r="4" />
           </svg><span class="sidebar-label">{% trans "Núcleos" %}</span>
-        </a>
+        </a></li>
         {% url 'eventos:lista' as eventos_lista_url %}
-        <a href="{{ eventos_lista_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Eventos' %}" aria-current="{% if request.path == eventos_lista_url %}page{% endif %}">
+        <li><a href="{{ eventos_lista_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Eventos' %}" aria-current="{% if request.path == eventos_lista_url %}page{% endif %}">
           <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <path d="M8 2v4" />
             <path d="M16 2v4" />
@@ -79,17 +79,17 @@
             <path d="M12 18h.01" />
             <path d="M16 18h.01" />
           </svg><span class="sidebar-label">{% trans "Eventos" %}</span>
-        </a>
+        </a></li>
         {% url 'feed:listar' as feed_listar_url %}
-        <a href="{{ feed_listar_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Feed' %}" aria-current="{% if request.path == feed_listar_url %}page{% endif %}">
+        <li><a href="{{ feed_listar_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Feed' %}" aria-current="{% if request.path == feed_listar_url %}page{% endif %}">
           <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <path d="M4 11a9 9 0 0 1 9 9" />
             <path d="M4 4a16 16 0 0 1 16 16" />
             <circle cx="5" cy="19" r="1" />
           </svg><span class="sidebar-label">{% trans "Feed" %}</span>
-        </a>
+        </a></li>
         {% url 'financeiro:repasses' as financeiro_repasses_url %}
-        <a href="{{ financeiro_repasses_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Financeiro' %}" aria-current="{% if request.path == financeiro_repasses_url %}page{% endif %}">
+        <li><a href="{{ financeiro_repasses_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Financeiro' %}" aria-current="{% if request.path == financeiro_repasses_url %}page{% endif %}">
           <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <path d="M11 15h2a2 2 0 1 0 0-4h-3c-.6 0-1.1.2-1.4.6L3 17" />
             <path d="m7 21 1.6-1.4c.3-.4.8-.6 1.4-.6h4c1.1 0 2.1-.4 2.8-1.2l4.6-4.4a2 2 0 0 0-2.75-2.91l-4.2 3.9" />
@@ -97,42 +97,42 @@
             <circle cx="16" cy="9" r="2.9" />
             <circle cx="6" cy="5" r="3" />
           </svg><span class="sidebar-label">{% trans "Financeiro" %}</span>
-        </a>
+        </a></li>
         {% url 'tokens:listar_api_tokens' as listar_api_tokens_url %}
-        <a href="{{ listar_api_tokens_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Tokens' %}" aria-current="{% if request.path == listar_api_tokens_url %}page{% endif %}">
+        <li><a href="{{ listar_api_tokens_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Tokens' %}" aria-current="{% if request.path == listar_api_tokens_url %}page{% endif %}">
           <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <path d="m15.5 7.5 2.3 2.3a1 1 0 0 0 1.4 0l2.1-2.1a1 1 0 0 0 0-1.4L19 4" />
             <path d="m21 2-9.6 9.6" />
             <circle cx="7.5" cy="15.5" r="5.5" />
           </svg><span class="sidebar-label">{% trans "Tokens" %}</span>
-        </a>
+        </a></li>
         {% url 'configuracoes' as configuracoes_url %}
-        <a href="{{ configuracoes_url }}" class="hover:text-primary transition" aria-label="{% trans 'Configurações' %}" aria-current="{% if request.path == configuracoes_url %}page{% endif %}">
+        <li><a href="{{ configuracoes_url }}" class="hover:text-primary transition" aria-label="{% trans 'Configurações' %}" aria-current="{% if request.path == configuracoes_url %}page{% endif %}">
           <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <path d="M9.671 4.136a2.34 2.34 0 0 1 4.659 0 2.34 2.34 0 0 0 3.319 1.915 2.34 2.34 0 0 1 2.33 4.033 2.34 2.34 0 0 0 0 3.831 2.34 2.34 0 0 1-2.33 4.033 2.34 2.34 0 0 0-3.319 1.915 2.34 2.34 0 0 1-4.659 0 2.34 2.34 0 0 0-3.32-1.915 2.34 2.34 0 0 1-2.33-4.033 2.34 2.34 0 0 0 0-3.831A2.34 2.34 0 0 1 6.35 6.051a2.34 2.34 0 0 0 3.319-1.915" />
             <circle cx="12" cy="12" r="3" />
           </svg><span class="sidebar-label">{% trans "Configurações" %}</span>
-        </a>
+        </a></li>
         {% url 'accounts:logout' as logout_url %}
-        <a href="{{ logout_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Sair' %}" aria-current="{% if request.path == logout_url %}page{% endif %}">
+        <li><a href="{{ logout_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Sair' %}" aria-current="{% if request.path == logout_url %}page{% endif %}">
           <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <path d="m16 17 5-5-5-5" />
             <path d="M21 12H9" />
             <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
           </svg><span class="sidebar-label">{% trans "Sair" %}</span>
-        </a>
+        </a></li>
       {% else %}
-        <a href="/" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Dashboard' %}" aria-current="{% if request.path == '/' %}page{% endif %}">
+        <li><a href="/" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Dashboard' %}" aria-current="{% if request.path == '/' %}page{% endif %}">
           <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <rect width="7" height="9" x="3" y="3" rx="1" />
             <rect width="7" height="5" x="14" y="3" rx="1" />
             <rect width="7" height="9" x="14" y="12" rx="1" />
             <rect width="7" height="5" x="3" y="16" rx="1" />
           </svg><span class="sidebar-label">{% trans "Dashboard" %}</span>
-        </a>
+        </a></li>
         {% if user.user_type != 'root' %}
           {% url 'empresas:lista' as empresas_lista_url %}
-          <a href="{{ empresas_lista_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Empresas' %}" aria-current="{% if request.path == empresas_lista_url %}page{% endif %}">
+          <li><a href="{{ empresas_lista_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Empresas' %}" aria-current="{% if request.path == empresas_lista_url %}page{% endif %}">
             <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <path d="M6 22V4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v18Z" />
               <path d="M6 12H4a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h2" />
@@ -142,20 +142,20 @@
               <path d="M10 14h4" />
               <path d="M10 18h4" />
             </svg><span class="sidebar-label">{% trans "Empresas" %}</span>
-          </a>
+          </a></li>
         {% endif %}
         {% if user.user_type != 'root' %}
           {% url 'empresas:buscar' as empresas_buscar_url %}
-          <a href="{{ empresas_buscar_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Buscar Empresas' %}" aria-current="{% if request.path == empresas_buscar_url %}page{% endif %}">
+          <li><a href="{{ empresas_buscar_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Buscar Empresas' %}" aria-current="{% if request.path == empresas_buscar_url %}page{% endif %}">
             <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <path d="m21 21-4.34-4.34" />
               <circle cx="11" cy="11" r="8" />
             </svg><span class="sidebar-label">{% trans "Buscar Empresas" %}</span>
-          </a>
+          </a></li>
         {% endif %}
         {% if user.user_type != 'root' %}
           {% url 'eventos:lista' as eventos_lista_url %}
-          <a href="{{ eventos_lista_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Eventos' %}" aria-current="{% if request.path == eventos_lista_url %}page{% endif %}">
+          <li><a href="{{ eventos_lista_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Eventos' %}" aria-current="{% if request.path == eventos_lista_url %}page{% endif %}">
             <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <path d="M8 2v4" />
               <path d="M16 2v4" />
@@ -168,43 +168,43 @@
               <path d="M12 18h.01" />
               <path d="M16 18h.01" />
             </svg><span class="sidebar-label">{% trans "Eventos" %}</span>
-          </a>
+          </a></li>
         {% endif %}
         {% if user.user_type != 'root' %}
           {% url 'feed:listar' as feed_listar_url %}
-          <a href="{{ feed_listar_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Feed' %}" aria-current="{% if request.path == feed_listar_url %}page{% endif %}">
+          <li><a href="{{ feed_listar_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Feed' %}" aria-current="{% if request.path == feed_listar_url %}page{% endif %}">
             <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <path d="M4 11a9 9 0 0 1 9 9" />
               <path d="M4 4a16 16 0 0 1 16 16" />
               <circle cx="5" cy="19" r="1" />
             </svg><span class="sidebar-label">{% trans "Feed" %}</span>
-          </a>
+          </a></li>
         {% endif %}
         {% if user.user_type != 'root' %}
           {% url 'nucleos:list' as nucleos_list_url %}
-          <a href="{{ nucleos_list_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Núcleos' %}" aria-current="{% if request.path == nucleos_list_url %}page{% endif %}">
+          <li><a href="{{ nucleos_list_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Núcleos' %}" aria-current="{% if request.path == nucleos_list_url %}page{% endif %}">
             <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
               <path d="M16 3.128a4 4 0 0 1 0 7.744" />
               <path d="M22 21v-2a4 4 0 0 0-3-3.87" />
               <circle cx="9" cy="7" r="4" />
             </svg><span class="sidebar-label">{% trans "Núcleos" %}</span>
-          </a>
+          </a></li>
         {% endif %}
         {% if user.user_type != 'root' and user.user_type != 'admin' %}
           {% url 'nucleos:meus' as nucleos_meus_url %}
-          <a href="{{ nucleos_meus_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Meus Núcleos' %}" aria-current="{% if request.path == nucleos_meus_url %}page{% endif %}">
+          <li><a href="{{ nucleos_meus_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Meus Núcleos' %}" aria-current="{% if request.path == nucleos_meus_url %}page{% endif %}">
             <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
               <path d="M22 21v-2a4 4 0 0 0-3-3.87" />
               <circle cx="9" cy="7" r="4" />
             </svg><span class="sidebar-label">{% trans "Meus Núcleos" %}</span>
-          </a>
+          </a></li>
         {% endif %}
         {% if user.is_authenticated %}
           {% if user.user_type == 'financeiro' or user.user_type == 'admin' %}
             {% url 'financeiro:repasses' as financeiro_repasses_url %}
-            <a href="{{ financeiro_repasses_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Financeiro' %}" aria-current="{% if request.path == financeiro_repasses_url %}page{% endif %}">
+            <li><a href="{{ financeiro_repasses_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Financeiro' %}" aria-current="{% if request.path == financeiro_repasses_url %}page{% endif %}">
               <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <path d="M11 15h2a2 2 0 1 0 0-4h-3c-.6 0-1.1.2-1.4.6L3 17" />
                 <path d="m7 21 1.6-1.4c.3-.4.8-.6 1.4-.6h4c1.1 0 2.1-.4 2.8-1.2l4.6-4.4a2 2 0 0 0-2.75-2.91l-4.2 3.9" />
@@ -212,12 +212,12 @@
                 <circle cx="16" cy="9" r="2.9" />
                 <circle cx="6" cy="5" r="3" />
               </svg><span class="sidebar-label">{% trans "Financeiro" %}</span>
-            </a>
+            </a></li>
           {% endif %}
         {% endif %}
         {% if user.is_authenticated and user.user_type == 'root' %}
           {% url 'organizacoes:list' as organizacoes_list_url %}
-          <a href="{{ organizacoes_list_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Organizações' %}" aria-current="{% if request.path == organizacoes_list_url %}page{% endif %}">
+          <li><a href="{{ organizacoes_list_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Organizações' %}" aria-current="{% if request.path == organizacoes_list_url %}page{% endif %}">
             <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <rect x="16" y="16" width="6" height="6" rx="1" />
               <rect x="2" y="16" width="6" height="6" rx="1" />
@@ -225,69 +225,70 @@
               <path d="M5 16v-3a1 1 0 0 1 1-1h12a1 1 0 0 1 1 1v3" />
               <path d="M12 12V8" />
             </svg><span class="sidebar-label">{% trans "Organizações" %}</span>
-          </a>
+          </a></li>
         {% endif %}
         {% if user.is_authenticated %}
           {% if user.user_type == 'root' or user.user_type == 'admin' or user.user_type == 'coordenador' %}
             {% if user.user_type == 'root' or user.user_type == 'admin' %}
               {% url 'tokens:listar_api_tokens' as listar_api_tokens_url %}
-              <a href="{{ listar_api_tokens_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Token' %}" aria-current="{% if request.path == listar_api_tokens_url %}page{% endif %}">
+              <li><a href="{{ listar_api_tokens_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Token' %}" aria-current="{% if request.path == listar_api_tokens_url %}page{% endif %}">
                 <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                   <path d="m15.5 7.5 2.3 2.3a1 1 0 0 0 1.4 0l2.1-2.1a1 1 0 0 0 0-1.4L19 4" />
                   <path d="m21 2-9.6 9.6" />
                   <circle cx="7.5" cy="15.5" r="5.5" />
                 </svg><span class="sidebar-label">{% trans "Token" %}</span>
-              </a>
+              </a></li>
             {% else %}
               {% url 'tokens:gerar_convite' as gerar_convite_url %}
-              <a href="{{ gerar_convite_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Token' %}" aria-current="{% if request.path == gerar_convite_url %}page{% endif %}">
+              <li><a href="{{ gerar_convite_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Token' %}" aria-current="{% if request.path == gerar_convite_url %}page{% endif %}">
                 <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                   <path d="m15.5 7.5 2.3 2.3a1 1 0 0 0 1.4 0l2.1-2.1a1 1 0 0 0 0-1.4L19 4" />
                   <path d="m21 2-9.6 9.6" />
                   <circle cx="7.5" cy="15.5" r="5.5" />
                 </svg><span class="sidebar-label">{% trans "Token" %}</span>
-              </a>
+              </a></li>
             {% endif %}
           {% endif %}
         {% endif %}
         {% if user.is_authenticated %}
           {% url 'configuracoes' as configuracoes_url %}
-          <a href="{{ configuracoes_url }}" class="hover:text-primary transition" aria-label="{% trans 'Configurações' %}" aria-current="{% if request.path == configuracoes_url %}page{% endif %}">
+          <li><a href="{{ configuracoes_url }}" class="hover:text-primary transition" aria-label="{% trans 'Configurações' %}" aria-current="{% if request.path == configuracoes_url %}page{% endif %}">
             <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <path d="M9.671 4.136a2.34 2.34 0 0 1 4.659 0 2.34 2.34 0 0 0 3.319 1.915 2.34 2.34 0 0 1 2.33 4.033 2.34 2.34 0 0 0 0 3.831 2.34 2.34 0 0 1-2.33 4.033 2.34 2.34 0 0 0-3.319 1.915 2.34 2.34 0 0 1-4.659 0 2.34 2.34 0 0 0-3.32-1.915 2.34 2.34 0 0 1-2.33-4.033 2.34 2.34 0 0 0 0-3.831A2.34 2.34 0 0 1 6.35 6.051a2.34 2.34 0 0 0 3.319-1.915" />
               <circle cx="12" cy="12" r="3" />
             </svg><span class="sidebar-label">{% trans "Configurações" %}</span>
-          </a>
+          </a></li>
           {% url 'accounts:logout' as logout_url %}
-          <a href="{{ logout_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Sair' %}" aria-current="{% if request.path == logout_url %}page{% endif %}">
+          <li><a href="{{ logout_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Sair' %}" aria-current="{% if request.path == logout_url %}page{% endif %}">
             <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <path d="m16 17 5-5-5-5" />
               <path d="M21 12H9" />
               <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
             </svg><span class="sidebar-label">{% trans "Sair" %}</span>
-          </a>
+          </a></li>
         {% else %}
           {% url 'accounts:login' as login_url %}
-          <a href="{{ login_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Entrar' %}" aria-current="{% if request.path == login_url %}page{% endif %}">
+          <li><a href="{{ login_url }}" class="flex items-center gap-x-2 hover:text-primary transition" aria-label="{% trans 'Entrar' %}" aria-current="{% if request.path == login_url %}page{% endif %}">
             <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <path d="m10 17 5-5-5-5" />
               <path d="M15 12H3" />
               <path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4" />
             </svg><span class="sidebar-label">{% trans "Entrar" %}</span>
-          </a>
+          </a></li>
           {% url 'accounts:onboarding' as onboarding_url %}
-          <a href="{{ onboarding_url }}" class="flex items-center gap-x-2 bg-primary text-white py-2 px-4 rounded-xl hover:bg-primary/90 transition" aria-label="{% trans 'Cadastrar' %}" aria-current="{% if request.path == onboarding_url %}page{% endif %}">
+          <li><a href="{{ onboarding_url }}" class="flex items-center gap-x-2 bg-primary text-white py-2 px-4 rounded-xl hover:bg-primary/90 transition" aria-label="{% trans 'Cadastrar' %}" aria-current="{% if request.path == onboarding_url %}page{% endif %}">
             <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
               <circle cx="9" cy="7" r="4" />
               <line x1="19" x2="19" y1="8" y2="14" />
               <line x1="22" x2="16" y1="11" y2="11" />
             </svg><span class="sidebar-label">{% trans "Cadastrar" %}</span>
-          </a>
+          </a></li>
         {% endif %}
       {% endif %}
+    </ul>
 
-      <div class="flex items-center gap-2" role="group" aria-label="{% trans 'Tema' %}">
+    <div class="flex items-center gap-2" role="group" aria-label="{% trans 'Tema' %}">
         <button
           type="button"
           class="btn-secondary btn-sm aria-pressed:bg-primary aria-pressed:text-white aria-pressed:border-primary"


### PR DESCRIPTION
## Summary
- wrap navigation links in sidebar within semantic `<ul>`/`<li>` structure
- preserve `aria-current` and `sidebar-label` classes on each link

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'silk')*

------
https://chatgpt.com/codex/tasks/task_e_68bb4aee54b083259e6fdaa8cbfe1ead