### PR TITLE
Padroniza estilos das listas de associados e empresas

### DIFF
--- a/accounts/templates/associados/lista.html
+++ b/accounts/templates/associados/lista.html
@@ -7,23 +7,8 @@
 {% include 'components/hero.html' with title=_('Associados') action_template='associados/partials/hero_action.html' %}
 
 
-<section class="max-w-6xl mx-auto mt-8 px-4">
-  <form method="get" class="mb-6 flex gap-2">
-    <div class="relative flex-grow">
-      <input
-        id="q"
-        name="q"
-        value="{{ request.GET.q }}"
-        class="peer placeholder-transparent border rounded px-3 py-2 w-full"
-        placeholder="{% trans 'Buscar' %}"
-      />
-      <label
-        for="q"
-        class="absolute left-3 -top-2 text-xs text-neutral-700 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600"
-      >{% trans 'Buscar' %}</label>
-    </div>
-    <button type="submit" class="bg-primary text-white px-4 py-2 rounded">{% trans 'Buscar' %}</button>
-  </form>
+<section class="max-w-6xl mx-auto py-8 px-4">
+  {% include 'components/search_form.html' with q=request.GET.q %}
 
   <!-- Cards de totais -->
   <div class="mb-6 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">

--- a/empresas/templates/empresas/lista.html
+++ b/empresas/templates/empresas/lista.html
@@ -5,24 +5,10 @@
 
 {% block content %}
 {% include 'components/hero.html' with title=_('Empresas') action_template='empresas/partials/hero_action.html' %}
-<section class="max-w-6xl mx-auto mt-8 px-4">
-
-
-  <form method="get" class="mb-6 flex gap-2">
-    <label for="q" class="sr-only">{% trans 'Buscar' %}</label>
-    <input
-      id="q"
-      name="q"
-      value="{{ request.GET.q }}"
-  class="border rounded px-3 py-2 flex-grow"
-      placeholder="{% trans 'Buscar' %}"
-    />
-    <button type="submit" class="bg-primary text-white px-4 py-2 rounded">{% trans 'Buscar' %}</button>
-  </form>
+<section class="max-w-6xl mx-auto py-8 px-4">
 
   {% url 'empresas:lista' as empresas_lista_url %}
   {% include 'components/search_form.html' with q=request.GET.q hx_get=empresas_lista_url hx_target='#empresas-grid' hx_push_url='true' %}
-
 
   <!-- Cards de totais -->
   <div class="mb-6 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">


### PR DESCRIPTION
## Summary
- unifica container das listas de associados e empresas
- reutiliza partial padronizado de busca

## Testing
- `pytest` *(81 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bc37ec38dc83259b3426b373135e2c