### PR TITLE
refactor: update form templates with floating labels

### DIFF
--- a/financeiro/templates/financeiro/extrato.html
+++ b/financeiro/templates/financeiro/extrato.html
@@ -11,22 +11,22 @@
         hx-trigger="change from:select,change from:input, submit"
         hx-on="htmx:afterRequest: renderLancamentos(event)">
     <legend class="sr-only">{{ _('Filtros') }}</legend>
-    <div>
-      <label for="filtro-status" class="block text-sm font-medium text-gray-700">{{ _('Status') }}</label>
-      <select name="status" id="filtro-status" class="border p-2 rounded">
+    <div class="relative">
+      <label for="filtro-status" class="label-float">{{ _('Status') }}</label>
+      <select name="status" id="filtro-status" class="peer placeholder-transparent form-input">
         <option value="">{{ _('Todos Status') }}</option>
         <option value="pendente">{{ _('Pendente') }}</option>
         <option value="pago">{{ _('Pago') }}</option>
         <option value="cancelado">{{ _('Cancelado') }}</option>
       </select>
     </div>
-    <div>
-      <label for="filtro-periodo-inicial" class="block text-sm font-medium text-gray-700">{{ _('Período inicial') }}</label>
-      <input id="filtro-periodo-inicial" type="month" name="periodo_inicial" class="border p-2 rounded" />
+    <div class="relative">
+      <label for="filtro-periodo-inicial" class="label-float">{{ _('Período inicial') }}</label>
+      <input id="filtro-periodo-inicial" type="month" name="periodo_inicial" class="peer placeholder-transparent form-input" />
     </div>
-    <div>
-      <label for="filtro-periodo-final" class="block text-sm font-medium text-gray-700">{{ _('Período final') }}</label>
-      <input id="filtro-periodo-final" type="month" name="periodo_final" class="border p-2 rounded" />
+    <div class="relative">
+      <label for="filtro-periodo-final" class="label-float">{{ _('Período final') }}</label>
+      <input id="filtro-periodo-final" type="month" name="periodo_final" class="peer placeholder-transparent form-input" />
     </div>
   </form>
   <div id="lista" aria-live="polite">

--- a/tokens/templates/tokens/ativar_2fa.html
+++ b/tokens/templates/tokens/ativar_2fa.html
@@ -13,7 +13,7 @@
   {% if messages %}
     <div class="mb-4 space-y-2">
       {% for message in messages %}
-        <p class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-green-100 text-green-700{% else %}bg-red-100 text-red-700{% endif %}">
+        <p role="alert" class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-green-100 text-green-700{% else %}bg-red-100 text-red-700{% endif %}">
           {{ message }}
         </p>
       {% endfor %}
@@ -29,15 +29,15 @@
     {% endif %}
     <form method="post" action="{% url 'tokens:ativar_2fa' %}" class="bg-white rounded-2xl shadow p-6 space-y-4">
       {% csrf_token %}
-      <div>
-        <label for="{{ form.codigo_totp.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.codigo_totp.label }}</label>
-        {{ form.codigo_totp|add_class:"form-input"|attr:"autofocus required pattern=\\d+ inputmode=numeric" }}
+      <div class="relative">
+        <label for="{{ form.codigo_totp.id_for_label }}" class="label-float">{{ form.codigo_totp.label }}</label>
+        {{ form.codigo_totp|add_class:"peer placeholder-transparent form-input"|attr:"autofocus required pattern=\\d+ inputmode=numeric" }}
         {% if form.codigo_totp.errors %}
-          <p class="text-sm text-red-600 mt-1">{{ form.codigo_totp.errors.0 }}</p>
+          <p role="alert" class="text-sm text-red-600 mt-1">{{ form.codigo_totp.errors.0 }}</p>
         {% endif %}
       </div>
       <div class="text-right">
-        <button type="submit" class="rounded-xl bg-primary px-4 py-2 text-white hover:bg-primary/90">{% trans "Ativar" %}</button>
+        <button type="submit" class="btn btn-primary">{% trans "Ativar" %}</button>
       </div>
     </form>
   </main>


### PR DESCRIPTION
## Summary
- style 2FA activation form with floating labels, updated inputs, and standardized button
- apply floating label inputs to extrato filter form

## Testing
- `pytest` *(fails: 81 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bb71a95bd08325b7e2c9d22f3769cd