### PR TITLE
feat: unify list search forms with partial

### DIFF
--- a/accounts/templates/associados/lista.html
+++ b/accounts/templates/associados/lista.html
@@ -7,22 +7,7 @@
 
 <section class="max-w-6xl mx-auto mt-8 px-4">
   <h1 class="text-2xl font-bold mb-6">{% trans 'Associados' %}</h1>
-  <form method="get" class="mb-6 flex gap-2">
-    <div class="relative flex-grow">
-      <input
-        id="q"
-        name="q"
-        value="{{ request.GET.q }}"
-        class="peer placeholder-transparent border rounded px-3 py-2 w-full"
-        placeholder="{% trans 'Buscar' %}"
-      />
-      <label
-        for="q"
-        class="absolute left-3 -top-2 text-xs text-neutral-700 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600"
-      >{% trans 'Buscar' %}</label>
-    </div>
-    <button type="submit" class="bg-primary text-white px-4 py-2 rounded">{% trans 'Buscar' %}</button>
-  </form>
+  {% include 'components/search_form.html' with q=request.GET.q %}
   <!-- Cards de totais -->
   <div class="mb-6 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
     <div class="p-4 rounded-2xl border border-neutral-200 bg-white shadow-sm">

--- a/empresas/templates/empresas/lista.html
+++ b/empresas/templates/empresas/lista.html
@@ -10,17 +10,8 @@
     <a href="{% url 'empresas:empresa_criar' %}" class="px-3 py-2 bg-green-600 text-white rounded hover:bg-green-700 text-sm">{% trans 'Nova Empresa' %}</a>
   </header>
 
-  <form hx-get="{% url 'empresas:lista' %}" hx-target="#empresas-grid" hx-push-url="true" method="get" class="mb-6 flex gap-2">
-    <label for="q" class="sr-only">{% trans 'Buscar' %}</label>
-    <input
-      id="q"
-      name="q"
-      value="{{ request.GET.q }}"
-  class="border rounded px-3 py-2 flex-grow"
-      placeholder="{% trans 'Buscar' %}"
-    />
-    <button type="submit" class="bg-primary text-white px-4 py-2 rounded">{% trans 'Buscar' %}</button>
-  </form>
+  {% url 'empresas:lista' as empresas_lista_url %}
+  {% include 'components/search_form.html' with q=request.GET.q hx_get=empresas_lista_url hx_target='#empresas-grid' hx_push_url='true' %}
 
   <!-- Cards de totais -->
   <div class="mb-6 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">

--- a/eventos/templates/eventos/evento_list.html
+++ b/eventos/templates/eventos/evento_list.html
@@ -10,11 +10,7 @@
 {% include 'components/hero.html' with title=_('Meus Eventos') action_template='eventos/hero_evento_list_action.html' %}
 {% endif %}
 <section class="max-w-6xl mx-auto mt-8 px-4">
-  <form method="get" class="mb-6 flex gap-2">
-    <label for="q" class="sr-only">{% trans 'Buscar' %}</label>
-    <input id="q" name="q" value="{{ q }}" class="border rounded px-3 py-2 flex-grow" placeholder="{% trans 'Buscar' %}" />
-    <button type="submit" class="bg-primary text-white px-4 py-2 rounded">{% trans 'Buscar' %}</button>
-  </form>
+  {% include 'components/search_form.html' with q=request.GET.q %}
   <!-- Cards de totais -->
   <div class="mb-6 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
     <div class="p-4 rounded-2xl border border-neutral-200 bg-white shadow-sm">
@@ -48,11 +44,11 @@
   {% if is_paginated %}
   <nav class="mt-6 flex justify-center items-center gap-2">
     {% if page_obj.has_previous %}
-      <a class="btn-secondary" href="?page={{ page_obj.previous_page_number }}&q={{ q }}">{% trans 'Anterior' %}</a>
+      <a class="btn-secondary" href="?page={{ page_obj.previous_page_number }}&q={{ request.GET.q }}">{% trans 'Anterior' %}</a>
     {% endif %}
     <span class="text-sm text-neutral-600">{% blocktrans %}Página {{ page_obj.number }} de {{ page_obj.paginator.num_pages }}{% endblocktrans %}</span>
     {% if page_obj.has_next %}
-      <a class="btn-secondary" href="?page={{ page_obj.next_page_number }}&q={{ q }}">{% trans 'Próxima' %}</a>
+      <a class="btn-secondary" href="?page={{ page_obj.next_page_number }}&q={{ request.GET.q }}">{% trans 'Próxima' %}</a>
     {% endif %}
   </nav>
   {% endif %}

--- a/eventos/templates/eventos/eventos_lista.html
+++ b/eventos/templates/eventos/eventos_lista.html
@@ -15,12 +15,7 @@
     {% endif %}
   </div>
 
