### PR TITLE
refactor: modernize dashboard templates

### DIFF
--- a/dashboard/templates/dashboard/cliente.html
+++ b/dashboard/templates/dashboard/cliente.html
@@ -4,53 +4,52 @@
 {% block title %}{% trans "Dashboard Cliente" %} | Hubx{% endblock %}
 
 {% block content %}
-<main class="max-w-7xl mx-auto px-4 py-10" role="main" aria-label="{% trans 'Dashboard' %}">
-  <h1 class="text-3xl font-semibold text-neutral-900 text-center mb-10">{% trans "Dashboard Cliente" %}</h1>
-
-  {% include 'dashboard/partials/messages.html' %}
-  {% include 'dashboard/partials/filters_form.html' %}
-
-  <div hx-get="{% url 'dashboard:metrics-partial' %}?{{ request.GET.urlencode }}" hx-trigger="load, every 10s" hx-target="#metrics" hx-swap="innerHTML">
-    {% include 'dashboard/partials/metrics_list.html' %}
-  </div>
-
-  <section
-    id="upcoming-events"
-    hx-get="{% url 'dashboard:eventos-partial' %}"
-    hx-trigger="load, every 20s"
-    hx-target="this"
-    hx-swap="outerHTML"
-  ></section>
-
-  <section
-    id="tasks"
-    hx-get="{% url 'dashboard:tarefas-partial' %}"
-    hx-trigger="load, every 20s"
-    hx-target="this"
-    hx-swap="outerHTML"
-  ></section>
-
-  <section
-    id="notifications"
-    hx-get="{% url 'dashboard:notificacoes-partial' %}"
-    hx-trigger="load, every 20s"
-    hx-target="this"
-    hx-swap="innerHTML"
-  ></section>
-
-  <section class="mb-8">
-    <h2 class="text-xl font-semibold mb-4">{% trans "Atalhos" %}</h2>
-    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-  <a href="{% url 'eventos:calendario' %}" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50" aria-label="{% trans 'Inscrever-se em Eventos' %}">
-        {% lucide 'calendar-plus' class='mb-2 mx-auto w-6 h-6' %}
-        <span class="block">{% trans "Inscrever-se em Eventos" %}</span>
-      </a>
-      <a href="{% url 'feed:listar' %}" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50" aria-label="{% trans 'Ver Feed' %}">
-        {% lucide 'rss' class='mb-2 mx-auto w-6 h-6' %}
-        <span class="block">{% trans "Ver Feed" %}</span>
-      </a>
+{% include 'components/hero.html' with title=_('Dashboard Cliente') %}
+<div class="container mx-auto p-6">
+  <div class="max-w-7xl mx-auto">
+    <div class="card">
+      <div class="card-body space-y-8">
+        {% include 'dashboard/partials/messages.html' %}
+        {% include 'dashboard/partials/filters_form.html' %}
+        <div hx-get="{% url 'dashboard:metrics-partial' %}?{{ request.GET.urlencode }}" hx-trigger="load, every 10s" hx-target="#metrics" hx-swap="innerHTML">
+          {% include 'dashboard/partials/metrics_list.html' %}
+        </div>
+        <section
+          id="upcoming-events"
+          hx-get="{% url 'dashboard:eventos-partial' %}"
+          hx-trigger="load, every 20s"
+          hx-target="this"
+          hx-swap="outerHTML"
+        ></section>
+        <section
+          id="tasks"
+          hx-get="{% url 'dashboard:tarefas-partial' %}"
+          hx-trigger="load, every 20s"
+          hx-target="this"
+          hx-swap="outerHTML"
+        ></section>
+        <section
+          id="notifications"
+          hx-get="{% url 'dashboard:notificacoes-partial' %}"
+          hx-trigger="load, every 20s"
+          hx-target="this"
+          hx-swap="innerHTML"
+        ></section>
+        <section class="mb-8">
+          <h2 class="text-xl font-semibold mb-4">{% trans "Atalhos" %}</h2>
+          <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            <a href="{% url 'eventos:calendario' %}" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50" aria-label="{% trans 'Inscrever-se em Eventos' %}">
+              {% lucide 'calendar-plus' class='mb-2 mx-auto w-6 h-6' %}
+              <span class="block">{% trans "Inscrever-se em Eventos" %}</span>
+            </a>
+            <a href="{% url 'feed:listar' %}" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50" aria-label="{% trans 'Ver Feed' %}">
+              {% lucide 'rss' class='mb-2 mx-auto w-6 h-6' %}
+              <span class="block">{% trans "Ver Feed" %}</span>
+            </a>
+          </div>
+        </section>
+      </div>
     </div>
-  </section>
-
-</main>
+  </div>
+</div>
 {% endblock %}

--- a/dashboard/templates/dashboard/config_confirm_delete.html
+++ b/dashboard/templates/dashboard/config_confirm_delete.html
@@ -2,12 +2,18 @@
 {% load i18n %}
 {% block title %}{% trans "Excluir Configuração" %} | Hubx{% endblock %}
 {% block content %}
-<main class="max-w-xl mx-auto p-4" role="main">
-  <h1 class="text-2xl mb-4">{% trans "Excluir Configuração" %}</h1>
-  <p>{% trans "Tem certeza que deseja excluir esta configuração?" %}</p>
-  <form method="post">
-    {% csrf_token %}
-    <button type="submit" class="btn btn-danger" aria-label="{% trans 'Excluir configuração' %}">{% trans "Excluir" %}</button>
-  </form>
-</main>
+{% include 'components/hero.html' with title=_('Excluir Configuração') %}
+<div class="container mx-auto p-6">
+  <div class="max-w-xl mx-auto">
+    <div class="card">
+      <div class="card-body space-y-4">
+        <p>{% trans "Tem certeza que deseja excluir esta configuração?" %}</p>
+        <form method="post" class="pt-4 border-t border-neutral-100">
+          {% csrf_token %}
+          <button type="submit" class="btn-danger" aria-label="{% trans 'Excluir configuração' %}">{% trans "Excluir" %}</button>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
 {% endblock %}

--- a/dashboard/templates/dashboard/config_form.html
+++ b/dashboard/templates/dashboard/config_form.html
@@ -2,40 +2,48 @@
 {% load i18n widget_tweaks %}
 {% block title %}{% trans 'Salvar configuração' %}{% endblock %}
 {% block content %}
