### PR TITLE
fix: adjust empresas grid wrapper

### DIFF
--- a/empresas/templates/empresas/lista.html
+++ b/empresas/templates/empresas/lista.html
@@ -15,15 +15,13 @@
     {% include "partials/cards/total_card.html" with label=_('Empresas') valor=total_empresas %}
   </div>
 
-  <main>
-    <div
-      id="empresas-grid"
-      class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6"
-      role="list"
-      aria-label="{% translate 'Lista de empresas' %}"
-    >
-      {% include "empresas/includes/empresas_grid.html" %}
-    </div>
-  </main>
+  <div
+    id="empresas-grid"
+    class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6"
+    role="list"
+    aria-label="{% translate 'Lista de empresas' %}"
+  >
+    {% include "empresas/includes/empresas_grid.html" %}
+  </div>
 </section>
 {% endblock %}


### PR DESCRIPTION
## Summary
- replace `<main>` wrapper with `<div>` for empresas grid

## Testing
- `pytest -q` *(fails: ModuleNotFoundError, ImportError issues)*

------
https://chatgpt.com/codex/tasks/task_e_68bc786852d88325ae3d0c6154f5cc58