### PR TITLE
style: apply floating labels to simple forms

### DIFF
--- a/accounts/templates/associados/lista.html
+++ b/accounts/templates/associados/lista.html
@@ -7,14 +7,19 @@
 <section class="max-w-6xl mx-auto mt-8 px-4">
   <h1 class="text-2xl font-bold mb-6">{% trans 'Associados' %}</h1>
   <form method="get" class="mb-6 flex gap-2">
-    <label for="q" class="sr-only">{% trans 'Buscar' %}</label>
-    <input
-      id="q"
-      name="q"
-      value="{{ request.GET.q }}"
-      class="border rounded px-3 py-2 flex-grow"
-      placeholder="{% trans 'Buscar' %}"
-    />
+    <div class="relative flex-grow">
+      <input
+        id="q"
+        name="q"
+        value="{{ request.GET.q }}"
+        class="peer placeholder-transparent border rounded px-3 py-2 w-full"
+        placeholder="{% trans 'Buscar' %}"
+      />
+      <label
+        for="q"
+        class="absolute left-3 -top-2 text-xs text-neutral-700 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600"
+      >{% trans 'Buscar' %}</label>
+    </div>
     <button type="submit" class="bg-primary text-white px-4 py-2 rounded">{% trans 'Buscar' %}</button>
   </form>
   <!-- Cards de totais -->

--- a/dashboard/templates/dashboard/config_form.html
+++ b/dashboard/templates/dashboard/config_form.html
@@ -1,19 +1,36 @@
 {% extends 'base.html' %}
-{% load i18n %}
+{% load i18n widget_tweaks %}
 {% block title %}{% trans 'Salvar configuração' %}{% endblock %}
 {% block content %}
 <main class="max-w-md mx-auto p-4" role="main">
   <h1 class="text-2xl font-semibold mb-4">{% trans 'Salvar configuração' %}</h1>
   <form method="post" class="space-y-4" aria-label="{% trans 'Formulário de configuração do dashboard' %}">
     {% csrf_token %}
