### PR TITLE
style: center avatar within profile cover

### DIFF
--- a/accounts/templates/perfil/perfil.html
+++ b/accounts/templates/perfil/perfil.html
@@ -11,13 +11,13 @@
 <div class="container mx-auto p-6">
   <div class="card flex flex-col min-h-[80vh] overflow-hidden">
     {% with perfil|default:user as profile %}
-    <div class="profile-cover relative h-48 w-full">
+    <div class="profile-cover relative h-48 w-full overflow-hidden">
       {% if profile.cover %}
         <img src="{{ profile.cover.url }}" alt="{% trans "Capa do usuário" %}" class="w-full h-full object-cover">
       {% else %}
         <div class="w-full h-full bg-gray-200" role="img" aria-label="{% trans "Capa padrão" %}"></div>
       {% endif %}
-      <div class="absolute inset-0 flex flex-col items-center justify-center text-white drop-shadow">
+      <div class="absolute inset-0 z-10 flex flex-col items-center justify-center text-white drop-shadow">
         {% if profile.avatar %}
           <img src="{{ profile.avatar.url }}" alt="{{ profile.username }}"
                class="w-28 h-28 rounded-full object-cover shadow mb-3">


### PR DESCRIPTION
## Summary
- ensure profile cover uses overflow-hidden
- overlay avatar block centered with z-10 on profile page

## Testing
- `pytest --no-cov tests/accounts/test_perfil_publico.py` *(fails: ModuleNotFoundError: No module named 'discussao')*

------
https://chatgpt.com/codex/tasks/task_e_68bd840c5c5c83258a4ef8bbc46f30f6