### PR TITLE
Improve sidebar active styling and mobile toggle

### DIFF
--- a/core/menu.py
+++ b/core/menu.py
@@ -13,6 +13,7 @@ class MenuItem:
     icon: str
     permissions: List[str] | None = None
     classes: str = "flex items-center gap-x-2 hover:text-primary transition"
+    active: bool = False
 
 
 # Icons as raw HTML so they can be injected into the template safely
@@ -211,11 +212,21 @@ def build_menu(request) -> List[MenuItem]:
     for item in items:
         perms = item.permissions or []
         if "anonymous" in perms and not user.is_authenticated:
-            filtered.append(item)
+            pass_condition = True
         elif "authenticated" in perms and user.is_authenticated:
-            filtered.append(item)
+            pass_condition = True
         elif user.is_authenticated and user.user_type in perms:
-            filtered.append(item)
+            pass_condition = True
         elif not perms:
+            pass_condition = True
+        else:
+            pass_condition = False
+
+        if pass_condition:
+            if item.path == "/":
+                item.active = request.path == "/"
+            else:
+                item.active = request.path.startswith(item.path)
             filtered.append(item)
+
     return filtered

--- a/templates/base.html
+++ b/templates/base.html
@@ -66,10 +66,21 @@
     {% include 'components/nav_sidebar.html' %}
   {% endif %}
 
-  <div id="content" class="flex flex-col flex-1 {% if not hide_nav %}ml-64{% else %}ml-0{% endif %} transition-all">
+  <div id="content" class="flex flex-col flex-1 {% if not hide_nav %}md:ml-64{% else %}ml-0{% endif %} transition-all">
     <header class="bg-white border-b">
       <div class="container mx-auto p-4 flex items-center gap-4 justify-between">
-        <a href="/" class="text-xl font-bold text-primary" aria-label="{% trans 'Página inicial' %}">HubX</a>
+        <div class="flex items-center gap-2">
+          {% if not hide_nav %}
+          <button id="sidebar-toggle" class="md:hidden text-gray-800" aria-label="{% trans 'Alternar menu' %}" aria-controls="sidebar" aria-expanded="false">
+            <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M4 5h16" />
+              <path d="M4 12h16" />
+              <path d="M4 19h16" />
+            </svg>
+          </button>
+          {% endif %}
+          <a href="/" class="text-xl font-bold text-primary" aria-label="{% trans 'Página inicial' %}">HubX</a>
+        </div>
         <form action="#" method="get" role="search" class="flex-1 max-w-md">
           <label for="header-search" class="sr-only">{% trans 'Buscar' %}</label>
           <input id="header-search" name="q" type="search" placeholder="{% trans 'Buscar' %}" class="w-full border rounded px-3 py-2" />
@@ -190,33 +201,11 @@
 
       const sidebarToggle = document.getElementById('sidebar-toggle');
       const sidebar = document.getElementById('sidebar');
-      const content = document.getElementById('content');
-      if (sidebarToggle && sidebar && content) {
-        const baseMargin = '{% if hide_nav %}ml-0{% else %}ml-64{% endif %}';
-        const saved = localStorage.getItem('sidebar') || 'expanded';
-        if (saved === 'collapsed') {
-          sidebar.classList.remove('w-64');
-          sidebar.classList.add('w-16');
-          content.classList.remove(baseMargin);
-          content.classList.add('ml-16');
-          sidebarToggle.setAttribute('aria-expanded', 'false');
-          document.querySelectorAll('#sidebar .sidebar-label').forEach(el => {
-            el.classList.add('hidden');
-          });
-        } else {
-          sidebarToggle.setAttribute('aria-expanded', 'true');
-        }
+      if (sidebarToggle && sidebar) {
         sidebarToggle.addEventListener('click', () => {
           const expanded = sidebarToggle.getAttribute('aria-expanded') === 'true';
           sidebarToggle.setAttribute('aria-expanded', String(!expanded));
-          sidebar.classList.toggle('w-64');
-          sidebar.classList.toggle('w-16');
-          content.classList.toggle(baseMargin);
-          content.classList.toggle('ml-16');
-          document.querySelectorAll('#sidebar .sidebar-label').forEach(el => {
-            el.classList.toggle('hidden');
-          });
-          localStorage.setItem('sidebar', expanded ? 'collapsed' : 'expanded');
+          sidebar.classList.toggle('-translate-x-full');
         });
       }
       document.body.classList.remove('preload');

--- a/templates/components/nav_sidebar.html
+++ b/templates/components/nav_sidebar.html
@@ -1,20 +1,13 @@
 {% load i18n %}
-<aside id="sidebar" class="fixed inset-y-0 left-0 z-20 w-64 bg-white border-r flex flex-col transition-all">
+<aside id="sidebar" class="fixed inset-y-0 left-0 z-20 w-64 bg-white border-r flex flex-col transform -translate-x-full md:translate-x-0 transition-transform">
   <div class="flex items-center justify-between p-4 border-b">
     <a href="/" class="text-2xl font-bold text-primary" aria-label="{% trans 'Página inicial' %}" aria-current="{% if request.path == '/' %}page{% endif %}"><span class="sidebar-label">HubX</span></a>
-    <button id="sidebar-toggle" class="text-gray-800" aria-label="{% trans 'Alternar menu' %}" aria-controls="sidebar" aria-expanded="true">
-      <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-        <path d="M4 5h16" />
-        <path d="M4 12h16" />
-        <path d="M4 19h16" />
-      </svg>
-    </button>
   </div>
   <nav class="flex-1 overflow-y-auto px-4 py-4" role="navigation" aria-label="{% trans 'Menu' %}">
     <ul class="flex flex-col gap-2 text-sm">
       {% for item in NAV_MENU %}
         <li>
-          <a href="{{ item.path }}" class="{{ item.classes }}" aria-label="{% trans item.label %}" aria-current="{% if request.path == item.path %}page{% endif %}">
+          <a href="{{ item.path }}" class="{{ item.classes }} {% if item.active %}text-primary font-semibold{% endif %}" aria-label="{% trans item.label %}" aria-current="{% if item.active %}page{% endif %}">
             {% if item.id == 'perfil' and user.avatar %}
               <img src="{{ user.avatar.url }}" alt="{{ user.username }}" class="w-6 h-6 rounded-full object-cover" />
             {% else %}


### PR DESCRIPTION
## Summary
- highlight active sidebar items
- check active menu paths with `startswith`
- add mobile toggle for sidebar

## Testing
- `pytest` *(fails: 81 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bb71afe8848325833195a27c91cfd3