### PR TITLE
Refatora templates de perfil com hero unificado e cards

### DIFF
--- a/accounts/templates/perfil/detail.html
+++ b/accounts/templates/perfil/detail.html
@@ -3,8 +3,7 @@
 {% block title %}{% trans "Meu Perfil" %} | Hubx{% endblock %}
 {% block perfil_content %}
 
-<section class="max-w-5xl mx-auto px-4">
-  <!-- Abas -->
+<div class="card-header">
   <div class="mt-2 border-b border-neutral-200">
     <nav class="-mb-px flex gap-6" aria-label="Tabs">
       <button type="button" class="tab-btn py-3 text-sm font-medium border-b-2 border-transparent text-neutral-600 data-[active=true]:border-blue-600 data-[active=true]:text-blue-600" data-tab="informacoes">{% trans 'Informações' %}</button>
@@ -15,11 +14,12 @@
       {% endif %}
     </nav>
   </div>
+</div>
 
+<div class="card-body">
   <div id="tab-panels" class="mt-6">
     <!-- Painel: Informações -->
     <div class="tab-panel" data-tab="informacoes">
-      <section class="max-w-4xl mx-auto px-4 py-6 bg-white rounded-xl shadow">
 
         {% if user.biografia %}
           <div class="mb-6">
@@ -27,7 +27,7 @@
           </div>
         {% endif %}
 
-        <div class="grid sm:grid-cols-2 gap-6 text-sm text-gray-700">
+        <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6 text-sm text-gray-700">
           <div>
             <h4 class="font-medium mb-1">{% trans "Contato" %}</h4>
             <p>{% trans "Email" %}: {{ user.email }}</p>
@@ -53,13 +53,12 @@
         <div class="mt-6 text-right">
           <a href="{% url 'accounts:informacoes_pessoais' %}" class="text-primary font-medium hover:underline">{% trans "Editar perfil" %}</a>
         </div>
-      </section>
     </div>
 
     {% if user.get_tipo_usuario != 'admin' %}
     <!-- Painel: Empresas -->
     <div class="tab-panel hidden" data-tab="empresas">
-      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+      <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
         {% for empresa in empresas %}
           {% include 'partials/cards/empresa_card.html' with empresa=empresa %}
         {% empty %}
@@ -70,7 +69,7 @@
 
     <!-- Painel: Núcleos -->
     <div class="tab-panel hidden" data-tab="nucleos">
-      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+      <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
         {% for nucleo in nucleos %}
           {% include 'partials/cards/nucleo_card.html' with nucleo=nucleo %}
         {% empty %}
@@ -81,7 +80,7 @@
 
     <!-- Painel: Eventos -->
     <div class="tab-panel hidden" data-tab="eventos">
-      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+      <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
         {% for ins in inscricoes %}
           {% include 'partials/cards/evento_card.html' with evento=ins.evento %}
         {% empty %}
@@ -104,6 +103,6 @@
     activate('informacoes');
     tabButtons.forEach(btn => btn.addEventListener('click', () => activate(btn.dataset.tab)));
   </script>
-</section>
+</div>
 
 {% endblock %}

--- a/accounts/templates/perfil/perfil.html
+++ b/accounts/templates/perfil/perfil.html
@@ -3,32 +3,39 @@
 
 {% block title %}{% trans "Perfil" %} | HubX{% endblock %}
 
+{% block hero_title %}{% endblock %}
+{% block hero_subtitle %}{% endblock %}
+
 {% block content %}
-<div class="max-w-5xl mx-auto mt-8 px-4">
-  <div class="bg-white rounded-2xl shadow overflow-hidden flex flex-col min-h-[80vh]">
+{% include 'components/hero.html' with title=block.hero_title|default:_('Meu Perfil') subtitle=block.hero_subtitle %}
+<div class="container mx-auto p-6">
+  <div class="card flex flex-col min-h-[80vh] overflow-hidden">
+    {% with perfil|default:user as profile %}
     <div class="profile-cover h-48 w-full">
