### PR TITLE
feat(perfil): substituir emojis por ícones Lucide

### DIFF
--- a/accounts/templates/perfil/conexoes.html
+++ b/accounts/templates/perfil/conexoes.html
@@ -1,5 +1,5 @@
 {% extends 'perfil/perfil.html' %}
-{% load static i18n %}
+{% load static i18n lucide_icons %}
 
 {% block title %}{% trans "Minhas Conexões" %} | HubX{% endblock %}
 
@@ -29,7 +29,9 @@
           placeholder="{% trans 'Buscar conexões...' %}"
           class="flex-grow border rounded-lg p-2 text-sm"
         />
-        <button type="submit" class="text-gray-600 text-sm" aria-label="{% trans 'Buscar' %}">🔍</button>
+        <button type="submit" class="btn-secondary btn-sm" aria-label="{% trans 'Buscar' %}">
+          {% lucide 'search' class='w-4 h-4' %}
+        </button>
       </form>
 
       <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
@@ -51,7 +53,9 @@
           <div class="flex gap-2">
             <form method="post" action="{% url 'accounts:remover_conexao' connection.id %}" onsubmit="return confirm('{% trans 'Tem certeza que deseja remover esta conexão?' %}');">
               {% csrf_token %}
-              <button title="{% trans 'Remover conexão' %}" class="text-red-500 hover:text-red-600">❌</button>
+              <button title="{% trans 'Remover conexão' %}" class="btn-danger btn-sm" aria-label="{% trans 'Remover conexão' %}">
+                {% lucide 'trash' class='w-4 h-4' %}
+              </button>
             </form>
           </div>
         </div>

--- a/accounts/templates/perfil/midia_confirm_delete.html
+++ b/accounts/templates/perfil/midia_confirm_delete.html
@@ -1,5 +1,5 @@
 {% extends 'perfil/perfil.html' %}
-{% load i18n %}
+{% load i18n lucide_icons %}
 {% block title %}{% trans "Remover Mídia" %} | Hubx{% endblock %}
 
 {% block perfil_content %}
@@ -8,8 +8,14 @@
   <p class="text-gray-600">{% trans "Tem certeza que deseja remover esta mídia?" %}</p>
   <form method="post" class="flex justify-end gap-2">
     {% csrf_token %}
-    <a href="{% url 'accounts:midias' %}" class="px-4 py-2 border rounded text-sm hover:bg-gray-100">{% trans "Cancelar" %}</a>
-    <button type="submit" class="bg-red-500 text-white px-4 py-2 rounded hover:bg-red-600">{% trans "Remover" %}</button>
+    <a href="{% url 'accounts:midias' %}" class="btn-secondary btn-sm inline-flex items-center gap-1">
+      {% lucide 'arrow-left' class='w-4 h-4' %}
+      {% trans "Cancelar" %}
+    </a>
+    <button type="submit" class="btn-danger btn-sm inline-flex items-center gap-1">
+      {% lucide 'trash' class='w-4 h-4' %}
+      {% trans "Remover" %}
+    </button>
   </form>
 </section>
 {% endblock %}

--- a/accounts/templates/perfil/midia_detail.html
+++ b/accounts/templates/perfil/midia_detail.html
@@ -1,5 +1,5 @@
 {% extends 'perfil/perfil.html' %}
-{% load i18n %}
+{% load i18n lucide_icons %}
 
 {% block title %}{% trans "Mídia" %} | Hubx{% endblock %}
 
@@ -16,17 +16,26 @@
       <embed src="{{ media.file.url }}" type="application/pdf" />
       <p class="text-center text-gray-700">
         {% trans "Este navegador não suporta visualização de PDF." %}
-        <a href="{{ media.file.url }}" class="text-primary hover:underline" download>{% trans "Baixar PDF" %}</a>
+        <a href="{{ media.file.url }}" class="inline-flex items-center gap-1 text-primary hover:underline" download>
+          {% lucide 'download' class='w-4 h-4' %}
+          {% trans "Baixar PDF" %}
+        </a>
       </p>
     </object>
   {% else %}
     <p class="text-center">
-      <a href="{{ media.file.url }}" class="text-primary hover:underline" download>{{ media.file.name }}</a>
+      <a href="{{ media.file.url }}" class="inline-flex items-center gap-1 text-primary hover:underline" download>
+        {% lucide 'download' class='w-4 h-4' %}
+        {{ media.file.name }}
+      </a>
     </p>
   {% endif %}
   <p class="text-center text-gray-700">{{ media.descricao }}</p>
   <div class="text-center">
-    <a href="{% url 'accounts:midias' %}" class="text-sm text-primary hover:underline">← {% trans "Voltar para mídias" %}</a>
+    <a href="{% url 'accounts:midias' %}" class="inline-flex items-center gap-1 text-sm text-primary hover:underline">
+      {% lucide 'arrow-left' class='w-4 h-4' %}
+      {% trans "Voltar para mídias" %}
+    </a>
   </div>
 </section>
 {% endblock %}

--- a/accounts/templates/perfil/midias.html
+++ b/accounts/templates/perfil/midias.html
@@ -1,5 +1,5 @@
 {% extends 'perfil/perfil.html' %}
-{% load static i18n %}
+{% load static i18n lucide_icons %}
 
 {% block title %}{% trans "Mídias" %} | Hubx{% endblock %}
 
@@ -56,8 +56,12 @@
     {% for media in medias %}
     <div class="bg-white border rounded-lg shadow p-3 relative">
       <div class="absolute top-2 right-2 flex gap-2">
-        <a href="{% url 'accounts:midia_edit' media.pk %}" class="text-sm text-blue-600 hover:underline" aria-label="{% trans 'Editar' %}">✏️</a>
-        <a href="{% url 'accounts:midia_delete' media.pk %}" class="text-sm text-red-600 hover:underline" aria-label="{% trans 'Excluir' %}">🗑️</a>
+        <a href="{% url 'accounts:midia_edit' media.pk %}" class="btn-secondary btn-sm" aria-label="{% trans 'Editar' %}">
+          {% lucide 'edit' class='w-4 h-4' %}
+        </a>
+        <a href="{% url 'accounts:midia_delete' media.pk %}" class="btn-danger btn-sm" aria-label="{% trans 'Excluir' %}">
+          {% lucide 'trash' class='w-4 h-4' %}
+        </a>
       </div>
       <a href="{% url 'accounts:midia_detail' media.pk %}">
         {% if media.media_type == 'image' %}


### PR DESCRIPTION
## Summary
- replace action emojis with Lucide icons in profile media and connection views
- add Lucide icons to media detail and delete confirmation pages

## Testing
- `pytest -o addopts="--no-cov" tests/accounts/test_connections.py tests/accounts/test_media_delete.py` *(fails: No module named 'discussao')*


------
https://chatgpt.com/codex/tasks/task_e_68bcb513e574832585cc99d603d1d9c7