### PR TITLE
Refactor template containers

### DIFF
--- a/accounts/templates/associados/lista.html
+++ b/accounts/templates/associados/lista.html
@@ -5,6 +5,7 @@
 
 {% block content %}
 {% include 'components/hero.html' with title=_('Associados') action_template='associados/partials/hero_action.html' %}
+<div class="container mx-auto p-6">
 
 
 <section class="max-w-6xl mx-auto py-8 px-4">
@@ -26,4 +27,5 @@
     {% endfor %}
   </div>
 </section>
+</div>
 {% endblock %}

--- a/accounts/templates/login/login.html
+++ b/accounts/templates/login/login.html
@@ -5,6 +5,7 @@
 
 {% block content %}
 {% include 'components/hero.html' with title=_('Bem-vindo de volta') %}
+<div class="container mx-auto p-6">
 <div class="bg-muted min-h-screen flex items-center justify-center px-4">
   <div class="card max-w-md w-full mx-auto" role="dialog">
     <div class="card-body">
@@ -93,5 +94,6 @@
     </div>
     </div>
   </div>
+</div>
 </div>
 {% endblock %}

--- a/core/templates/core/about.html
+++ b/core/templates/core/about.html
@@ -5,6 +5,7 @@
 
 {% block content %}
 {% include 'components/hero.html' with title=_('Sobre o HubX') %}
+<div class="container mx-auto p-6">
 <section class="max-w-3xl mx-auto px-4 py-12 grid grid-cols-1 gap-6">
   <div class="card">
     <div class="card-header">
@@ -16,4 +17,5 @@
     </div>
   </div>
 </section>
+</div>
 {% endblock %}

--- a/core/templates/core/home.html
+++ b/core/templates/core/home.html
@@ -5,6 +5,7 @@
 
 {% block content %}
 {% include 'components/hero.html' with title=_('Junte-se à comunidade Hubx.space') subtitle=_('Plataforma colaborativa que conecta organizações, empresas e pessoas.') %}
+<div class="container mx-auto p-6">
 <div class="text-center my-8">
   {% if user.is_authenticated %}
   <div class="flex justify-center gap-4">
@@ -101,4 +102,5 @@
 <footer class="py-6 text-center text-sm text-neutral-500">
   &copy; {{ now|date:"Y" }} {% trans "Hubx" %}
 </footer>
+</div>
 {% endblock %}

--- a/core/templates/core/privacy.html
+++ b/core/templates/core/privacy.html
@@ -5,6 +5,7 @@
 
 {% block content %}
 {% include 'components/hero.html' with title=_('Política de Privacidade') %}
+<div class="container mx-auto p-6">
 <section class="max-w-3xl mx-auto px-4 py-12 grid grid-cols-1 gap-6">
   <div class="card">
     <div class="card-header">
@@ -15,4 +16,5 @@
     </div>
   </div>
 </section>
+</div>
 {% endblock %}

--- a/core/templates/core/terms.html
+++ b/core/templates/core/terms.html
@@ -5,6 +5,7 @@
 
 {% block content %}
 {% include 'components/hero.html' with title=_('Termos de Uso') %}
+<div class="container mx-auto p-6">
 <section class="max-w-3xl mx-auto px-4 py-12 grid grid-cols-1 gap-6">
   <div class="card">
     <div class="card-header">
@@ -15,4 +16,5 @@
     </div>
   </div>
 </section>
+</div>
 {% endblock %}

--- a/dashboard/templates/dashboard/admin.html
+++ b/dashboard/templates/dashboard/admin.html
@@ -5,6 +5,7 @@
 
 {% block content %}
 {% include 'components/hero.html' with title=_('Dashboard Admin') %}
+<div class="container mx-auto p-6">
 <section class="max-w-7xl mx-auto px-4 py-10 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6" aria-label="{% trans 'Dashboard' %}">
   <div class="card col-span-full">
     <div class="card-header">
@@ -79,4 +80,5 @@
     </div>
   </div>
 </section>
+</div>
 {% endblock %}

--- a/empresas/templates/empresas/lista.html
+++ b/empresas/templates/empresas/lista.html
@@ -5,6 +5,7 @@
 
 {% block content %}
 {% include 'components/hero.html' with title=_('Empresas') action_template='empresas/partials/hero_action.html' %}
+<div class="container mx-auto p-6">
 <section class="max-w-6xl mx-auto py-8 px-4">
 
   {% url 'empresas:lista' as empresas_lista_url %}
@@ -24,4 +25,5 @@
     {% include "empresas/includes/empresas_grid.html" %}
   </div>
 </section>
+</div>
 {% endblock %}

--- a/eventos/templates/eventos/briefing_form.html
+++ b/eventos/templates/eventos/briefing_form.html
@@ -8,6 +8,7 @@
 {% else %}
   {% include 'components/hero.html' with title=_('Novo Briefing') %}
 {% endif %}
+<div class="container mx-auto p-6">
 <section class="max-w-3xl mx-auto px-4 py-12 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
   <div class="card">
     <div class="card-header">