-<main class="max-w-md mx-auto p-4" role="main">
-  <h1 class="text-2xl font-semibold mb-4">{% trans 'Salvar configuração' %}</h1>
-  <form method="post" class="space-y-4" aria-label="{% trans 'Formulário de configuração do dashboard' %}">
-    {% csrf_token %}
-    {% trans 'Nome' as nome_label %}
-    <div class="relative">
-      {% if form.nome.errors %}
-        {% render_field form.nome class="peer placeholder-transparent w-full rounded border border-neutral-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder=nome_label aria-describedby="nome_error" aria-invalid="true" %}
-      {% else %}
-        {% render_field form.nome class="peer placeholder-transparent w-full rounded border border-neutral-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder=nome_label aria-describedby="nome_error" %}
-      {% endif %}
-      <label for="{{ form.nome.id_for_label }}" class="absolute left-3 -top-2 text-xs text-neutral-700 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600">{{ nome_label }}</label>
-      {% if form.nome.errors %}
-        <div id="nome_error" class="text-red-600 text-xs mt-1" role="alert">{{ form.nome.errors }}</div>
-      {% endif %}
-    </div>
-  {% if request.user.user_type == 'root' or request.user.user_type == 'admin' %}
-    <div>
-      <div class="flex items-center gap-2">
-        {% if form.publico.errors %}
-          {% render_field form.publico aria-invalid="true" aria-describedby="publico_error" %}
-        {% else %}
-          {% render_field form.publico aria-describedby="publico_error" %}
-        {% endif %}
-        <label for="{{ form.publico.id_for_label }}" class="text-sm text-neutral-700">{% trans 'Público' %}</label>
+{% include 'components/hero.html' with title=_('Salvar configuração') %}
+<div class="container mx-auto p-6">
+  <div class="max-w-md mx-auto">
+    <div class="card">
+      <div class="card-body">
+        <form method="post" class="space-y-4" aria-label="{% trans 'Formulário de configuração do dashboard' %}">
+          {% csrf_token %}
+          {% trans 'Nome' as nome_label %}
+          <div class="relative">
+            {% if form.nome.errors %}
+              {% render_field form.nome class="peer placeholder-transparent w-full rounded border border-neutral-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder=nome_label aria-describedby="nome_error" aria-invalid="true" %}
+            {% else %}
+              {% render_field form.nome class="peer placeholder-transparent w-full rounded border border-neutral-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder=nome_label aria-describedby="nome_error" %}
+            {% endif %}
+            <label for="{{ form.nome.id_for_label }}" class="absolute left-3 -top-2 text-xs text-neutral-700 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600">{{ nome_label }}</label>
+            {% if form.nome.errors %}
+              <div id="nome_error" class="text-red-600 text-xs mt-1" role="alert">{{ form.nome.errors }}</div>
+            {% endif %}
+          </div>
+        {% if request.user.user_type == 'root' or request.user.user_type == 'admin' %}
+          <div>
+            <div class="flex items-center gap-2">
+              {% if form.publico.errors %}
+                {% render_field form.publico aria-invalid="true" aria-describedby="publico_error" %}
+              {% else %}
+                {% render_field form.publico aria-describedby="publico_error" %}
+              {% endif %}
+              <label for="{{ form.publico.id_for_label }}" class="text-sm text-neutral-700">{% trans 'Público' %}</label>
+            </div>
+            {% if form.publico.errors %}
+              <div id="publico_error" class="text-red-600 text-xs mt-1" role="alert">{{ form.publico.errors }}</div>
+            {% endif %}
+          </div>
+          {% else %}
+          <p class="text-sm text-neutral-700">{% trans 'Apenas administradores podem publicar itens.' %}</p>
+          {% endif %}
+          <div class="pt-4 border-t border-neutral-100 flex justify-end">
+            <button type="submit" class="btn-primary" aria-label="{% trans 'Salvar configuração' %}">{% trans 'Salvar' %}</button>
+          </div>
+        </form>
       </div>
-      {% if form.publico.errors %}
-        <div id="publico_error" class="text-red-600 text-xs mt-1" role="alert">{{ form.publico.errors }}</div>
-      {% endif %}
     </div>
-    {% else %}
-    <p class="text-sm text-neutral-700">{% trans 'Apenas administradores podem publicar itens.' %}</p>
-    {% endif %}
-    <button type="submit" class="px-4 py-2 bg-primary-600 text-white rounded focus:outline-none focus:ring" aria-label="{% trans 'Salvar configuração' %}">{% trans 'Salvar' %}</button>
-  </form>
-</main>
+  </div>
+</div>
 {% endblock %}

--- a/dashboard/templates/dashboard/config_list.html
+++ b/dashboard/templates/dashboard/config_list.html
@@ -2,24 +2,30 @@
 {% load i18n %}
 {% block title %}{% trans 'Configurações salvas' %}{% endblock %}
 {% block content %}
-<main class="max-w-2xl mx-auto p-4" role="main">
-  <h1 class="text-2xl font-semibold mb-4">{% trans 'Configurações salvas' %}</h1>
-  {% include 'dashboard/partials/messages.html' %}
-  <ul class="space-y-2">
-    {% for cfg in object_list %}
-      <li class="flex justify-between items-center p-2 bg-white rounded shadow">
-        <span>{{ cfg.nome }}</span>
-        <div class="space-x-2">
-          <a href="{% url 'dashboard:config-apply' cfg.pk %}" class="text-primary-600 underline" aria-label="{% trans 'Aplicar configuração' %}">{% trans 'Aplicar' %}</a>
-          {% if cfg.user_id == request.user.id or request.user.user_type == 'admin' or request.user.user_type == 'root' %}
-            <a href="{% url 'dashboard:config-edit' cfg.pk %}" class="text-primary-600 underline" aria-label="{% trans 'Editar configuração' %}">{% trans 'Editar' %}</a>
-            <a href="{% url 'dashboard:config-delete' cfg.pk %}" class="text-danger-600 underline" aria-label="{% trans 'Excluir configuração' %}">{% trans 'Excluir' %}</a>
-          {% endif %}
-        </div>
-      </li>
-    {% empty %}
-      <li>{% trans 'Nenhuma configuração salva.' %}</li>
-    {% endfor %}
-  </ul>
-</main>
+{% include 'components/hero.html' with title=_('Configurações salvas') %}
+<div class="container mx-auto p-6">
+  <div class="max-w-2xl mx-auto">
+    <div class="card">
+      <div class="card-body">
+        {% include 'dashboard/partials/messages.html' %}
+        <ul class="space-y-2">
+          {% for cfg in object_list %}
+            <li class="flex justify-between items-center p-2 bg-white rounded shadow">
+              <span>{{ cfg.nome }}</span>
+              <div class="space-x-2">
+                <a href="{% url 'dashboard:config-apply' cfg.pk %}" class="text-primary-600 underline" aria-label="{% trans 'Aplicar configuração' %}">{% trans 'Aplicar' %}</a>
+                {% if cfg.user_id == request.user.id or request.user.user_type == 'admin' or request.user.user_type == 'root' %}
+                  <a href="{% url 'dashboard:config-edit' cfg.pk %}" class="text-primary-600 underline" aria-label="{% trans 'Editar configuração' %}">{% trans 'Editar' %}</a>
+                  <a href="{% url 'dashboard:config-delete' cfg.pk %}" class="text-danger-600 underline" aria-label="{% trans 'Excluir configuração' %}">{% trans 'Excluir' %}</a>
+                {% endif %}
+              </div>
+            </li>
+          {% empty %}
+            <li>{% trans 'Nenhuma configuração salva.' %}</li>
+          {% endfor %}
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
 {% endblock %}

--- a/dashboard/templates/dashboard/coordenador.html
+++ b/dashboard/templates/dashboard/coordenador.html
@@ -5,37 +5,37 @@
 {% block title %}{% trans "Dashboard Coordenador" %} | Hubx{% endblock %}
 
 {% block content %}
-<main class="max-w-7xl mx-auto px-4 py-10" role="main" aria-label="{% trans 'Dashboard' %}">
-  <h1 class="text-3xl font-semibold text-neutral-900 text-center mb-10">{% trans "Dashboard Coordenador" %}</h1>
-
-  {% include 'dashboard/partials/messages.html' %}
-  {% include 'dashboard/partials/filters_form.html' %}
-
-  <div hx-get="{% url 'dashboard:metrics-partial' %}?{{ request.GET.urlencode }}" hx-trigger="load, every 10s" hx-target="#metrics" hx-swap="innerHTML">
-    {% include 'dashboard/partials/metrics_list.html' %}
-  </div>
-
-  <section
-    id="tasks"
-    hx-get="{% url 'dashboard:tarefas-partial' %}"
-    hx-trigger="load, every 15s"
-    hx-target="this"
-    hx-swap="outerHTML"
-  ></section>
-
-  <section
-    id="notifications"
-    hx-get="{% url 'dashboard:notificacoes-partial' %}"
-    hx-trigger="load, every 15s"
-    hx-target="this"
-    hx-swap="innerHTML"
-  ></section>
-
-  <section class="mb-8">
-    <h2 class="text-xl font-semibold mb-4">{% trans "Ações Rápidas" %}</h2>
-    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+{% include 'components/hero.html' with title=_('Dashboard Coordenador') %}
+<div class="container mx-auto p-6">
+  <div class="max-w-7xl mx-auto">
+    <div class="card">
+      <div class="card-body space-y-8">
+        {% include 'dashboard/partials/messages.html' %}
+        {% include 'dashboard/partials/filters_form.html' %}
+        <div hx-get="{% url 'dashboard:metrics-partial' %}?{{ request.GET.urlencode }}" hx-trigger="load, every 10s" hx-target="#metrics" hx-swap="innerHTML">
+          {% include 'dashboard/partials/metrics_list.html' %}
+        </div>
+        <section
+          id="tasks"
+          hx-get="{% url 'dashboard:tarefas-partial' %}"
+          hx-trigger="load, every 15s"
+          hx-target="this"
+          hx-swap="outerHTML"
+        ></section>
+        <section
+          id="notifications"
+          hx-get="{% url 'dashboard:notificacoes-partial' %}"
+          hx-trigger="load, every 15s"
+          hx-target="this"
+          hx-swap="innerHTML"
+        ></section>
+        <section class="mb-8">
+          <h2 class="text-xl font-semibold mb-4">{% trans "Ações Rápidas" %}</h2>
+          <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          </div>
+        </section>
+      </div>
     </div>
-  </section>
-
-</main>
+  </div>
+</div>
 {% endblock %}

--- a/dashboard/templates/dashboard/custom_metric_confirm_delete.html
+++ b/dashboard/templates/dashboard/custom_metric_confirm_delete.html
@@ -2,14 +2,20 @@
 {% load i18n %}
 {% block title %}{% trans 'Excluir métrica' %}{% endblock %}
 {% block content %}
-<main class="max-w-md mx-auto p-4" role="main">
-  <h1 class="text-2xl font-semibold mb-4">{% trans 'Excluir métrica' %}</h1>
-  <p class="mb-4">{% blocktrans %}Tem certeza que deseja excluir a métrica "{{ object.nome }}"?{% endblocktrans %}</p>
-  <form method="post">
-    {% csrf_token %}
-    <button type="submit" class="px-4 py-2 bg-danger-600 text-white rounded" aria-label="{% trans 'Confirmar exclusão' %}">{% trans 'Excluir' %}</button>
-    <a href="{% url 'dashboard:custom-metrics' %}" class="ml-2 underline" aria-label="{% trans 'Cancelar exclusão' %}">{% trans 'Cancelar' %}</a>
-  </form>
-</main>
+{% include 'components/hero.html' with title=_('Excluir métrica') %}
+<div class="container mx-auto p-6">
+  <div class="max-w-md mx-auto">
+    <div class="card">
+      <div class="card-body space-y-4">
+        <p>{% blocktrans %}Tem certeza que deseja excluir a métrica "{{ object.nome }}"?{% endblocktrans %}</p>
+        <form method="post" class="pt-4 border-t border-neutral-100 flex items-center gap-2">
+          {% csrf_token %}
+          <button type="submit" class="btn-danger" aria-label="{% trans 'Confirmar exclusão' %}">{% trans 'Excluir' %}</button>
+          <a href="{% url 'dashboard:custom-metrics' %}" class="btn-secondary" aria-label="{% trans 'Cancelar exclusão' %}">{% trans 'Cancelar' %}</a>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
 {% endblock %}
 

--- a/dashboard/templates/dashboard/custom_metric_form.html
+++ b/dashboard/templates/dashboard/custom_metric_form.html
@@ -1,73 +1,82 @@
 {% extends 'base.html' %}
 {% load i18n widget_tweaks %}
 {% block title %}{% trans 'Métrica personalizada' %}{% endblock %}
+
 {% block content %}
-<main class="max-w-md mx-auto p-4" role="main">
-  <h1 class="text-2xl font-semibold mb-4">{% trans 'Métrica personalizada' %}</h1>
-    <form method="post" class="space-y-4" aria-label="{% trans 'Formulário de métrica personalizada' %}">
-      {% csrf_token %}
-      {% trans 'Código' as code_label %}
-      <div class="relative">
-        {% if form.code.errors %}
-          {% render_field form.code class="peer placeholder-transparent w-full rounded border border-neutral-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder=code_label aria-describedby="code_error" aria-invalid="true" %}
-        {% else %}
-          {% render_field form.code class="peer placeholder-transparent w-full rounded border border-neutral-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder=code_label aria-describedby="code_error" %}
-        {% endif %}
-        <label for="{{ form.code.id_for_label }}" class="absolute left-3 -top-2 text-xs text-neutral-700 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600">{{ code_label }}</label>
-        {% if form.code.errors %}
-          <div id="code_error" class="text-red-600 text-xs mt-1" role="alert">{{ form.code.errors }}</div>
-        {% endif %}
+{% include 'components/hero.html' with title=_('Métrica personalizada') %}
+<div class="container mx-auto p-6">
+  <div class="max-w-md mx-auto">
+    <div class="card">
+      <div class="card-body">
+        <form method="post" class="space-y-4" aria-label="{% trans 'Formulário de métrica personalizada' %}">
+          {% csrf_token %}
+          {% trans 'Código' as code_label %}
+          <div class="relative">
+            {% if form.code.errors %}
+              {% render_field form.code class="peer placeholder-transparent w-full rounded border border-neutral-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder=code_label aria-describedby="code_error" aria-invalid="true" %}
+            {% else %}
+              {% render_field form.code class="peer placeholder-transparent w-full rounded border border-neutral-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder=code_label aria-describedby="code_error" %}
+            {% endif %}
+            <label for="{{ form.code.id_for_label }}" class="absolute left-3 -top-2 text-xs text-neutral-700 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600">{{ code_label }}</label>
+            {% if form.code.errors %}
+              <div id="code_error" class="text-red-600 text-xs mt-1" role="alert">{{ form.code.errors }}</div>
+            {% endif %}
+          </div>
+          {% trans 'Nome' as nome_label %}
+          <div class="relative">
+            {% if form.nome.errors %}
+              {% render_field form.nome class="peer placeholder-transparent w-full rounded border border-neutral-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder=nome_label aria-describedby="nome_error" aria-invalid="true" %}
+            {% else %}
+              {% render_field form.nome class="peer placeholder-transparent w-full rounded border border-neutral-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder=nome_label aria-describedby="nome_error" %}
+            {% endif %}
+            <label for="{{ form.nome.id_for_label }}" class="absolute left-3 -top-2 text-xs text-neutral-700 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600">{{ nome_label }}</label>
+            {% if form.nome.errors %}
+              <div id="nome_error" class="text-red-600 text-xs mt-1" role="alert">{{ form.nome.errors }}</div>
+            {% endif %}
+          </div>
+          {% trans 'Descrição' as descricao_label %}
+          <div class="relative">
+            {% if form.descricao.errors %}
+              {% render_field form.descricao class="peer placeholder-transparent w-full rounded border border-neutral-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder=descricao_label aria-describedby="descricao_error" aria-invalid="true" %}
+            {% else %}
+              {% render_field form.descricao class="peer placeholder-transparent w-full rounded border border-neutral-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder=descricao_label aria-describedby="descricao_error" %}
+            {% endif %}
+            <label for="{{ form.descricao.id_for_label }}" class="absolute left-3 -top-2 text-xs text-neutral-700 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600">{{ descricao_label }}</label>
+            {% if form.descricao.errors %}
+              <div id="descricao_error" class="text-red-600 text-xs mt-1" role="alert">{{ form.descricao.errors }}</div>
+            {% endif %}
+          </div>
+          {% trans 'Query spec' as query_label %}
+          <div class="relative">
+            {% if form.query_spec.errors %}
+              {% render_field form.query_spec class="peer placeholder-transparent w-full rounded border border-neutral-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder=query_label aria-describedby="query_error" aria-invalid="true" %}
+            {% else %}
+              {% render_field form.query_spec class="peer placeholder-transparent w-full rounded border border-neutral-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder=query_label aria-describedby="query_error" %}
+            {% endif %}
+            <label for="{{ form.query_spec.id_for_label }}" class="absolute left-3 -top-2 text-xs text-neutral-700 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600">{{ query_label }}</label>
+            {% if form.query_spec.errors %}
+              <div id="query_error" class="text-red-600 text-xs mt-1" role="alert">{{ form.query_spec.errors }}</div>
+            {% endif %}
+          </div>
+          {% trans 'Escopo' as escopo_label %}
+          <div class="relative">
+            {% if form.escopo.errors %}
+              {% render_field form.escopo class="peer placeholder-transparent w-full rounded border border-neutral-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder=escopo_label aria-describedby="escopo_error" aria-invalid="true" %}
+            {% else %}
+              {% render_field form.escopo class="peer placeholder-transparent w-full rounded border border-neutral-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder=escopo_label aria-describedby="escopo_error" %}
+            {% endif %}
+            <label for="{{ form.escopo.id_for_label }}" class="absolute left-3 -top-2 text-xs text-neutral-700 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600">{{ escopo_label }}</label>
+            {% if form.escopo.errors %}
+              <div id="escopo_error" class="text-red-600 text-xs mt-1" role="alert">{{ form.escopo.errors }}</div>
+            {% endif %}
+          </div>
+          <div class="pt-4 border-t border-neutral-100 flex justify-end">
+            <button type="submit" class="btn-primary" aria-label="{% trans 'Salvar métrica' %}">{% trans 'Salvar' %}</button>
+          </div>
+        </form>
       </div>
-      {% trans 'Nome' as nome_label %}
-      <div class="relative">
-        {% if form.nome.errors %}
-          {% render_field form.nome class="peer placeholder-transparent w-full rounded border border-neutral-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder=nome_label aria-describedby="nome_error" aria-invalid="true" %}
-        {% else %}
-          {% render_field form.nome class="peer placeholder-transparent w-full rounded border border-neutral-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder=nome_label aria-describedby="nome_error" %}
-        {% endif %}
-        <label for="{{ form.nome.id_for_label }}" class="absolute left-3 -top-2 text-xs text-neutral-700 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600">{{ nome_label }}</label>
-        {% if form.nome.errors %}
-          <div id="nome_error" class="text-red-600 text-xs mt-1" role="alert">{{ form.nome.errors }}</div>
-        {% endif %}
-      </div>
-      {% trans 'Descrição' as descricao_label %}
-      <div class="relative">
-        {% if form.descricao.errors %}
-          {% render_field form.descricao class="peer placeholder-transparent w-full rounded border border-neutral-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder=descricao_label aria-describedby="descricao_error" aria-invalid="true" %}
-        {% else %}
-          {% render_field form.descricao class="peer placeholder-transparent w-full rounded border border-neutral-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder=descricao_label aria-describedby="descricao_error" %}
-        {% endif %}
-        <label for="{{ form.descricao.id_for_label }}" class="absolute left-3 -top-2 text-xs text-neutral-700 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600">{{ descricao_label }}</label>
-        {% if form.descricao.errors %}
-          <div id="descricao_error" class="text-red-600 text-xs mt-1" role="alert">{{ form.descricao.errors }}</div>
-        {% endif %}
-      </div>
-      {% trans 'Query spec' as query_label %}
-      <div class="relative">
-        {% if form.query_spec.errors %}
-          {% render_field form.query_spec class="peer placeholder-transparent w-full rounded border border-neutral-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder=query_label aria-describedby="query_error" aria-invalid="true" %}
-        {% else %}
-          {% render_field form.query_spec class="peer placeholder-transparent w-full rounded border border-neutral-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder=query_label aria-describedby="query_error" %}
-        {% endif %}
-        <label for="{{ form.query_spec.id_for_label }}" class="absolute left-3 -top-2 text-xs text-neutral-700 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600">{{ query_label }}</label>
-        {% if form.query_spec.errors %}
-          <div id="query_error" class="text-red-600 text-xs mt-1" role="alert">{{ form.query_spec.errors }}</div>
-        {% endif %}
-      </div>
-      {% trans 'Escopo' as escopo_label %}
-      <div class="relative">
-        {% if form.escopo.errors %}
-          {% render_field form.escopo class="peer placeholder-transparent w-full rounded border border-neutral-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder=escopo_label aria-describedby="escopo_error" aria-invalid="true" %}
-        {% else %}
-          {% render_field form.escopo class="peer placeholder-transparent w-full rounded border border-neutral-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder=escopo_label aria-describedby="escopo_error" %}
-        {% endif %}
-        <label for="{{ form.escopo.id_for_label }}" class="absolute left-3 -top-2 text-xs text-neutral-700 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600">{{ escopo_label }}</label>
-        {% if form.escopo.errors %}
-          <div id="escopo_error" class="text-red-600 text-xs mt-1" role="alert">{{ form.escopo.errors }}</div>
-        {% endif %}
-      </div>
-      <button type="submit" class="px-4 py-2 bg-primary-600 text-white rounded" aria-label="{% trans 'Salvar métrica' %}">{% trans 'Salvar' %}</button>
-    </form>
-</main>
+    </div>
+  </div>
+</div>
 {% endblock %}
 

--- a/dashboard/templates/dashboard/custom_metric_list.html
+++ b/dashboard/templates/dashboard/custom_metric_list.html
@@ -2,23 +2,29 @@
 {% load i18n %}
 {% block title %}{% trans 'Métricas personalizadas' %}{% endblock %}
 {% block content %}
-<main class="max-w-2xl mx-auto p-4" role="main">
-  <h1 class="text-2xl font-semibold mb-4">{% trans 'Métricas personalizadas' %}</h1>
-  {% include 'dashboard/partials/messages.html' %}
-  <a href="{% url 'dashboard:custom-metric-create' %}" class="inline-block mb-4 px-4 py-2 bg-primary-600 text-white rounded" aria-label="{% trans 'Nova métrica' %}">{% trans 'Nova métrica' %}</a>
-  <ul class="space-y-2">
-    {% for m in object_list %}
-      <li class="flex justify-between items-center p-2 bg-white rounded shadow">
-        <span>{{ m.nome }}</span>
-        <div class="space-x-2">
-          <a href="{% url 'dashboard:custom-metric-edit' m.pk %}" class="text-primary-600 underline" aria-label="{% trans 'Editar métrica' %}">{% trans 'Editar' %}</a>
-          <a href="{% url 'dashboard:custom-metric-delete' m.pk %}" class="text-danger-600 underline" aria-label="{% trans 'Excluir métrica' %}">{% trans 'Excluir' %}</a>
-        </div>
-      </li>
-    {% empty %}
-      <li>{% trans 'Nenhuma métrica cadastrada.' %}</li>
-    {% endfor %}
-  </ul>
-</main>
+{% include 'components/hero.html' with title=_('Métricas personalizadas') %}
+<div class="container mx-auto p-6">
+  <div class="max-w-2xl mx-auto">
+    <div class="card">
+      <div class="card-body">
+        {% include 'dashboard/partials/messages.html' %}
+        <a href="{% url 'dashboard:custom-metric-create' %}" class="btn-primary mb-4" aria-label="{% trans 'Nova métrica' %}">{% trans 'Nova métrica' %}</a>
+        <ul class="space-y-2">
+          {% for m in object_list %}
+            <li class="flex justify-between items-center p-2 bg-white rounded shadow">
+              <span>{{ m.nome }}</span>
+              <div class="space-x-2">
+                <a href="{% url 'dashboard:custom-metric-edit' m.pk %}" class="text-primary-600 underline" aria-label="{% trans 'Editar métrica' %}">{% trans 'Editar' %}</a>
+                <a href="{% url 'dashboard:custom-metric-delete' m.pk %}" class="text-danger-600 underline" aria-label="{% trans 'Excluir métrica' %}">{% trans 'Excluir' %}</a>
+              </div>
+            </li>
+          {% empty %}
+            <li>{% trans 'Nenhuma métrica cadastrada.' %}</li>
+          {% endfor %}
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
 {% endblock %}
 

--- a/dashboard/templates/dashboard/filter_form.html
+++ b/dashboard/templates/dashboard/filter_form.html
@@ -2,42 +2,48 @@
 {% load i18n widget_tweaks %}
 {% block title %}{% trans 'Salvar filtro' %}{% endblock %}
 {% block content %}
-
-<main class="max-w-md mx-auto p-4" role="main">
-  <h1 class="text-2xl font-semibold mb-4">{% trans 'Salvar filtro' %}</h1>
-  <form method="post" class="space-y-4" aria-label="{% trans 'Formulário de filtro rápido' %}">
-    {% csrf_token %}
-    {% trans 'Nome' as nome_label %}
-    <div class="relative">
-      {% if form.nome.errors %}
-        {% render_field form.nome class="peer placeholder-transparent w-full rounded border border-neutral-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder=nome_label aria-describedby="nome_error" aria-invalid="true" %}
-      {% else %}
-        {% render_field form.nome class="peer placeholder-transparent w-full rounded border border-neutral-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder=nome_label aria-describedby="nome_error" %}
-      {% endif %}
-      <label for="{{ form.nome.id_for_label }}" class="absolute left-3 -top-2 text-xs text-neutral-700 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600">{{ nome_label }}</label>
-      {% if form.nome.errors %}
-        <div id="nome_error" class="text-red-600 text-xs mt-1" role="alert">{{ form.nome.errors }}</div>
-      {% endif %}
-    </div>
-  {% if request.user.user_type == 'root' or request.user.user_type == 'admin' %}
-    <div>
-      <div class="flex items-center gap-2">
-        {% if form.publico.errors %}
-          {% render_field form.publico aria-invalid="true" aria-describedby="publico_error" %}
+{% include 'components/hero.html' with title=_('Salvar filtro') %}
+<div class="container mx-auto p-6">
+  <div class="max-w-md mx-auto">
+    <div class="card">
+      <div class="card-body">
+        <form method="post" class="space-y-4" aria-label="{% trans 'Formulário de filtro rápido' %}">
+          {% csrf_token %}
+          {% trans 'Nome' as nome_label %}
+          <div class="relative">
+            {% if form.nome.errors %}
+              {% render_field form.nome class="peer placeholder-transparent w-full rounded border border-neutral-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder=nome_label aria-describedby="nome_error" aria-invalid="true" %}
+            {% else %}
+              {% render_field form.nome class="peer placeholder-transparent w-full rounded border border-neutral-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder=nome_label aria-describedby="nome_error" %}
+            {% endif %}
+            <label for="{{ form.nome.id_for_label }}" class="absolute left-3 -top-2 text-xs text-neutral-700 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600">{{ nome_label }}</label>
+            {% if form.nome.errors %}
+              <div id="nome_error" class="text-red-600 text-xs mt-1" role="alert">{{ form.nome.errors }}</div>
+            {% endif %}
+          </div>
+        {% if request.user.user_type == 'root' or request.user.user_type == 'admin' %}
+          <div>
+            <div class="flex items-center gap-2">
+              {% if form.publico.errors %}
+                {% render_field form.publico aria-invalid="true" aria-describedby="publico_error" %}
+              {% else %}
+                {% render_field form.publico aria-describedby="publico_error" %}
+              {% endif %}
+              <label for="{{ form.publico.id_for_label }}" class="text-sm text-neutral-700">{% trans 'Público' %}</label>
+            </div>
+            {% if form.publico.errors %}
+              <div id="publico_error" class="text-red-600 text-xs mt-1" role="alert">{{ form.publico.errors }}</div>
+            {% endif %}
+          </div>
         {% else %}
-          {% render_field form.publico aria-describedby="publico_error" %}
+          <p class="text-sm text-neutral-700">{% trans 'Apenas administradores podem publicar itens.' %}</p>
         {% endif %}
-        <label for="{{ form.publico.id_for_label }}" class="text-sm text-neutral-700">{% trans 'Público' %}</label>
+          <div class="pt-4 border-t border-neutral-100 flex justify-end">
+            <button type="submit" class="btn-primary" aria-label="{% trans 'Salvar filtro' %}">{% trans 'Salvar' %}</button>
+          </div>
+        </form>
       </div>
-      {% if form.publico.errors %}
-        <div id="publico_error" class="text-red-600 text-xs mt-1" role="alert">{{ form.publico.errors }}</div>
-      {% endif %}
     </div>
-    {% else %}
-    <p class="text-sm text-neutral-700">{% trans 'Apenas administradores podem publicar itens.' %}</p>
-    {% endif %}
-    <button type="submit" class="px-4 py-2 bg-primary-600 text-white rounded focus:outline-none focus:ring" aria-label="{% trans 'Salvar filtro' %}">{% trans 'Salvar' %}</button>
-  </form>
-</main>
-
+  </div>
+</div>
 {% endblock %}

--- a/dashboard/templates/dashboard/filter_list.html
+++ b/dashboard/templates/dashboard/filter_list.html
@@ -2,27 +2,33 @@
 {% load i18n %}
 {% block title %}{% trans 'Filtros salvos' %}{% endblock %}
 {% block content %}
-<main class="max-w-2xl mx-auto p-4" role="main">
-  <h1 class="text-2xl font-semibold mb-4">{% trans 'Filtros salvos' %}</h1>
-  {% include 'dashboard/partials/messages.html' %}
-  <ul class="space-y-2">
-    {% for f in object_list %}
-      <li class="flex justify-between items-center p-2 bg-white rounded shadow">
-        <span>{{ f.nome }}</span>
-        <span class="flex gap-2">
-          <a href="{% url 'dashboard:filter-apply' f.pk %}" class="text-primary-600 underline" aria-label="{% trans 'Aplicar filtro' %}">{% trans 'Aplicar' %}</a>
-          {% if f.user_id == request.user.id or request.user.user_type == 'admin' or request.user.user_type == 'root' %}
-            <a href="{% url 'dashboard:filter-edit' f.pk %}" class="text-primary-600 underline" aria-label="{% trans 'Editar filtro' %}">{% trans 'Editar' %}</a>
-            <form method="post" action="{% url 'dashboard:filter-delete' f.pk %}">
-              {% csrf_token %}
-              <button type="submit" class="text-red-600 underline" aria-label="{% trans 'Excluir filtro' %}">{% trans 'Excluir' %}</button>
-            </form>
-          {% endif %}
-        </span>
-      </li>
-    {% empty %}
-      <li>{% trans 'Nenhum filtro salvo.' %}</li>
-    {% endfor %}
-  </ul>
-</main>
+{% include 'components/hero.html' with title=_('Filtros salvos') %}
+<div class="container mx-auto p-6">
+  <div class="max-w-2xl mx-auto">
+    <div class="card">
+      <div class="card-body">
+        {% include 'dashboard/partials/messages.html' %}
+        <ul class="space-y-2">
+          {% for f in object_list %}
+            <li class="flex justify-between items-center p-2 bg-white rounded shadow">
+              <span>{{ f.nome }}</span>
+              <span class="flex gap-2">
+                <a href="{% url 'dashboard:filter-apply' f.pk %}" class="text-primary-600 underline" aria-label="{% trans 'Aplicar filtro' %}">{% trans 'Aplicar' %}</a>
+                {% if f.user_id == request.user.id or request.user.user_type == 'admin' or request.user.user_type == 'root' %}
+                  <a href="{% url 'dashboard:filter-edit' f.pk %}" class="text-primary-600 underline" aria-label="{% trans 'Editar filtro' %}">{% trans 'Editar' %}</a>
+                  <form method="post" action="{% url 'dashboard:filter-delete' f.pk %}" class="inline">
+                    {% csrf_token %}
+                    <button type="submit" class="text-red-600 underline" aria-label="{% trans 'Excluir filtro' %}">{% trans 'Excluir' %}</button>
+                  </form>
+                {% endif %}
+              </span>
+            </li>
+          {% empty %}
+            <li>{% trans 'Nenhum filtro salvo.' %}</li>
+          {% endfor %}
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
 {% endblock %}

--- a/dashboard/templates/dashboard/layout_confirm_delete.html
+++ b/dashboard/templates/dashboard/layout_confirm_delete.html
@@ -2,12 +2,18 @@
 {% load i18n %}
 {% block title %}{% trans "Excluir Layout" %} | Hubx{% endblock %}
 {% block content %}
-<main class="max-w-xl mx-auto p-4" role="main">
-  <h1 class="text-2xl mb-4">{% trans "Excluir Layout" %}</h1>
-  <p>{% trans "Tem certeza que deseja excluir este layout?" %}</p>
-  <form method="post">
-    {% csrf_token %}
-    <button type="submit" class="btn btn-danger" aria-label="{% trans 'Excluir layout' %}">{% trans "Excluir" %}</button>
-  </form>
-</main>
+{% include 'components/hero.html' with title=_('Excluir Layout') %}
+<div class="container mx-auto p-6">
+  <div class="max-w-xl mx-auto">
+    <div class="card">
+      <div class="card-body space-y-4">
+        <p>{% trans "Tem certeza que deseja excluir este layout?" %}</p>
+        <form method="post" class="pt-4 border-t border-neutral-100">
+          {% csrf_token %}
+          <button type="submit" class="btn-danger" aria-label="{% trans 'Excluir layout' %}">{% trans "Excluir" %}</button>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
 {% endblock %}

--- a/dashboard/templates/dashboard/layout_form.html
+++ b/dashboard/templates/dashboard/layout_form.html
@@ -2,46 +2,52 @@
 {% load i18n static widget_tweaks %}
 {% block title %}{% trans "Layout" %} | Hubx{% endblock %}
 {% block content %}
-<main class="max-w-7xl mx-auto p-4" role="main" aria-label="{% trans 'Layout form' %}">
-  <h1 class="text-2xl mb-4">{% trans "Layout" %}</h1>
-  <form method="post">
-    {% csrf_token %}
-    {% trans "Nome" as nome_label %}
-    <div class="mb-4 relative">
-      {% if form.nome.errors %}
-        {% render_field form.nome class="peer placeholder-transparent w-full rounded border border-neutral-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder=nome_label aria-describedby="nome_error" aria-invalid="true" %}
-      {% else %}
-        {% render_field form.nome class="peer placeholder-transparent w-full rounded border border-neutral-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder=nome_label aria-describedby="nome_error" %}
-      {% endif %}
-      <label for="{{ form.nome.id_for_label }}" class="absolute left-3 -top-2 text-xs text-neutral-700 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600">{{ nome_label }}</label>
-      {% if form.nome.errors %}
-        <div id="nome_error" class="text-red-600 text-xs mt-1" role="alert">{{ form.nome.errors }}</div>
-      {% endif %}
-    </div>
-  {% if request.user.user_type == 'root' or request.user.user_type == 'admin' %}
-    <div class="mb-4">
-      <div class="flex items-center gap-2">
-        {% if form.publico.errors %}
-          {% render_field form.publico aria-invalid="true" aria-describedby="publico_error" %}
+{% include 'components/hero.html' with title=_('Layout') %}
+<div class="container mx-auto p-6">
+  <div class="max-w-7xl mx-auto">
+    <div class="card">
+      <div class="card-body space-y-6">
+        <form method="post" class="space-y-4">
+          {% csrf_token %}
+          {% trans "Nome" as nome_label %}
+          <div class="relative">
+            {% if form.nome.errors %}
+              {% render_field form.nome class="peer placeholder-transparent w-full rounded border border-neutral-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder=nome_label aria-describedby="nome_error" aria-invalid="true" %}
+            {% else %}
+              {% render_field form.nome class="peer placeholder-transparent w-full rounded border border-neutral-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder=nome_label aria-describedby="nome_error" %}
+            {% endif %}
+            <label for="{{ form.nome.id_for_label }}" class="absolute left-3 -top-2 text-xs text-neutral-700 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600">{{ nome_label }}</label>
+            {% if form.nome.errors %}
+              <div id="nome_error" class="text-red-600 text-xs mt-1" role="alert">{{ form.nome.errors }}</div>
+            {% endif %}
+          </div>
+        {% if request.user.user_type == 'root' or request.user.user_type == 'admin' %}
+          <div>
+            <div class="flex items-center gap-2">
+              {% if form.publico.errors %}
+                {% render_field form.publico aria-invalid="true" aria-describedby="publico_error" %}
+              {% else %}
+                {% render_field form.publico aria-describedby="publico_error" %}
+              {% endif %}
+              <label for="{{ form.publico.id_for_label }}" class="text-sm">{{ form.publico.label }}</label>
+            </div>
+            {% if form.publico.errors %}
+              <div id="publico_error" class="text-red-600 text-xs mt-1" role="alert">{{ form.publico.errors }}</div>
+            {% endif %}
+          </div>
         {% else %}
-          {% render_field form.publico aria-describedby="publico_error" %}
+          <p class="text-sm text-neutral-700">{% trans 'Apenas administradores podem publicar itens.' %}</p>
         {% endif %}
-        <label for="{{ form.publico.id_for_label }}" class="text-sm">{{ form.publico.label }}</label>
+        <input type="hidden" name="layout_json" id="layout_json" value="{{ object.layout_json|default:'{}' }}">
+        <div class="flex justify-end pt-4 border-t border-neutral-100">
+          <button type="submit" class="btn-primary" aria-label="{% trans 'Salvar layout' %}">{% trans "Salvar" %}</button>
+        </div>
+        </form>
+        {% include 'dashboard/partials/metrics_list.html' %}
       </div>
-      {% if form.publico.errors %}
-        <div id="publico_error" class="text-red-600 text-xs mt-1" role="alert">{{ form.publico.errors }}</div>
-      {% endif %}
     </div>
-
-    {% else %}
-    <p class="mb-4 text-sm text-neutral-700">{% trans 'Apenas administradores podem publicar itens.' %}</p>
-    {% endif %}
-    <input type="hidden" name="layout_json" id="layout_json" value="{{ object.layout_json|default:'{}' }}">
-
-    <button type="submit" class="btn btn-primary" aria-label="{% trans 'Salvar layout' %}">{% trans "Salvar" %}</button>
-  </form>
-  {% include 'dashboard/partials/metrics_list.html' %}
-</main>
+  </div>
+</div>
 {% endblock %}
 
 {% block extra_js %}

--- a/dashboard/templates/dashboard/layout_list.html
+++ b/dashboard/templates/dashboard/layout_list.html
@@ -2,23 +2,31 @@
 {% load i18n %}
 {% block title %}{% trans "Layouts" %} | Hubx{% endblock %}
 {% block content %}
-<main class="max-w-3xl mx-auto p-4" role="main" aria-label="{% trans 'Layouts' %}">
-  <h1 class="text-2xl mb-4">{% trans "Meus Layouts" %}</h1>
-  <ul class="space-y-2">
-    {% for layout in object_list %}
-      <li class="flex justify-between items-center p-2 bg-white rounded shadow">
-        <span>{{ layout.nome }}</span>
-        {% if layout.user_id == request.user.id or request.user.user_type == 'admin' or request.user.user_type == 'root' %}
-          <span class="flex gap-2">
-            <a href="{% url 'dashboard:layout-edit' layout.pk %}" class="text-primary-600 underline" aria-label="{% trans 'Editar layout' %}">{% trans 'Editar' %}</a>
-            <a href="{% url 'dashboard:layout-delete' layout.pk %}" class="text-danger-600 underline" aria-label="{% trans 'Excluir layout' %}">{% trans 'Excluir' %}</a>
-          </span>
-        {% endif %}
-      </li>
-    {% empty %}
-      <li>{% trans "Nenhum layout" %}</li>
-    {% endfor %}
-  </ul>
-  <a href="{% url 'dashboard:layout-create' %}" class="btn btn-primary" aria-label="{% trans 'Novo Layout' %}">{% trans "Novo Layout" %}</a>
-</main>
+{% include 'components/hero.html' with title=_('Meus Layouts') %}
+<div class="container mx-auto p-6">
+  <div class="max-w-3xl mx-auto">
+    <div class="card">
+      <div class="card-body">
+        <ul class="space-y-2">
+          {% for layout in object_list %}
+            <li class="flex justify-between items-center p-2 bg-white rounded shadow">
+              <span>{{ layout.nome }}</span>
+              {% if layout.user_id == request.user.id or request.user.user_type == 'admin' or request.user.user_type == 'root' %}
+                <span class="flex gap-2">
+                  <a href="{% url 'dashboard:layout-edit' layout.pk %}" class="text-primary-600 underline" aria-label="{% trans 'Editar layout' %}">{% trans 'Editar' %}</a>
+                  <a href="{% url 'dashboard:layout-delete' layout.pk %}" class="text-danger-600 underline" aria-label="{% trans 'Excluir layout' %}">{% trans 'Excluir' %}</a>
+                </span>
+              {% endif %}
+            </li>
+          {% empty %}
+            <li>{% trans "Nenhum layout" %}</li>
+          {% endfor %}
+        </ul>
+        <div class="pt-4 border-t border-neutral-100 mt-4">
+          <a href="{% url 'dashboard:layout-create' %}" class="btn-primary" aria-label="{% trans 'Novo Layout' %}">{% trans "Novo Layout" %}</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
 {% endblock %}

--- a/dashboard/templates/dashboard/root.html
+++ b/dashboard/templates/dashboard/root.html
@@ -4,76 +4,73 @@
 {% block title %}{% trans "Dashboard Root" %} | Hubx{% endblock %}
 
 {% block content %}
-<main class="max-w-7xl mx-auto px-4 py-10" role="main" aria-label="{% trans 'Dashboard' %}">
-  <h1 class="text-3xl font-semibold text-neutral-900 text-center mb-10">{% trans "Dashboard Root" %}</h1>
-
-  {% include 'dashboard/partials/messages.html' %}
-  {% include 'dashboard/partials/filters_form.html' %}
-
-  <div hx-get="{% url 'dashboard:metrics-partial' %}?{{ request.GET.urlencode }}" hx-trigger="load, every 10s" hx-target="#metrics" hx-swap="innerHTML">
-    {% include 'dashboard/partials/metrics_list.html' %}
+{% include 'components/hero.html' with title=_('Dashboard Root') %}
+<div class="container mx-auto p-6">
+  <div class="max-w-7xl mx-auto">
+    <div class="card">
+      <div class="card-body space-y-8">
+        {% include 'dashboard/partials/messages.html' %}
+        {% include 'dashboard/partials/filters_form.html' %}
+        <div hx-get="{% url 'dashboard:metrics-partial' %}?{{ request.GET.urlencode }}" hx-trigger="load, every 10s" hx-target="#metrics" hx-swap="innerHTML">
+          {% include 'dashboard/partials/metrics_list.html' %}
+        </div>
+        {% with labels='["'|add:_('Usuários')|add:'","'|add:_('Eventos')|add:'","'|add:_('Posts')|add:'"]' %}
+        {% include 'dashboard/partials/chart.html' with chart_id='root_chart' title=_('Distribuição de Métricas') labels=labels|safe data=chart_data %}
+        {% endwith %}
+        <section class="mb-8">
+          <h2 class="text-xl font-semibold mb-4">{% trans "Status dos Serviços" %}</h2>
+          <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div class="p-4 bg-white rounded-lg shadow">
+              <span class="block font-medium">{% trans "Celery" %}</span>
+              <span>{{ service_status.celery }}</span>
+            </div>
+            <div class="p-4 bg-white rounded-lg shadow">
+              <span class="block font-medium">{% trans "Fila de Mensagens" %}</span>
+              <span>{{ service_status.fila_mensagens }}</span>
+            </div>
+            <div class="p-4 bg-white rounded-lg shadow">
+              <span class="block font-medium">{% trans "Uso de Disco" %}</span>
+              <span>{{ service_status.disco }}%</span>
+            </div>
+          </div>
+        </section>
+        <section class="mb-8">
+          <h2 class="text-xl font-semibold mb-4">{% trans "Métricas de Segurança" %}</h2>
+          <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div class="p-4 bg-white rounded-lg shadow">
+              <span class="block font-medium">{% trans "Tentativas de Login Bloqueadas" %}</span>
+              <span>{{ security_metrics.login_bloqueados }}</span>
+            </div>
+          </div>
+        </section>
+        <section class="mb-8">
+          <h2 class="text-xl font-semibold mb-4">{% trans "Organizações" %}</h2>
+          <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {% include 'dashboard/partials/org_cards.html' %}
+          </div>
+        </section>
+        <section
+          id="notifications"
+          hx-get="{% url 'dashboard:notificacoes-partial' %}"
+          hx-trigger="load, every 20s"
+          hx-target="this"
+          hx-swap="innerHTML"
+        ></section>
+        <section class="mb-8">
+          <h2 class="text-xl font-semibold mb-4">{% trans "Ações Rápidas" %}</h2>
+          <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            <a href="{% url 'admin:index' %}" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50" aria-label="{% trans 'Django Admin' %}">
+              {% lucide 'wrench' class='mb-2 mx-auto w-6 h-6' %}
+              <span class="block">{% trans "Django Admin" %}</span>
+            </a>
+            <a href="{% url 'dashboard:custom-metrics' %}" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50" aria-label="{% trans 'Métricas Personalizadas' %}">
+              {% lucide 'chart-line' class='mb-2 mx-auto w-6 h-6' %}
+              <span class="block">{% trans "Métricas Personalizadas" %}</span>
+            </a>
+          </div>
+        </section>
+      </div>
+    </div>
   </div>
-
-  {% with labels='["'|add:_('Usuários')|add:'","'|add:_('Eventos')|add:'","'|add:_('Posts')|add:'"]' %}
-  {% include 'dashboard/partials/chart.html' with chart_id='root_chart' title=_('Distribuição de Métricas') labels=labels|safe data=chart_data %}
-  {% endwith %}
-
-  <section class="mb-8">
-    <h2 class="text-xl font-semibold mb-4">{% trans "Status dos Serviços" %}</h2>
-    <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-      <div class="p-4 bg-white rounded-lg shadow">
-        <span class="block font-medium">{% trans "Celery" %}</span>
-        <span>{{ service_status.celery }}</span>
-      </div>
-      <div class="p-4 bg-white rounded-lg shadow">
-        <span class="block font-medium">{% trans "Fila de Mensagens" %}</span>
-        <span>{{ service_status.fila_mensagens }}</span>
-      </div>
-      <div class="p-4 bg-white rounded-lg shadow">
-        <span class="block font-medium">{% trans "Uso de Disco" %}</span>
-        <span>{{ service_status.disco }}%</span>
-      </div>
-    </div>
-  </section>
-
-  <section class="mb-8">
-    <h2 class="text-xl font-semibold mb-4">{% trans "Métricas de Segurança" %}</h2>
-    <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-      <div class="p-4 bg-white rounded-lg shadow">
-        <span class="block font-medium">{% trans "Tentativas de Login Bloqueadas" %}</span>
-        <span>{{ security_metrics.login_bloqueados }}</span>
-      </div>
-    </div>
-  </section>
-
-  <section class="mb-8">
-    <h2 class="text-xl font-semibold mb-4">{% trans "Organizações" %}</h2>
-    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-      {% include 'dashboard/partials/org_cards.html' %}
-    </div>
-  </section>
-
-  <section
-    id="notifications"
-    hx-get="{% url 'dashboard:notificacoes-partial' %}"
-    hx-trigger="load, every 20s"
-    hx-target="this"
-    hx-swap="innerHTML"
-  ></section>
-
-  <section class="mb-8">
-    <h2 class="text-xl font-semibold mb-4">{% trans "Ações Rápidas" %}</h2>
-    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-        <a href="{% url 'admin:index' %}" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50" aria-label="{% trans 'Django Admin' %}">
-          {% lucide 'wrench' class='mb-2 mx-auto w-6 h-6' %}
-          <span class="block">{% trans "Django Admin" %}</span>
-        </a>
-        <a href="{% url 'dashboard:custom-metrics' %}" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50" aria-label="{% trans 'Métricas Personalizadas' %}">
-          {% lucide 'chart-line' class='mb-2 mx-auto w-6 h-6' %}
-          <span class="block">{% trans "Métricas Personalizadas" %}</span>
-        </a>
-      </div>
-    </section>
-
-</main>
+</div>
 {% endblock %}

--- a/organizacoes/templates/organizacoes/update.html
+++ b/organizacoes/templates/organizacoes/update.html
@@ -1,160 +1,48 @@
 {% extends 'base.html' %}
-{% load i18n %}
+{% load i18n widget_tweaks %}
 
 {% block title %}{% trans "Editar Organização" %} | Hubx{% endblock %}
 
 {% block content %}
-<section class="max-w-2xl mx-auto px-4 py-10">
-  <header class="mb-6 flex items-center gap-4">
-    <a href="{% url 'organizacoes:list' %}" class="inline-flex items-center text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100">
-      <svg class="mr-2" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-        <polyline points="15,18 9,12 15,6" />
-      </svg>
-      {% trans "Voltar" %}
-    </a>
-    <h1 class="text-2xl font-bold text-neutral-900">{% trans "Editar Organização" %}</h1>
-  </header>
+{% include 'components/hero.html' with title=_('Editar Organização') %}
+<div class="container mx-auto p-6">
+  <div class="max-w-2xl mx-auto">
+    <div class="card">
+      <div class="card-body">
+        {% if messages %}
+        <div class="mb-4 space-y-2">
+          {% for message in messages %}
+            <p class="rounded-xl px-4 py-2 text-sm {% if 'success' in message.tags %}bg-green-100 text-green-700{% else %}bg-red-100 text-red-700{% endif %}">{{ message }}</p>
+          {% endfor %}
+        </div>
+        {% endif %}
 
-  {% if messages %}
-  <div class="mb-4 space-y-2">
-    {% for message in messages %}
-      <p class="rounded-xl px-4 py-2 text-sm {% if 'success' in message.tags %}bg-green-100 text-green-700{% else %}bg-red-100 text-red-700{% endif %}">{{ message }}</p>
-    {% endfor %}
+        <form method="post" enctype="multipart/form-data" class="space-y-6">
+          {% csrf_token %}
+          {% for field in form %}
+          <div class="relative">
+            {% if field.errors %}
+              {% render_field field class="peer w-full rounded border border-neutral-300 px-3 py-2 placeholder-transparent focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder=field.label aria-describedby=field.name|add:'_error' aria-invalid="true" %}
+            {% else %}
+              {% render_field field class="peer w-full rounded border border-neutral-300 px-3 py-2 placeholder-transparent focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder=field.label aria-describedby=field.name|add:'_error' %}
+            {% endif %}
+            <label for="{{ field.id_for_label }}" class="absolute left-3 -top-2 text-xs text-neutral-700 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600">{{ field.label }}</label>
+            {% if field.errors %}
+              <div id="{{ field.name }}_error" class="text-red-600 text-xs mt-1" role="alert">{{ field.errors }}</div>
+            {% endif %}
+          </div>
+          {% endfor %}
+          <div class="flex justify-end gap-3 pt-4 border-t border-neutral-100">
+            <a href="{% url 'organizacoes:list' %}" class="btn-secondary" aria-label="{% trans 'Cancelar edição' %}">{% trans "Cancelar" %}</a>
+            <button type="submit" class="btn-primary" aria-label="{% trans 'Salvar organização' %}">{% trans "Salvar" %}</button>
+          </div>
+        </form>
+      </div>
+    </div>
+    <div class="text-right mt-6">
+      <a href="{% url 'organizacoes:list' %}" class="text-sm text-primary hover:underline">{% trans "Voltar à lista" %}</a>
+    </div>
   </div>
-  {% endif %}
-
-  <main>
-  <form method="post" enctype="multipart/form-data" class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 space-y-6">
-    {% csrf_token %}
-
-    <div class="grid md:grid-cols-2 gap-6">
-      <div>
-        <label for="{{ form.nome.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.nome.label }}</label>
-        {{ form.nome }}
-        {% if form.nome.errors %}
-          <p class="text-red-500 text-xs mt-1">{{ form.nome.errors }}</p>
-        {% endif %}
-      </div>
-      <div>
-        <label for="{{ form.cnpj.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.cnpj.label }}</label>
-        {{ form.cnpj }}
-        {% if form.cnpj.errors %}
-          <p class="text-red-500 text-xs mt-1">{{ form.cnpj.errors }}</p>
-        {% endif %}
-      </div>
-    </div>
-    <div>
-      <label for="{{ form.tipo.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.tipo.label }}</label>
-      {{ form.tipo }}
-      {% if form.tipo.errors %}
-        <p class="text-red-500 text-xs mt-1">{{ form.tipo.errors }}</p>
-      {% endif %}
-    </div>
-
-    <div>
-      <label for="{{ form.descricao.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.descricao.label }}</label>
-      {{ form.descricao }}
-      {% if form.descricao.errors %}
-        <p class="text-red-500 text-xs mt-1">{{ form.descricao.errors }}</p>
-      {% endif %}
-    </div>
-
-    <div class="grid md:grid-cols-3 gap-6">
-      <div class="md:col-span-3">
-        <label for="{{ form.rua.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.rua.label }}</label>
-        {{ form.rua }}
-        {% if form.rua.errors %}
-          <p class="text-red-500 text-xs mt-1">{{ form.rua.errors }}</p>
-        {% endif %}
-      </div>
-      <div class="md:col-span-2">
-        <label for="{{ form.cidade.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.cidade.label }}</label>
-        {{ form.cidade }}
-        {% if form.cidade.errors %}
-          <p class="text-red-500 text-xs mt-1">{{ form.cidade.errors }}</p>
-        {% endif %}
-      </div>
-      <div>
-        <label for="{{ form.estado.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.estado.label }}</label>
-        {{ form.estado }}
-        {% if form.estado.errors %}
-          <p class="text-red-500 text-xs mt-1">{{ form.estado.errors }}</p>
-        {% endif %}
-      </div>
-    </div>
-
-    <div class="grid md:grid-cols-3 gap-6">
-      <div>
-        <label for="{{ form.contato_nome.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.contato_nome.label }}</label>
-        {{ form.contato_nome }}
-        {% if form.contato_nome.errors %}
-          <p class="text-red-500 text-xs mt-1">{{ form.contato_nome.errors }}</p>
-        {% endif %}
-      </div>
-      <div>
-        <label for="{{ form.contato_email.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.contato_email.label }}</label>
-        {{ form.contato_email }}
-        {% if form.contato_email.errors %}
-          <p class="text-red-500 text-xs mt-1">{{ form.contato_email.errors }}</p>
-        {% endif %}
-      </div>
-      <div>
-        <label for="{{ form.contato_telefone.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.contato_telefone.label }}</label>
-        {{ form.contato_telefone }}
-        {% if form.contato_telefone.errors %}
-          <p class="text-red-500 text-xs mt-1">{{ form.contato_telefone.errors }}</p>
-        {% endif %}
-      </div>
-    </div>
-
-    <div>
-      <label for="{{ form.slug.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.slug.label }}</label>
-      {{ form.slug }}
-      {% if form.slug.errors %}
-        <p class="text-red-500 text-xs mt-1">{{ form.slug.errors }}</p>
-      {% endif %}
-    </div>
-
-    <div>
-      <label for="{{ form.rate_limit_multiplier.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.rate_limit_multiplier.label }}</label>
-      {{ form.rate_limit_multiplier }}
-      {% if form.rate_limit_multiplier.errors %}
-        <p class="text-red-500 text-xs mt-1">{{ form.rate_limit_multiplier.errors }}</p>
-      {% endif %}
-    </div>
-
-    <div>
-      <label for="{{ form.indice_reajuste.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.indice_reajuste.label }}</label>
-      {{ form.indice_reajuste }}
-      {% if form.indice_reajuste.errors %}
-        <p class="text-red-500 text-xs mt-1">{{ form.indice_reajuste.errors }}</p>
-      {% endif %}
-    </div>
-
-    <div>
-      <label for="{{ form.avatar.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.avatar.label }}</label>
-      {{ form.avatar }}
-      {% if form.avatar.errors %}
-        <p class="text-red-500 text-xs mt-1">{{ form.avatar.errors }}</p>
-      {% endif %}
-    </div>
-
-    <div>
-      <label for="{{ form.cover.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.cover.label }}</label>
-      {{ form.cover }}
-      {% if form.cover.errors %}
-        <p class="text-red-500 text-xs mt-1">{{ form.cover.errors }}</p>
-      {% endif %}
-    </div>
-
-    <div class="flex justify-end gap-3 pt-4 border-t border-neutral-100">
-      <a href="{% url 'organizacoes:list' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100">{% trans "Cancelar" %}</a>
-      <button type="submit" class="text-sm px-4 py-2 rounded-xl bg-green-600 text-white hover:bg-green-700">{% trans "Salvar" %}</button>
-    </div>
-  </form>
-  </main>
-  <footer class="mt-6 text-right">
-    <a href="{% url 'organizacoes:list' %}" class="text-sm text-blue-600 hover:underline">{% trans "Voltar à lista" %}</a>
-  </footer>
-</section>
+</div>
 {% endblock %}
+


### PR DESCRIPTION
## Summary
- replace legacy headers with hero component
- wrap dashboard pages in card layout and use btn styles
- adopt floating label pattern in organization update form

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'silk'; after installing deps, 81 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bd7df20530832582ef28f58944d275