### PR TITLE
refactor: improve event details layout

### DIFF
--- a/eventos/templates/eventos/detail.html
+++ b/eventos/templates/eventos/detail.html
@@ -3,125 +3,126 @@
 {% block title %}{{ object.titulo }} | Hubx{% endblock %}
 
 {% block content %}
-<section class="max-w-screen-xl mx-auto pt-8 px-6 lg:px-8">
-
-  <!-- Cabeçalho -->
-  <div class="text-center mb-6">
-    <div class="mx-auto w-20 h-20 bg-neutral-100 rounded-xl flex items-center justify-center text-2xl font-bold text-neutral-700 mb-4" role="img" aria-label="{{ object.titulo }}">
-      {{ object.titulo|make_list|first|upper }}
-    </div>
-    <h1 class="text-2xl font-semibold text-neutral-900">{{ object.titulo }}</h1>
-    {% if object.descricao %}
-      <p class="text-sm text-neutral-600 mt-2">{{ object.descricao }}</p>
-    {% endif %}
-  </div>
-
-  <!-- Informações -->
-  <div class="space-y-2 text-sm text-neutral-800 mb-6">
-
-    <p><strong>{% trans "Início" %}:</strong> {{ object.data_inicio|date:'SHORT_DATETIME_FORMAT' }}</p>
-    <p><strong>{% trans "Fim" %}:</strong> {{ object.data_fim|date:'SHORT_DATETIME_FORMAT' }}</p>
-    <p><strong>{% trans "Local" %}:</strong> {{ object.local }}</p>
-    <p><strong>{% trans "Cidade" %}:</strong> {{ object.cidade }}</p>
-    <p><strong>{% trans "Estado" %}:</strong> {{ object.estado }}</p>
-    <p><strong>{% trans "CEP" %}:</strong> {{ object.cep }}</p>
-    <p>
-      <strong>{% trans "Contato" %}:</strong>
-      {{ object.contato_nome }}
-      {% if object.contato_email %}- {{ object.contato_email }}{% endif %}
-      {% if object.contato_whatsapp %}- {{ object.contato_whatsapp }}{% endif %}
-    </p>
-    {% if object.participantes_maximo %}
-      <p><strong>{% trans "Participantes máximo" %}:</strong> {{ object.participantes_maximo }}</p>
-    {% endif %}
-    <p>
-      <strong>{% trans "Lista de espera" %}:</strong>
-      {% if object.espera_habilitada %}
-        {% trans "Habilitada" %}
-      {% else %}
-        {% trans "Desabilitada" %}
-      {% endif %}
-    </p>
-    {% if object.orcamento %}
-      <p><strong>{% trans "Orçamento" %}:</strong> {{ object.orcamento }}</p>
-    {% endif %}
-    {% if object.orcamento_estimado %}
-      <p><strong>{% trans "Orçamento estimado" %}:</strong> {{ object.orcamento_estimado }}</p>
-    {% endif %}
-    {% if object.valor_gasto %}
-      <p><strong>{% trans "Valor gasto" %}:</strong> {{ object.valor_gasto }}</p>
-    {% endif %}
-
-  </div>
-
-  <!-- Inscrição -->
-  {% if user.is_authenticated and user.user_type != 'admin' %}
-    {% if inscricao %}
-      <div class="mb-10 space-y-4">
-        <img src="{{ inscricao.qrcode_url }}" alt="{% trans 'QR Code da inscrição' %}" class="mx-auto h-48 w-48" />
-        {% if avaliacao_permitida %}
-          <form method="post" action="{% url 'eventos:evento_feedback' object.pk %}" class="space-y-4">
-            {% csrf_token %}
-            <div>
-              <label for="nota" class="block text-sm font-medium">{% trans "Nota" %}</label>
-              <select id="nota" name="nota" class="form-select w-full" required>
-                {% for n in '12345' %}
-                <option value="{{ n }}">{{ n }}</option>
-                {% endfor %}
-              </select>
-            </div>
-            <div>
-              <label for="comentario" class="block text-sm font-medium">{% trans "Comentário" %}</label>
-              <textarea id="comentario" name="comentario" rows="4" class="form-textarea w-full" placeholder="{% trans 'Opcional' %}"></textarea>
-            </div>
-            <div class="text-right">
-              <button type="submit" class="btn-primary" aria-label="{% trans 'Enviar avaliação' %}">{% trans 'Enviar avaliação' %}</button>
-            </div>
-          </form>
-        {% else %}
-          <form method="post" action="{% url 'eventos:evento_subscribe' object.pk %}">
-            {% csrf_token %}
-            <button type="submit" class="btn-secondary" aria-label="{% trans 'Cancelar inscrição' %}">{% trans "Cancelar inscrição" %}</button>
-          </form>
+{% include 'components/hero.html' with title=object.titulo %}
+<section class="container mx-auto p-6">
+  <div class="grid gap-6 md:grid-cols-2">
+    <div class="card">
+      <div class="card-header">
+        <h2 class="text-xl font-semibold">{% trans "Informações" %}</h2>
+      </div>
+      <div class="card-body space-y-2 text-sm">
+        <p><strong>{% trans "Início" %}:</strong> {{ object.data_inicio|date:'SHORT_DATETIME_FORMAT' }}</p>
+        <p><strong>{% trans "Fim" %}:</strong> {{ object.data_fim|date:'SHORT_DATETIME_FORMAT' }}</p>
+        <p><strong>{% trans "Local" %}:</strong> {{ object.local }}</p>
+        <p><strong>{% trans "Cidade" %}:</strong> {{ object.cidade }}</p>
+        <p><strong>{% trans "Estado" %}:</strong> {{ object.estado }}</p>
+        <p><strong>{% trans "CEP" %}:</strong> {{ object.cep }}</p>
+        <p>
+          <strong>{% trans "Contato" %}:</strong>
+          {{ object.contato_nome }}
+          {% if object.contato_email %}- {{ object.contato_email }}{% endif %}
+          {% if object.contato_whatsapp %}- {{ object.contato_whatsapp }}{% endif %}
+        </p>
+        {% if object.participantes_maximo %}
+          <p><strong>{% trans "Participantes máximo" %}:</strong> {{ object.participantes_maximo }}</p>
+        {% endif %}
+        <p>
+          <strong>{% trans "Lista de espera" %}:</strong>
+          {% if object.espera_habilitada %}
+            {% trans "Habilitada" %}
+          {% else %}
+            {% trans "Desabilitada" %}
+          {% endif %}
+        </p>
+        {% if object.orcamento %}
+          <p><strong>{% trans "Orçamento" %}:</strong> {{ object.orcamento }}</p>
+        {% endif %}
+        {% if object.orcamento_estimado %}
+          <p><strong>{% trans "Orçamento estimado" %}:</strong> {{ object.orcamento_estimado }}</p>
+        {% endif %}
+        {% if object.valor_gasto %}
+          <p><strong>{% trans "Valor gasto" %}:</strong> {{ object.valor_gasto }}</p>
         {% endif %}
       </div>
