### PR TITLE
refactor: apply floating labels and tokens

### DIFF
--- a/accounts/templates/perfil/disable_2fa.html
+++ b/accounts/templates/perfil/disable_2fa.html
@@ -3,17 +3,17 @@
 {% block title %}{% trans "Desativar 2FA" %} | HubX{% endblock %}
 {% block perfil_content %}
 <h3 class="text-xl font-semibold mb-4">{% trans "Desativar 2FA" %}</h3>
-<p class="text-sm text-gray-600 mb-4">{% trans "Digite o código do seu aplicativo autenticador para desativar a verificação em duas etapas." %}</p>
+<p class="text-sm text-neutral-500 dark:text-neutral-400 mb-4">{% trans "Digite o código do seu aplicativo autenticador para desativar a verificação em duas etapas." %}</p>
 <form method="post" class="space-y-4">
   {% csrf_token %}
-  <div>
-    <label for="code" class="block text-sm font-medium text-gray-700">{% trans "Código" %}</label>
-    <input type="text" name="code" id="code" class="mt-1 block w-full border rounded-lg p-2 text-sm" required />
+  <div class="relative">
+    <input type="text" name="code" id="code" class="peer form-input placeholder-transparent" placeholder=" " required />
+    <label for="code" class="label-float">{% trans "Código" %}</label>
   </div>
-  <div>
-    <label for="password" class="block text-sm font-medium text-gray-700">{% trans "Senha" %}</label>
-    <input type="password" name="password" id="password" class="mt-1 block w-full border rounded-lg p-2 text-sm" required />
+  <div class="relative">
+    <input type="password" name="password" id="password" class="peer form-input placeholder-transparent" placeholder=" " required />
+    <label for="password" class="label-float">{% trans "Senha" %}</label>
   </div>
-  <button type="submit" class="bg-primary text-white px-4 py-2 rounded-lg text-sm">{% trans "Desativar" %}</button>
+  <button type="submit" class="btn btn-primary">{% trans "Desativar" %}</button>
 </form>
 {% endblock %}

--- a/accounts/templates/perfil/enable_2fa.html
+++ b/accounts/templates/perfil/enable_2fa.html
@@ -3,18 +3,18 @@
 {% block title %}{% trans "Ativar 2FA" %} | HubX{% endblock %}
 {% block perfil_content %}
 <h3 class="text-xl font-semibold mb-4">{% trans "Ativar 2FA" %}</h3>
-<p class="text-sm text-gray-600 mb-4">{% trans "Escaneie o QR-code abaixo com seu aplicativo autenticador e informe o código gerado." %}</p>
+<p class="text-sm text-neutral-500 dark:text-neutral-400 mb-4">{% trans "Escaneie o QR-code abaixo com seu aplicativo autenticador e informe o código gerado." %}</p>
 <img src="data:image/png;base64,{{ qr_base64 }}" alt="{% trans 'QR Code' %}" class="mb-4 mx-auto"/>
 <form method="post" class="space-y-4">
   {% csrf_token %}
-  <div>
-    <label for="code" class="block text-sm font-medium text-gray-700">{% trans "Código" %}</label>
-    <input type="text" name="code" id="code" class="mt-1 block w-full border rounded-lg p-2 text-sm" required />
+  <div class="relative">
+    <input type="text" name="code" id="code" class="peer form-input placeholder-transparent" placeholder=" " required />
+    <label for="code" class="label-float">{% trans "Código" %}</label>
   </div>
-  <div>
-    <label for="password" class="block text-sm font-medium text-gray-700">{% trans "Senha" %}</label>
-    <input type="password" name="password" id="password" class="mt-1 block w-full border rounded-lg p-2 text-sm" required />
+  <div class="relative">
+    <input type="password" name="password" id="password" class="peer form-input placeholder-transparent" placeholder=" " required />
+    <label for="password" class="label-float">{% trans "Senha" %}</label>
   </div>
-  <button type="submit" class="bg-primary text-white px-4 py-2 rounded-lg text-sm">{% trans "Ativar" %}</button>
+  <button type="submit" class="btn btn-primary">{% trans "Ativar" %}</button>
 </form>
 {% endblock %}

