### PR TITLE
Refactor empresa detail layout with hero component and design tokens

### DIFF
--- a/empresas/templates/empresas/detail.html
+++ b/empresas/templates/empresas/detail.html
@@ -3,29 +3,11 @@
 {% block title %}{{ empresa.nome }} | Hubx{% endblock %}
 
 {% block content %}
-<section class="py-10 px-4 max-w-4xl mx-auto">
-  {% if empresa.cover %}
-    <div class="mb-6">
-      <img src="{{ empresa.cover.url }}" alt="{{ empresa.nome }}" class="w-full h-48 object-cover rounded-xl" />
-    </div>
-  {% endif %}
-  <div class="text-center mb-6">
-    {% if empresa.avatar %}
-      <img src="{{ empresa.avatar.url }}" alt="{{ empresa.nome }}" class="h-20 w-20 mx-auto rounded-xl object-cover" />
-    {% else %}
-      <div class="h-20 w-20 mx-auto rounded-xl bg-neutral-100 flex items-center justify-center text-xl font-bold text-neutral-700" role="img" aria-label="{{ empresa.nome }}">
-        {{ empresa.nome|make_list|first|upper }}
-      </div>
-    {% endif %}
-  </div>
-
-  <h1 class="text-2xl font-semibold text-neutral-900 text-center">{{ empresa.nome }}</h1>
-
-  {% if empresa.descricao %}
-    <p class="text-center text-sm text-neutral-600 mt-2">{{ empresa.descricao }}</p>
-  {% endif %}
-
-  <div class="mt-6 space-y-1 text-sm text-neutral-800">
+{% include 'components/hero.html' with title=empresa.nome subtitle=empresa.descricao %}
+<div class="container mx-auto p-6">
+  <div class="card max-w-4xl mx-auto">
+    <div class="card-body">
+      <div class="space-y-1 text-sm text-neutral-800">
     <p><strong>{% trans "CNPJ" %}:</strong> {{ empresa.cnpj|localize }}</p>
     <p><strong>{% trans "Status de validação" %}:</strong>
       {% if empresa.validado_em %}
@@ -36,42 +18,42 @@
         {% trans "Pendente" %}
       {% endif %}
     </p>
-    <p><strong>{% trans "Localização" %}:</strong> {{ empresa.municipio }}, {{ empresa.estado }}</p>
-    {% if pode_visualizar_contatos %}
-      {% with empresa.get_contato_principal as contato %}
-        {% if contato %}
-          <p><strong>{% trans "Contato" %}:</strong> {{ contato.nome }}</p>
-        {% else %}
-          <p><strong>{% trans "Contato" %}:</strong> {% trans "Nenhum contato cadastrado" %}</p>
+        <p><strong>{% trans "Localização" %}:</strong> {{ empresa.municipio }}, {{ empresa.estado }}</p>
+        {% if pode_visualizar_contatos %}
+          {% with empresa.get_contato_principal as contato %}
+            {% if contato %}
+              <p><strong>{% trans "Contato" %}:</strong> {{ contato.nome }}</p>
+            {% else %}
+              <p><strong>{% trans "Contato" %}:</strong> {% trans "Nenhum contato cadastrado" %}</p>
+            {% endif %}
+          {% endwith %}
         {% endif %}
-      {% endwith %}
-    {% endif %}
-  </div>
-
-  {% if pode_visualizar_contatos %}
-    <h2 class="mt-8 text-lg font-semibold text-neutral-900">{% trans "Contatos" %}</h2>
-    <div class="mt-4 space-y-4">
-      {% for contato in contatos %}
-        <div class="flex justify-between items-start bg-white border border-neutral-200 rounded-xl p-4">
-          <div class="text-sm">
-            <p class="font-medium text-neutral-800">{{ contato.nome }}</p>
-            <p class="text-neutral-600">{{ contato.cargo }}</p>
-            <p class="text-neutral-600">{{ contato.email }}</p>
-            <p class="text-neutral-600">{{ contato.telefone }}</p>
-          </div>
-          <div class="flex gap-2">
-            <a href="{% url 'empresas:contato_editar' contato.id %}" class="text-sm px-3 py-1 rounded-lg border border-neutral-300 text-neutral-700 hover:bg-neutral-100">{% trans "Editar" %}</a>
-            <a href="{% url 'empresas:contato_remover' contato.id %}" class="text-sm px-3 py-1 rounded-lg border border-red-300 text-red-700 hover:bg-red-100">{% trans "Remover" %}</a>
-          </div>
-        </div>
-      {% empty %}
-        <p class="text-sm text-neutral-500">{% trans "Nenhum contato cadastrado." %}</p>
-      {% endfor %}
-      <div>
-        <a href="{% url 'empresas:contato_novo' empresa.id %}" class="inline-block text-sm mt-2 px-4 py-2 rounded-xl bg-primary-600 text-white hover:bg-primary-700">{% trans "Adicionar" %}</a>
       </div>
