### PR TITLE
refactor: remove manual main wrappers

### DIFF
--- a/accounts/templates/associados/lista.html
+++ b/accounts/templates/associados/lista.html
@@ -4,54 +4,56 @@
 {% block title %}{% trans 'Associados' %}{% endblock %}
 
 {% block content %}
-<section class="max-w-6xl mx-auto mt-8 px-4">
-  <h1 class="text-2xl font-bold mb-6">{% trans 'Associados' %}</h1>
-  <form method="get" class="mb-6 flex gap-2">
-    <label for="q" class="sr-only">{% trans 'Buscar' %}</label>
-    <input
-      id="q"
-      name="q"
-      value="{{ request.GET.q }}"
-      class="border rounded px-3 py-2 flex-grow"
-      placeholder="{% trans 'Buscar' %}"
-    />
-    <button type="submit" class="bg-primary text-white px-4 py-2 rounded">{% trans 'Buscar' %}</button>
-  </form>
-  <!-- Cards de totais -->
-  <div class="mb-6 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-    <div class="p-4 rounded-2xl border border-neutral-200 bg-white shadow-sm">
-      <div class="text-sm text-neutral-500">{% trans 'Usuários' %}</div>
-      <div class="mt-1 text-2xl font-bold text-neutral-900">{{ total_usuarios }}</div>
-    </div>
-    <div class="p-4 rounded-2xl border border-neutral-200 bg-white shadow-sm">
-      <div class="text-sm text-neutral-500">{% trans 'Associados' %}</div>
-      <div class="mt-1 text-2xl font-bold text-neutral-900">{{ total_associados }}</div>
-    </div>
-    <div class="p-4 rounded-2xl border border-neutral-200 bg-white shadow-sm">
-      <div class="text-sm text-neutral-500">{% trans 'Nucleados' %}</div>
-      <div class="mt-1 text-2xl font-bold text-neutral-900">{{ total_nucleados }}</div>
+{% include 'components/hero.html' with title=_('Associados') %}
+<section class="container mt-8 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+  <div class="card col-span-full">
+    <div class="card-body">
+      <form method="get" class="mb-6 flex gap-2">
+        <label for="q" class="sr-only">{% trans 'Buscar' %}</label>
+        <input
+          id="q"
+          name="q"
+          value="{{ request.GET.q }}"
+          class="border rounded px-3 py-2 flex-grow"
+          placeholder="{% trans 'Buscar' %}"
+        />
+        <button type="submit" class="bg-primary text-white px-4 py-2 rounded">{% trans 'Buscar' %}</button>
+      </form>
+      <!-- Cards de totais -->
+      <div class="mb-6 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+        <div class="p-4 rounded-2xl border border-neutral-200 bg-white shadow-sm">
+          <div class="text-sm text-neutral-500">{% trans 'Usuários' %}</div>
+          <div class="mt-1 text-2xl font-bold text-neutral-900">{{ total_usuarios }}</div>
+        </div>
+        <div class="p-4 rounded-2xl border border-neutral-200 bg-white shadow-sm">
+          <div class="text-sm text-neutral-500">{% trans 'Associados' %}</div>
+          <div class="mt-1 text-2xl font-bold text-neutral-900">{{ total_associados }}</div>
+        </div>
+        <div class="p-4 rounded-2xl border border-neutral-200 bg-white shadow-sm">
+          <div class="text-sm text-neutral-500">{% trans 'Nucleados' %}</div>
+          <div class="mt-1 text-2xl font-bold text-neutral-900">{{ total_nucleados }}</div>
+        </div>
+      </div>
+      <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6" role="list" aria-label="{% trans 'Lista de usuários' %}">
+        {% for associado in associados %}
+          {% include 'associados/partials/card.html' with user=associado %}
+        {% empty %}
+          <p class="col-span-full text-center text-neutral-500">{% trans 'Nenhum associado encontrado.' %}</p>
+        {% endfor %}
+      </div>
+
+      {% if is_paginated %}
+      <nav class="mt-6 flex justify-center items-center gap-2">
+        {% if page_obj.has_previous %}
+          <a class="btn-secondary" href="?page={{ page_obj.previous_page_number }}&q={{ request.GET.q }}">{% trans 'Anterior' %}</a>
+        {% endif %}
+        <span class="text-sm text-neutral-600">{% blocktrans %}Página {{ page_obj.number }} de {{ page_obj.paginator.num_pages }}{% endblocktrans %}</span>
+        {% if page_obj.has_next %}
+          <a class="btn-secondary" href="?page={{ page_obj.next_page_number }}&q={{ request.GET.q }}">{% trans 'Próxima' %}</a>
+        {% endif %}
+      </nav>
+      {% endif %}
     </div>
   </div>
