### PR TITLE
Adjust empresas grid layout

### DIFF
--- a/empresas/templates/empresas/includes/empresas_grid.html
+++ b/empresas/templates/empresas/includes/empresas_grid.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 {% if empresas %}
-<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4" role="list" aria-label="{% translate 'Lista de empresas' %}">
+<div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6" role="list" aria-label="{% translate 'Lista de empresas' %}">
   {% for empresa in empresas %}
     <div role="listitem">
       {% include 'empresas/partials/card.html' with empresa=empresa %}


### PR DESCRIPTION
## Summary
- expand empresas grid to 4 columns with wider gaps

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'axe_core_python'; ModuleNotFoundError: No module named 'discussao'; IndentationError in tests/notificacoes/test_templates_view.py)*

------
https://chatgpt.com/codex/tasks/task_e_68bc72159040832584f24de2407cc8a6