-    </div>
-  {% endif %}
+
+      {% if pode_visualizar_contatos %}
+        <h2 class="mt-8 text-lg font-semibold text-neutral-900">{% trans "Contatos" %}</h2>
+        <div class="mt-4 grid gap-4 sm:grid-cols-2">
+          {% for contato in contatos %}
+            <div class="flex justify-between items-start bg-white border border-neutral-200 rounded-xl p-4">
+              <div class="text-sm">
+                <p class="font-medium text-neutral-800">{{ contato.nome }}</p>
+                <p class="text-neutral-600">{{ contato.cargo }}</p>
+                <p class="text-neutral-600">{{ contato.email }}</p>
+                <p class="text-neutral-600">{{ contato.telefone }}</p>
+              </div>
+              <div class="flex gap-2">
+                <a href="{% url 'empresas:contato_editar' contato.id %}" class="btn-secondary btn-sm">{% trans "Editar" %}</a>
+                <a href="{% url 'empresas:contato_remover' contato.id %}" class="btn-danger btn-sm">{% trans "Remover" %}</a>
+              </div>
+            </div>
+          {% empty %}
+            <p class="text-sm text-neutral-500">{% trans "Nenhum contato cadastrado." %}</p>
+          {% endfor %}
+        </div>
+        <div class="mt-4">
+          <a href="{% url 'empresas:contato_novo' empresa.id %}" class="btn-primary btn-sm">{% trans "Adicionar" %}</a>
+        </div>
+      {% endif %}
 
   {% if empresa_tags %}
     <div class="mt-4">
@@ -84,43 +66,43 @@
     </div>
   {% endif %}
 
-  {% if prod_tags %}
-    <h2 class="mt-8 text-lg font-semibold text-neutral-900">{% trans "Produtos" %}</h2>
-    <div class="grid gap-6 sm:grid-cols-2 md:grid-cols-3 mt-4">
-      {% for tag in prod_tags %}
-        <div class="bg-white border border-neutral-200 rounded-2xl p-4 shadow-sm">
-          <h3 class="text-base font-medium text-neutral-800">{{ tag.nome }}</h3>
+      {% if prod_tags %}
+        <h2 class="mt-8 text-lg font-semibold text-neutral-900">{% trans "Produtos" %}</h2>
+        <div class="grid gap-6 sm:grid-cols-2 md:grid-cols-3 mt-4">
+          {% for tag in prod_tags %}
+            <div class="bg-white border border-neutral-200 rounded-2xl p-4 shadow-sm">
+              <h3 class="text-base font-medium text-neutral-800">{{ tag.nome }}</h3>
+            </div>
+          {% empty %}
+            <p class="text-sm text-neutral-500">{% trans "Nenhum produto cadastrado." %}</p>
+          {% endfor %}
         </div>
-      {% empty %}
-        <p class="text-sm text-neutral-500">{% trans "Nenhum produto cadastrado." %}</p>
-      {% endfor %}
-    </div>
-  {% endif %}
+      {% endif %}
 
-  {% if serv_tags %}
-    <h2 class="mt-8 text-lg font-semibold text-neutral-900">{% trans "Serviços" %}</h2>
-    <div class="grid gap-6 sm:grid-cols-2 md:grid-cols-3 mt-4">
-      {% for tag in serv_tags %}
-        <div class="bg-white border border-neutral-200 rounded-2xl p-4 shadow-sm">
-          <h3 class="text-base font-medium text-neutral-800">{{ tag.nome }}</h3>
+      {% if serv_tags %}
+        <h2 class="mt-8 text-lg font-semibold text-neutral-900">{% trans "Serviços" %}</h2>
+        <div class="grid gap-6 sm:grid-cols-2 md:grid-cols-3 mt-4">
+          {% for tag in serv_tags %}
+            <div class="bg-white border border-neutral-200 rounded-2xl p-4 shadow-sm">
+              <h3 class="text-base font-medium text-neutral-800">{{ tag.nome }}</h3>
+            </div>
+          {% empty %}
+            <p class="text-sm text-neutral-500">{% trans "Nenhum serviço cadastrado." %}</p>
+          {% endfor %}
         </div>
-      {% empty %}
-        <p class="text-sm text-neutral-500">{% trans "Nenhum serviço cadastrado." %}</p>
-      {% endfor %}
-    </div>
-  {% endif %}
+      {% endif %}
 