-  <main>
-    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4" role="list" aria-label="{% trans 'Lista de usuários' %}">
-      {% for associado in associados %}
-        {% include 'associados/partials/card.html' with user=associado %}
-      {% empty %}
-        <p class="col-span-full text-center text-neutral-500">{% trans 'Nenhum associado encontrado.' %}</p>
-      {% endfor %}
-    </div>
-  </main>
-
-  {% if is_paginated %}
-  <nav class="mt-6 flex justify-center items-center gap-2">
-    {% if page_obj.has_previous %}
-      <a class="btn-secondary" href="?page={{ page_obj.previous_page_number }}&q={{ request.GET.q }}">{% trans 'Anterior' %}</a>
-    {% endif %}
-    <span class="text-sm text-neutral-600">{% blocktrans %}Página {{ page_obj.number }} de {{ page_obj.paginator.num_pages }}{% endblocktrans %}</span>
-    {% if page_obj.has_next %}
-      <a class="btn-secondary" href="?page={{ page_obj.next_page_number }}&q={{ request.GET.q }}">{% trans 'Próxima' %}</a>
-    {% endif %}
-  </nav>
-  {% endif %}
 </section>
 {% endblock %}

--- a/dashboard/templates/dashboard/filter_form.html
+++ b/dashboard/templates/dashboard/filter_form.html
@@ -2,23 +2,27 @@
 {% load i18n %}
 {% block title %}{% trans 'Salvar filtro' %}{% endblock %}
 {% block content %}
-<main class="max-w-md mx-auto p-4" role="main">
-  <h1 class="text-2xl font-semibold mb-4">{% trans 'Salvar filtro' %}</h1>
-  <form method="post" class="space-y-4" aria-label="{% trans 'Formulário de filtro rápido' %}">
-    {% csrf_token %}
-    <div>
-      <label for="id_nome" class="block text-sm font-medium text-neutral-700">{% trans 'Nome' %}</label>
-      {{ form.nome }}
+{% include 'components/hero.html' with title=_('Salvar filtro') %}
+<section class="container grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+  <div class="card col-span-full">
+    <div class="card-body">
+      <form method="post" class="space-y-4" aria-label="{% trans 'Formulário de filtro rápido' %}">
+        {% csrf_token %}
+        <div>
+          <label for="id_nome" class="block text-sm font-medium text-neutral-700">{% trans 'Nome' %}</label>
+          {{ form.nome }}
+        </div>
+      {% if request.user.user_type == 'root' or request.user.user_type == 'admin' %}
+        <div class="flex items-center gap-2">
+          {{ form.publico }}
+          <label for="id_publico" class="text-sm text-neutral-700">{% trans 'Público' %}</label>
+        </div>
+        {% else %}
+        <p class="text-sm text-neutral-700">{% trans 'Apenas administradores podem publicar itens.' %}</p>
+        {% endif %}
+        <button type="submit" class="px-4 py-2 bg-primary-600 text-white rounded focus:outline-none focus:ring" aria-label="{% trans 'Salvar filtro' %}">{% trans 'Salvar' %}</button>
+      </form>
     </div>
-  {% if request.user.user_type == 'root' or request.user.user_type == 'admin' %}
-    <div class="flex items-center gap-2">
-      {{ form.publico }}
-      <label for="id_publico" class="text-sm text-neutral-700">{% trans 'Público' %}</label>
-    </div>
-    {% else %}
-    <p class="text-sm text-neutral-700">{% trans 'Apenas administradores podem publicar itens.' %}</p>
-    {% endif %}
-    <button type="submit" class="px-4 py-2 bg-primary-600 text-white rounded focus:outline-none focus:ring" aria-label="{% trans 'Salvar filtro' %}">{% trans 'Salvar' %}</button>
-  </form>
-</main>
+  </div>
+</section>
 {% endblock %}


### PR DESCRIPTION
## Summary
- use shared hero layout for associates list and dashboard filter form
- wrap lists and forms in cards with responsive grid and container classes

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'silk')*

------
https://chatgpt.com/codex/tasks/task_e_68bb605a330c8325a0c81ee4fc559ae4