-    <div>
-      <label for="id_nome" class="block text-sm font-medium text-neutral-700">{% trans 'Nome' %}</label>
-      {{ form.nome }}
+    {% trans 'Nome' as nome_label %}
+    <div class="relative">
+      {% if form.nome.errors %}
+        {% render_field form.nome class="peer placeholder-transparent w-full rounded border border-neutral-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder=nome_label aria-describedby="nome_error" aria-invalid="true" %}
+      {% else %}
+        {% render_field form.nome class="peer placeholder-transparent w-full rounded border border-neutral-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder=nome_label aria-describedby="nome_error" %}
+      {% endif %}
+      <label for="{{ form.nome.id_for_label }}" class="absolute left-3 -top-2 text-xs text-neutral-700 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600">{{ nome_label }}</label>
+      {% if form.nome.errors %}
+        <div id="nome_error" class="text-red-600 text-xs mt-1" role="alert">{{ form.nome.errors }}</div>
+      {% endif %}
     </div>
   {% if request.user.user_type == 'root' or request.user.user_type == 'admin' %}
-    <div class="flex items-center gap-2">
-      {{ form.publico }}
-      <label for="id_publico" class="text-sm text-neutral-700">{% trans 'Público' %}</label>
+    <div>
+      <div class="flex items-center gap-2">
+        {% if form.publico.errors %}
+          {% render_field form.publico aria-invalid="true" aria-describedby="publico_error" %}
+        {% else %}
+          {% render_field form.publico aria-describedby="publico_error" %}
+        {% endif %}
+        <label for="{{ form.publico.id_for_label }}" class="text-sm text-neutral-700">{% trans 'Público' %}</label>
+      </div>
+      {% if form.publico.errors %}
+        <div id="publico_error" class="text-red-600 text-xs mt-1" role="alert">{{ form.publico.errors }}</div>
+      {% endif %}
     </div>
     {% else %}
     <p class="text-sm text-neutral-700">{% trans 'Apenas administradores podem publicar itens.' %}</p>

--- a/dashboard/templates/dashboard/custom_metric_form.html
+++ b/dashboard/templates/dashboard/custom_metric_form.html
@@ -1,33 +1,73 @@
 {% extends 'base.html' %}
-{% load i18n %}
+{% load i18n widget_tweaks %}
 {% block title %}{% trans 'Métrica personalizada' %}{% endblock %}
 {% block content %}
 <main class="max-w-md mx-auto p-4" role="main">
   <h1 class="text-2xl font-semibold mb-4">{% trans 'Métrica personalizada' %}</h1>
-  <form method="post" class="space-y-4" aria-label="{% trans 'Formulário de métrica personalizada' %}">
-    {% csrf_token %}
-    <div>
-      <label for="id_code" class="block text-sm font-medium text-neutral-700">{% trans 'Código' %}</label>
-      {{ form.code }}
-    </div>
-    <div>
-      <label for="id_nome" class="block text-sm font-medium text-neutral-700">{% trans 'Nome' %}</label>
-      {{ form.nome }}
-    </div>
-    <div>
-      <label for="id_descricao" class="block text-sm font-medium text-neutral-700">{% trans 'Descrição' %}</label>
-      {{ form.descricao }}
-    </div>
-    <div>
-      <label for="id_query_spec" class="block text-sm font-medium text-neutral-700">{% trans 'Query spec' %}</label>
-      {{ form.query_spec }}
-    </div>
-    <div>
-      <label for="id_escopo" class="block text-sm font-medium text-neutral-700">{% trans 'Escopo' %}</label>
-      {{ form.escopo }}
-    </div>
-    <button type="submit" class="px-4 py-2 bg-primary-600 text-white rounded" aria-label="{% trans 'Salvar métrica' %}">{% trans 'Salvar' %}</button>
-  </form>
+    <form method="post" class="space-y-4" aria-label="{% trans 'Formulário de métrica personalizada' %}">
+      {% csrf_token %}
+      {% trans 'Código' as code_label %}
+      <div class="relative">
+        {% if form.code.errors %}
+          {% render_field form.code class="peer placeholder-transparent w-full rounded border border-neutral-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder=code_label aria-describedby="code_error" aria-invalid="true" %}
+        {% else %}
+          {% render_field form.code class="peer placeholder-transparent w-full rounded border border-neutral-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder=code_label aria-describedby="code_error" %}
+        {% endif %}
+        <label for="{{ form.code.id_for_label }}" class="absolute left-3 -top-2 text-xs text-neutral-700 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600">{{ code_label }}</label>
+        {% if form.code.errors %}
+          <div id="code_error" class="text-red-600 text-xs mt-1" role="alert">{{ form.code.errors }}</div>
+        {% endif %}
+      </div>
+      {% trans 'Nome' as nome_label %}
+      <div class="relative">
+        {% if form.nome.errors %}
+          {% render_field form.nome class="peer placeholder-transparent w-full rounded border border-neutral-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder=nome_label aria-describedby="nome_error" aria-invalid="true" %}
+        {% else %}
+          {% render_field form.nome class="peer placeholder-transparent w-full rounded border border-neutral-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder=nome_label aria-describedby="nome_error" %}
+        {% endif %}
+        <label for="{{ form.nome.id_for_label }}" class="absolute left-3 -top-2 text-xs text-neutral-700 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600">{{ nome_label }}</label>
+        {% if form.nome.errors %}
+          <div id="nome_error" class="text-red-600 text-xs mt-1" role="alert">{{ form.nome.errors }}</div>
+        {% endif %}
+      </div>
+      {% trans 'Descrição' as descricao_label %}
+      <div class="relative">
+        {% if form.descricao.errors %}
+          {% render_field form.descricao class="peer placeholder-transparent w-full rounded border border-neutral-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder=descricao_label aria-describedby="descricao_error" aria-invalid="true" %}
+        {% else %}
+          {% render_field form.descricao class="peer placeholder-transparent w-full rounded border border-neutral-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder=descricao_label aria-describedby="descricao_error" %}
+        {% endif %}
+        <label for="{{ form.descricao.id_for_label }}" class="absolute left-3 -top-2 text-xs text-neutral-700 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600">{{ descricao_label }}</label>
+        {% if form.descricao.errors %}
+          <div id="descricao_error" class="text-red-600 text-xs mt-1" role="alert">{{ form.descricao.errors }}</div>
+        {% endif %}
+      </div>
+      {% trans 'Query spec' as query_label %}
+      <div class="relative">
+        {% if form.query_spec.errors %}
+          {% render_field form.query_spec class="peer placeholder-transparent w-full rounded border border-neutral-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder=query_label aria-describedby="query_error" aria-invalid="true" %}
+        {% else %}
+          {% render_field form.query_spec class="peer placeholder-transparent w-full rounded border border-neutral-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder=query_label aria-describedby="query_error" %}
+        {% endif %}
+        <label for="{{ form.query_spec.id_for_label }}" class="absolute left-3 -top-2 text-xs text-neutral-700 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600">{{ query_label }}</label>
+        {% if form.query_spec.errors %}
+          <div id="query_error" class="text-red-600 text-xs mt-1" role="alert">{{ form.query_spec.errors }}</div>
+        {% endif %}
+      </div>
+      {% trans 'Escopo' as escopo_label %}
+      <div class="relative">
+        {% if form.escopo.errors %}
+          {% render_field form.escopo class="peer placeholder-transparent w-full rounded border border-neutral-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder=escopo_label aria-describedby="escopo_error" aria-invalid="true" %}
+        {% else %}
+          {% render_field form.escopo class="peer placeholder-transparent w-full rounded border border-neutral-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder=escopo_label aria-describedby="escopo_error" %}
+        {% endif %}
+        <label for="{{ form.escopo.id_for_label }}" class="absolute left-3 -top-2 text-xs text-neutral-700 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600">{{ escopo_label }}</label>
+        {% if form.escopo.errors %}
+          <div id="escopo_error" class="text-red-600 text-xs mt-1" role="alert">{{ form.escopo.errors }}</div>
+        {% endif %}
+      </div>
+      <button type="submit" class="px-4 py-2 bg-primary-600 text-white rounded" aria-label="{% trans 'Salvar métrica' %}">{% trans 'Salvar' %}</button>
+    </form>
 </main>
 {% endblock %}
 

--- a/dashboard/templates/dashboard/filter_form.html
+++ b/dashboard/templates/dashboard/filter_form.html
@@ -1,19 +1,36 @@
 {% extends 'base.html' %}
-{% load i18n %}
+{% load i18n widget_tweaks %}
 {% block title %}{% trans 'Salvar filtro' %}{% endblock %}
 {% block content %}
 <main class="max-w-md mx-auto p-4" role="main">
   <h1 class="text-2xl font-semibold mb-4">{% trans 'Salvar filtro' %}</h1>
   <form method="post" class="space-y-4" aria-label="{% trans 'Formulário de filtro rápido' %}">
     {% csrf_token %}
-    <div>
-      <label for="id_nome" class="block text-sm font-medium text-neutral-700">{% trans 'Nome' %}</label>
-      {{ form.nome }}
+    {% trans 'Nome' as nome_label %}
+    <div class="relative">
+      {% if form.nome.errors %}
+        {% render_field form.nome class="peer placeholder-transparent w-full rounded border border-neutral-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder=nome_label aria-describedby="nome_error" aria-invalid="true" %}
+      {% else %}
+        {% render_field form.nome class="peer placeholder-transparent w-full rounded border border-neutral-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder=nome_label aria-describedby="nome_error" %}
+      {% endif %}
+      <label for="{{ form.nome.id_for_label }}" class="absolute left-3 -top-2 text-xs text-neutral-700 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600">{{ nome_label }}</label>
+      {% if form.nome.errors %}
+        <div id="nome_error" class="text-red-600 text-xs mt-1" role="alert">{{ form.nome.errors }}</div>
+      {% endif %}
     </div>
   {% if request.user.user_type == 'root' or request.user.user_type == 'admin' %}
-    <div class="flex items-center gap-2">
-      {{ form.publico }}
-      <label for="id_publico" class="text-sm text-neutral-700">{% trans 'Público' %}</label>
+    <div>
+      <div class="flex items-center gap-2">
+        {% if form.publico.errors %}
+          {% render_field form.publico aria-invalid="true" aria-describedby="publico_error" %}
+        {% else %}
+          {% render_field form.publico aria-describedby="publico_error" %}
+        {% endif %}
+        <label for="{{ form.publico.id_for_label }}" class="text-sm text-neutral-700">{% trans 'Público' %}</label>
+      </div>
+      {% if form.publico.errors %}
+        <div id="publico_error" class="text-red-600 text-xs mt-1" role="alert">{{ form.publico.errors }}</div>
+      {% endif %}
     </div>
     {% else %}
     <p class="text-sm text-neutral-700">{% trans 'Apenas administradores podem publicar itens.' %}</p>

--- a/dashboard/templates/dashboard/layout_form.html
+++ b/dashboard/templates/dashboard/layout_form.html
@@ -1,19 +1,36 @@
 {% extends "base.html" %}
-{% load i18n static %}
+{% load i18n static widget_tweaks %}
 {% block title %}{% trans "Layout" %} | Hubx{% endblock %}
 {% block content %}
 <main class="max-w-7xl mx-auto p-4" role="main" aria-label="{% trans 'Layout form' %}">
   <h1 class="text-2xl mb-4">{% trans "Layout" %}</h1>
   <form method="post">
     {% csrf_token %}
-    <div class="mb-4">
-      <label for="id_nome" class="block mb-1">{% trans "Nome" %}</label>
-      {{ form.nome }}
+    {% trans "Nome" as nome_label %}
+    <div class="mb-4 relative">
+      {% if form.nome.errors %}
+        {% render_field form.nome class="peer placeholder-transparent w-full rounded border border-neutral-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder=nome_label aria-describedby="nome_error" aria-invalid="true" %}
+      {% else %}
+        {% render_field form.nome class="peer placeholder-transparent w-full rounded border border-neutral-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder=nome_label aria-describedby="nome_error" %}
+      {% endif %}
+      <label for="{{ form.nome.id_for_label }}" class="absolute left-3 -top-2 text-xs text-neutral-700 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600">{{ nome_label }}</label>
+      {% if form.nome.errors %}
+        <div id="nome_error" class="text-red-600 text-xs mt-1" role="alert">{{ form.nome.errors }}</div>
+      {% endif %}
     </div>
   {% if request.user.user_type == 'root' or request.user.user_type == 'admin' %}
     <div class="mb-4">
-      <label for="id_publico" class="block">{{ form.publico.label }}</label>
-      {{ form.publico }}
+      <div class="flex items-center gap-2">
+        {% if form.publico.errors %}
+          {% render_field form.publico aria-invalid="true" aria-describedby="publico_error" %}
+        {% else %}
+          {% render_field form.publico aria-describedby="publico_error" %}
+        {% endif %}
+        <label for="{{ form.publico.id_for_label }}" class="text-sm">{{ form.publico.label }}</label>
+      </div>
+      {% if form.publico.errors %}
+        <div id="publico_error" class="text-red-600 text-xs mt-1" role="alert">{{ form.publico.errors }}</div>
+      {% endif %}
     </div>
 
     {% else %}


### PR DESCRIPTION
## Summary
- apply floating label style to search on associados list
- update dashboard forms to use floating labels with accessible errors

## Testing
- `pytest` *(fails: 81 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bb606d5bdc83259ea2e09426c5c680