### PR TITLE
Adopt hero component in list templates

### DIFF
--- a/accounts/templates/associados/lista.html
+++ b/accounts/templates/associados/lista.html
@@ -4,9 +4,9 @@
 {% block title %}{% trans 'Associados' %}{% endblock %}
 
 {% block content %}
+{% include 'components/hero.html' with title=_('Associados') action_template='associados/partials/hero_action.html' %}
 
 <section class="max-w-6xl mx-auto mt-8 px-4">
-  <h1 class="text-2xl font-bold mb-6">{% trans 'Associados' %}</h1>
   <form method="get" class="mb-6 flex gap-2">
     <div class="relative flex-grow">
       <input

--- a/accounts/templates/associados/partials/hero_action.html
+++ b/accounts/templates/associados/partials/hero_action.html
@@ -1,0 +1,2 @@
+{% load i18n %}
+<a href="{% url 'tokens:gerar_convite' %}" class="btn-primary">{% trans 'Gerar Convite' %}</a>

--- a/docs/style_guide_frontend.md
+++ b/docs/style_guide_frontend.md
@@ -95,7 +95,8 @@ entre visual mobile e desktop automaticamente.
 
 Seções de destaque devem ocupar a área inicial da página com uma mensagem
 principal e call to action opcional. Utilize `components/hero.html` para manter
-consistência de espaçamento e tipografia.
+consistência de espaçamento e tipografia. Páginas de listagem devem iniciar com
+este componente, destacando o título e ações relevantes.
 
 ```django
 {% include "components/hero.html" with title="Bem-vindo" subtitle="Resumo do app" %}

--- a/empresas/templates/empresas/lista.html
+++ b/empresas/templates/empresas/lista.html
@@ -4,11 +4,8 @@
 {% block title %}{% trans 'Empresas' %}{% endblock %}
 
 {% block content %}
-<section class="max-w-6xl mx-auto py-8 px-4">
-  <header class="mb-4 flex items-center justify-between">
-    <h1 class="text-2xl font-bold text-neutral-900">{% trans 'Empresas' %}</h1>
-    <a href="{% url 'empresas:empresa_criar' %}" class="px-3 py-2 bg-green-600 text-white rounded hover:bg-green-700 text-sm">{% trans 'Nova Empresa' %}</a>
-  </header>
+{% include 'components/hero.html' with title=_('Empresas') action_template='empresas/partials/hero_action.html' %}
+<section class="max-w-6xl mx-auto mt-8 px-4">
 
   <form hx-get="{% url 'empresas:lista' %}" hx-target="#empresas-grid" hx-push-url="true" method="get" class="mb-6 flex gap-2">
     <label for="q" class="sr-only">{% trans 'Buscar' %}</label>

--- a/empresas/templates/empresas/partials/hero_action.html
+++ b/empresas/templates/empresas/partials/hero_action.html
@@ -1,0 +1,4 @@
+{% load i18n lucide_icons %}
+<a href="{% url 'empresas:empresa_criar' %}" class="btn-primary inline-flex items-center gap-2">
+  {% lucide 'plus' class='w-4 h-4' %} {% trans 'Nova Empresa' %}
+</a>

--- a/eventos/templates/eventos/eventos_lista.html
+++ b/eventos/templates/eventos/eventos_lista.html
@@ -4,16 +4,8 @@
 {% block title %}{% trans 'Eventos' %}{% endblock %}
 
 {% block content %}
+{% include 'components/hero.html' with title=_('Eventos') action_template='eventos/hero_eventos_lista_action.html' %}
 <section class="max-w-6xl mx-auto mt-8 px-4">
-  <div class="flex items-center justify-between gap-4 mb-6">
-    <h1 class="text-2xl font-bold">{% trans 'Eventos' %}</h1>
-    {% if pode_criar_evento %}
-      <a href="{% url 'eventos:evento_novo' %}"
-         class="inline-flex items-center gap-2 bg-primary text-white px-4 py-2 rounded">
-          {% lucide 'plus' class='w-4 h-4' %} {% trans 'Novo evento' %}
-      </a>
-    {% endif %}
-  </div>
 
   <form method="get" class="mb-6 flex gap-2">
     <label for="q" class="sr-only">{% trans 'Buscar' %}</label>

--- a/eventos/templates/eventos/hero_eventos_lista_action.html
+++ b/eventos/templates/eventos/hero_eventos_lista_action.html
@@ -1,0 +1,6 @@
+{% load i18n lucide_icons %}
+{% if pode_criar_evento %}
+<a href="{% url 'eventos:evento_novo' %}" class="btn-primary inline-flex items-center gap-2">
+  {% lucide 'plus' class='w-4 h-4' %} {% trans 'Novo evento' %}
+</a>
+{% endif %}


### PR DESCRIPTION
## Summary
- use shared hero component in Associados, Empresas, and Eventos lists
- add per-page action buttons for creating invites, companies, and events
- document hero as default header for list pages

## Testing
- `pytest tests/accounts/test_associados.py tests/empresas/test_views.py tests/eventos/test_views.py` *(fails: ModuleNotFoundError: No module named 'factory')*
- `pytest tests/accounts/test_associados.py::test_admin_list_associados -vv` *(fails: Required test coverage of 90% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3b8194e08325a315a50c4a07428f