### PR TITLE
chore: remove sidebar theme selector

### DIFF
--- a/templates/components/nav_sidebar.html
+++ b/templates/components/nav_sidebar.html
@@ -314,30 +314,6 @@ n
         {% endif %}
       {% endif %}
     </ul>
-
-    <div class="flex items-center gap-2" role="group" aria-label="{% trans 'Tema' %}">
-        <button
-          type="button"
-          class="btn-secondary btn-sm aria-pressed:bg-primary aria-pressed:text-white aria-pressed:border-primary"
-          data-theme-option="claro"
-          aria-pressed="false">
-          {% trans "Claro" %}
-        </button>
-        <button
-          type="button"
-          class="btn-secondary btn-sm aria-pressed:bg-primary aria-pressed:text-white aria-pressed:border-primary"
-          data-theme-option="escuro"
-          aria-pressed="false">
-          {% trans "Escuro" %}
-        </button>
-        <button
-          type="button"
-          class="btn-secondary btn-sm aria-pressed:bg-primary aria-pressed:text-white aria-pressed:border-primary"
-          data-theme-option="automatico"
-          aria-pressed="false">
-          {% trans "Automático" %}
-        </button>
-      </div>
-    </nav>
+  </nav>
   </aside>
 


### PR DESCRIPTION
## Summary
- remove theme button group from sidebar
- keep header theme selector that syncs aria-pressed across `[data-theme-option]`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'silk'; 81 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bb588bf3a883258518f8df64071157