-  {% if empresa.usuario %}
-    <h2 class="mt-8 text-lg font-semibold text-neutral-900">{% trans "Proprietário" %}</h2>
-    <div class="flex items-center gap-4 mt-4">
+      {% if empresa.usuario %}
+        <h2 class="mt-8 text-lg font-semibold text-neutral-900">{% trans "Proprietário" %}</h2>
+        <div class="flex items-center gap-4 mt-4">
       {% with dono=empresa.usuario %}
         {% if dono.avatar %}
           <img src="{{ dono.avatar.url }}" alt="{{ dono.username }}" class="w-12 h-12 rounded-full object-cover" />
         {% else %}
           <div class="w-12 h-12 rounded-full bg-neutral-100 flex items-center justify-center text-sm font-semibold text-neutral-700" role="img" aria-label="{{ dono.username }}">
             {{ dono.username|make_list|first|upper }}
-          </div>
-        {% endif %}
+        </div>
+      {% endif %}
         <div>
           <p class="text-sm font-medium text-neutral-800">{{ dono.get_full_name|default:dono.username }}</p>
           <p class="text-xs text-neutral-600">{{ dono.email }}</p>
@@ -129,75 +111,77 @@
     </div>
   {% endif %}
 
-  {% if nucleos_dono %}
-    <h2 class="mt-8 text-lg font-semibold text-neutral-900">{% trans "Núcleos" %}</h2>
-    <div class="grid gap-6 sm:grid-cols-2 md:grid-cols-3 mt-4">
-      {% for nucleo in nucleos_dono %}
-        <div class="bg-white border border-neutral-200 rounded-2xl p-4 shadow-sm text-center">
-          {% if nucleo.avatar %}
-            <img src="{{ nucleo.avatar.url }}" alt="{{ nucleo.nome }}" class="w-16 h-16 rounded-full object-cover mx-auto mb-2" />
-          {% else %}
-            <div class="w-16 h-16 rounded-full bg-neutral-100 flex items-center justify-center text-sm font-medium text-neutral-700 mx-auto mb-2" role="img" aria-label="{{ nucleo.nome }}">
-              {{ nucleo.nome|make_list|first|upper }}
+      {% if nucleos_dono %}
+        <h2 class="mt-8 text-lg font-semibold text-neutral-900">{% trans "Núcleos" %}</h2>
+        <div class="grid gap-6 sm:grid-cols-2 md:grid-cols-3 mt-4">
+          {% for nucleo in nucleos_dono %}
+            <div class="bg-white border border-neutral-200 rounded-2xl p-4 shadow-sm text-center">
+              {% if nucleo.avatar %}
+                <img src="{{ nucleo.avatar.url }}" alt="{{ nucleo.nome }}" class="w-16 h-16 rounded-full object-cover mx-auto mb-2" />
+              {% else %}
+                <div class="w-16 h-16 rounded-full bg-neutral-100 flex items-center justify-center text-sm font-medium text-neutral-700 mx-auto mb-2" role="img" aria-label="{{ nucleo.nome }}">
+                  {{ nucleo.nome|make_list|first|upper }}
+                </div>
+              {% endif %}
+              <h3 class="text-sm font-medium text-neutral-800">{{ nucleo.nome }}</h3>
             </div>
-          {% endif %}
-          <h3 class="text-sm font-medium text-neutral-800">{{ nucleo.nome }}</h3>
+          {% empty %}
+            <p class="text-sm text-neutral-500">{% trans "Nenhum núcleo." %}</p>
+          {% endfor %}
         </div>
-      {% empty %}
-        <p class="text-sm text-neutral-500">{% trans "Nenhum núcleo." %}</p>
-      {% endfor %}
-    </div>
-  {% endif %}
-
-  {% if eventos_dono %}
-    <h2 class="mt-8 text-lg font-semibold text-neutral-900">{% trans "Eventos" %}</h2>
-    <div class="grid gap-6 sm:grid-cols-2 md:grid-cols-3 mt-4">
-      {% for evento in eventos_dono %}
-        <div class="bg-white border border-neutral-200 rounded-2xl p-4 shadow-sm">
-          <h3 class="text-base font-medium text-neutral-800">{{ evento.titulo }}</h3>
-          <p class="text-sm text-neutral-600">{{ evento.data_inicio|date:"SHORT_DATE_FORMAT" }}</p>
-        </div>
-      {% empty %}
-        <p class="text-sm text-neutral-500">{% trans "Nenhum evento." %}</p>
-      {% endfor %}
-    </div>
-  {% endif %}
-
-  <div class="mt-8">
-    {% include "empresas/includes/avaliacoes.html" %}
-  </div>
-
-  <div class="flex justify-end gap-3 mt-8">
-    <a href="{% url 'empresas:lista' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100">{% trans "Voltar" %}</a>
-    {% translate "Favoritar" as txt_favoritar %}
-    {% translate "Desfavoritar" as txt_desfavoritar %}
-    <button
-      id="favorito-btn"
-      class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100"
-      {% if empresa.favoritado %}
-        hx-delete="{% url 'empresas_api:empresa-favoritar' empresa.id %}"
-      {% else %}
-        hx-post="{% url 'empresas_api:empresa-favoritar' empresa.id %}"
       {% endif %}
