### PR TITLE
Adjust empresas grid layout

### DIFF
--- a/empresas/templates/empresas/busca.html
+++ b/empresas/templates/empresas/busca.html
@@ -15,7 +15,12 @@
     <button type="submit" class="bg-primary-600 text-white px-4 py-2 rounded hover:bg-primary-700">🔍</button>
   </form>
 
-  <div id="empresas-grid">
+  <div
+    id="empresas-grid"
+    class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6"
+    role="list"
+    aria-label="{% translate 'Lista de empresas' %}"
+  >
     {% include 'empresas/includes/empresas_grid.html' with empresas=empresas %}
   </div>
 

--- a/empresas/templates/empresas/includes/empresas_grid.html
+++ b/empresas/templates/empresas/includes/empresas_grid.html
@@ -1,15 +1,13 @@
 {% load i18n %}
 {% if empresas %}
-<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4" role="list" aria-label="{% translate 'Lista de empresas' %}">
   {% for empresa in empresas %}
     <div role="listitem">
       {% include 'empresas/partials/card.html' with empresa=empresa %}
     </div>
   {% endfor %}
-</div>
-{% include 'components/pagination.html' with page_obj=page_obj querystring=querystring %}
+  <div class="col-span-full">
+    {% include 'components/pagination.html' with page_obj=page_obj querystring=querystring %}
+  </div>
 {% else %}
-<div class="grid grid-cols-1">
   <p class="col-span-full text-center text-neutral-500 py-10">{% translate 'Nenhuma empresa encontrada.' %}</p>
-</div>
 {% endif %}

--- a/empresas/templates/empresas/lista.html
+++ b/empresas/templates/empresas/lista.html
@@ -16,7 +16,12 @@
   </div>
 
   <main>
-    <div id="empresas-grid">
+    <div
+      id="empresas-grid"
+      class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6"
+      role="list"
+      aria-label="{% translate 'Lista de empresas' %}"
+    >
       {% include "empresas/includes/empresas_grid.html" %}
     </div>
   </main>


### PR DESCRIPTION
## Summary
- align empresas listing and search pages with associates grid structure
- refactor empresas grid partial to output items and full-width pagination only

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'silk')*


------
https://chatgpt.com/codex/tasks/task_e_68bc72159040832584f24de2407cc8a6