-      {% if user.cover %}
-        <img src="{{ user.cover.url }}" alt="{% trans "Capa do usuário" %}" class="w-full h-full object-cover">
+      {% if profile.cover %}
+        <img src="{{ profile.cover.url }}" alt="{% trans "Capa do usuário" %}" class="w-full h-full object-cover">
       {% else %}
         <div class="w-full h-full bg-gray-200" role="img" aria-label="{% trans "Capa padrão" %}"></div>
       {% endif %}
     </div>
-    <div class="p-6 flex flex-col flex-grow">
+    <div class="card-body flex flex-col flex-grow">
 
       <!-- Avatar + Nome -->
       <div class="flex flex-col items-center">
-        {% if user.avatar %}
-          <img src="{{ user.avatar.url }}" alt="{{ user.username }}"
+        {% if profile.avatar %}
+          <img src="{{ profile.avatar.url }}" alt="{{ profile.username }}"
                class="w-28 h-28 rounded-full object-cover shadow mb-3">
         {% else %}
-          <div class="w-28 h-28 rounded-full bg-gray-200 flex items-center justify-center text-2xl font-semibold text-primary shadow mb-3" role="img" aria-label="{{ user.username }}">
-            {{ user.username|first|upper }}
+          <div class="w-28 h-28 rounded-full bg-gray-200 flex items-center justify-center text-2xl font-semibold text-primary shadow mb-3" role="img" aria-label="{{ profile.username }}">
+            {{ profile.username|first|upper }}
           </div>
         {% endif %}
 
-        <h2 class="text-lg font-bold">{{ user.get_full_name }}</h2>
-        <p class="text-sm text-gray-500 mb-2">@{{ user.username }}</p>
+        <h2 class="text-lg font-bold">{{ profile.get_full_name }}</h2>
+        <p class="text-sm text-gray-500 mb-2">@{{ profile.username }}</p>
+        {% if profile == request.user %}
         <button class="text-sm text-primary hover:underline">{% trans "Alterar foto" %}</button>
+        {% endif %}
       </div>
 
       <!-- Abas de navegação -->
@@ -53,9 +60,8 @@
         {% endblock %}
       </div>
 
-      
-
-      </div>
     </div>
+    {% endwith %}
   </div>
-  {% endblock %}
+</div>
+{% endblock %}

--- a/accounts/templates/perfil/publico.html
+++ b/accounts/templates/perfil/publico.html
@@ -1,40 +1,11 @@
-{% extends 'base.html' %}
+{% extends 'perfil/perfil.html' %}
 {% load static i18n %}
 {% block title %}{{ perfil.get_full_name|default:perfil.username }} | Hubx{% endblock %}
-{% block content %}
-<div class="max-w-3xl mx-auto mt-8 px-4">
-  <div class="bg-white rounded-2xl shadow overflow-hidden">
-    <div class="profile-cover h-48 w-full">
-      {% if perfil.cover %}
-        <img src="{{ perfil.cover.url }}" alt="{% trans "Capa do usuário" %}" class="w-full h-full object-cover">
-      {% else %}
-        <div class="w-full h-full bg-gray-200" role="img" aria-label="{% trans "Capa padrão" %}"></div>
-      {% endif %}
-    </div>
-    <div class="p-6">
-      <div class="flex items-center gap-4">
-        {% if perfil.avatar %}
-          <img src="{{ perfil.avatar.url }}" alt="{{ perfil.username }}" class="w-20 h-20 rounded-full object-cover">
-        {% else %}
-          <div class="w-20 h-20 rounded-full bg-gray-200 flex items-center justify-center text-xl font-semibold text-primary" role="img" aria-label="{{ perfil.username }}">
-            {{ perfil.username|first|upper }}
-          </div>
-        {% endif %}
-        <div>
-          <h1 class="text-lg font-bold">{{ perfil.get_full_name|default:perfil.username }}</h1>
-          <p class="text-sm text-gray-500">@{{ perfil.username }}</p>
-        </div>
-      </div>
-      {% if perfil.biografia %}
-        <p class="mt-4 text-gray-700 whitespace-pre-line">{{ perfil.biografia }}</p>
-      {% endif %}
-    </div>
-  </div>
-</div>
+{% block hero_title %}{{ perfil.get_full_name|default:perfil.username }}{% endblock %}
+{% block hero_subtitle %}@{{ perfil.username }}{% endblock %}
 