@@ -42,4 +43,5 @@
     </div>
   </div>
 </section>
+</div>
 {% endblock %}

--- a/eventos/templates/eventos/evento_list.html
+++ b/eventos/templates/eventos/evento_list.html
@@ -9,6 +9,7 @@
 {% else %}
 {% include 'components/hero.html' with title=_('Meus Eventos') action_template='eventos/hero_evento_list_action.html' %}
 {% endif %}
+<div class="container mx-auto p-6">
 <section class="max-w-6xl mx-auto mt-8 px-4">
   {% include 'components/search_form.html' with q=request.GET.q %}
   <!-- Cards de totais -->
@@ -32,4 +33,5 @@
   {% include 'components/pagination.html' with page_obj=page_obj querystring="q="|add:q %}
 
 </section>
+</div>
 {% endblock %}

--- a/eventos/templates/eventos/eventos_lista.html
+++ b/eventos/templates/eventos/eventos_lista.html
@@ -6,6 +6,7 @@
 {% block content %}
 
 {% include 'components/hero.html' with title=_('Eventos') action_template='eventos/hero_eventos_lista_action.html' %}
+<div class="container mx-auto p-6">
 <section class="max-w-6xl mx-auto mt-8 px-4">
 
   {% include 'components/search_form.html' with q=request.GET.q %}
@@ -29,4 +30,5 @@
   </main>
   {% include 'components/pagination.html' with page_obj=page_obj querystring=querystring %}
 </section>
+</div>
 {% endblock %}

--- a/feed/templates/feed/bookmarks.html
+++ b/feed/templates/feed/bookmarks.html
@@ -7,8 +7,10 @@
   <p class="text-center text-neutral-500">{% trans "Usuário root não tem acesso ao feed." %}</p>
 {% else %}
 {% include 'components/hero.html' with title=_('Meus Favoritos') action_template='feed/hero_actions_bookmarks.html' %}
+<div class="container mx-auto p-6">
 <section class="max-w-6xl mx-auto px-4 py-10">
   {% include "feed/_grid.html" with posts=posts %}
 </section>
+</div>
 {% endif %}
 {% endblock %}

--- a/feed/templates/feed/feed.html
+++ b/feed/templates/feed/feed.html
@@ -8,6 +8,7 @@
   <p class="text-center text-neutral-500">{% trans "Usuário root não tem acesso ao feed." %}</p>
 {% else %}
 {% include 'components/hero.html' with title=_('Feed de Postagens') action_template='feed/hero_actions.html' %}
+<div class="container mx-auto p-6">
 <section class="max-w-7xl mx-auto px-4 py-10">
 
 
@@ -29,5 +30,6 @@
 
 </section>
 <script src="{% static 'feed/js/feed.js' %}"></script>
+</div>
 {% endif %}
 {% endblock %}

--- a/feed/templates/feed/mural.html
+++ b/feed/templates/feed/mural.html
@@ -7,8 +7,10 @@
   <p class="text-center text-neutral-500">{% trans "Usuário root não tem acesso ao feed." %}</p>
 {% else %}
 {% include 'components/hero.html' with title=_('Meu Mural') action_template='feed/hero_actions_mural.html' %}
+<div class="container mx-auto p-6">
 <section class="max-w-6xl mx-auto px-4 py-10">
     {% include "feed/_grid.html" with posts=posts %}
 </section>
+</div>
 {% endif %}
 {% endblock %}

--- a/financeiro/templates/financeiro/centros_list.html
+++ b/financeiro/templates/financeiro/centros_list.html
@@ -5,6 +5,7 @@
 
 {% block content %}
 {% include 'components/hero.html' with title=_('Centros de Custo') action_template='financeiro/hero_centros_action.html' %}
+<div class="container mx-auto p-6">
 <main class="p-4 max-w-5xl mx-auto">
   <section id="centros-list" class="overflow-x-auto" aria-live="polite">
     <table class="min-w-full divide-y divide-gray-200">
@@ -49,5 +50,6 @@
   </section>
   <div id="modal" class="mt-4" aria-live="assertive"></div>
 </main>
+</div>
 {% endblock %}
 

--- a/financeiro/templates/financeiro/integracoes_list.html
+++ b/financeiro/templates/financeiro/integracoes_list.html
@@ -5,6 +5,7 @@
 
 {% block content %}
 {% include 'components/hero.html' with title=_('Integrações') action_template='financeiro/hero_integracoes_action.html' %}
+<div class="container mx-auto p-6">
 <main class="p-4 max-w-5xl mx-auto">
   <section id="integracoes-list" class="overflow-x-auto" aria-live="polite">
     <table class="min-w-full divide-y divide-gray-200">
@@ -54,4 +55,5 @@
   </section>
   <div id="modal" class="mt-4" aria-live="assertive"></div>
 </main>
+</div>
 {% endblock %}