--- a/accounts/templates/perfil/informacoes_pessoais.html
+++ b/accounts/templates/perfil/informacoes_pessoais.html
@@ -6,57 +6,61 @@
 {% block perfil_content %}
 <div class="max-w-3xl mx-auto">
   <h3 class="text-xl font-semibold mb-1">{% trans "Informações Pessoais" %}</h3>
-  <p class="text-sm text-gray-500 mb-6">{% trans "Atualize seus dados básicos e de contato" %}</p>
+  <p class="text-sm text-neutral-500 dark:text-neutral-400 mb-6">{% trans "Atualize seus dados básicos e de contato" %}</p>
 
   <form method="post" enctype="multipart/form-data" class="space-y-6">
     {% csrf_token %}
 
     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-      <div>
-        {{ form.first_name.label_tag }}
-        {{ form.first_name }}
+      <div class="relative">
+        {{ form.first_name|add_class:'peer form-input placeholder-transparent'|attr:'placeholder: ' }}
+        <label for="{{ form.first_name.id_for_label }}" class="label-float">{{ form.first_name.label }}</label>
         {{ form.first_name.errors }}
       </div>
-      <div>
-        {{ form.last_name.label_tag }}
-        {{ form.last_name }}
+      <div class="relative">
+        {{ form.last_name|add_class:'peer form-input placeholder-transparent'|attr:'placeholder: ' }}
+        <label for="{{ form.last_name.id_for_label }}" class="label-float">{{ form.last_name.label }}</label>
         {{ form.last_name.errors }}
       </div>
     </div>
 
     <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
-      <div>
-        {{ form.username.label_tag }}
-        {{ form.username }}
+      <div class="relative">
+        {{ form.username|add_class:'peer form-input placeholder-transparent'|attr:'placeholder: ' }}
+        <label for="{{ form.username.id_for_label }}" class="label-float">{{ form.username.label }}</label>
         {{ form.username.errors }}
       </div>
 
-      <div>
-        {{ form.email.label_tag }}
-        {{ form.email }}
+      <div class="relative">
+        {{ form.email|add_class:'peer form-input placeholder-transparent'|attr:'placeholder: ' }}
+        <label for="{{ form.email.id_for_label }}" class="label-float">{{ form.email.label }}</label>
         {{ form.email.errors }}
       </div>
     </div>
 
-    <div>
-      {{ form.cpf.label_tag }}
-      {{ form.cpf }}
+    <div class="relative">
+      {{ form.cpf|add_class:'peer form-input placeholder-transparent'|attr:'placeholder: ' }}
+      <label for="{{ form.cpf.id_for_label }}" class="label-float">{{ form.cpf.label }}</label>
       {{ form.cpf.errors }}
     </div>
 
-    <div>
-      {{ form.biografia.label_tag }}
-      {{ form.biografia }}
+    <div class="relative">
+      {{ form.biografia|add_class:'peer form-input placeholder-transparent'|attr:'placeholder: ' }}
+      <label for="{{ form.biografia.id_for_label }}" class="label-float">{{ form.biografia.label }}</label>
       {{ form.biografia.errors }}
     </div>
 
-    <div>
-      {{ form.avatar.label_tag }}
-      {{ form.avatar }}
-      {{ form.avatar.errors }}
-      {{ form.cover.label_tag }}
-      {{ form.cover }}
-      {{ form.cover.errors }}
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <div class="relative">
+        {{ form.avatar|add_class:'peer form-input placeholder-transparent'|attr:'placeholder: ' }}
+        <label for="{{ form.avatar.id_for_label }}" class="label-float">{{ form.avatar.label }}</label>
+        {{ form.avatar.errors }}
+      </div>
+      <div class="relative">
+        {{ form.cover|add_class:'peer form-input placeholder-transparent'|attr:'placeholder: ' }}
+        <label for="{{ form.cover.id_for_label }}" class="label-float">{{ form.cover.label }}</label>
+        {{ form.cover.errors }}
+      </div>
     </div>
 
     <hr class="my-6">
@@ -64,45 +68,44 @@
     <h4 class="text-lg font-semibold">{% trans "Informações de Contato" %}</h4>
 
     <div class="grid md:grid-cols-2 gap-4">