-    {% else %}
-      <div class="mb-10">
-        <a href="{% url 'eventos:inscricao_criar' object.pk %}" class="btn-primary" aria-label="{% trans 'Inscrever-se' %}">{% trans "Inscrever-se" %}</a>
-      </div>
-    {% endif %}
-  {% endif %}
-
-  <!-- Lista de Inscritos -->
-  <h2 class="text-lg font-semibold text-neutral-900 mb-4">{% trans "Inscritos" %}</h2>
-
-  {% if object.inscricoes.all %}
-    <div class="grid gap-4 sm:grid-cols-2">
-      {% for ins in object.inscricoes.all %}
-        {% with inscrito=ins.user %}
-        <div class="flex items-center gap-4 border border-neutral-200 rounded-xl p-4 bg-white shadow-sm">
-          {% if inscrito.avatar %}
-            <img src="{{ inscrito.avatar.url }}" alt="{{ inscrito.username }}" class="w-12 h-12 rounded-full object-cover">
-          {% else %}
-            <div class="w-12 h-12 rounded-full bg-neutral-100 flex items-center justify-center text-sm font-semibold text-neutral-700" role="img" aria-label="{{ inscrito.username }}">
-              {{ inscrito.username|make_list|first|upper }}
-            </div>
-          {% endif %}
-          <div>
-            <h4 class="text-sm font-medium text-neutral-800">{{ inscrito.get_full_name|default:inscrito.username }}</h4>
-            <p class="text-xs text-neutral-500">@{{ inscrito.username }}</p>
-          </div>
-        </div>
-        {% endwith %}
-      {% endfor %}
     </div>
-  {% else %}
-    <p class="text-sm text-neutral-500 mb-6">{% trans "Nenhum inscrito." %}</p>
-  {% endif %}
 