-{# Abas: Informações, Empresas, Núcleos, Eventos #}
-<section class="max-w-6xl mx-auto mt-8 px-4">
-  {# Navegação das abas #}
+{% block perfil_content %}
+<div class="card-header">
   <nav class="border-b border-gray-200">
     <ul class="-mb-px flex flex-wrap gap-2" role="tablist" aria-label="{% trans 'Navegação de abas do perfil' %}">
       <li>
@@ -65,55 +36,51 @@
       {% endif %}
     </ul>
   </nav>
+</div>
 
-  {# Conteúdo das abas #}
+<div class="card-body">
   <div class="mt-4">
-    {# Informações #}
-    <section id="tab-informacoes" role="tabpanel" data-tab-panel class="block">
-      <div class="bg-white rounded-xl shadow p-5">
-        <h2 class="text-base font-semibold mb-4">{% trans "Informações do usuário" %}</h2>
-        <dl class="grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-3 text-sm">
-          <div>
-            <dt class="text-gray-500">{% trans "Nome completo" %}</dt>
-            <dd class="font-medium">{{ perfil.get_full_name|default:perfil.username }}</dd>
-          </div>
-          <div>
-            <dt class="text-gray-500">{% trans "Usuário" %}</dt>
-            <dd class="font-medium">@{{ perfil.username }}</dd>
-          </div>
-          {% if perfil.email %}
-          <div>
-            <dt class="text-gray-500">{% trans "E-mail" %}</dt>
-            <dd class="font-medium">{{ perfil.email }}</dd>
-          </div>
-          {% endif %}
-          {% if perfil.date_joined %}
-          <div>
-            <dt class="text-gray-500">{% trans "Membro desde" %}</dt>
-            <dd class="font-medium">{{ perfil.date_joined|date:"d/m/Y H:i" }}</dd>
-          </div>
-          {% endif %}
-          {% if perfil.last_login %}
-          <div>
-            <dt class="text-gray-500">{% trans "Último acesso" %}</dt>
-            <dd class="font-medium">{{ perfil.last_login|date:"d/m/Y H:i" }}</dd>
-          </div>
-          {% endif %}
-        </dl>
-        {% if perfil.biografia %}
-          <div class="mt-4">
-            <h3 class="text-sm font-semibold mb-1">{% trans "Biografia" %}</h3>
-            <p class="text-gray-700 whitespace-pre-line">{{ perfil.biografia }}</p>
-          </div>
+    <div id="tab-informacoes" role="tabpanel" data-tab-panel class="block">
+      <dl class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6 text-sm">
+        <div>
+          <dt class="text-gray-500">{% trans "Nome completo" %}</dt>
+          <dd class="font-medium">{{ perfil.get_full_name|default:perfil.username }}</dd>
+        </div>
+        <div>
+          <dt class="text-gray-500">{% trans "Usuário" %}</dt>
+          <dd class="font-medium">@{{ perfil.username }}</dd>
+        </div>
+        {% if perfil.email %}
+        <div>
+          <dt class="text-gray-500">{% trans "E-mail" %}</dt>
+          <dd class="font-medium">{{ perfil.email }}</dd>
+        </div>
         {% endif %}
-      </div>
-    </section>
+        {% if perfil.date_joined %}
+        <div>
+          <dt class="text-gray-500">{% trans "Membro desde" %}</dt>
+          <dd class="font-medium">{{ perfil.date_joined|date:"d/m/Y H:i" }}</dd>
+        </div>
+        {% endif %}
+        {% if perfil.last_login %}
+        <div>
+          <dt class="text-gray-500">{% trans "Último acesso" %}</dt>
+          <dd class="font-medium">{{ perfil.last_login|date:"d/m/Y H:i" }}</dd>
+        </div>
+        {% endif %}
+      </dl>
+      {% if perfil.biografia %}
+        <div class="mt-4">
+          <h3 class="text-sm font-semibold mb-1">{% trans "Biografia" %}</h3>
+          <p class="text-gray-700 whitespace-pre-line">{{ perfil.biografia }}</p>
+        </div>
+      {% endif %}
+    </div>
 
     {% if not perfil.is_superuser %}
-    {# Empresas #}
-    <section id="tab-empresas" role="tabpanel" data-tab-panel class="hidden">
+    <div id="tab-empresas" role="tabpanel" data-tab-panel class="hidden">
       {% if empresas %}
-      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4" role="list" aria-label="{% translate 'Lista de empresas' %}">
+      <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6" role="list" aria-label="{% translate 'Lista de empresas' %}">
         {% for empresa in empresas %}
           <div role="listitem">
             {% include 'empresas/partials/card.html' with empresa=empresa %}
@@ -125,35 +92,31 @@
         <p class="col-span-full text-center text-neutral-500 py-10">{% translate 'Nenhuma empresa encontrada.' %}</p>
       </div>
       {% endif %}
-    </section>
+    </div>
 
-    {# Núcleos #}
-    <section id="tab-nucleos" role="tabpanel" data-tab-panel class="hidden">
-      <div role="list" aria-label="{% trans 'Lista de núcleos' %}" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+    <div id="tab-nucleos" role="tabpanel" data-tab-panel class="hidden">
+      <div role="list" aria-label="{% trans 'Lista de núcleos' %}" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
         {% for nucleo in nucleos %}
           {% include 'nucleos/partials/card.html' with nucleo=nucleo %}
         {% empty %}
           <p class="col-span-full text-center text-neutral-500">{% trans "Nenhum núcleo encontrado." %}</p>
         {% endfor %}
       </div>
-    </section>
+    </div>
 
-    {# Eventos #}
-    <section id="tab-eventos" role="tabpanel" data-tab-panel class="hidden">
-      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4" role="list" aria-label="{% trans 'Lista de eventos' %}">
+    <div id="tab-eventos" role="tabpanel" data-tab-panel class="hidden">
+      <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6" role="list" aria-label="{% trans 'Lista de eventos' %}">
         {% for ins in inscricoes %}
           {% include 'partials/cards/evento_card.html' with evento=ins.evento %}
         {% empty %}
           <p class="col-span-full text-center text-neutral-500">{% trans "Nenhum evento encontrado." %}</p>
         {% endfor %}
       </div>
-    </section>
+    </div>
     {% endif %}
   </div>
-</section>
 
-{# Script leve para navegação das abas (sem dependências) #}
-<script>
+  <script>
   (function () {
     const container = document.currentScript && document.currentScript.previousElementSibling;
     if (!container) return;
@@ -171,7 +134,6 @@
       if (current) current.classList.remove('hidden');
     }
 
-    // Estado inicial pelo hash da URL, se houver
     const initial = (location.hash || '#tab-informacoes').replace('#', '');
     if (container.querySelector('[data-tab-target="' + initial + '"]')) {
       activate(initial);
@@ -188,6 +150,7 @@
       });
     });
   })();
-</script>
-
+  </script>
+</div>
 {% endblock %}
+


### PR DESCRIPTION
## Summary
- Adiciona blocos `hero_title` e `hero_subtitle` no layout de perfil e inclui componente de hero
- Atualiza estrutura dos templates `detail` e `publico` para usar `card-header`/`card-body` e grades responsivas

## Testing
- `pytest -q` *(falha: ModuleNotFoundError: No module named 'freezegun')*


------
https://chatgpt.com/codex/tasks/task_e_68bcb504bd04832596fa1037700ddf89