--- a/notificacoes/templates/notificacoes/templates_list.html
+++ b/notificacoes/templates/notificacoes/templates_list.html
@@ -3,6 +3,7 @@
 {% block title %}{% trans 'Templates de Notificação' %} | HubX{% endblock %}
 {% block content %}
 {% include 'components/hero.html' with title=_('Templates de Notificação') subtitle=_('Gerencie as mensagens utilizadas nos envios.') action_template='notificacoes/hero_action.html' %}
+<div class="container mx-auto p-6">
 <div class="max-w-6xl mx-auto px-4 py-10">
   {% if messages %}
   <div class="mb-4 space-y-2" aria-live="polite">
@@ -59,5 +60,6 @@
   {% else %}
     <p class="text-center text-neutral-600">{% trans 'Nenhum template cadastrado.' %}</p>
   {% endif %}
+</div>
 </div>
 {% endblock %}

--- a/nucleos/templates/nucleos/meus_list.html
+++ b/nucleos/templates/nucleos/meus_list.html
@@ -5,6 +5,7 @@
 
 {% block content %}
 {% include 'components/hero.html' with title=_('Meus Núcleos') action_template='nucleos/hero_meus_list_action.html' %}
+<div class="container mx-auto p-6">
 <section class="max-w-5xl mx-auto py-8">
   <form method="get" class="mb-4 flex gap-2">
     <input type="text" name="q" value="{{ form.q.value }}" placeholder="{% trans 'Buscar...' %}" class="border rounded px-2 py-1 flex-1" />
@@ -39,4 +40,5 @@
   </div>
   {% include 'components/pagination.html' with page_obj=page_obj querystring=querystring %}
 </section>
+</div>
 {% endblock %}

--- a/organizacoes/templates/organizacoes/list.html
+++ b/organizacoes/templates/organizacoes/list.html
@@ -5,7 +5,9 @@
 
 {% block content %}
 {% include 'components/hero.html' with title=_('Organizações') subtitle=_('Gerencie as organizações cadastradas') action_template='organizacoes/partials/hero_action.html' %}
+<div class="container mx-auto p-6">
 <section class="max-w-6xl mx-auto px-4 py-10" id="org-list">
   {% include 'organizacoes/partials/list_section.html' %}
 </section>
+</div>
 {% endblock %}

--- a/templates/404.html
+++ b/templates/404.html
@@ -5,6 +5,7 @@
 
 {% block content %}
 {% include 'components/hero.html' with title=_('404') %}
+<div class="container mx-auto p-6">
 <div class="py-16 text-center">
   <div class="card max-w-md mx-auto">
     <div class="card-body">
@@ -12,5 +13,6 @@
       <a href="{% url 'core:home' %}" class="text-sm bg-primary text-white px-4 py-2 rounded hover:bg-primary/90">{% trans "Voltar para a Home" %}</a>
     </div>
   </div>
+</div>
 </div>
 {% endblock %}

--- a/templates/500.html
+++ b/templates/500.html
@@ -5,6 +5,7 @@
 
 {% block content %}
 {% include 'components/hero.html' with title=_('500') %}
+<div class="container mx-auto p-6">
 <div class="py-16 text-center">
   <div class="card max-w-md mx-auto">
     <div class="card-body">
@@ -12,5 +13,6 @@
       <a href="{% url 'core:home' %}" class="text-sm bg-primary text-white px-4 py-2 rounded hover:bg-primary/90">{% trans "Voltar para a Home" %}</a>
     </div>
   </div>
+</div>
 </div>
 {% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -109,7 +109,7 @@
         </div>
       </div>
     </header>
-    <main id="main-content" class="container mx-auto p-6 flex-grow">
+    <main id="main-content" class="flex-grow">
       {% block content %}{% endblock %}
     </main>
 

--- a/tokens/templates/tokens/api_tokens.html
+++ b/tokens/templates/tokens/api_tokens.html
@@ -4,6 +4,7 @@
 
 {% block content %}
 {% include 'components/hero.html' with title=_('Tokens de API') %}
+<div class="container mx-auto p-6">
 <section class="max-w-3xl mx-auto px-4 py-12 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
   <div class="card">
     <div class="card-header">
@@ -80,4 +81,5 @@
     </div>
   </div>
 </section>
+</div>
 {% endblock %}

--- a/tokens/templates/tokens/listar_convites.html
+++ b/tokens/templates/tokens/listar_convites.html
@@ -5,6 +5,7 @@
 {% block content %}
 
 {% include 'components/hero.html' with title=_('Convites Emitidos') action_template='tokens/hero_action.html' %}
+<div class="container mx-auto p-6">
 
 <section class="max-w-6xl mx-auto mt-8 px-4">
   <div class="flex items-center justify-between gap-4 mb-6">
@@ -76,4 +77,5 @@
     <a href="{% url 'configuracoes' %}" class="text-sm text-blue-600 hover:underline">{% trans "Voltar ao painel de segurança" %}</a>
   </div>
 </section>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- remove global container from base template
- wrap page content in containers so hero spans full width

## Testing
- `pytest` *(fails: 81 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bc79b2b5d0832581767b207f0ef92b