-      <div>
-        {{ form.phone_number.label_tag }}
-        {{ form.phone_number }}
+      <div class="relative">
+        {{ form.phone_number|add_class:'peer form-input placeholder-transparent'|attr:'placeholder: ' }}
+        <label for="{{ form.phone_number.id_for_label }}" class="label-float">{{ form.phone_number.label }}</label>
         {{ form.phone_number.errors }}
       </div>
-      <div>
-        {{ form.whatsapp.label_tag }}
-        {{ form.whatsapp }}
+      <div class="relative">
+        {{ form.whatsapp|add_class:'peer form-input placeholder-transparent'|attr:'placeholder: ' }}
+        <label for="{{ form.whatsapp.id_for_label }}" class="label-float">{{ form.whatsapp.label }}</label>
         {{ form.whatsapp.errors }}
       </div>
     </div>
 
-    <div>
-      {{ form.endereco.label_tag }}
-      {{ form.endereco|add_class:'w-full' }}
+    <div class="relative">
+      {{ form.endereco|add_class:'w-full peer form-input placeholder-transparent'|attr:'placeholder: ' }}
+      <label for="{{ form.endereco.id_for_label }}" class="label-float">{{ form.endereco.label }}</label>
       {{ form.endereco.errors }}
     </div>
 
     <div class="grid md:grid-cols-3 gap-4">
-      <div>
-        {{ form.cidade.label_tag }}
-        {{ form.cidade }}
+      <div class="relative">
+        {{ form.cidade|add_class:'peer form-input placeholder-transparent'|attr:'placeholder: ' }}
+        <label for="{{ form.cidade.id_for_label }}" class="label-float">{{ form.cidade.label }}</label>
         {{ form.cidade.errors }}
       </div>
-      <div>
-        {{ form.estado.label_tag }}
-        {{ form.estado }}
+      <div class="relative">
+        {{ form.estado|add_class:'peer form-input placeholder-transparent'|attr:'placeholder: ' }}
+        <label for="{{ form.estado.id_for_label }}" class="label-float">{{ form.estado.label }}</label>
         {{ form.estado.errors }}
       </div>
-      <div>
-        {{ form.cep.label_tag }}
-        {{ form.cep }}
+      <div class="relative">
+        {{ form.cep|add_class:'peer form-input placeholder-transparent'|attr:'placeholder: ' }}
+        <label for="{{ form.cep.id_for_label }}" class="label-float">{{ form.cep.label }}</label>
         {{ form.cep.errors }}
       </div>
     </div>
 
     <div class="pt-4">
-      <button type="submit"
-              class="bg-primary text-white px-5 py-2 rounded-xl font-semibold text-sm hover:bg-primary/90 transition">
+      <button type="submit" class="btn btn-primary">
         {% trans "Salvar Alterações" %}
       </button>
     </div>

--- a/accounts/templates/perfil/midia_form.html
+++ b/accounts/templates/perfil/midia_form.html
@@ -1,5 +1,5 @@
 {% extends 'perfil/perfil.html' %}
-{% load i18n %}
+{% load i18n custom_filters %}
 
 {% block title %}{% if form.instance.pk %}{% trans "Editar Mídia" %}{% else %}{% trans "Nova Mídia" %}{% endif %} | Hubx{% endblock %}
 
@@ -11,10 +11,26 @@
 
   <form method="post" enctype="multipart/form-data" class="space-y-4">
     {% csrf_token %}
-    {{ form.as_p }}
+
+    <div class="relative">
+      {{ form.file|add_class:'peer form-input placeholder-transparent'|attr:'placeholder: ' }}
+      <label for="{{ form.file.id_for_label }}" class="label-float">{{ form.file.label }}</label>
+      {{ form.file.errors }}
+    </div>
+    <div class="relative">
+      {{ form.descricao|add_class:'peer form-input placeholder-transparent'|attr:'placeholder: ' }}
+      <label for="{{ form.descricao.id_for_label }}" class="label-float">{{ form.descricao.label }}</label>
+      {{ form.descricao.errors }}
+    </div>
+    <div class="relative">
+      {{ form.tags_field|add_class:'peer form-input placeholder-transparent'|attr:'placeholder: ' }}
+      <label for="{{ form.tags_field.id_for_label }}" class="label-float">{{ form.tags_field.label }}</label>
+      {{ form.tags_field.errors }}
+    </div>
+
     <div class="flex justify-end gap-2">
