### PR TITLE
refactor: add reusable total card partial

### DIFF
--- a/accounts/templates/associados/lista.html
+++ b/accounts/templates/associados/lista.html
@@ -25,19 +25,9 @@
   </form>
   <!-- Cards de totais -->
   <div class="mb-6 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-    <div class="p-4 rounded-2xl border border-neutral-200 bg-white shadow-sm">
-      <div class="text-sm text-neutral-500">{% trans 'Usuários' %}</div>
-      <div class="mt-1 text-2xl font-bold text-neutral-900">{{ total_usuarios }}</div>
-    </div>
-    <div class="p-4 rounded-2xl border border-neutral-200 bg-white shadow-sm">
-      <div class="text-sm text-neutral-500">{% trans 'Associados' %}</div>
-      <div class="mt-1 text-2xl font-bold text-neutral-900">{{ total_associados }}</div>
-    </div>
-    <div class="p-4 rounded-2xl border border-neutral-200 bg-white shadow-sm">
-      <div class="text-sm text-neutral-500">{% trans 'Nucleados' %}</div>
-      <div class="mt-1 text-2xl font-bold text-neutral-900">{{ total_nucleados }}</div>
-
-    </div>
+    {% include "partials/cards/total_card.html" with label=_('Usuários') valor=total_usuarios %}
+    {% include "partials/cards/total_card.html" with label=_('Associados') valor=total_associados %}
+    {% include "partials/cards/total_card.html" with label=_('Nucleados') valor=total_nucleados %}
   </div>
   <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
     {% for user in associados %}

--- a/empresas/templates/empresas/lista.html
+++ b/empresas/templates/empresas/lista.html
@@ -24,10 +24,7 @@
 
   <!-- Cards de totais -->
   <div class="mb-6 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-    <div class="p-4 rounded-2xl border border-neutral-200 bg-white shadow-sm">
-      <div class="text-sm text-neutral-500">{% trans 'Empresas' %}</div>
-      <div class="mt-1 text-2xl font-bold text-neutral-900">{{ total_empresas }}</div>
-    </div>
+    {% include "partials/cards/total_card.html" with label=_('Empresas') valor=total_empresas %}
   </div>
 
   <main>

--- a/eventos/templates/eventos/evento_list.html
+++ b/eventos/templates/eventos/evento_list.html
@@ -17,22 +17,10 @@
   </form>
   <!-- Cards de totais -->
   <div class="mb-6 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-    <div class="p-4 rounded-2xl border border-neutral-200 bg-white shadow-sm">
-      <div class="text-sm text-neutral-500">{% trans 'Eventos' %}</div>
-      <div class="mt-1 text-2xl font-bold text-neutral-900">{{ total_eventos }}</div>
-    </div>
-    <div class="p-4 rounded-2xl border border-neutral-200 bg-white shadow-sm">
-      <div class="text-sm text-neutral-500">{% trans 'Ativos' %}</div>
-      <div class="mt-1 text-2xl font-bold text-neutral-900">{{ total_eventos_ativos }}</div>
-    </div>
-    <div class="p-4 rounded-2xl border border-neutral-200 bg-white shadow-sm">
-      <div class="text-sm text-neutral-500">{% trans 'Concluídos' %}</div>
-      <div class="mt-1 text-2xl font-bold text-neutral-900">{{ total_eventos_concluidos }}</div>
-    </div>
-    <div class="p-4 rounded-2xl border border-neutral-200 bg-white shadow-sm">
-      <div class="text-sm text-neutral-500">{% trans 'Inscritos (total)' %}</div>
-      <div class="mt-1 text-2xl font-bold text-neutral-900">{{ total_inscritos }}</div>
-    </div>
+    {% include "partials/cards/total_card.html" with label=_('Eventos') valor=total_eventos %}
+    {% include "partials/cards/total_card.html" with label=_('Ativos') valor=total_eventos_ativos %}
+    {% include "partials/cards/total_card.html" with label=_('Concluídos') valor=total_eventos_concluidos %}
+    {% include "partials/cards/total_card.html" with label=_('Inscritos (total)') valor=total_inscritos %}
   </div>
 
   <main>

--- a/eventos/templates/eventos/eventos_lista.html
+++ b/eventos/templates/eventos/eventos_lista.html
@@ -24,22 +24,10 @@
 
   <!-- Cards de totais (organização) -->
   <div class="mb-6 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-    <div class="p-4 rounded-2xl border border-neutral-200 bg-white shadow-sm">
-      <div class="text-sm text-neutral-500">{% trans 'Eventos' %}</div>
-      <div class="mt-1 text-2xl font-bold text-neutral-900">{{ total_eventos }}</div>
-    </div>
-    <div class="p-4 rounded-2xl border border-neutral-200 bg-white shadow-sm">
-      <div class="text-sm text-neutral-500">{% trans 'Ativos' %}</div>
-      <div class="mt-1 text-2xl font-bold text-neutral-900">{{ total_eventos_ativos }}</div>
-    </div>
-    <div class="p-4 rounded-2xl border border-neutral-200 bg-white shadow-sm">
-      <div class="text-sm text-neutral-500">{% trans 'Concluídos' %}</div>
-      <div class="mt-1 text-2xl font-bold text-neutral-900">{{ total_eventos_concluidos }}</div>
-    </div>
-    <div class="p-4 rounded-2xl border border-neutral-200 bg-white shadow-sm">
-      <div class="text-sm text-neutral-500">{% trans 'Inscritos (total)' %}</div>
-      <div class="mt-1 text-2xl font-bold text-neutral-900">{{ total_inscritos }}</div>
-    </div>
+    {% include "partials/cards/total_card.html" with label=_('Eventos') valor=total_eventos %}
+    {% include "partials/cards/total_card.html" with label=_('Ativos') valor=total_eventos_ativos %}
+    {% include "partials/cards/total_card.html" with label=_('Concluídos') valor=total_eventos_concluidos %}
+    {% include "partials/cards/total_card.html" with label=_('Inscritos (total)') valor=total_inscritos %}
   </div>
 
   <main>