-  <!-- Voltar -->
-  <div class="flex justify-end mt-10">
-    <a href="{% url 'eventos:calendario' %}" class="btn-secondary" aria-label="{% trans 'Voltar' %}">{% trans "Voltar" %}</a>
+    {% if user.is_authenticated and user.user_type != 'admin' %}
+    <div class="card">
+      <div class="card-header">
+        {% if inscricao and avaliacao_permitida %}
+          <h2 class="text-xl font-semibold">{% trans "Avaliação" %}</h2>
+        {% else %}
+          <h2 class="text-xl font-semibold">{% trans "Inscrição" %}</h2>
+        {% endif %}
+      </div>
+      <div class="card-body space-y-4">
+        {% if inscricao %}
+          {% if avaliacao_permitida %}
+            <form method="post" action="{% url 'eventos:evento_feedback' object.pk %}" class="space-y-4">
+              {% csrf_token %}
+              <div class="relative">
+                <select id="nota" name="nota" class="floating peer w-full" required>
+                  {% for n in '12345' %}
+                  <option value="{{ n }}">{{ n }}</option>
+                  {% endfor %}
+                </select>
+                <label for="nota" class="label-float">{% trans "Nota" %}</label>
+              </div>
+              <div class="relative">
+                <textarea id="comentario" name="comentario" rows="4" placeholder=" " class="floating peer w-full"></textarea>
+                <label for="comentario" class="label-float">{% trans "Comentário" %}</label>
+              </div>
+              <div class="text-right">
+                <button type="submit" class="btn-primary" aria-label="{% trans 'Enviar avaliação' %}">{% trans 'Enviar avaliação' %}</button>
+              </div>
+            </form>
+          {% else %}
+            <form method="post" action="{% url 'eventos:evento_subscribe' object.pk %}">
+              {% csrf_token %}
+              <button type="submit" class="btn-secondary" aria-label="{% trans 'Cancelar inscrição' %}">{% trans 'Cancelar inscrição' %}</button>
+            </form>
+          {% endif %}
+        {% else %}
+          <a href="{% url 'eventos:inscricao_criar' object.pk %}" class="btn-primary" aria-label="{% trans 'Inscrever-se' %}">{% trans 'Inscrever-se' %}</a>
+        {% endif %}
+      </div>
+    </div>
+    {% endif %}
+
+    <div class="card md:col-span-2">
+      <div class="card-header">
+        <h2 class="text-lg font-semibold">{% trans "Inscritos" %}</h2>
+      </div>
+      <div class="card-body">
+        {% if object.inscricoes.all %}
+          <div class="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+            {% for ins in object.inscricoes.all %}
+              {% with inscrito=ins.user %}
+              <div class="flex items-center gap-4 p-4 border rounded-xl bg-base-100 shadow-sm">
+                {% if inscrito.avatar %}
+                  <img src="{{ inscrito.avatar.url }}" alt="{{ inscrito.username }}" class="w-12 h-12 rounded-full object-cover">
+                {% else %}
+                  <div class="w-12 h-12 rounded-full bg-base-200 flex items-center justify-center text-sm font-semibold" role="img" aria-label="{{ inscrito.username }}">
+                    {{ inscrito.username|make_list|first|upper }}
+                  </div>
+                {% endif %}
+                <div>
+                  <h4 class="text-sm font-medium">{{ inscrito.get_full_name|default:inscrito.username }}</h4>
+                  <p class="text-xs">@{{ inscrito.username }}</p>
+                </div>
+              </div>
+              {% endwith %}
+            {% endfor %}
+          </div>
+        {% else %}
+          <p class="text-sm">{% trans "Nenhum inscrito." %}</p>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+
+  <div class="flex justify-end mt-6">
+    <a href="{% url 'eventos:calendario' %}" class="btn-secondary" aria-label="{% trans 'Voltar' %}">{% trans 'Voltar' %}</a>
   </div>
 </section>
 {% endblock %}

--- a/eventos/templates/eventos/tarefa_detail.html
+++ b/eventos/templates/eventos/tarefa_detail.html
@@ -3,48 +3,62 @@
 {% block title %}{{ object.titulo }} | Hubx{% endblock %}
 
 {% block content %}
-<section class="max-w-screen-xl mx-auto pt-8 px-6 lg:px-8">
-  <header class="mb-6 flex items-center justify-between">
-    <h1 class="text-2xl font-bold text-neutral-900">{{ object.titulo }}</h1>
-    <a href="{% url 'eventos:tarefa_list' %}" class="btn-secondary" aria-label="{% trans 'Voltar' %}">{% trans "Voltar" %}</a>
-  </header>
+{% include 'components/hero.html' with title=object.titulo %}
+<section class="container mx-auto p-6">
+  <div class="grid gap-6 md:grid-cols-2">
+    <div class="card">
+      <div class="card-header">
+        <h2 class="text-xl font-semibold">{% trans "Detalhes" %}</h2>
+      </div>
+      <div class="card-body">
+        {% if object.descricao %}
+          <p class="mb-4 text-sm">{{ object.descricao }}</p>
+        {% endif %}
+        <div class="space-y-2 text-sm">
+          <p><strong>{% trans "Data de início" %}:</strong> {{ object.data_inicio|date:'SHORT_DATETIME_FORMAT' }}</p>
+          <p><strong>{% trans "Data de fim" %}:</strong> {{ object.data_fim|date:'SHORT_DATETIME_FORMAT' }}</p>
+          <p><strong>{% trans "Responsável" %}:</strong> {{ object.responsavel }}</p>
+          <p><strong>{% trans "Status" %}:</strong> {{ object.get_status_display }}</p>
+        </div>
+      </div>
+    </div>
 