-  <form method="get" class="mb-6 flex gap-2">
-    <label for="q" class="sr-only">{% trans 'Buscar' %}</label>
-    <input id="q" name="q" value="{{ request.GET.q }}" class="border rounded px-3 py-2 flex-grow"
-           placeholder="{% trans 'Buscar' %}" />
-    <button type="submit" class="bg-primary text-white px-4 py-2 rounded">{% trans 'Buscar' %}</button>
-  </form>
+  {% include 'components/search_form.html' with q=request.GET.q %}
 
   <!-- Cards de totais (organização) -->
   <div class="mb-6 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">

--- a/eventos/templates/eventos/inscricao_list.html
+++ b/eventos/templates/eventos/inscricao_list.html
@@ -17,26 +17,8 @@
     </div>
   {% endif %}
 
-  <form
-    hx-get="{% url 'eventos:inscricao_list' %}"
-    hx-target="#inscricao-container"
-    hx-push-url="true"
-    class="mb-6 flex gap-2"
-  >
-    <input
-      type="text"
-      name="q"
-      value="{{ request.GET.q }}"
-      placeholder="{% trans 'Buscar por usuário ou evento' %}"
-      class="w-full rounded-md border-gray-300 px-3 py-2"
-    />
-    <button
-      type="submit"
-      class="rounded-md bg-primary px-4 py-2 text-white hover:bg-primary/90"
-    >
-      {% trans "Filtrar" %}
-    </button>
-  </form>
+  {% url 'eventos:inscricao_list' as inscricao_list_url %}
+  {% include 'components/search_form.html' with q=request.GET.q hx_get=inscricao_list_url hx_target='#inscricao-container' hx_push_url='true' %}
 
   <main>
     <div class="overflow-x-auto bg-white border border-neutral-200 rounded-2xl shadow-sm">

--- a/nucleos/templates/nucleos/list.html
+++ b/nucleos/templates/nucleos/list.html
@@ -6,10 +6,7 @@
 {% block content %}
 <section class="max-w-6xl mx-auto py-8 px-4">
   <h1 class="text-2xl font-bold mb-4">{% trans "Núcleos" %}</h1>
-  <form method="get" class="mb-4 flex gap-2">
-      <input type="text" name="q" value="{{ form.q.value|default:'' }}" placeholder="{% trans 'Buscar...' %}" class="border rounded px-2 py-1 flex-1" />
-    <button class="px-3 py-1 bg-blue-600 text-white rounded" aria-label="{% trans 'Buscar núcleos' %}">{% trans 'Buscar' %}</button>
-  </form>
+  {% include 'components/search_form.html' with q=request.GET.q %}
   {% if request.user.user_type != 'admin' %}
   <div class="mb-4">
     <a href="{% url 'nucleos:meus' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100" aria-label="{% trans 'Ver meus núcleos' %}">{% trans 'Meus Núcleos' %}</a>

--- a/nucleos/templates/nucleos/meus_list.html
+++ b/nucleos/templates/nucleos/meus_list.html
@@ -6,10 +6,7 @@
 {% block content %}
 {% include 'components/hero.html' with title=_('Meus Núcleos') action_template='nucleos/hero_meus_list_action.html' %}
 <section class="max-w-5xl mx-auto py-8">
-  <form method="get" class="mb-4 flex gap-2">
-    <input type="text" name="q" value="{{ form.q.value }}" placeholder="{% trans 'Buscar...' %}" class="border rounded px-2 py-1 flex-1" />
-    <button class="px-3 py-1 bg-blue-600 text-white rounded" aria-label="{% trans 'Buscar núcleos' %}">{% trans 'Buscar' %}</button>
-  </form>
+  {% include 'components/search_form.html' with q=request.GET.q %}
     <ul role="list" class="grid grid-cols-1 md:grid-cols-2 gap-4">
 
     {% for nucleo in object_list %}

--- a/templates/components/search_form.html
+++ b/templates/components/search_form.html
@@ -1,0 +1,6 @@
+{% load i18n %}
+<form method="get" class="mb-6 flex gap-2" {% if hx_get %}hx-get="{{ hx_get }}"{% endif %} {% if hx_target %}hx-target="{{ hx_target }}"{% endif %} {% if hx_push_url %}hx-push-url="{{ hx_push_url }}"{% endif %}>
+  <label for="q" class="sr-only">{% trans 'Buscar' %}</label>
+  <input id="q" name="q" value="{{ q }}" class="border rounded px-3 py-2 w-full" placeholder="{% trans 'Buscar' %}" />
+  <button type="submit" class="bg-primary text-white px-4 py-2 rounded">{% trans 'Buscar' %}</button>
+</form>


### PR DESCRIPTION
## Summary
- add reusable search form component
- replace list search forms to use new partial

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'silk')*
- `pre-commit run --files templates/components/search_form.html eventos/templates/eventos/evento_list.html eventos/templates/eventos/eventos_lista.html empresas/templates/empresas/lista.html accounts/templates/associados/lista.html nucleos/templates/nucleos/list.html nucleos/templates/nucleos/meus_list.html eventos/templates/eventos/inscricao_list.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3b7f793c8325aed9ff01d145915d