--- a/nucleos/templates/nucleos/detail.html
+++ b/nucleos/templates/nucleos/detail.html
@@ -23,22 +23,10 @@
   
   <!-- Cards de totais -->
   <div class="mt-6 grid grid-cols-1 sm:grid-cols-4 gap-4">
-    <div class="p-4 rounded-2xl border border-neutral-200 bg-white shadow-sm">
-      <div class="text-sm text-neutral-500">{% trans 'Membros' %}</div>
-      <div class="mt-1 text-2xl font-bold text-neutral-900">{{ total_membros }}</div>
-    </div>
-    <div class="p-4 rounded-2xl border border-neutral-200 bg-white shadow-sm">
-      <div class="text-sm text-neutral-500">{% trans 'Eventos (ativos + concluídos)' %}</div>
-      <div class="mt-1 text-2xl font-bold text-neutral-900">{{ total_eventos }}</div>
-    </div>
-    <div class="p-4 rounded-2xl border border-neutral-200 bg-white shadow-sm">
-      <div class="text-sm text-neutral-500">{% trans 'Eventos ativos' %}</div>
-      <div class="mt-1 text-2xl font-bold text-neutral-900">{{ total_eventos_ativos }}</div>
-    </div>
-    <div class="p-4 rounded-2xl border border-neutral-200 bg-white shadow-sm">
-      <div class="text-sm text-neutral-500">{% trans 'Eventos concluídos' %}</div>
-      <div class="mt-1 text-2xl font-bold text-neutral-900">{{ total_eventos_concluidos }}</div>
-    </div>
+    {% include "partials/cards/total_card.html" with label=_('Membros') valor=total_membros %}
+    {% include "partials/cards/total_card.html" with label=_('Eventos (ativos + concluídos)') valor=total_eventos %}
+    {% include "partials/cards/total_card.html" with label=_('Eventos ativos') valor=total_eventos_ativos %}
+    {% include "partials/cards/total_card.html" with label=_('Eventos concluídos') valor=total_eventos_concluidos %}
   </div>
 
   <!-- Abas -->

--- a/nucleos/templates/nucleos/list.html
+++ b/nucleos/templates/nucleos/list.html
@@ -23,26 +23,11 @@
 
   <!-- Cards de totais (organização) -->
   <div class="mb-6 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-    <div class="p-4 rounded-2xl border border-neutral-200 bg-white shadow-sm">
-      <div class="text-sm text-neutral-500">{% trans 'Núcleos' %}</div>
-      <div class="mt-1 text-2xl font-bold text-neutral-900">{{ total_nucleos }}</div>
-    </div>
-    <div class="p-4 rounded-2xl border border-neutral-200 bg-white shadow-sm">
-      <div class="text-sm text-neutral-500">{% trans 'Membros (todos os núcleos)' %}</div>
-      <div class="mt-1 text-2xl font-bold text-neutral-900">{{ total_membros_org }}</div>
-    </div>
-    <div class="p-4 rounded-2xl border border-neutral-200 bg-white shadow-sm">
-      <div class="text-sm text-neutral-500">{% trans 'Eventos (todos)' %}</div>
-      <div class="mt-1 text-2xl font-bold text-neutral-900">{{ total_eventos_org }}</div>
-    </div>
-    <div class="p-4 rounded-2xl border border-neutral-200 bg-white shadow-sm">
-      <div class="text-sm text-neutral-500">{% trans 'Eventos ativos' %}</div>
-      <div class="mt-1 text-2xl font-bold text-neutral-900">{{ total_eventos_ativos_org }}</div>
-    </div>
-    <div class="p-4 rounded-2xl border border-neutral-200 bg-white shadow-sm">
-      <div class="text-sm text-neutral-500">{% trans 'Eventos concluídos' %}</div>
-      <div class="mt-1 text-2xl font-bold text-neutral-900">{{ total_eventos_concluidos_org }}</div>
-    </div>
+    {% include "partials/cards/total_card.html" with label=_('Núcleos') valor=total_nucleos %}
+    {% include "partials/cards/total_card.html" with label=_('Membros (todos os núcleos)') valor=total_membros_org %}
+    {% include "partials/cards/total_card.html" with label=_('Eventos (todos)') valor=total_eventos_org %}
+    {% include "partials/cards/total_card.html" with label=_('Eventos ativos') valor=total_eventos_ativos_org %}
+    {% include "partials/cards/total_card.html" with label=_('Eventos concluídos') valor=total_eventos_concluidos_org %}
   </div>
 
   <main>

--- a/templates/partials/cards/total_card.html
+++ b/templates/partials/cards/total_card.html
@@ -1,0 +1,5 @@
+{# Card de total #}
+<div class="p-4 rounded-2xl border border-neutral-200 bg-white shadow-sm">
+  <div class="text-sm text-neutral-500">{{ label }}</div>
+  <div class="mt-1 text-2xl font-bold text-neutral-900">{{ valor }}</div>
+</div>


### PR DESCRIPTION
## Summary
- add total_card partial for total displays
- use total_card partial across list templates for consistent layout

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'factory')*


------
https://chatgpt.com/codex/tasks/task_e_68bc3b853cb08325a3c9454bda99f0f5