-      <a href="{% url 'accounts:midias' %}" class="text-sm px-4 py-2 border rounded hover:bg-gray-100">{% trans "Cancelar" %}</a>
-      <button type="submit" class="bg-primary text-white px-4 py-2 rounded hover:bg-emerald-600">{% trans "Salvar" %}</button>
+      <a href="{% url 'accounts:midias' %}" class="btn btn-secondary">{% trans "Cancelar" %}</a>
+      <button type="submit" class="btn btn-primary">{% trans "Salvar" %}</button>
     </div>
   </form>
 </section>

--- a/accounts/templates/perfil/redes_sociais.html
+++ b/accounts/templates/perfil/redes_sociais.html
@@ -6,37 +6,36 @@
 {% block perfil_content %}
 <div class="max-w-3xl mx-auto">
   <h3 class="text-xl font-semibold mb-1">{% trans "Redes Sociais" %}</h3>
-  <p class="text-sm text-gray-500 mb-6">{% trans "Conecte suas redes sociais com seu perfil" %}</p>
+  <p class="text-sm text-neutral-500 dark:text-neutral-400 mb-6">{% trans "Conecte suas redes sociais com seu perfil" %}</p>
 
   <form method="post" action="{% url 'accounts:redes_sociais' %}" class="space-y-6">
     {% csrf_token %}
 
     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-      <div>
-        {{ form.facebook.label_tag }}
-        {{ form.facebook|add_class:'w-full' }}
+      <div class="relative">
+        {{ form.facebook|add_class:'w-full peer form-input placeholder-transparent'|attr:'placeholder: ' }}
+        <label for="{{ form.facebook.id_for_label }}" class="label-float">{{ form.facebook.label }}</label>
         {{ form.facebook.errors }}
       </div>
-      <div>
-        {{ form.twitter.label_tag }}
-        {{ form.twitter|add_class:'w-full' }}
+      <div class="relative">
+        {{ form.twitter|add_class:'w-full peer form-input placeholder-transparent'|attr:'placeholder: ' }}
+        <label for="{{ form.twitter.id_for_label }}" class="label-float">{{ form.twitter.label }}</label>
         {{ form.twitter.errors }}
       </div>
-      <div>
-        {{ form.instagram.label_tag }}
-        {{ form.instagram|add_class:'w-full' }}
+      <div class="relative">
+        {{ form.instagram|add_class:'w-full peer form-input placeholder-transparent'|attr:'placeholder: ' }}
+        <label for="{{ form.instagram.id_for_label }}" class="label-float">{{ form.instagram.label }}</label>
         {{ form.instagram.errors }}
       </div>
-      <div>
-        {{ form.linkedin.label_tag }}
-        {{ form.linkedin|add_class:'w-full' }}
+      <div class="relative">
+        {{ form.linkedin|add_class:'w-full peer form-input placeholder-transparent'|attr:'placeholder: ' }}
+        <label for="{{ form.linkedin.id_for_label }}" class="label-float">{{ form.linkedin.label }}</label>
         {{ form.linkedin.errors }}
       </div>
     </div>
 
     <div class="pt-4">
-      <button type="submit"
-              class="bg-primary text-white px-5 py-2 rounded-xl font-semibold text-sm hover:bg-primary/90 transition">
+      <button type="submit" class="btn btn-primary">
         {% trans "Salvar Alterações" %}
       </button>
     </div>


### PR DESCRIPTION
## Summary
- apply floating label pattern and token colors to profile and 2FA templates
- standardize buttons with design system classes

## Testing
- `pytest tests/accounts/test_two_factor.py::test_enable_2fa_flow --override-ini=addopts= -p no:cov -q` *(fails: ModuleNotFoundError: No module named 'discussao')*


------
https://chatgpt.com/codex/tasks/task_e_68bcb50b107483258b36a8262a8ba4a6