-  {% if object.descricao %}
-    <p class="text-sm text-neutral-600 mb-4">{{ object.descricao }}</p>
-  {% endif %}
-
-  <div class="space-y-2 text-sm text-neutral-800 mb-6">
-    <p><strong>{% trans "Data de início" %}:</strong> {{ object.data_inicio|date:'SHORT_DATETIME_FORMAT' }}</p>
-    <p><strong>{% trans "Data de fim" %}:</strong> {{ object.data_fim|date:'SHORT_DATETIME_FORMAT' }}</p>
-    <p><strong>{% trans "Responsável" %}:</strong> {{ object.responsavel }}</p>
-    <p><strong>{% trans "Status" %}:</strong> {{ object.get_status_display }}</p>
+    <div class="card md:col-span-2">
+      <div class="card-header">
+        <h2 class="text-lg font-semibold">{% trans "Logs" %}</h2>
+      </div>
+      <div class="card-body">
+        {% if logs %}
+          <div class="overflow-x-auto">
+            <table class="min-w-full divide-y">
+              <thead>
+                <tr>
+                  <th class="px-4 py-2 text-left text-xs font-medium">{% trans "Data" %}</th>
+                  <th class="px-4 py-2 text-left text-xs font-medium">{% trans "Usuário" %}</th>
+                  <th class="px-4 py-2 text-left text-xs font-medium">{% trans "Ação" %}</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y">
+                {% for log in logs %}
+                <tr>
+                  <td class="px-4 py-2 text-sm">{{ log.created_at|date:'SHORT_DATETIME_FORMAT' }}</td>
+                  <td class="px-4 py-2 text-sm">{{ log.usuario }}</td>
+                  <td class="px-4 py-2 text-sm">{{ log.acao }}</td>
+                </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+        {% else %}
+          <p class="text-sm">{% trans "Nenhum log disponível." %}</p>
+        {% endif %}
+      </div>
+    </div>
   </div>
 
-  <h2 class="text-lg font-semibold text-neutral-900 mb-4">{% trans "Logs" %}</h2>
-  {% if logs %}
-    <div class="overflow-x-auto">
-      <table class="min-w-full divide-y divide-neutral-200 bg-white border border-neutral-200 rounded-2xl shadow-sm">
-        <thead class="bg-neutral-50">
-          <tr>
-            <th class="px-4 py-2 text-left text-xs font-medium text-neutral-500">{% trans "Data" %}</th>
-            <th class="px-4 py-2 text-left text-xs font-medium text-neutral-500">{% trans "Usuário" %}</th>
-            <th class="px-4 py-2 text-left text-xs font-medium text-neutral-500">{% trans "Ação" %}</th>
-          </tr>
-        </thead>
-        <tbody class="divide-y divide-neutral-200">
-          {% for log in logs %}
-          <tr>
-            <td class="px-4 py-2 text-sm text-neutral-800">{{ log.created_at|date:'SHORT_DATETIME_FORMAT' }}</td>
-            <td class="px-4 py-2 text-sm text-neutral-800">{{ log.usuario }}</td>
-            <td class="px-4 py-2 text-sm text-neutral-800">{{ log.acao }}</td>
-          </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-    </div>
-  {% else %}
-    <p class="text-sm text-neutral-500">{% trans "Nenhum log disponível." %}</p>
-  {% endif %}
+  <div class="flex justify-end mt-6">
+    <a href="{% url 'eventos:tarefa_list' %}" class="btn-secondary" aria-label="{% trans 'Voltar' %}">{% trans 'Voltar' %}</a>
+  </div>
 </section>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- add hero and card layout to evento and tarefa details
- use floating labels with peer classes for event evaluation form
- normalize buttons and responsive grids for attendee and log sections

## Testing
- `pytest eventos/tests -q` *(fails: Required test coverage of 90% not reached and multiple errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bc876972588325aededc7e987968bc