### PR TITLE
feat(tokens): refine invitation list layout

### DIFF
--- a/tokens/templates/tokens/listar_convites.html
+++ b/tokens/templates/tokens/listar_convites.html
@@ -3,11 +3,41 @@
 {% block title %}{% trans "Convites Emitidos" %} | HubX{% endblock %}
 
 {% block content %}
-{% include 'components/hero.html' with title=_('Convites Emitidos') action_template='tokens/hero_action.html' %}
-<section class="max-w-3xl mx-auto px-4 py-10">
+<section class="max-w-6xl mx-auto mt-8 px-4">
+  <div class="flex items-center justify-between gap-4 mb-6">
+    <h1 class="text-2xl font-bold">{% trans "Convites Emitidos" %}</h1>
+    <a href="{% url 'tokens:gerar_convite' %}"
+       class="inline-flex items-center gap-2 bg-primary text-white px-4 py-2 rounded">
+      {% trans "Gerar Token" %}
+    </a>
+  </div>
+
+  <div class="mb-6 grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-4">
+    <div class="p-4 rounded-2xl border border-neutral-200 bg-white shadow-sm">
+      <div class="text-sm text-neutral-500">{% trans "Total" %}</div>
+      <div class="mt-1 text-2xl font-bold text-neutral-900">{{ totais.total }}</div>
+    </div>
+    <div class="p-4 rounded-2xl border border-neutral-200 bg-white shadow-sm">
+      <div class="text-sm text-neutral-500">{% trans "Não usados" %}</div>
+      <div class="mt-1 text-2xl font-bold text-neutral-900">{{ totais.novos }}</div>
+    </div>
+    <div class="p-4 rounded-2xl border border-neutral-200 bg-white shadow-sm">
+      <div class="text-sm text-neutral-500">{% trans "Usados" %}</div>
+      <div class="mt-1 text-2xl font-bold text-neutral-900">{{ totais.usados }}</div>
+    </div>
+    <div class="p-4 rounded-2xl border border-neutral-200 bg-white shadow-sm">
+      <div class="text-sm text-neutral-500">{% trans "Expirados" %}</div>
+      <div class="mt-1 text-2xl font-bold text-neutral-900">{{ totais.expirados }}</div>
+    </div>
+    <div class="p-4 rounded-2xl border border-neutral-200 bg-white shadow-sm">
+      <div class="text-sm text-neutral-500">{% trans "Revogados" %}</div>
+      <div class="mt-1 text-2xl font-bold text-neutral-900">{{ totais.revogados }}</div>
+    </div>
+  </div>
+
   {% if convites %}
-  <div class="overflow-x-auto">
-    <table class="min-w-full divide-y divide-neutral-200 bg-white shadow-sm rounded-2xl">
+  <div class="overflow-x-auto rounded-2xl border border-neutral-200 bg-white shadow-sm">
+    <table class="min-w-full divide-y divide-neutral-200">
       <thead class="bg-neutral-50">
         <tr>
           <th class="px-4 py-2 text-left text-sm font-medium text-neutral-700">{% trans "Tipo" %}</th>
@@ -22,7 +52,8 @@
           <td class="px-4 py-2 text-sm text-neutral-900">{{ token.get_estado_display }}</td>
           <td class="px-4 py-2 text-sm">
             {% if token.estado != 'revogado' %}
-            <form method="post" action="{% url 'tokens:revogar_convite' token.id %}" hx-confirm="{% trans 'Confirmar revogação?' %}">
+            <form method="post" action="{% url 'tokens:revogar_convite' token.id %}"
+                  hx-confirm="{% trans 'Confirmar revogação?' %}">
               {% csrf_token %}
               <button type="submit" class="text-red-600 hover:underline">{% trans "Revogar" %}</button>
             </form>

--- a/tokens/views.py
+++ b/tokens/views.py
@@ -61,8 +61,7 @@ User = get_user_model()
 
 def token(request):
     if request.user.is_authenticated and (
-        request.user.is_superuser
-        or request.user.user_type in [UserType.ROOT, UserType.ADMIN]
+        request.user.is_superuser or request.user.user_type in [UserType.ROOT, UserType.ADMIN]
     ):
         return redirect("tokens:listar_api_tokens")
 
@@ -80,7 +79,17 @@ def listar_convites(request):
         messages.error(request, _("Você não tem permissão para visualizar convites."))
         return redirect("accounts:perfil")
     convites = TokenAcesso.objects.filter(gerado_por=request.user)
-    return render(request, "tokens/listar_convites.html", {"convites": convites})
+
+    totais = {
+        "total": convites.count(),
+        "novos": convites.filter(estado=TokenAcesso.Estado.NOVO).count(),
+        "usados": convites.filter(estado=TokenAcesso.Estado.USADO).count(),
+        "expirados": convites.filter(estado=TokenAcesso.Estado.EXPIRADO).count(),
+        "revogados": convites.filter(estado=TokenAcesso.Estado.REVOGADO).count(),
+    }
+
+    context = {"convites": convites, "totais": totais}
+    return render(request, "tokens/listar_convites.html", context)
 
 
 @login_required


### PR DESCRIPTION
## Summary
- show invitation totals in header cards
- apply consistent container and action button styling

## Testing
- `pytest tests/tokens/test_views.py::test_gerar_convite_form_fields -q --override-ini=addopts=""` *(fails: ModuleNotFoundError: No module named 'discussao')*

------
https://chatgpt.com/codex/tasks/task_e_68bc3b8dbf248325b1a90ea9f226828e