-      hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
-      hx-swap="none"
-      hx-on:afterRequest="
-        if (event.detail.xhr.status === 201) {
-          this.innerText='{{ txt_desfavoritar }}';
-          this.setAttribute('hx-delete', '{% url 'empresas_api:empresa-favoritar' empresa.id %}');
-          this.removeAttribute('hx-post');
-        } else if (event.detail.xhr.status === 204) {
-          this.innerText='{{ txt_favoritar }}';
-          this.setAttribute('hx-post', '{% url 'empresas_api:empresa-favoritar' empresa.id %}');
-          this.removeAttribute('hx-delete');
-        }
-      "
-    >
-      {% if empresa.favoritado %}{{ txt_desfavoritar }}{% else %}{{ txt_favoritar }}{% endif %}
-    </button>
-    {% if request.user == empresa.usuario %}
-      <a href="{% url 'empresas:empresa_editar' empresa.id %}" class="text-sm px-4 py-2 rounded-xl bg-primary-600 text-white hover:bg-primary-700">{% trans "Editar" %}</a>
-    {% endif %}
+
+      {% if eventos_dono %}
+        <h2 class="mt-8 text-lg font-semibold text-neutral-900">{% trans "Eventos" %}</h2>
+        <div class="grid gap-6 sm:grid-cols-2 md:grid-cols-3 mt-4">
+          {% for evento in eventos_dono %}
+            <div class="bg-white border border-neutral-200 rounded-2xl p-4 shadow-sm">
+              <h3 class="text-base font-medium text-neutral-800">{{ evento.titulo }}</h3>
+              <p class="text-sm text-neutral-600">{{ evento.data_inicio|date:"SHORT_DATE_FORMAT" }}</p>
+            </div>
+          {% empty %}
+            <p class="text-sm text-neutral-500">{% trans "Nenhum evento." %}</p>
+          {% endfor %}
+        </div>
+      {% endif %}
+
+      <div class="mt-8">
+        {% include "empresas/includes/avaliacoes.html" %}
+      </div>
+
+      <div class="flex justify-end gap-3 mt-8">
+        <a href="{% url 'empresas:lista' %}" class="btn-secondary btn-sm">{% trans "Voltar" %}</a>
+        {% translate "Favoritar" as txt_favoritar %}
+        {% translate "Desfavoritar" as txt_desfavoritar %}
+        <button
+          id="favorito-btn"
+          class="btn-secondary btn-sm"
+          {% if empresa.favoritado %}
+            hx-delete="{% url 'empresas_api:empresa-favoritar' empresa.id %}"
+          {% else %}
+            hx-post="{% url 'empresas_api:empresa-favoritar' empresa.id %}"
+          {% endif %}
+          hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+          hx-swap="none"
+          hx-on:afterRequest="
+            if (event.detail.xhr.status === 201) {
+              this.innerText='{{ txt_desfavoritar }}';
+              this.setAttribute('hx-delete', '{% url 'empresas_api:empresa-favoritar' empresa.id %}');
+              this.removeAttribute('hx-post');
+            } else if (event.detail.xhr.status === 204) {
+              this.innerText='{{ txt_favoritar }}';
+              this.setAttribute('hx-post', '{% url 'empresas_api:empresa-favoritar' empresa.id %}');
+              this.removeAttribute('hx-delete');
+            }
+          "
+        >
+          {% if empresa.favoritado %}{{ txt_desfavoritar }}{% else %}{{ txt_favoritar }}{% endif %}
+        </button>
+        {% if request.user == empresa.usuario %}
+          <a href="{% url 'empresas:empresa_editar' empresa.id %}" class="btn-primary btn-sm">{% trans "Editar" %}</a>
+        {% endif %}
+      </div>
+    </div>
   </div>
-</section>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- replace custom section with reusable hero component
- wrap empresa detail content in card and apply responsive grids
- switch buttons to design system utilities

## Testing
- `pytest -m "not slow"` *(fails: Module errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bc87678e0c832593844d924eb88e3d