### PR TITLE
fix: remove card hover scaling

### DIFF
--- a/templates/partials/cards/base_card.html
+++ b/templates/partials/cards/base_card.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 <a href="{{ url }}"
-   class="group block rounded-2xl border border-neutral-200 bg-white shadow-sm hover:shadow-lg hover:scale-[1.01] transition-transform focus:outline-none focus:ring-2 focus:ring-primary/40"
+   class="group block rounded-2xl border border-neutral-200 bg-white shadow-sm hover:shadow-lg transition-shadow focus:outline-none focus:ring-2 focus:ring-primary/40"
    aria-label="{{ title }}">
   <article class="overflow-hidden rounded-2xl" role="article">
     <header class="relative">

--- a/templates/partials/cards/empresa_card.html
+++ b/templates/partials/cards/empresa_card.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 {# Card de Empresa #}
 <a href="{% url 'empresas:detail' empresa.pk %}"
-   class="group block rounded-2xl border border-neutral-200 bg-white shadow-sm hover:shadow-lg hover:scale-[1.01] transition-transform focus:outline-none focus:ring-2 focus:ring-primary/40">
+   class="group block rounded-2xl border border-neutral-200 bg-white shadow-sm hover:shadow-lg transition-shadow focus:outline-none focus:ring-2 focus:ring-primary/40">
   <article class="overflow-hidden rounded-2xl" role="article" aria-label="{{ empresa.nome }}">
     <header class="relative">
       {% if empresa.cover %}


### PR DESCRIPTION
## Summary
- remove hover scale transform from shared card component
- drop scaling effect from standalone company card

## Testing
- `pytest empresas/tests/test_list_view.py::test_admin_list_empresas_cards -q --no-cov` *(fails: fixture 'db' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc67de4e5c8325aa02f2cb93a67afe