### PR TITLE
refactor: modernize page layouts

### DIFF
--- a/empresas/templates/empresas/favoritos.html
+++ b/empresas/templates/empresas/favoritos.html
@@ -4,29 +4,27 @@
 {% block title %}{% translate "Empresas Favoritas" %}{% endblock %}
 
 {% block content %}
-<main class="max-w-7xl mx-auto px-4 py-10">
-  <header class="mb-4">
-    <h1 class="text-2xl font-bold text-neutral-900">{% translate "Empresas Favoritas" %}</h1>
-  </header>
-  <ul
-    class="space-y-4"
-    id="lista-favoritos"
-    hx-on:afterRequest="if (this.children.length === 0) { const li=document.createElement('li'); li.className='text-neutral-600'; li.textContent='{{ _('Nenhuma empresa favorita.')|escapejs }}'; this.appendChild(li); }"
-  >
-    {% for empresa in empresas %}
-      <li id="empresa-{{ empresa.id }}" class="p-4 bg-white rounded shadow">
-        <h2 class="text-lg font-semibold">{{ empresa.nome }}</h2>
-        <button
-          class="text-sm text-red-600 hover:underline"
-          hx-delete="{% url 'empresas_api:empresa-favoritar' empresa.id %}"
-          hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
-          hx-target="#empresa-{{ empresa.id }}"
-          hx-swap="outerHTML"
-        >{% translate "Remover" %}</button>
-      </li>
-    {% empty %}
-      <li class="text-neutral-600">{% translate "Nenhuma empresa favorita." %}</li>
-    {% endfor %}
-  </ul>
-</main>
+{% include 'components/hero.html' with title=_('Empresas Favoritas') %}
+<div class="container mx-auto p-6">
+  <div class="card">
+    <div class="card-body">
+      <ul class="space-y-4" id="lista-favoritos" hx-on:afterRequest="if (this.children.length === 0) { const li=document.createElement('li'); li.className='text-neutral-600'; li.textContent='{{ _('Nenhuma empresa favorita.')|escapejs }}'; this.appendChild(li); }">
+        {% for empresa in empresas %}
+          <li id="empresa-{{ empresa.id }}" class="p-4 bg-white rounded shadow">
+            <h2 class="text-lg font-semibold">{{ empresa.nome }}</h2>
+            <button
+              class="text-sm text-red-600 hover:underline"
+              hx-delete="{% url 'empresas_api:empresa-favoritar' empresa.id %}"
+              hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+              hx-target="#empresa-{{ empresa.id }}"
+              hx-swap="outerHTML"
+            >{% translate "Remover" %}</button>
+          </li>
+        {% empty %}
+          <li class="text-neutral-600">{% translate "Nenhuma empresa favorita." %}</li>
+        {% endfor %}
+      </ul>
+    </div>
+  </div>
+</div>
 {% endblock %}

--- a/eventos/templates/eventos/_lista_eventos_dia.html
+++ b/eventos/templates/eventos/_lista_eventos_dia.html
@@ -7,12 +7,10 @@
   <p class="sr-only">{% trans 'Lista de eventos do dia' %}</p>
 </header>
 
-<main>
-  <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-    {% for ev in eventos %}
-      {% include 'eventos/partials/card.html' with evento=ev %}
-    {% empty %}
-      <p class="text-sm text-neutral-400">{% trans "Sem eventos." %}</p>
-    {% endfor %}
-  </div>
-</main>
+<div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+  {% for ev in eventos %}
+    {% include 'eventos/partials/card.html' with evento=ev %}
+  {% empty %}
+    <p class="text-sm text-neutral-400">{% trans "Sem eventos." %}</p>
+  {% endfor %}
+</div>

--- a/eventos/templates/eventos/avaliacao_form.html
+++ b/eventos/templates/eventos/avaliacao_form.html
@@ -3,25 +3,29 @@
 {% block title %}{% trans "Avaliar evento" %}{% endblock %}
 
 {% block content %}
-<main class="max-w-md mx-auto py-8 px-4">
-  <h1 class="text-xl font-semibold mb-4">{% trans "Avaliar evento" %}</h1>
-  <form method="post" class="space-y-4">
-    {% csrf_token %}
-    <div>
-      <label for="nota" class="block text-sm font-medium">{% trans "Nota" %}</label>
-      <select id="nota" name="nota" class="form-select w-full" required>
-        {% for n in '12345' %}
-        <option value="{{ n }}">{{ n }}</option>
-        {% endfor %}
-      </select>
+{% include 'components/hero.html' with title=_('Avaliar evento') %}
+<div class="container mx-auto p-6">
+  <div class="card">
+    <div class="card-body">
+      <form method="post" class="space-y-4">
+        {% csrf_token %}
+        <div>
+          <label for="nota" class="block text-sm font-medium">{% trans "Nota" %}</label>
+          <select id="nota" name="nota" class="form-select w-full" required>
+            {% for n in '12345' %}
+            <option value="{{ n }}">{{ n }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div>
+          <label for="comentario" class="block text-sm font-medium">{% trans "Comentário" %}</label>
+          <textarea id="comentario" name="comentario" rows="4" class="form-textarea w-full" placeholder="{% trans 'Opcional' %}"></textarea>
+        </div>
+        <div class="text-right">
+          <button type="submit" class="btn-primary" aria-label="{% trans 'Enviar avaliação' %}">{% trans 'Enviar avaliação' %}</button>
+        </div>
+      </form>
     </div>
-    <div>
-      <label for="comentario" class="block text-sm font-medium">{% trans "Comentário" %}</label>
-      <textarea id="comentario" name="comentario" rows="4" class="form-textarea w-full" placeholder="{% trans 'Opcional' %}"></textarea>
-    </div>
-    <div class="text-right">
-      <button type="submit" class="btn-primary" aria-label="{% trans 'Enviar avaliação' %}">{% trans 'Enviar avaliação' %}</button>
-    </div>
-  </form>
-</main>
+  </div>
+</div>
 {% endblock %}

--- a/eventos/templates/eventos/briefing_list.html
+++ b/eventos/templates/eventos/briefing_list.html
@@ -4,131 +4,81 @@
 {% block title %}{% trans "Briefings" %} | Hubx{% endblock %}
 
 {% block content %}
-<section id="briefing-container" class="max-w-7xl mx-auto px-4 py-10">
-  <header class="mb-6 flex items-center justify-between">
-    <h1 class="text-2xl font-bold text-neutral-900">{% trans "Briefings de Eventos" %}</h1>
-    <a
-      href="{% url 'eventos:briefing_criar' %}"
-      class="btn-primary"
-    >{% trans "Novo Briefing" %}</a>
-  </header>
-
-  {% if messages %}
-    <div class="mb-4 space-y-2">
-      {% for message in messages %}
-        <p class="rounded-xl px-4 py-2 text-sm {% if 'success' in message.tags %}bg-green-100 text-green-700{% else %}bg-red-100 text-red-700{% endif %}">{{ message }}</p>
-      {% endfor %}
+{% include 'components/hero.html' with title=_('Briefings de Eventos') %}
+<div id="briefing-container" class="container mx-auto p-6">
+  <div class="card">
+    <div class="card-header flex items-center justify-between">
+      <a href="{% url 'eventos:briefing_criar' %}" class="btn-primary">{% trans "Novo Briefing" %}</a>
     </div>
-  {% endif %}
-
-  <form
-    hx-get="{% url 'eventos:briefing_list' %}"
-    hx-target="#briefing-container"
-    hx-push-url="true"
-    class="mb-6 flex gap-2"
-  >
-    <input
-      type="text"
-      name="q"
-      value="{{ request.GET.q }}"
-      placeholder="{% trans 'Buscar por evento' %}"
-      class="w-full rounded-md border-gray-300 px-3 py-2"
-    />
-    <button
-      type="submit"
-      class="rounded-md bg-primary px-4 py-2 text-white hover:bg-primary/90"
-    >
-      {% trans "Filtrar" %}
-    </button>
-  </form>
-
-  <main>
-    <div class="overflow-x-auto bg-white border border-neutral-200 rounded-2xl shadow-sm">
-      <table class="min-w-full divide-y divide-neutral-200 table-auto text-sm">
-        <thead class="bg-neutral-50">
-          <tr>
-            <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Evento" %}</th>
-            <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Objetivos" %}</th>
-            <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Público Alvo" %}</th>
-            <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Requisitos Técnicos" %}</th>
-            <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Cronograma Resumido" %}</th>
-            <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Conteúdo Programático" %}</th>
-            <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Observações" %}</th>
-            <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Ações" %}</th>
-          </tr>
-        </thead>
-        <tbody class="divide-y divide-neutral-200">
-          {% for briefing in briefings %}
-            <tr>
-              <td class="px-4 py-2">{{ briefing.evento }}</td>
-              <td class="px-4 py-2">{{ briefing.objetivos }}</td>
-              <td class="px-4 py-2">{{ briefing.publico_alvo }}</td>
-              <td class="px-4 py-2">{{ briefing.requisitos_tecnicos }}</td>
-              <td class="px-4 py-2">{{ briefing.cronograma_resumido }}</td>
-              <td class="px-4 py-2">{{ briefing.conteudo_programatico }}</td>
-              <td class="px-4 py-2">{{ briefing.observacoes }}</td>
-              <td class="px-4 py-2 space-x-2">
-                <a
-                  href="{% url 'eventos:briefing_editar' briefing.pk %}"
-                  class="text-blue-600 hover:underline"
-                >{% trans "Editar" %}</a>
-                <form
-                  method="post"
-                  action="{% url 'eventos:briefing_status' briefing.pk 'orcamentado' %}"
-                  class="inline space-x-1"
-                >
-                  {% csrf_token %}
-                  <input
-                    type="datetime-local"
-                    name="prazo_limite_resposta"
-                    required
-                    class="rounded-md border-gray-300 px-2 py-1 text-xs"
-                  />
-                  <button type="submit" class="text-green-600 hover:underline">
-                    {% trans "Orçar" %}
-                  </button>
-                </form>
-                <form
-                  method="post"
-                  action="{% url 'eventos:briefing_status' briefing.pk 'aprovado' %}"
-                  class="inline"
-                >
-                  {% csrf_token %}
-                  <button type="submit" class="text-primary hover:underline">
-                    {% trans "Aprovar" %}
-                  </button>
-                </form>
-                <form
-                  method="post"
-                  action="{% url 'eventos:briefing_status' briefing.pk 'recusado' %}"
-                  class="inline space-x-1"
-                >
-                  {% csrf_token %}
-                  <input
-                    type="text"
-                    name="motivo_recusa"
-                    placeholder="{% trans 'Motivo' %}"
-                    required
-                    class="rounded-md border-gray-300 px-2 py-1 text-xs"
-                  />
-                  <button type="submit" class="text-red-600 hover:underline">
-                    {% trans "Recusar" %}
-                  </button>
-                </form>
-              </td>
-            </tr>
-          {% empty %}
-            <tr>
-              <td colspan="8" class="px-4 py-4 text-center text-neutral-500">{% trans "Nenhum briefing encontrado." %}</td>
-            </tr>
+    <div class="card-body">
+      {% if messages %}
+        <div class="mb-4 space-y-2">
+          {% for message in messages %}
+            <p class="rounded-xl px-4 py-2 text-sm {% if 'success' in message.tags %}bg-green-100 text-green-700{% else %}bg-red-100 text-red-700{% endif %}">{{ message }}</p>
           {% endfor %}
-        </tbody>
-      </table>
-    </div>
-  </main>
+        </div>
+      {% endif %}
 
-  <footer class="mt-6 text-right">
-    <a href="{% url 'eventos:calendario' %}" class="text-sm text-blue-600 hover:underline">{% trans "Voltar aos eventos" %}</a>
-  </footer>
-</section>
+      <form hx-get="{% url 'eventos:briefing_list' %}" hx-target="#briefing-container" hx-push-url="true" class="mb-6 flex gap-2">
+        <input type="text" name="q" value="{{ request.GET.q }}" placeholder="{% trans 'Buscar por evento' %}" class="w-full rounded-md border-gray-300 px-3 py-2" />
+        <button type="submit" class="rounded-md bg-primary px-4 py-2 text-white hover:bg-primary/90">{% trans "Filtrar" %}</button>
+      </form>
+
+      <div class="overflow-x-auto bg-white border border-neutral-200 rounded-2xl shadow-sm">
+        <table class="min-w-full divide-y divide-neutral-200 table-auto text-sm">
+          <thead class="bg-neutral-50">
+            <tr>
+              <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Evento" %}</th>
+              <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Objetivos" %}</th>
+              <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Público Alvo" %}</th>
+              <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Requisitos Técnicos" %}</th>
+              <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Cronograma Resumido" %}</th>
+              <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Conteúdo Programático" %}</th>
+              <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Observações" %}</th>
+              <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Ações" %}</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-neutral-200">
+            {% for briefing in briefings %}
+              <tr>
+                <td class="px-4 py-2">{{ briefing.evento }}</td>
+                <td class="px-4 py-2">{{ briefing.objetivos }}</td>
+                <td class="px-4 py-2">{{ briefing.publico_alvo }}</td>
+                <td class="px-4 py-2">{{ briefing.requisitos_tecnicos }}</td>
+                <td class="px-4 py-2">{{ briefing.cronograma_resumido }}</td>
+                <td class="px-4 py-2">{{ briefing.conteudo_programatico }}</td>
+                <td class="px-4 py-2">{{ briefing.observacoes }}</td>
+                <td class="px-4 py-2 space-x-2">
+                  <a href="{% url 'eventos:briefing_editar' briefing.pk %}" class="text-blue-600 hover:underline">{% trans "Editar" %}</a>
+                  <form method="post" action="{% url 'eventos:briefing_status' briefing.pk 'orcamentado' %}" class="inline space-x-1">
+                    {% csrf_token %}
+                    <input type="datetime-local" name="prazo_limite_resposta" required class="rounded-md border-gray-300 px-2 py-1 text-xs" />
+                    <button type="submit" class="text-green-600 hover:underline">{% trans "Orçar" %}</button>
+                  </form>
+                  <form method="post" action="{% url 'eventos:briefing_status' briefing.pk 'aprovado' %}" class="inline">
+                    {% csrf_token %}
+                    <button type="submit" class="text-primary hover:underline">{% trans "Aprovar" %}</button>
+                  </form>
+                  <form method="post" action="{% url 'eventos:briefing_status' briefing.pk 'recusado' %}" class="inline space-x-1">
+                    {% csrf_token %}
+                    <input type="text" name="motivo_recusa" placeholder="{% trans 'Motivo' %}" required class="rounded-md border-gray-300 px-2 py-1 text-xs" />
+                    <button type="submit" class="text-red-600 hover:underline">{% trans "Recusar" %}</button>
+                  </form>
+                </td>
+              </tr>
+            {% empty %}
+              <tr>
+                <td colspan="8" class="px-4 py-4 text-center text-neutral-500">{% trans "Nenhum briefing encontrado." %}</td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+
+      <footer class="mt-6 text-right">
+        <a href="{% url 'eventos:calendario' %}" class="text-sm text-blue-600 hover:underline">{% trans "Voltar aos eventos" %}</a>
+      </footer>
+    </div>
+  </div>
+</div>
 {% endblock %}

--- a/eventos/templates/eventos/checkin_form.html
+++ b/eventos/templates/eventos/checkin_form.html
@@ -3,19 +3,23 @@
 {% block title %}{% trans "Check-in" %}{% endblock %}
 
 {% block content %}
-<main class="max-w-md mx-auto py-8 px-4">
-  <h1 class="text-xl font-semibold mb-4">{% trans "Check-in do evento" %}</h1>
-  <form method="post" action="{% url 'eventos:inscricao_checkin' inscricao.id %}" id="checkin-form" class="space-y-4">
-    {% csrf_token %}
-    <label for="codigo" class="block text-sm font-medium">{% trans "Código do check-in" %}</label>
-    <input type="text" id="codigo" name="codigo" class="form-input w-full" placeholder="{% trans 'Escaneie ou digite o código' %}" required>
-    <div id="feedback" class="text-sm"></div>
-    <div id="reader" class="w-full mb-4"></div>
-    <div class="text-right">
-      <button type="submit" class="btn-primary" aria-label="{% trans 'Confirmar presença' %}">{% trans 'Confirmar presença' %}</button>
+{% include 'components/hero.html' with title=_('Check-in do evento') %}
+<div class="container mx-auto p-6">
+  <div class="card">
+    <div class="card-body">
+      <form method="post" action="{% url 'eventos:inscricao_checkin' inscricao.id %}" id="checkin-form" class="space-y-4">
+        {% csrf_token %}
+        <label for="codigo" class="block text-sm font-medium">{% trans "Código do check-in" %}</label>
+        <input type="text" id="codigo" name="codigo" class="form-input w-full" placeholder="{% trans 'Escaneie ou digite o código' %}" required>
+        <div id="feedback" class="text-sm"></div>
+        <div id="reader" class="w-full mb-4"></div>
+        <div class="text-right">
+          <button type="submit" class="btn-primary" aria-label="{% trans 'Confirmar presença' %}">{% trans 'Confirmar presença' %}</button>
+        </div>
+      </form>
     </div>
-  </form>
-</main>
+  </div>
+</div>
 
 <script src="https://unpkg.com/html5-qrcode" defer></script>
 <script>
@@ -26,7 +30,6 @@ document.addEventListener("DOMContentLoaded", function () {
   const successMessage = "{% trans 'Check-in realizado com sucesso!' %}";
   const readerEl = document.getElementById("reader");
 
-  // Inicializa o leitor de QR code
   if (window.Html5Qrcode && readerEl) {
     const qr = new Html5Qrcode("reader");
     qr.start(

--- a/eventos/templates/eventos/evento_list.html
+++ b/eventos/templates/eventos/evento_list.html
@@ -10,28 +10,26 @@
 {% include 'components/hero.html' with title=_('Meus Eventos') action_template='eventos/hero_evento_list_action.html' %}
 {% endif %}
 <div class="container mx-auto p-6">
-<section class="max-w-6xl mx-auto mt-8 px-4">
-  {% include 'components/search_form.html' with q=request.GET.q %}
-  <!-- Cards de totais -->
-  <div class="mb-6 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-    {% include "partials/cards/total_card.html" with label=_('Eventos') valor=total_eventos %}
-    {% include "partials/cards/total_card.html" with label=_('Ativos') valor=total_eventos_ativos %}
-    {% include "partials/cards/total_card.html" with label=_('Concluídos') valor=total_eventos_concluidos %}
-    {% include "partials/cards/total_card.html" with label=_('Inscritos (total)') valor=total_inscritos %}
-  </div>
-
-  <main>
-    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4" role="list" aria-label="{% trans 'Lista de eventos' %}">
-      {% for evento in eventos %}
-        {% include 'partials/cards/evento_card.html' %}
-      {% empty %}
-        <p class="col-span-full text-center text-neutral-500">{% trans 'Nenhum evento encontrado.' %}</p>
-      {% endfor %}
+  <div class="card">
+    <div class="card-header">
+      {% include 'components/search_form.html' with q=request.GET.q %}
     </div>
-  </main>
-
-  {% include 'components/pagination.html' with page_obj=page_obj querystring="q="|add:q %}
-
-</section>
+    <div class="card-body">
+      <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6 mb-6">
+        {% include "partials/cards/total_card.html" with label=_('Eventos') valor=total_eventos %}
+        {% include "partials/cards/total_card.html" with label=_('Ativos') valor=total_eventos_ativos %}
+        {% include "partials/cards/total_card.html" with label=_('Concluídos') valor=total_eventos_concluidos %}
+        {% include "partials/cards/total_card.html" with label=_('Inscritos (total)') valor=total_inscritos %}
+      </div>
+      <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6" role="list" aria-label="{% trans 'Lista de eventos' %}">
+        {% for evento in eventos %}
+          {% include 'partials/cards/evento_card.html' %}
+        {% empty %}
+          <p class="col-span-full text-center text-neutral-500">{% trans 'Nenhum evento encontrado.' %}</p>
+        {% endfor %}
+      </div>
+      {% include 'components/pagination.html' with page_obj=page_obj querystring="q="|add:q %}
+    </div>
+  </div>
 </div>
 {% endblock %}

--- a/eventos/templates/eventos/eventos_lista.html
+++ b/eventos/templates/eventos/eventos_lista.html
@@ -7,28 +7,26 @@
 
 {% include 'components/hero.html' with title=_('Eventos') action_template='eventos/hero_eventos_lista_action.html' %}
 <div class="container mx-auto p-6">
-<section class="max-w-6xl mx-auto mt-8 px-4">
-
-  {% include 'components/search_form.html' with q=request.GET.q %}
-
-  <!-- Cards de totais (organização) -->
-  <div class="mb-6 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-    {% include "partials/cards/total_card.html" with label=_('Eventos') valor=total_eventos %}
-    {% include "partials/cards/total_card.html" with label=_('Ativos') valor=total_eventos_ativos %}
-    {% include "partials/cards/total_card.html" with label=_('Concluídos') valor=total_eventos_concluidos %}
-    {% include "partials/cards/total_card.html" with label=_('Inscritos (total)') valor=total_inscritos %}
-  </div>
-
-  <main>
-    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4" role="list" aria-label="{% trans 'Lista de eventos' %}">
-      {% for evento in eventos %}
-        {% include 'partials/cards/evento_card.html' %}
-      {% empty %}
-        <p class="col-span-full text-center text-neutral-500">{% trans 'Nenhum evento encontrado.' %}</p>
-      {% endfor %}
+  <div class="card">
+    <div class="card-header">
+      {% include 'components/search_form.html' with q=request.GET.q %}
     </div>
-  </main>
-  {% include 'components/pagination.html' with page_obj=page_obj querystring=querystring %}
-</section>
+    <div class="card-body">
+      <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6 mb-6">
+        {% include "partials/cards/total_card.html" with label=_('Eventos') valor=total_eventos %}
+        {% include "partials/cards/total_card.html" with label=_('Ativos') valor=total_eventos_ativos %}
+        {% include "partials/cards/total_card.html" with label=_('Concluídos') valor=total_eventos_concluidos %}
+        {% include "partials/cards/total_card.html" with label=_('Inscritos (total)') valor=total_inscritos %}
+      </div>
+      <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6" role="list" aria-label="{% trans 'Lista de eventos' %}">
+        {% for evento in eventos %}
+          {% include 'partials/cards/evento_card.html' %}
+        {% empty %}
+          <p class="col-span-full text-center text-neutral-500">{% trans 'Nenhum evento encontrado.' %}</p>
+        {% endfor %}
+      </div>
+      {% include 'components/pagination.html' with page_obj=page_obj querystring=querystring %}
+    </div>
+  </div>
 </div>
 {% endblock %}

--- a/eventos/templates/eventos/inscricao_list.html
+++ b/eventos/templates/eventos/inscricao_list.html
@@ -4,91 +4,79 @@
 {% block title %}{% trans "Inscrições" %} | Hubx{% endblock %}
 
 {% block content %}
-<section id="inscricao-container" class="max-w-7xl mx-auto px-4 py-10">
-  <header class="mb-6">
-    <h1 class="text-2xl font-bold text-neutral-900">{% trans "Lista de Inscrições" %}</h1>
-  </header>
-
-  {% if messages %}
-    <div class="mb-4 space-y-2">
-        {% for message in messages %}
-          <p class="rounded-xl px-4 py-2 text-sm {% if 'success' in message.tags %}bg-green-100 text-green-700{% else %}bg-red-100 text-red-700{% endif %}">{{ message }}</p>
-        {% endfor %}
-    </div>
-  {% endif %}
-
-  {% url 'eventos:inscricao_list' as inscricao_list_url %}
-  {% include 'components/search_form.html' with q=request.GET.q hx_get=inscricao_list_url hx_target='#inscricao-container' hx_push_url='true' %}
-
-  <main>
-    <div class="overflow-x-auto bg-white border border-neutral-200 rounded-2xl shadow-sm">
-      <table class="min-w-full divide-y divide-neutral-200 table-auto text-sm">
-        <thead class="bg-neutral-50">
-          <tr>
-            <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Usuário" %}</th>
-            <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Evento" %}</th>
-            <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Status" %}</th>
-            <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Posição na espera" %}</th>
-            <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Presente" %}</th>
-            <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Valor Pago" %}</th>
-            <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Método de Pagamento" %}</th>
-            <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Comprovante" %}</th>
-            <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Observação" %}</th>
-            <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Ações" %}</th>
-          </tr>
-        </thead>
-        <tbody class="divide-y divide-neutral-200">
-          {% for inscricao in inscricoes %}
-            <tr>
-              <td class="px-4 py-2">{{ inscricao.user }}</td>
-              <td class="px-4 py-2">{{ inscricao.evento }}</td>
-              <td class="px-4 py-2">{{ inscricao.get_status_display }}</td>
-              <td class="px-4 py-2">
-                {% if inscricao.status == 'pendente' %}
-                  {{ inscricao.posicao_espera }}
-                {% else %}
-                  -
-                {% endif %}
-              </td>
-              <td class="px-4 py-2">{{ inscricao.presente }}</td>
-              <td class="px-4 py-2">{{ inscricao.valor_pago }}</td>
-              <td class="px-4 py-2">{{ inscricao.get_metodo_pagamento_display }}</td>
-              <td class="px-4 py-2">
-                {% if inscricao.comprovante_pagamento %}
-                  <a href="{{ inscricao.comprovante_pagamento.url }}" class="text-blue-600 hover:underline" target="_blank">{% trans "Ver" %}</a>
-                {% else %}
-                  -
-                {% endif %}
-              </td>
-              <td class="px-4 py-2">{{ inscricao.observacao }}</td>
-              <td class="px-4 py-2">
-                <a
-                  href="{% url 'eventos:evento_detalhe' inscricao.evento.pk %}"
-                  class="text-blue-600 hover:underline"
-                >
-                  {% trans "Ver" %}
-                </a>
-                |
-                <a
-                  href="{% url 'eventos:inscricao_checkin_form' inscricao.pk %}"
-                  class="text-blue-600 hover:underline"
-                >
-                  {% trans "Check-in" %}
-                </a>
-              </td>
-            </tr>
-          {% empty %}
-            <tr>
-              <td colspan="10" class="px-4 py-4 text-center text-neutral-500">{% trans "Nenhuma inscrição encontrada." %}</td>
-            </tr>
+{% include 'components/hero.html' with title=_('Lista de Inscrições') %}
+<div id="inscricao-container" class="container mx-auto p-6">
+  <div class="card">
+    <div class="card-body">
+      {% if messages %}
+        <div class="mb-4 space-y-2">
+          {% for message in messages %}
+            <p class="rounded-xl px-4 py-2 text-sm {% if 'success' in message.tags %}bg-green-100 text-green-700{% else %}bg-red-100 text-red-700{% endif %}">{{ message }}</p>
           {% endfor %}
-        </tbody>
-      </table>
-    </div>
-  </main>
+        </div>
+      {% endif %}
 
-  <footer class="mt-6 text-right">
-    <a href="{% url 'eventos:calendario' %}" class="text-sm text-blue-600 hover:underline">{% trans "Voltar aos eventos" %}</a>
-  </footer>
-</section>
+      {% url 'eventos:inscricao_list' as inscricao_list_url %}
+      {% include 'components/search_form.html' with q=request.GET.q hx_get=inscricao_list_url hx_target='#inscricao-container' hx_push_url='true' %}
+
+      <div class="overflow-x-auto bg-white border border-neutral-200 rounded-2xl shadow-sm mt-6">
+        <table class="min-w-full divide-y divide-neutral-200 table-auto text-sm">
+          <thead class="bg-neutral-50">
+            <tr>
+              <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Usuário" %}</th>
+              <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Evento" %}</th>
+              <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Status" %}</th>
+              <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Posição na espera" %}</th>
+              <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Presente" %}</th>
+              <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Valor Pago" %}</th>
+              <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Método de Pagamento" %}</th>
+              <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Comprovante" %}</th>
+              <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Observação" %}</th>
+              <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Ações" %}</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-neutral-200">
+            {% for inscricao in inscricoes %}
+              <tr>
+                <td class="px-4 py-2">{{ inscricao.user }}</td>
+                <td class="px-4 py-2">{{ inscricao.evento }}</td>
+                <td class="px-4 py-2">{{ inscricao.get_status_display }}</td>
+                <td class="px-4 py-2">
+                  {% if inscricao.status == 'pendente' %}
+                    {{ inscricao.posicao_espera }}
+                  {% else %}
+                    -
+                  {% endif %}
+                </td>
+                <td class="px-4 py-2">{{ inscricao.presente }}</td>
+                <td class="px-4 py-2">{{ inscricao.valor_pago }}</td>
+                <td class="px-4 py-2">{{ inscricao.get_metodo_pagamento_display }}</td>
+                <td class="px-4 py-2">
+                  {% if inscricao.comprovante_pagamento %}
+                    <a href="{{ inscricao.comprovante_pagamento.url }}" class="text-blue-600 hover:underline" target="_blank">{% trans "Ver" %}</a>
+                  {% else %}
+                    -
+                  {% endif %}
+                </td>
+                <td class="px-4 py-2">{{ inscricao.observacao }}</td>
+                <td class="px-4 py-2">
+                  <a href="{% url 'eventos:evento_detalhe' inscricao.evento.pk %}" class="text-blue-600 hover:underline">{% trans "Ver" %}</a> |
+                  <a href="{% url 'eventos:inscricao_checkin_form' inscricao.pk %}" class="text-blue-600 hover:underline">{% trans "Check-in" %}</a>
+                </td>
+              </tr>
+            {% empty %}
+              <tr>
+                <td colspan="10" class="px-4 py-4 text-center text-neutral-500">{% trans "Nenhuma inscrição encontrada." %}</td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+
+      <footer class="mt-6 text-right">
+        <a href="{% url 'eventos:calendario' %}" class="text-sm text-blue-600 hover:underline">{% trans "Voltar aos eventos" %}</a>
+      </footer>
+    </div>
+  </div>
+</div>
 {% endblock %}

--- a/eventos/templates/eventos/material_list.html
+++ b/eventos/templates/eventos/material_list.html
@@ -4,58 +4,49 @@
 {% block title %}{% trans "Materiais de Divulgação" %} | Hubx{% endblock %}
 
 {% block content %}
-<section id="material-container" class="max-w-7xl mx-auto px-4 py-10">
-  <header class="mb-6 flex items-center justify-between">
-    <h1 class="text-2xl font-bold text-neutral-900">{% trans "Materiais de Divulgação" %}</h1>
-    <a href="{% url 'eventos:material_criar' %}" class="btn-primary">{% trans "Novo Material" %}</a>
-  </header>
-
-{% include "eventos/_messages.html" %}
-
-  <form method="get" class="mb-6 flex gap-2">
-    <input
-      type="text"
-      name="q"
-      value="{{ request.GET.q }}"
-      placeholder="{% trans 'Buscar por título' %}"
-      class="w-full rounded-md border-gray-300 px-3 py-2"
-    />
-    <button
-      type="submit"
-      class="rounded-md bg-primary px-4 py-2 text-white hover:bg-primary/90"
-    >
-      {% trans "Filtrar" %}
-    </button>
-  </form>
-
-  <main>
-    <div class="overflow-x-auto bg-white border border-neutral-200 rounded-2xl shadow-sm">
-      <table class="min-w-full divide-y divide-neutral-200 table-auto text-sm">
-        <thead class="bg-neutral-50">
-          <tr>
-            <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Título" %}</th>
-            <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Descrição" %}</th>
-            <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Status" %}</th>
-            <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Arquivo" %}</th>
-            <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Ações" %}</th>
-          </tr>
-        </thead>
-        <tbody class="divide-y divide-neutral-200">
-          {% for material in materiais %}
-            {% include "eventos/_material_row.html" with material=material %}
-          {% empty %}
-            <tr>
-              <td colspan="5" class="px-4 py-4 text-center text-neutral-500">{% trans "Nenhum material disponível." %}</td>
-            </tr>
-          {% endfor %}
-        </tbody>
-      </table>
+{% include 'components/hero.html' with title=_('Materiais de Divulgação') %}
+<div id="material-container" class="container mx-auto p-6">
+  <div class="card">
+    <div class="card-header flex items-center justify-between">
+      <a href="{% url 'eventos:material_criar' %}" class="btn-primary">{% trans "Novo Material" %}</a>
     </div>
-  </main>
-  {% include 'components/pagination.html' with page_obj=page_obj querystring=querystring %}
+    <div class="card-body">
+      {% include "eventos/_messages.html" %}
 
-  <footer class="mt-6 text-right">
-    <a href="{% url 'eventos:calendario' %}" class="text-sm text-blue-600 hover:underline">{% trans "Voltar aos eventos" %}</a>
-  </footer>
-</section>
+      <form method="get" class="mb-6 flex gap-2">
+        <input type="text" name="q" value="{{ request.GET.q }}" placeholder="{% trans 'Buscar por título' %}" class="w-full rounded-md border-gray-300 px-3 py-2" />
+        <button type="submit" class="rounded-md bg-primary px-4 py-2 text-white hover:bg-primary/90">{% trans "Filtrar" %}</button>
+      </form>
+
+      <div class="overflow-x-auto bg-white border border-neutral-200 rounded-2xl shadow-sm">
+        <table class="min-w-full divide-y divide-neutral-200 table-auto text-sm">
+          <thead class="bg-neutral-50">
+            <tr>
+              <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Título" %}</th>
+              <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Descrição" %}</th>
+              <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Status" %}</th>
+              <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Arquivo" %}</th>
+              <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Ações" %}</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-neutral-200">
+            {% for material in materiais %}
+              {% include "eventos/_material_row.html" with material=material %}
+            {% empty %}
+              <tr>
+                <td colspan="5" class="px-4 py-4 text-center text-neutral-500">{% trans "Nenhum material disponível." %}</td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+
+      {% include 'components/pagination.html' with page_obj=page_obj querystring=querystring %}
+
+      <footer class="mt-6 text-right">
+        <a href="{% url 'eventos:calendario' %}" class="text-sm text-blue-600 hover:underline">{% trans "Voltar aos eventos" %}</a>
+      </footer>
+    </div>
+  </div>
+</div>
 {% endblock %}

--- a/eventos/templates/eventos/parceria_avaliar.html
+++ b/eventos/templates/eventos/parceria_avaliar.html
@@ -3,33 +3,32 @@
 {% block title %}{% trans "Avaliar parceria" %}{% endblock %}
 
 {% block content %}
-<main class="max-w-md mx-auto py-8 px-4">
-  <h1 class="text-xl font-semibold mb-4">{% trans "Avaliar parceria" %}</h1>
-  <form
-    id="avaliacao-form"
-    method="post"
-    action="{% url 'eventos_api:parceria-avaliar' parceria.pk %}"
-    class="space-y-4"
-  >
-    {% csrf_token %}
-    <div>
-      <label for="avaliacao" class="block text-sm font-medium">{% trans "Nota" %}</label>
-      <select id="avaliacao" name="avaliacao" class="form-select w-full" required>
-        {% for n in '12345' %}
-        <option value="{{ n }}">{{ n }}</option>
-        {% endfor %}
-      </select>
+{% include 'components/hero.html' with title=_('Avaliar parceria') %}
+<div class="container mx-auto p-6">
+  <div class="card">
+    <div class="card-body">
+      <form id="avaliacao-form" method="post" action="{% url 'eventos_api:parceria-avaliar' parceria.pk %}" class="space-y-4">
+        {% csrf_token %}
+        <div>
+          <label for="avaliacao" class="block text-sm font-medium">{% trans "Nota" %}</label>
+          <select id="avaliacao" name="avaliacao" class="form-select w-full" required>
+            {% for n in '12345' %}
+            <option value="{{ n }}">{{ n }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div>
+          <label for="comentario" class="block text-sm font-medium">{% trans "Comentário" %}</label>
+          <textarea id="comentario" name="comentario" rows="4" class="form-textarea w-full" placeholder="{% trans 'Opcional' %}"></textarea>
+        </div>
+        <div class="text-right">
+          <button type="submit" class="btn-primary" aria-label="{% trans 'Enviar avaliação' %}">{% trans 'Enviar avaliação' %}</button>
+        </div>
+      </form>
+      <p id="message" class="mt-4 text-sm"></p>
     </div>
-    <div>
-      <label for="comentario" class="block text-sm font-medium">{% trans "Comentário" %}</label>
-      <textarea id="comentario" name="comentario" rows="4" class="form-textarea w-full" placeholder="{% trans 'Opcional' %}"></textarea>
-    </div>
-    <div class="text-right">
-      <button type="submit" class="btn-primary" aria-label="{% trans 'Enviar avaliação' %}">{% trans 'Enviar avaliação' %}</button>
-    </div>
-  </form>
-  <p id="message" class="mt-4 text-sm"></p>
-</main>
+  </div>
+</div>
 <script>
 const successMessage = gettext('Avaliação enviada com sucesso.');
 const errorMessage = gettext('Erro ao enviar avaliação.');

--- a/eventos/templates/eventos/parceria_list.html
+++ b/eventos/templates/eventos/parceria_list.html
@@ -4,66 +4,55 @@
 {% block title %}{% trans "Parcerias" %} | Hubx{% endblock %}
 
 {% block content %}
-<section class="max-w-7xl mx-auto px-4 py-10">
-  <header class="mb-6 flex items-center justify-between">
-    <h1 class="text-2xl font-bold text-neutral-900">{% trans "Parcerias" %}</h1>
-    <a href="{% url 'eventos:parceria_criar' %}" class="btn-primary">{% trans "Nova Parceria" %}</a>
-  </header>
-
-  <main>
-    <div class="overflow-x-auto bg-white border border-neutral-200 rounded-2xl shadow-sm">
-      <table class="min-w-full divide-y divide-neutral-200 table-auto text-sm">
-        <thead class="bg-neutral-50">
-          <tr>
-            <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Empresa" %}</th>
-            <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Evento" %}</th>
-            <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Tipo" %}</th>
-            <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Avaliação" %}</th>
-            <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Comentário" %}</th>
-            <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Ações" %}</th>
-          </tr>
-        </thead>
-        <tbody class="divide-y divide-neutral-200">
-          {% for parceria in parcerias %}
-            <tr>
-              <td class="px-4 py-2">{{ parceria.empresa.nome }}</td>
-              <td class="px-4 py-2">{{ parceria.evento.titulo }}</td>
-              <td class="px-4 py-2">{{ parceria.get_tipo_parceria_display }}</td>
-              {% if parceria.avaliacao is not None %}
-                <td class="px-4 py-2">{{ parceria.avaliacao }}</td>
-                <td class="px-4 py-2">{{ parceria.comentario }}</td>
-              {% else %}
-                <td class="px-4 py-2">-</td>
-                <td class="px-4 py-2">-</td>
-              {% endif %}
-              <td class="px-4 py-2 space-x-2">
-                {% if parceria.avaliacao is None %}
-                  <a
-                    href="{% url 'eventos:parceria_avaliar' parceria.pk %}"
-                    class="text-green-600 hover:underline"
-                    >{% trans "Avaliar" %}</a
-                  >
-                {% endif %}
-                <a
-                  href="{% url 'eventos:parceria_editar' parceria.pk %}"
-                  class="text-blue-600 hover:underline"
-                  >{% trans "Editar" %}</a
-                >
-                <a
-                  href="{% url 'eventos:parceria_excluir' parceria.pk %}"
-                  class="text-red-600 hover:underline"
-                  >{% trans "Excluir" %}</a
-                >
-              </td>
-            </tr>
-          {% empty %}
-            <tr>
-              <td colspan="6" class="px-4 py-4 text-center text-neutral-500">{% trans "Nenhuma parceria encontrada." %}</td>
-            </tr>
-          {% endfor %}
-        </tbody>
-      </table>
+{% include 'components/hero.html' with title=_('Parcerias') %}
+<div class="container mx-auto p-6">
+  <div class="card">
+    <div class="card-header flex items-center justify-between">
+      <a href="{% url 'eventos:parceria_criar' %}" class="btn-primary">{% trans "Nova Parceria" %}</a>
     </div>
-  </main>
-</section>
+    <div class="card-body">
+      <div class="overflow-x-auto bg-white border border-neutral-200 rounded-2xl shadow-sm">
+        <table class="min-w-full divide-y divide-neutral-200 table-auto text-sm">
+          <thead class="bg-neutral-50">
+            <tr>
+              <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Empresa" %}</th>
+              <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Evento" %}</th>
+              <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Tipo" %}</th>
+              <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Avaliação" %}</th>
+              <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Comentário" %}</th>
+              <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Ações" %}</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-neutral-200">
+            {% for parceria in parcerias %}
+              <tr>
+                <td class="px-4 py-2">{{ parceria.empresa.nome }}</td>
+                <td class="px-4 py-2">{{ parceria.evento.titulo }}</td>
+                <td class="px-4 py-2">{{ parceria.get_tipo_parceria_display }}</td>
+                {% if parceria.avaliacao is not None %}
+                  <td class="px-4 py-2">{{ parceria.avaliacao }}</td>
+                  <td class="px-4 py-2">{{ parceria.comentario }}</td>
+                {% else %}
+                  <td class="px-4 py-2">-</td>
+                  <td class="px-4 py-2">-</td>
+                {% endif %}
+                <td class="px-4 py-2 space-x-2">
+                  {% if parceria.avaliacao is None %}
+                    <a href="{% url 'eventos:parceria_avaliar' parceria.pk %}" class="text-green-600 hover:underline">{% trans "Avaliar" %}</a>
+                  {% endif %}
+                  <a href="{% url 'eventos:parceria_editar' parceria.pk %}" class="text-blue-600 hover:underline">{% trans "Editar" %}</a>
+                  <a href="{% url 'eventos:parceria_excluir' parceria.pk %}" class="text-red-600 hover:underline">{% trans "Excluir" %}</a>
+                </td>
+              </tr>
+            {% empty %}
+              <tr>
+                <td colspan="6" class="px-4 py-4 text-center text-neutral-500">{% trans "Nenhuma parceria encontrada." %}</td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>
 {% endblock %}

--- a/financeiro/templates/financeiro/centros_list.html
+++ b/financeiro/templates/financeiro/centros_list.html
@@ -6,9 +6,10 @@
 {% block content %}
 {% include 'components/hero.html' with title=_('Centros de Custo') action_template='financeiro/hero_centros_action.html' %}
 <div class="container mx-auto p-6">
-<main class="p-4 max-w-5xl mx-auto">
-  <section id="centros-list" class="overflow-x-auto" aria-live="polite">
-    <table class="min-w-full divide-y divide-gray-200">
+  <div class="card">
+    <div class="card-body">
+      <section id="centros-list" class="overflow-x-auto" aria-live="polite">
+        <table class="min-w-full divide-y divide-gray-200">
       <thead class="bg-gray-50">
         <tr>
           <th scope="col" class="px-3 py-2 text-left text-xs font-medium text-gray-500">{% trans "Nome" %}</th>
@@ -39,17 +40,18 @@
         {% endfor %}
       </tbody>
     </table>
-    <div class="mt-4 flex justify-between">
-      {% if prev %}
-        <button class="px-3 py-1 text-sm bg-gray-200 rounded" hx-get="?offset={{ prev }}" hx-target="#centros-list" hx-trigger="click" hx-swap="outerHTML">{% trans "Anterior" %}</button>
-      {% endif %}
-      {% if next %}
-        <button class="px-3 py-1 text-sm bg-gray-200 rounded ml-auto" hx-get="?offset={{ next }}" hx-target="#centros-list" hx-trigger="click" hx-swap="outerHTML">{% trans "Próximo" %}</button>
-      {% endif %}
+        <div class="mt-4 flex justify-between">
+          {% if prev %}
+            <button class="px-3 py-1 text-sm bg-gray-200 rounded" hx-get="?offset={{ prev }}" hx-target="#centros-list" hx-trigger="click" hx-swap="outerHTML">{% trans "Anterior" %}</button>
+          {% endif %}
+          {% if next %}
+            <button class="px-3 py-1 text-sm bg-gray-200 rounded ml-auto" hx-get="?offset={{ next }}" hx-target="#centros-list" hx-trigger="click" hx-swap="outerHTML">{% trans "Próximo" %}</button>
+          {% endif %}
+        </div>
+      </section>
+      <div id="modal" class="mt-4" aria-live="assertive"></div>
     </div>
-  </section>
-  <div id="modal" class="mt-4" aria-live="assertive"></div>
-</main>
+  </div>
 </div>
 {% endblock %}
 

--- a/financeiro/templates/financeiro/extrato.html
+++ b/financeiro/templates/financeiro/extrato.html
@@ -4,71 +4,50 @@
 {% block title %}{{ _('Extrato') }}{% endblock %}
 
 {% block content %}
+{% include 'components/hero.html' with title=_('Extrato') %}
+<div class="container mx-auto p-6">
+  <div class="card">
+    <div class="card-header">
+      <form id="filtros" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6"
+            hx-get="/api/financeiro/lancamentos/" hx-target="#lista" hx-swap="none"
+            hx-trigger="change from:select,change from:input, submit"
+            hx-on="htmx:afterRequest: renderLancamentos(event)">
+        <legend class="sr-only">{{ _('Filtros') }}</legend>
 
-<main class="p-4 max-w-4xl mx-auto">
-  <h1 class="text-2xl font-semibold mb-2">{{ _('Extrato') }}</h1>
-  <form id="filtros" class="mb-4 grid grid-cols-1 md:grid-cols-4 gap-4"
-        hx-get="/api/financeiro/lancamentos/" hx-target="#lista" hx-swap="none"
-        hx-trigger="change from:select,change from:input, submit"
-        hx-on="htmx:afterRequest: renderLancamentos(event)">
-    <legend class="sr-only">{{ _('Filtros') }}</legend>
+        <div class="relative">
+          <label for="filtro-status" class="label-float">{{ _('Status') }}</label>
+          <select name="status" id="filtro-status" class="peer placeholder-transparent form-input">
+            <option value="">{{ _('Todos Status') }}</option>
+            <option value="pendente">{{ _('Pendente') }}</option>
+            <option value="pago">{{ _('Pago') }}</option>
+            <option value="cancelado">{{ _('Cancelado') }}</option>
+          </select>
+        </div>
 
-    <div class="relative">
-      <label for="filtro-status" class="label-float">{{ _('Status') }}</label>
-      <select name="status" id="filtro-status" class="peer placeholder-transparent form-input">
-        <option value="">{{ _('Todos Status') }}</option>
-        <option value="pendente">{{ _('Pendente') }}</option>
-        <option value="pago">{{ _('Pago') }}</option>
-        <option value="cancelado">{{ _('Cancelado') }}</option>
-      </select>
+        <div class="relative">
+          <label for="filtro-periodo-inicial" class="label-float">{{ _('Período inicial') }}</label>
+          <input id="filtro-periodo-inicial" type="month" name="periodo_inicial" class="peer placeholder-transparent form-input" />
+        </div>
+        <div class="relative">
+          <label for="filtro-periodo-final" class="label-float">{{ _('Período final') }}</label>
+          <input id="filtro-periodo-final" type="month" name="periodo_final" class="peer placeholder-transparent form-input" />
+        </div>
+      </form>
     </div>
-
-    <div class="relative">
-      <label for="filtro-periodo-inicial" class="label-float">{{ _('Período inicial') }}</label>
-      <input id="filtro-periodo-inicial" type="month" name="periodo_inicial" class="peer placeholder-transparent form-input" />
-    </div>
-    <div class="relative">
-      <label for="filtro-periodo-final" class="label-float">{{ _('Período final') }}</label>
-      <input id="filtro-periodo-final" type="month" name="periodo_final" class="peer placeholder-transparent form-input" />
-
-    </div>
-  </form>
-  <div id="lista" aria-live="polite">
-    <table class="min-w-full divide-y divide-[var(--border-primary)]">
-      <thead>
-        <tr class="bg-[var(--bg-tertiary)]">
-          <th class="px-3 py-2 text-left text-xs font-medium text-[var(--text-secondary)]">{{ _('Centro de Custo') }}</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-[var(--text-secondary)]">{{ _('Tipo') }}</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-[var(--text-secondary)]">{{ _('Valor') }}</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-[var(--text-secondary)]">{{ _('Data de Lançamento') }}</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-[var(--text-secondary)]">{{ _('Status') }}</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for l in lancamentos %}
-        <tr>
-          <td class="px-3 py-2">{{ l.centro_custo }}</td>
-          <td class="px-3 py-2">{{ l.tipo }}</td>
-          <td class="px-3 py-2">{{ l.valor }}</td>
-          <td class="px-3 py-2">{{ l.data_lancamento }}</td>
-          <td class="px-3 py-2">{{ l.status }}</td>
-        </tr>
-        {% empty %}
-        <tr><td colspan="5" class="px-3 py-2 text-center">{{ _('Nenhum lançamento') }}</td></tr>
-        {% endfor %}
-      </tbody>
-    </table>
-  </div>
-  <script src="{% url 'javascript-catalog' %}"></script>
-  <script>
-    function renderLancamentos(evt) {
-      const tbody = document.querySelector('#lista tbody');
-      tbody.innerHTML = '';
-      try {
-        const data = JSON.parse(evt.detail.xhr.response);
-        const itens = data.results || data;
-        const rows = itens
-          .map(l => `
+    <div class="card-body">
+      <div id="lista" aria-live="polite">
+        <table class="min-w-full divide-y divide-[var(--border-primary)]">
+          <thead>
+            <tr class="bg-[var(--bg-tertiary)]">
+              <th class="px-3 py-2 text-left text-xs font-medium text-[var(--text-secondary)]">{{ _('Centro de Custo') }}</th>
+              <th class="px-3 py-2 text-left text-xs font-medium text-[var(--text-secondary)]">{{ _('Tipo') }}</th>
+              <th class="px-3 py-2 text-left text-xs font-medium text-[var(--text-secondary)]">{{ _('Valor') }}</th>
+              <th class="px-3 py-2 text-left text-xs font-medium text-[var(--text-secondary)]">{{ _('Data de Lançamento') }}</th>
+              <th class="px-3 py-2 text-left text-xs font-medium text-[var(--text-secondary)]">{{ _('Status') }}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for l in lancamentos %}
             <tr>
               <td class="px-3 py-2">{{ l.centro_custo }}</td>
               <td class="px-3 py-2">{{ l.tipo }}</td>
@@ -112,5 +91,5 @@
       </script>
     </div>
   </div>
-</section>
+</div>
 {% endblock %}

--- a/financeiro/templates/financeiro/importacoes_list.html
+++ b/financeiro/templates/financeiro/importacoes_list.html
@@ -4,73 +4,77 @@
 {% block title %}{% trans "Importações de Pagamentos" %}{% endblock %}
 
 {% block content %}
-<main class="p-4 max-w-5xl mx-auto">
-  <h1 class="text-2xl font-semibold mb-4">{% trans "Importações de Pagamentos" %}</h1>
-  <div id="importacoes"
-       hx-get="/api/financeiro/importacoes/"
-       hx-trigger="load"
-       hx-target="#importacoes"
-       hx-swap="none"
-       hx-on="htmx:afterRequest: renderImportacoes(event)">
-    <table class="min-w-full divide-y divide-gray-200">
-      <thead class="bg-gray-50">
-        <tr>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{% trans "Arquivo" %}</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{% trans "Status" %}</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{% trans "Processados" %}</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{% trans "Ações" %}</th>
-        </tr>
-      </thead>
-      <tbody></tbody>
-    </table>
-    <div id="paginacao" class="mt-4 flex justify-between"></div>
+{% include 'components/hero.html' with title=_('Importações de Pagamentos') %}
+<div class="container mx-auto p-6">
+  <div class="card">
+    <div class="card-body">
+      <div id="importacoes"
+           hx-get="/api/financeiro/importacoes/"
+           hx-trigger="load"
+           hx-target="#importacoes"
+           hx-swap="none"
+           hx-on="htmx:afterRequest: renderImportacoes(event)">
+        <table class="min-w-full divide-y divide-gray-200">
+          <thead class="bg-gray-50">
+            <tr>
+              <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{% trans "Arquivo" %}</th>
+              <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{% trans "Status" %}</th>
+              <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{% trans "Processados" %}</th>
+              <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{% trans "Ações" %}</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+        <div id="paginacao" class="mt-4 flex justify-between"></div>
+      </div>
+      <script>
+        const csrfToken = "{{ csrf_token }}";
+        function basename(path) {
+          return path.split('/').pop();
+        }
+        function renderImportacoes(evt) {
+          const tbody = document.querySelector('#importacoes tbody');
+          const pag = document.getElementById('paginacao');
+          tbody.innerHTML = '';
+          pag.innerHTML = '';
+          try {
+            const data = JSON.parse(evt.detail.xhr.response);
+            const itens = data.results || data;
+            const rows = itens.map(i => {
+              const token = basename(i.arquivo);
+              const acao = (i.erros && i.erros.length)
+                ? `<div class="space-y-1">
+                     <a href="/media/importacoes/${token}.errors.csv" download class="text-blue-600 underline">{{ _('Baixar erros') }}</a>
+                     <form hx-post="/api/financeiro/importar-pagamentos/reprocessar/${token}/"
+                           hx-target="closest tr"
+                           hx-encoding="multipart/form-data"
+                           hx-headers='{"X-CSRFToken": "${csrfToken}"}'
+                           class="space-y-1">
+                         <input type="file" name="file" accept=".csv,.xlsx" class="block w-full border p-1 rounded" required />
+                         <button type="submit" class="bg-primary text-white px-2 py-1 rounded">{{ _('Reprocessar') }}</button>
+                     </form>
+                   </div>`
+                : '';
+              return `<tr>
+                        <td class="px-3 py-2">${token}</td>
+                        <td class="px-3 py-2">${i.status}</td>
+                        <td class="px-3 py-2">${i.total_processado}</td>
+                        <td class="px-3 py-2">${acao}</td>
+                      </tr>`;
+            }).join('');
+            tbody.innerHTML = rows || `<tr><td colspan="4" class="px-3 py-2 text-center">{{ _('Nenhuma importação') }}</td></tr>`;
+            if (data.previous) {
+              pag.innerHTML += `<button class="px-3 py-1 bg-gray-200 rounded" hx-get="${data.previous}" hx-target="#importacoes" hx-swap="none">{{ _('Anterior') }}</button>`;
+            }
+            if (data.next) {
+              pag.innerHTML += `<button class="px-3 py-1 bg-gray-200 rounded ml-auto" hx-get="${data.next}" hx-target="#importacoes" hx-swap="none">{{ _('Próximo') }}</button>`;
+            }
+          } catch (e) {
+            tbody.innerHTML = `<tr><td colspan="4" class="px-3 py-2 text-center text-red-600">{{ _('Erro ao carregar') }}</td></tr>`;
+          }
+        }
+      </script>
+    </div>
   </div>
-  <script>
-    const csrfToken = "{{ csrf_token }}";
-    function basename(path) {
-      return path.split('/').pop();
-    }
-    function renderImportacoes(evt) {
-      const tbody = document.querySelector('#importacoes tbody');
-      const pag = document.getElementById('paginacao');
-      tbody.innerHTML = '';
-      pag.innerHTML = '';
-      try {
-        const data = JSON.parse(evt.detail.xhr.response);
-        const itens = data.results || data;
-        const rows = itens.map(i => {
-          const token = basename(i.arquivo);
-          const acao = (i.erros && i.erros.length)
-            ? `<div class="space-y-1">
-                 <a href="/media/importacoes/${token}.errors.csv" download class="text-blue-600 underline">{{ _('Baixar erros') }}</a>
-                 <form hx-post="/api/financeiro/importar-pagamentos/reprocessar/${token}/"
-                       hx-target="closest tr"
-                       hx-encoding="multipart/form-data"
-                       hx-headers='{"X-CSRFToken": "${csrfToken}"}'
-                       class="space-y-1">
-                   <input type="file" name="file" accept=".csv,.xlsx" class="block w-full border p-1 rounded" required />
-                   <button type="submit" class="bg-primary text-white px-2 py-1 rounded">{{ _('Reprocessar') }}</button>
-                 </form>
-               </div>`
-            : '';
-          return `<tr>
-                    <td class="px-3 py-2">${token}</td>
-                    <td class="px-3 py-2">${i.status}</td>
-                    <td class="px-3 py-2">${i.total_processado}</td>
-                    <td class="px-3 py-2">${acao}</td>
-                  </tr>`;
-        }).join('');
-        tbody.innerHTML = rows || `<tr><td colspan="4" class="px-3 py-2 text-center">{{ _('Nenhuma importação') }}</td></tr>`;
-        if (data.previous) {
-          pag.innerHTML += `<button class="px-3 py-1 bg-gray-200 rounded" hx-get="${data.previous}" hx-target="#importacoes" hx-swap="none">{{ _('Anterior') }}</button>`;
-        }
-        if (data.next) {
-          pag.innerHTML += `<button class="px-3 py-1 bg-gray-200 rounded ml-auto" hx-get="${data.next}" hx-target="#importacoes" hx-swap="none">{{ _('Próximo') }}</button>`;
-        }
-      } catch (e) {
-        tbody.innerHTML = `<tr><td colspan="4" class="px-3 py-2 text-center text-red-600">{{ _('Erro ao carregar') }}</td></tr>`;
-      }
-    }
-  </script>
-</main>
+</div>
 {% endblock %}

--- a/financeiro/templates/financeiro/importar_pagamentos.html
+++ b/financeiro/templates/financeiro/importar_pagamentos.html
@@ -4,24 +4,25 @@
 {% block title %}{% trans "Importar Pagamentos" %}{% endblock %}
 
 {% block content %}
-<main class="max-w-3xl mx-auto p-4">
-  <section>
-    <h1 class="text-2xl font-semibold mb-4">{% trans "Importar Pagamentos" %}</h1>
-    <div class="mb-4">
-      <a href="{% url 'financeiro:importacoes' %}" class="text-blue-600 underline">{% trans "Ver importações" %}</a>
-    </div>
-    <form id="upload-form" method="post" enctype="multipart/form-data" class="space-y-4 border p-4 rounded-lg bg-white">
-      {% csrf_token %}
-      <label for="file" class="block text-sm font-medium text-gray-700">{% trans "Arquivo" %}</label>
-      <input id="file" type="file" name="file" accept=".csv,.xlsx" class="block w-full border p-2 rounded" required
-             hx-post="/api/financeiro/importar-pagamentos/"
-             hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
-             hx-target="#preview"
-             hx-trigger="change"
-             hx-include="#upload-form"
-             hx-on="htmx:afterRequest: renderPreview(event)" />
-      <p class="text-sm text-gray-500">{% trans "Apenas CSV ou XLSX até 5MB" %}</p>
-    </form>
+{% include 'components/hero.html' with title=_('Importar Pagamentos') %}
+<div class="container mx-auto p-6">
+  <div class="card">
+    <div class="card-body">
+      <div class="mb-4">
+        <a href="{% url 'financeiro:importacoes' %}" class="text-blue-600 underline">{% trans "Ver importações" %}</a>
+      </div>
+      <form id="upload-form" method="post" enctype="multipart/form-data" class="space-y-4 border p-4 rounded-lg bg-white">
+        {% csrf_token %}
+        <label for="file" class="block text-sm font-medium text-gray-700">{% trans "Arquivo" %}</label>
+        <input id="file" type="file" name="file" accept=".csv,.xlsx" class="block w-full border p-2 rounded" required
+               hx-post="/api/financeiro/importar-pagamentos/"
+               hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+               hx-target="#preview"
+               hx-trigger="change"
+               hx-include="#upload-form"
+               hx-on="htmx:afterRequest: renderPreview(event)" />
+        <p class="text-sm text-gray-500">{% trans "Apenas CSV ou XLSX até 5MB" %}</p>
+      </form>
       <button id="preview-btn"
               class="mt-2 bg-primary text-white px-4 py-2 rounded"
               hx-post="/api/financeiro/importar-pagamentos/"
@@ -30,17 +31,17 @@
               hx-trigger="click"
               hx-include="#upload-form"
               hx-on="htmx:afterRequest: renderPreview(event)">
-      {% trans "Pré-visualizar" %}
-    </button>
-    <div id="preview" class="mt-6" aria-live="polite"></div>
-    <div id="messages" class="mt-4 text-sm" aria-live="polite"></div>
-    <div id="reprocess" class="mt-4"></div>
-    <form id="confirm-form">
-      {% csrf_token %}
-      <input type="hidden" id="confirm-id" name="id" />
-      <input type="hidden" id="confirm-importacao-id" name="importacao_id" />
-    </form>
-    <div class="mt-4 flex items-center gap-2">
+        {% trans "Pré-visualizar" %}
+      </button>
+      <div id="preview" class="mt-6" aria-live="polite"></div>
+      <div id="messages" class="mt-4 text-sm" aria-live="polite"></div>
+      <div id="reprocess" class="mt-4"></div>
+      <form id="confirm-form">
+        {% csrf_token %}
+        <input type="hidden" id="confirm-id" name="id" />
+        <input type="hidden" id="confirm-importacao-id" name="importacao_id" />
+      </form>
+      <div class="mt-4 flex items-center gap-2">
         <button id="confirm-btn" disabled
                 hx-post="/api/financeiro/importar-pagamentos/confirmar/"
                 hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
@@ -48,53 +49,52 @@
                 hx-include="#confirm-form"
                 hx-indicator="#loading"
                 class="bg-secondary text-white px-4 py-2 rounded">
-        {% trans "Confirmar Importação" %}
-      </button>
-      <span id="loading" class="htmx-indicator text-sm">{% trans "Processando..." %}</span>
-    </div>
-  </section>
-  <script>
-    const csrfToken = "{{ csrf_token }}";
-    function renderPreview(evt) {
-      const preview = document.getElementById('preview');
-      const messages = document.getElementById('messages');
-      const reprocess = document.getElementById('reprocess');
-      preview.innerHTML = '';
-      messages.innerHTML = '';
-      reprocess.innerHTML = '';
-      try {
-        const data = JSON.parse(evt.detail.xhr.response);
-        if (data.preview && data.preview.length) {
-          const rows = data.preview.map(r => `<tr><td class="px-2 py-1">${r.centro_custo}</td><td class="px-2 py-1">${r.conta_associado || ''}</td><td class="px-2 py-1">${r.tipo}</td><td class="px-2 py-1">${r.valor}</td><td class="px-2 py-1">${r.data_lancamento}</td></tr>`).join('');
-          preview.innerHTML = `<table class="min-w-full divide-y divide-gray-200"><thead><tr><th class="px-2 py-1 text-left text-xs font-medium text-gray-500">{% trans "Centro de Custo" %}</th><th class="px-2 py-1 text-left text-xs font-medium text-gray-500">{% trans "Conta" %}</th><th class="px-2 py-1 text-left text-xs font-medium text-gray-500">{% trans "Tipo" %}</th><th class="px-2 py-1 text-left text-xs font-medium text-gray-500">{% trans "Valor" %}</th><th class="px-2 py-1 text-left text-xs font-medium text-gray-500">{% trans "Data" %}</th></tr></thead><tbody>${rows}</tbody></table>`;
-          document.getElementById('confirm-id').value = data.id;
-          document.getElementById('confirm-importacao-id').value = data.importacao_id;
-          document.getElementById('confirm-btn').disabled = false;
-        }
-        if (data.erros && data.erros.length) {
-          const ul = document.createElement('ul');
-          ul.className = 'list-disc text-red-600 pl-5';
-          data.erros.forEach((err) => {
-            const li = document.createElement('li');
-            li.textContent = err;
-            ul.appendChild(li);
-          });
-          messages.appendChild(ul);
-          if (!data.preview || !data.preview.length) {
+          {% trans "Confirmar Importação" %}
+        </button>
+        <span id="loading" class="htmx-indicator text-sm">{% trans "Processando..." %}</span>
+      </div>
+      <script>
+        const csrfToken = "{{ csrf_token }}";
+        function renderPreview(evt) {
+          const preview = document.getElementById('preview');
+          const messages = document.getElementById('messages');
+          const reprocess = document.getElementById('reprocess');
+          preview.innerHTML = '';
+          messages.innerHTML = '';
+          reprocess.innerHTML = '';
+          try {
+            const data = JSON.parse(evt.detail.xhr.response);
+            if (data.preview && data.preview.length) {
+              const rows = data.preview.map(r => `<tr><td class="px-2 py-1">${r.centro_custo}</td><td class="px-2 py-1">${r.conta_associado || ''}</td><td class="px-2 py-1">${r.tipo}</td><td class="px-2 py-1">${r.valor}</td><td class="px-2 py-1">${r.data_lancamento}</td></tr>`).join('');
+              preview.innerHTML = `<table class="min-w-full divide-y divide-gray-200"><thead><tr><th class="px-2 py-1 text-left text-xs font-medium text-gray-500">{% trans "Centro de Custo" %}</th><th class="px-2 py-1 text-left text-xs font-medium text-gray-500">{% trans "Conta" %}</th><th class="px-2 py-1 text-left text-xs font-medium text-gray-500">{% trans "Tipo" %}</th><th class="px-2 py-1 text-left text-xs font-medium text-gray-500">{% trans "Valor" %}</th><th class="px-2 py-1 text-left text-xs font-medium text-gray-500">{% trans "Data" %}</th></tr></thead><tbody>${rows}</tbody></table>`;
+              document.getElementById('confirm-id').value = data.id;
+              document.getElementById('confirm-importacao-id').value = data.importacao_id;
+              document.getElementById('confirm-btn').disabled = false;
+            }
+            if (data.erros && data.erros.length) {
+              const ul = document.createElement('ul');
+              ul.className = 'list-disc text-red-600 pl-5';
+              data.erros.forEach((err) => {
+                const li = document.createElement('li');
+                li.textContent = err;
+                ul.appendChild(li);
+              });
+              messages.appendChild(ul);
+              if (!data.preview || !data.preview.length) {
+                document.getElementById('confirm-btn').disabled = true;
+              }
+            }
+            if (data.token_erros) {
+              const token = data.token_erros;
+              reprocess.innerHTML = `<div class="space-y-2"><a href="/media/importacoes/${token}.errors.csv" download class="text-blue-600 underline">{% trans "Baixar arquivo de erros" %}</a><form id="reprocess-form" class="space-y-2" enctype="multipart/form-data">{% csrf_token %}<input type="file" name="file" accept=".csv,.xlsx" class="block w-full border p-2 rounded" required /><button type="submit" class="bg-primary text-white px-4 py-2 rounded" hx-post="/api/financeiro/importar-pagamentos/reprocessar/${token}/" hx-target="#messages" hx-include="#reprocess-form" hx-encoding="multipart/form-data" hx-headers='{"X-CSRFToken": "${csrfToken}"}'>{% trans "Reprocessar" %}</button></form></div>`;
+            }
+          } catch (e) {
+            messages.textContent = '{% trans "Erro ao processar pré-visualização" %}';
             document.getElementById('confirm-btn').disabled = true;
           }
         }
-        if (data.token_erros) {
-          const token = data.token_erros;
-            reprocess.innerHTML = `<div class="space-y-2"><a href="/media/importacoes/${token}.errors.csv" download class="text-blue-600 underline">{% trans "Baixar arquivo de erros" %}</a><form id="reprocess-form" class="space-y-2" enctype="multipart/form-data">{% csrf_token %}<input type="file" name="file" accept=".csv,.xlsx" class="block w-full border p-2 rounded" required /><button type="submit" class="bg-primary text-white px-4 py-2 rounded" hx-post="/api/financeiro/importar-pagamentos/reprocessar/${token}/" hx-target="#messages" hx-include="#reprocess-form" hx-encoding="multipart/form-data" hx-headers='{"X-CSRFToken": "${csrfToken}"}'>{% trans "Reprocessar" %}</button></form></div>`;
-        }
-      } catch (e) {
-        messages.textContent = '{% trans "Erro ao processar pré-visualização" %}';
-        document.getElementById('confirm-btn').disabled = true;
-      }
-    }
-  </script>
-</main>
-
+      </script>
+    </div>
+  </div>
+</div>
 {% endblock %}
-

--- a/financeiro/templates/financeiro/integracoes_list.html
+++ b/financeiro/templates/financeiro/integracoes_list.html
@@ -6,9 +6,10 @@
 {% block content %}
 {% include 'components/hero.html' with title=_('Integrações') action_template='financeiro/hero_integracoes_action.html' %}
 <div class="container mx-auto p-6">
-<main class="p-4 max-w-5xl mx-auto">
-  <section id="integracoes-list" class="overflow-x-auto" aria-live="polite">
-    <table class="min-w-full divide-y divide-gray-200">
+  <div class="card">
+    <div class="card-body">
+      <section id="integracoes-list" class="overflow-x-auto" aria-live="polite">
+        <table class="min-w-full divide-y divide-gray-200">
       <thead class="bg-gray-50">
         <tr>
           <th scope="col" class="px-3 py-2 text-left text-xs font-medium text-gray-500">{% trans "Nome" %}</th>
@@ -51,9 +52,9 @@
                 hx-get="?offset={{ next }}" hx-target="#integracoes-list"
                 hx-trigger="click" hx-swap="outerHTML">{% trans "Próximo" %}</button>
       {% endif %}
+      </section>
+      <div id="modal" class="mt-4" aria-live="assertive"></div>
     </div>
-  </section>
-  <div id="modal" class="mt-4" aria-live="assertive"></div>
-</main>
+  </div>
 </div>
 {% endblock %}

--- a/financeiro/templates/financeiro/lancamentos_list.html
+++ b/financeiro/templates/financeiro/lancamentos_list.html
@@ -4,104 +4,108 @@
 {% block title %}{{ _('Lançamentos Financeiros') }}{% endblock %}
 
 {% block content %}
-<main class="p-4 max-w-6xl mx-auto">
-  <h1 class="text-2xl font-semibold mb-2">{{ _('Lançamentos') }}</h1>
-  <form id="filtros" class="mb-4 grid grid-cols-1 md:grid-cols-5 gap-4" hx-get="/api/financeiro/lancamentos/" hx-target="#lista" hx-swap="none" hx-trigger="change from:select,change from:input, submit" hx-on="htmx:afterRequest: renderLancamentos(event)">
-    <legend class="sr-only">{{ _('Filtros') }}</legend>
-    <div>
-      <label for="filtro-status" class="block text-sm font-medium text-gray-700">{{ _('Status') }}</label>
-      <select name="status" id="filtro-status" class="border p-2 rounded">
-        <option value="">{{ _('Todos Status') }}</option>
-        <option value="pendente">{{ _('Pendente') }}</option>
-        <option value="pago">{{ _('Pago') }}</option>
-        <option value="cancelado">{{ _('Cancelado') }}</option>
-      </select>
+{% include 'components/hero.html' with title=_('Lançamentos') %}
+<div class="container mx-auto p-6">
+  <div class="card">
+    <div class="card-header">
+      <form id="filtros" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6" hx-get="/api/financeiro/lancamentos/" hx-target="#lista" hx-swap="none" hx-trigger="change from:select,change from:input, submit" hx-on="htmx:afterRequest: renderLancamentos(event)">
+        <legend class="sr-only">{{ _('Filtros') }}</legend>
+        <div>
+          <label for="filtro-status" class="block text-sm font-medium text-gray-700">{{ _('Status') }}</label>
+          <select name="status" id="filtro-status" class="border p-2 rounded">
+            <option value="">{{ _('Todos Status') }}</option>
+            <option value="pendente">{{ _('Pendente') }}</option>
+            <option value="pago">{{ _('Pago') }}</option>
+            <option value="cancelado">{{ _('Cancelado') }}</option>
+          </select>
+        </div>
+        <div>
+          <label for="filtro-centro" class="block text-sm font-medium text-gray-700">{{ _('Centro de Custo') }}</label>
+          <select name="centro" id="filtro-centro" class="border p-2 rounded">
+            <option value="">{{ _('Todos Centros') }}</option>
+            {% for c in centros %}
+              <option value="{{ c.id }}">{{ c.nome }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div>
+          <label for="filtro-nucleo" class="block text-sm font-medium text-gray-700">{{ _('Núcleo') }}</label>
+          <select name="nucleo" id="filtro-nucleo" class="border p-2 rounded">
+            <option value="">{{ _('Todos Núcleos') }}</option>
+            {% for n in nucleos %}
+              <option value="{{ n.id }}">{{ n.nome }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div>
+          <label for="filtro-periodo-inicial" class="block text-sm font-medium text-gray-700">{{ _('Período inicial') }}</label>
+          <input id="filtro-periodo-inicial" type="month" name="periodo_inicial" class="border p-2 rounded" />
+        </div>
+        <div>
+          <label for="filtro-periodo-final" class="block text-sm font-medium text-gray-700">{{ _('Período final') }}</label>
+          <input id="filtro-periodo-final" type="month" name="periodo_final" class="border p-2 rounded" />
+        </div>
+      </form>
     </div>
-    <div>
-      <label for="filtro-centro" class="block text-sm font-medium text-gray-700">{{ _('Centro de Custo') }}</label>
-      <select name="centro" id="filtro-centro" class="border p-2 rounded">
-        <option value="">{{ _('Todos Centros') }}</option>
-        {% for c in centros %}
-          <option value="{{ c.id }}">{{ c.nome }}</option>
-        {% endfor %}
-      </select>
-    </div>
-    <div>
-      <label for="filtro-nucleo" class="block text-sm font-medium text-gray-700">{{ _('Núcleo') }}</label>
-      <select name="nucleo" id="filtro-nucleo" class="border p-2 rounded">
-        <option value="">{{ _('Todos Núcleos') }}</option>
-        {% for n in nucleos %}
-          <option value="{{ n.id }}">{{ n.nome }}</option>
-        {% endfor %}
-      </select>
-    </div>
-    <div>
-      <label for="filtro-periodo-inicial" class="block text-sm font-medium text-gray-700">{{ _('Período inicial') }}</label>
-      <input id="filtro-periodo-inicial" type="month" name="periodo_inicial" class="border p-2 rounded" />
-    </div>
-    <div>
-      <label for="filtro-periodo-final" class="block text-sm font-medium text-gray-700">{{ _('Período final') }}</label>
-      <input id="filtro-periodo-final" type="month" name="periodo_final" class="border p-2 rounded" />
-    </div>
-  </form>
-  <div id="lista" aria-live="polite">
-    <table class="min-w-full divide-y divide-gray-200">
-      <thead>
-        <tr class="bg-gray-50">
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{{ _('ID') }}</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{{ _('Centro de Custo') }}</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{{ _('Conta Associada') }}</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{{ _('Tipo') }}</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{{ _('Valor') }}</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{{ _('Data de Lançamento') }}</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{{ _('Status') }}</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{{ _('Data de Vencimento') }}</th>
-          <th class="px-3 py-2"></th>
-        </tr>
-      </thead>
-      <tbody></tbody>
-    </table>
-  </div>
-  <script src="{% url 'javascript-catalog' %}"></script>
-  <script>
-    const csrfToken = "{{ csrf_token }}";
-    function renderLancamentos(evt) {
-      const tbody = document.querySelector('#lista tbody');
-      tbody.innerHTML = '';
-      try {
-        const data = JSON.parse(evt.detail.xhr.response);
-        const itens = data.results || data;
-        const rows = itens
-          .map(l => `
-            <tr>
-              <td class="px-3 py-2">${l.id}</td>
-              <td class="px-3 py-2">${l.centro_custo || ''}</td>
-              <td class="px-3 py-2">${l.conta_associado || ''}</td>
-              <td class="px-3 py-2">${l.tipo}</td>
-              <td class="px-3 py-2">${l.valor}</td>
-              <td class="px-3 py-2">${l.data_lancamento}</td>
-              <td class="px-3 py-2">${l.status}</td>
-              <td class="px-3 py-2">${l.data_vencimento || ''}</td>
-              <td class="px-3 py-2 space-x-2">
-                ${l.status === 'pendente' ? `
-                <button hx-post="/api/financeiro/lancamentos/${l.id}/pagar/" hx-headers='{"X-CSRFToken": "${csrfToken}"}' hx-on="htmx:afterRequest: htmx.trigger('#filtros','submit')" class="text-green-600 hover:underline">{% trans "Pagar" %}</button>
-                <button hx-patch="/api/financeiro/lancamentos/${l.id}/" hx-vals='{"status":"cancelado"}' hx-headers='{"X-CSRFToken": "${csrfToken}"}' hx-on="htmx:afterRequest: htmx.trigger('#filtros','submit')" class="text-red-600 hover:underline">{% trans "Cancelar" %}</button>
-                <button hx-get="/financeiro/lancamentos/${encodeURIComponent(l.id)}/ajustar/" hx-target="#modal" class="text-blue-600 hover:underline">{% trans "Ajustar" %}</button>
-                ` : ''}
-              </td>
+    <div class="card-body">
+      <div id="lista" aria-live="polite">
+        <table class="min-w-full divide-y divide-gray-200">
+          <thead>
+            <tr class="bg-gray-50">
+              <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{{ _('ID') }}</th>
+              <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{{ _('Centro de Custo') }}</th>
+              <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{{ _('Conta Associada') }}</th>
+              <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{{ _('Tipo') }}</th>
+              <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{{ _('Valor') }}</th>
+              <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{{ _('Data de Lançamento') }}</th>
+              <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{{ _('Status') }}</th>
+              <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{{ _('Data de Vencimento') }}</th>
+              <th class="px-3 py-2"></th>
             </tr>
-          `)
-          .join('');
-        tbody.innerHTML = rows || `<tr><td colspan="9" class="px-3 py-2 text-center">${gettext('Nenhum lançamento')}</td></tr>`;
-      } catch (e) {
-        tbody.innerHTML = `<tr><td colspan="9" class="px-3 py-2 text-center">${gettext('Erro ao carregar')}</td></tr>`;
-      }
-    }
-    document.addEventListener('DOMContentLoaded', () => {
-      htmx.trigger('#filtros', 'submit');
-    });
-  </script>
-</main>
-
+          </thead>
+          <tbody></tbody>
+        </table>
+      </div>
+      <script src="{% url 'javascript-catalog' %}"></script>
+      <script>
+        const csrfToken = "{{ csrf_token }}";
+        function renderLancamentos(evt) {
+          const tbody = document.querySelector('#lista tbody');
+          tbody.innerHTML = '';
+          try {
+            const data = JSON.parse(evt.detail.xhr.response);
+            const itens = data.results || data;
+            const rows = itens
+              .map(l => `
+                <tr>
+                  <td class="px-3 py-2">${l.id}</td>
+                  <td class="px-3 py-2">${l.centro_custo || ''}</td>
+                  <td class="px-3 py-2">${l.conta_associado || ''}</td>
+                  <td class="px-3 py-2">${l.tipo}</td>
+                  <td class="px-3 py-2">${l.valor}</td>
+                  <td class="px-3 py-2">${l.data_lancamento}</td>
+                  <td class="px-3 py-2">${l.status}</td>
+                  <td class="px-3 py-2">${l.data_vencimento || ''}</td>
+                  <td class="px-3 py-2 space-x-2">
+                    ${l.status === 'pendente' ? `
+                    <button hx-post="/api/financeiro/lancamentos/${l.id}/pagar/" hx-headers='{"X-CSRFToken": "${csrfToken}"}' hx-on="htmx:afterRequest: htmx.trigger('#filtros','submit')" class="text-green-600 hover:underline">{% trans "Pagar" %}</button>
+                    <button hx-patch="/api/financeiro/lancamentos/${l.id}/" hx-vals='{"status":"cancelado"}' hx-headers='{"X-CSRFToken": "${csrfToken}"}' hx-on="htmx:afterRequest: htmx.trigger('#filtros','submit')" class="text-red-600 hover:underline">{% trans "Cancelar" %}</button>
+                    <button hx-get="/financeiro/lancamentos/${encodeURIComponent(l.id)}/ajustar/" hx-target="#modal" class="text-blue-600 hover:underline">{% trans "Ajustar" %}</button>
+                    ` : ''}
+                  </td>
+                </tr>
+              `)
+              .join('');
+            tbody.innerHTML = rows || `<tr><td colspan="9" class="px-3 py-2 text-center">${gettext('Nenhum lançamento')}</td></tr>`;
+          } catch (e) {
+            tbody.innerHTML = `<tr><td colspan="9" class="px-3 py-2 text-center">${gettext('Erro ao carregar')}</td></tr>`;
+          }
+        }
+        document.addEventListener('DOMContentLoaded', () => {
+          htmx.trigger('#filtros', 'submit');
+        });
+      </script>
+    </div>
+  </div>
+</div>
 {% endblock %}
-

--- a/financeiro/templates/financeiro/logs_list.html
+++ b/financeiro/templates/financeiro/logs_list.html
@@ -4,81 +4,87 @@
 {% block title %}{{ _('Logs Financeiros') }}{% endblock %}
 
 {% block content %}
-<main class="p-4 max-w-6xl mx-auto">
-  <h1 class="text-2xl font-semibold mb-2">{{ _('Logs Financeiros') }}</h1>
-  <form id="filtros" class="mb-4 grid grid-cols-1 md:grid-cols-4 gap-4"
-        hx-get="/api/financeiro/logs/"
-        hx-target="#lista"
-        hx-swap="none"
-        hx-trigger="change from:select,change from:input, submit"
-        hx-on="htmx:afterRequest: renderLogs(event)">
-    <legend class="sr-only">{{ _('Filtros') }}</legend>
-    <div>
-      <label for="filtro-acao" class="block text-sm font-medium text-gray-700">{{ _('Ação') }}</label>
-      <select name="acao" id="filtro-acao" class="border p-2 rounded">
-        <option value="">{{ _('Todas Ações') }}</option>
-        {% for value, label in acoes %}
-          <option value="{{ value }}">{{ label }}</option>
-        {% endfor %}
-      </select>
+{% include 'components/hero.html' with title=_('Logs Financeiros') %}
+<div class="container mx-auto p-6">
+  <div class="card">
+    <div class="card-header">
+      <form id="filtros" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6"
+            hx-get="/api/financeiro/logs/"
+            hx-target="#lista"
+            hx-swap="none"
+            hx-trigger="change from:select,change from:input, submit"
+            hx-on="htmx:afterRequest: renderLogs(event)">
+        <legend class="sr-only">{{ _('Filtros') }}</legend>
+        <div>
+          <label for="filtro-acao" class="block text-sm font-medium text-gray-700">{{ _('Ação') }}</label>
+          <select name="acao" id="filtro-acao" class="border p-2 rounded">
+            <option value="">{{ _('Todas Ações') }}</option>
+            {% for value, label in acoes %}
+              <option value="{{ value }}">{{ label }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div>
+          <label for="filtro-usuario" class="block text-sm font-medium text-gray-700">{{ _('Usuário') }}</label>
+          <select name="usuario" id="filtro-usuario" class="border p-2 rounded">
+            <option value="">{{ _('Todos Usuários') }}</option>
+            {% for u in usuarios %}
+              <option value="{{ u.id }}">{{ u.email }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div>
+          <label for="filtro-inicio" class="block text-sm font-medium text-gray-700">{{ _('Início') }}</label>
+          <input id="filtro-inicio" type="date" name="inicio" class="border p-2 rounded" />
+        </div>
+        <div>
+          <label for="filtro-fim" class="block text-sm font-medium text-gray-700">{{ _('Fim') }}</label>
+          <input id="filtro-fim" type="date" name="fim" class="border p-2 rounded" />
+        </div>
+      </form>
     </div>
-    <div>
-      <label for="filtro-usuario" class="block text-sm font-medium text-gray-700">{{ _('Usuário') }}</label>
-      <select name="usuario" id="filtro-usuario" class="border p-2 rounded">
-        <option value="">{{ _('Todos Usuários') }}</option>
-        {% for u in usuarios %}
-          <option value="{{ u.id }}">{{ u.email }}</option>
-        {% endfor %}
-      </select>
-    </div>
-    <div>
-      <label for="filtro-inicio" class="block text-sm font-medium text-gray-700">{{ _('Início') }}</label>
-      <input id="filtro-inicio" type="date" name="inicio" class="border p-2 rounded" />
-    </div>
-    <div>
-      <label for="filtro-fim" class="block text-sm font-medium text-gray-700">{{ _('Fim') }}</label>
-      <input id="filtro-fim" type="date" name="fim" class="border p-2 rounded" />
-    </div>
-  </form>
-  <div id="lista" aria-live="polite">
-    <table class="min-w-full divide-y divide-gray-200">
-      <thead>
-        <tr class="bg-gray-50">
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{{ _('ID') }}</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{{ _('Ação') }}</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{{ _('Usuário') }}</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{{ _('Data') }}</th>
-        </tr>
-      </thead>
-      <tbody></tbody>
-    </table>
-  </div>
-  <script src="{% url 'javascript-catalog' %}"></script>
-  <script>
-    function renderLogs(evt) {
-      const tbody = document.querySelector('#lista tbody');
-      tbody.innerHTML = '';
-      try {
-        const data = JSON.parse(evt.detail.xhr.response);
-        const itens = data.results || data;
-        const rows = itens
-          .map(l => `
-            <tr>
-              <td class="px-3 py-2">${l.id}</td>
-              <td class="px-3 py-2">${l.acao}</td>
-              <td class="px-3 py-2">${l.usuario || ''}</td>
-              <td class="px-3 py-2">${l.created_at}</td>
+    <div class="card-body">
+      <div id="lista" aria-live="polite">
+        <table class="min-w-full divide-y divide-gray-200">
+          <thead>
+            <tr class="bg-gray-50">
+              <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{{ _('ID') }}</th>
+              <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{{ _('Ação') }}</th>
+              <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{{ _('Usuário') }}</th>
+              <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{{ _('Data') }}</th>
             </tr>
-          `)
-          .join('');
-        tbody.innerHTML = rows || `<tr><td colspan="4" class="px-3 py-2 text-center">${gettext('Nenhum log')}</td></tr>`;
-      } catch (e) {
-        tbody.innerHTML = `<tr><td colspan="4" class="px-3 py-2 text-center">${gettext('Erro ao carregar')}</td></tr>`;
-      }
-    }
-    document.addEventListener('DOMContentLoaded', () => {
-      htmx.trigger('#filtros', 'submit');
-    });
-  </script>
-</main>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </div>
+      <script src="{% url 'javascript-catalog' %}"></script>
+      <script>
+        function renderLogs(evt) {
+          const tbody = document.querySelector('#lista tbody');
+          tbody.innerHTML = '';
+          try {
+            const data = JSON.parse(evt.detail.xhr.response);
+            const itens = data.results || data;
+            const rows = itens
+              .map(l => `
+                <tr>
+                  <td class="px-3 py-2">${l.id}</td>
+                  <td class="px-3 py-2">${l.acao}</td>
+                  <td class="px-3 py-2">${l.usuario || ''}</td>
+                  <td class="px-3 py-2">${l.created_at}</td>
+                </tr>
+              `)
+              .join('');
+            tbody.innerHTML = rows || `<tr><td colspan="4" class="px-3 py-2 text-center">${gettext('Nenhum log')}</td></tr>`;
+          } catch (e) {
+            tbody.innerHTML = `<tr><td colspan="4" class="px-3 py-2 text-center">${gettext('Erro ao carregar')}</td></tr>`;
+          }
+        }
+        document.addEventListener('DOMContentLoaded', () => {
+          htmx.trigger('#filtros', 'submit');
+        });
+      </script>
+    </div>
+  </div>
+</div>
 {% endblock %}

--- a/financeiro/templates/financeiro/relatorios.html
+++ b/financeiro/templates/financeiro/relatorios.html
@@ -4,90 +4,92 @@
 {% block title %}{% trans "Relatórios Financeiros" %}{% endblock %}
 
 {% block content %}
-<main class="max-w-5xl mx-auto p-4 space-y-4">
-  <h1 class="text-2xl font-semibold mb-2">{% trans "Relatórios" %}</h1>
-  <form id="relatorio-form" class="space-y-4">
-    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-      <div>
-        <label for="rel-centro" class="block text-sm font-medium text-gray-700">{% trans "Centro de Custo" %}</label>
-        <select id="rel-centro" name="centro" class="mt-1 block w-full border rounded p-2">
-          <option value="">{% trans "Todos" %}</option>
-          {% for c in centros %}
-            <option value="{{ c.id }}">{{ c.nome }}</option>
-          {% endfor %}
-        </select>
-      </div>
-      <div>
-        <label for="rel-nucleo" class="block text-sm font-medium text-gray-700">{% trans "Núcleo" %}</label>
-        <select id="rel-nucleo" name="nucleo" class="mt-1 block w-full border rounded p-2">
-          <option value="">{% trans "Todos" %}</option>
-          {% for n in nucleos %}
-            <option value="{{ n.id }}">{{ n.nome }}</option>
-          {% endfor %}
-        </select>
-      </div>
-    </div>
-    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-      <div>
-        <label for="rel-periodo-inicial" class="block text-sm font-medium text-gray-700">{% trans "Período inicial" %}</label>
-        <input id="rel-periodo-inicial" type="month" name="periodo_inicial" class="mt-1 block w-full border rounded p-2" />
-      </div>
-      <div>
-        <label for="rel-periodo-final" class="block text-sm font-medium text-gray-700">{% trans "Período final" %}</label>
-        <input id="rel-periodo-final" type="month" name="periodo_final" class="mt-1 block w-full border rounded p-2" />
-      </div>
-    </div>
-    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-      <div>
-        <label for="rel-tipo" class="block text-sm font-medium text-gray-700">{% trans "Tipo" %}</label>
-        <select id="rel-tipo" name="tipo" class="mt-1 block w-full border rounded p-2">
-          <option value="">{% trans "Todos" %}</option>
-          <option value="receitas">{% trans "Receitas" %}</option>
-          <option value="despesas">{% trans "Despesas" %}</option>
-        </select>
-      </div>
-      <div>
-        <label for="rel-status" class="block text-sm font-medium text-gray-700">{% trans "Status" %}</label>
-        <select id="rel-status" name="status" class="mt-1 block w-full border rounded p-2">
-          <option value="">{% trans "Todos" %}</option>
-          <option value="pendente">{% trans "Pendente" %}</option>
-          <option value="pago">{% trans "Pago" %}</option>
-          <option value="cancelado">{% trans "Cancelado" %}</option>
-        </select>
-      </div>
-    </div>
-    <button type="button" id="gerar-relatorio" class="bg-primary text-white px-4 py-2 rounded"
-            hx-get="/api/financeiro/relatorios/"
-            hx-target="#relatorio"
-            hx-include="#relatorio-form"
-            hx-trigger="click"
-            hx-on="htmx:afterRequest: renderRelatorio(event)">
-      {% trans "Gerar Relatório" %}
-    </button>
-  </form>
+{% include 'components/hero.html' with title=_('Relatórios') %}
+<div class="container mx-auto p-6">
+  <div class="card">
+    <div class="card-body space-y-4">
+      <form id="relatorio-form" class="space-y-4">
+        <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+          <div>
+            <label for="rel-centro" class="block text-sm font-medium text-gray-700">{% trans "Centro de Custo" %}</label>
+            <select id="rel-centro" name="centro" class="mt-1 block w-full border rounded p-2">
+              <option value="">{% trans "Todos" %}</option>
+              {% for c in centros %}
+                <option value="{{ c.id }}">{{ c.nome }}</option>
+              {% endfor %}
+            </select>
+          </div>
+          <div>
+            <label for="rel-nucleo" class="block text-sm font-medium text-gray-700">{% trans "Núcleo" %}</label>
+            <select id="rel-nucleo" name="nucleo" class="mt-1 block w-full border rounded p-2">
+              <option value="">{% trans "Todos" %}</option>
+              {% for n in nucleos %}
+                <option value="{{ n.id }}">{{ n.nome }}</option>
+              {% endfor %}
+            </select>
+          </div>
+        </div>
+        <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+          <div>
+            <label for="rel-periodo-inicial" class="block text-sm font-medium text-gray-700">{% trans "Período inicial" %}</label>
+            <input id="rel-periodo-inicial" type="month" name="periodo_inicial" class="mt-1 block w-full border rounded p-2" />
+          </div>
+          <div>
+            <label for="rel-periodo-final" class="block text-sm font-medium text-gray-700">{% trans "Período final" %}</label>
+            <input id="rel-periodo-final" type="month" name="periodo_final" class="mt-1 block w-full border rounded p-2" />
+          </div>
+        </div>
+        <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+          <div>
+            <label for="rel-tipo" class="block text-sm font-medium text-gray-700">{% trans "Tipo" %}</label>
+            <select id="rel-tipo" name="tipo" class="mt-1 block w-full border rounded p-2">
+              <option value="">{% trans "Todos" %}</option>
+              <option value="receitas">{% trans "Receitas" %}</option>
+              <option value="despesas">{% trans "Despesas" %}</option>
+            </select>
+          </div>
+          <div>
+            <label for="rel-status" class="block text-sm font-medium text-gray-700">{% trans "Status" %}</label>
+            <select id="rel-status" name="status" class="mt-1 block w-full border rounded p-2">
+              <option value="">{% trans "Todos" %}</option>
+              <option value="pendente">{% trans "Pendente" %}</option>
+              <option value="pago">{% trans "Pago" %}</option>
+              <option value="cancelado">{% trans "Cancelado" %}</option>
+            </select>
+          </div>
+        </div>
+        <button type="button" id="gerar-relatorio" class="bg-primary text-white px-4 py-2 rounded"
+                hx-get="/api/financeiro/relatorios/"
+                hx-target="#relatorio"
+                hx-include="#relatorio-form"
+                hx-trigger="click"
+                hx-on="htmx:afterRequest: renderRelatorio(event)">
+          {% trans "Gerar Relatório" %}
+        </button>
+      </form>
 
-  <div id="relatorio" class="mt-6" aria-live="polite"></div>
-  
-    <script src="{% url 'javascript-catalog' %}"></script>
-    <script>
-    function renderRelatorio(evt) {
-      const container = document.getElementById('relatorio');
-      container.innerHTML = '';
-      try {
-        const data = JSON.parse(evt.detail.xhr.response);
-        const rows = data.serie
-          .map(r => `<tr><td class=\"px-2 py-1\">${r.mes}</td><td class=\"px-2 py-1\">${r.receitas}</td><td class=\"px-2 py-1\">${r.despesas}</td><td class=\"px-2 py-1\">${r.saldo}</td></tr>`)
-          .join('');
-        container.innerHTML = `
-          <p class=\"mb-2 font-medium\">{% trans "Saldo atual" %}: ${data.saldo_atual}</p>
-          <p class=\"mb-2 font-medium\">{% trans "Total inadimplentes" %}: ${data.total_inadimplentes}</p>
-          <table class=\"min-w-full divide-y divide-gray-200\"><thead><tr><th class=\"px-2 py-1 text-left text-xs font-medium text-gray-500\">{% trans "Mês" %}</th><th class=\"px-2 py-1 text-left text-xs font-medium text-gray-500\">{% trans "Receitas" %}</th><th class=\"px-2 py-1 text-left text-xs font-medium text-gray-500\">{% trans "Despesas" %}</th><th class=\"px-2 py-1 text-left text-xs font-medium text-gray-500\">{% trans "Saldo" %}</th></tr></thead><tbody>${rows}</tbody></table>`;
-      } catch (e) {
-        container.textContent = gettext('Erro ao gerar relatório');
-      }
-    }
-  </script>
-</main>
+      <div id="relatorio" class="mt-6" aria-live="polite"></div>
 
+      <script src="{% url 'javascript-catalog' %}"></script>
+      <script>
+        function renderRelatorio(evt) {
+          const container = document.getElementById('relatorio');
+          container.innerHTML = '';
+          try {
+            const data = JSON.parse(evt.detail.xhr.response);
+            const rows = data.serie
+              .map(r => `<tr><td class=\"px-2 py-1\">${r.mes}</td><td class=\"px-2 py-1\">${r.receitas}</td><td class=\"px-2 py-1\">${r.despesas}</td><td class=\"px-2 py-1\">${r.saldo}</td></tr>`)
+              .join('');
+            container.innerHTML = `
+              <p class=\"mb-2 font-medium\">{% trans "Saldo atual" %}: ${data.saldo_atual}</p>
+              <p class=\"mb-2 font-medium\">{% trans "Total inadimplentes" %}: ${data.total_inadimplentes}</p>
+              <table class=\"min-w-full divide-y divide-gray-200\"><thead><tr><th class=\"px-2 py-1 text-left text-xs font-medium text-gray-500\">{% trans "Mês" %}</th><th class=\"px-2 py-1 text-left text-xs font-medium text-gray-500\">{% trans "Receitas" %}</th><th class=\"px-2 py-1 text-left text-xs font-medium text-gray-500\">{% trans "Despesas" %}</th><th class=\"px-2 py-1 text-left text-xs font-medium text-gray-500\">{% trans "Saldo" %}</th></tr></thead><tbody>${rows}</tbody></table>`;
+          } catch (e) {
+            container.textContent = gettext('Erro ao gerar relatório');
+          }
+        }
+      </script>
+    </div>
+  </div>
+</div>
 {% endblock %}
-

--- a/financeiro/templates/financeiro/repasses.html
+++ b/financeiro/templates/financeiro/repasses.html
@@ -4,58 +4,64 @@
 {% block title %}{% trans "Repasses de Receita" %}{% endblock %}
 
 {% block content %}
-<main class="p-4 max-w-5xl mx-auto">
-  <h1 class="text-2xl font-semibold mb-2">{% trans "Repasses" %}</h1>
-  <form id="filtros" class="mb-4 flex gap-4" hx-get="/api/financeiro/repasses/" hx-target="#lista" hx-swap="none" hx-trigger="change from:select,change from:input, submit" hx-on="htmx:afterRequest: renderRepasses(event)">
-    <div>
-      <label for="filtro-evento" class="block text-sm font-medium text-gray-700">{% trans "Evento" %}</label>
-      <select id="filtro-evento" name="evento" class="border p-2 rounded">
-        <option value="">{% trans "Todos" %}</option>
-        {% for e in eventos %}
-          <option value="{{ e.id }}">{{ e.titulo }}</option>
-        {% endfor %}
-      </select>
+{% include 'components/hero.html' with title=_('Repasses') %}
+<div class="container mx-auto p-6">
+  <div class="card">
+    <div class="card-header">
+      <form id="filtros" class="flex gap-4" hx-get="/api/financeiro/repasses/" hx-target="#lista" hx-swap="none" hx-trigger="change from:select,change from:input, submit" hx-on="htmx:afterRequest: renderRepasses(event)">
+        <div>
+          <label for="filtro-evento" class="block text-sm font-medium text-gray-700">{% trans "Evento" %}</label>
+          <select id="filtro-evento" name="evento" class="border p-2 rounded">
+            <option value="">{% trans "Todos" %}</option>
+            {% for e in eventos %}
+              <option value="{{ e.id }}">{{ e.titulo }}</option>
+            {% endfor %}
+          </select>
+        </div>
+      </form>
     </div>
-  </form>
-  <div id="lista" aria-live="polite">
-    <table class="min-w-full divide-y divide-gray-200">
-      <thead>
-        <tr class="bg-gray-50">
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{% trans "ID" %}</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{% trans "Centro de Custo" %}</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{% trans "Conta Associada" %}</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{% trans "Valor" %}</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{% trans "Data de Lançamento" %}</th>
-        </tr>
-      </thead>
-      <tbody></tbody>
-    </table>
+    <div class="card-body">
+      <div id="lista" aria-live="polite">
+        <table class="min-w-full divide-y divide-gray-200">
+          <thead>
+            <tr class="bg-gray-50">
+              <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{% trans "ID" %}</th>
+              <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{% trans "Centro de Custo" %}</th>
+              <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{% trans "Conta Associada" %}</th>
+              <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{% trans "Valor" %}</th>
+              <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{% trans "Data de Lançamento" %}</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </div>
+      <script src="{% url 'javascript-catalog' %}"></script>
+      <script>
+        function renderRepasses(evt) {
+          const tbody = document.querySelector('#lista tbody');
+          tbody.innerHTML = '';
+          try {
+            const data = JSON.parse(evt.detail.xhr.response);
+            const itens = data.results || data;
+            const rows = itens.map(r => `
+              <tr>
+                <td class=\"px-3 py-2\">${r.id}</td>
+                <td class=\"px-3 py-2\">${r.centro_custo || ''}</td>
+                <td class=\"px-3 py-2\">${r.conta_associado || ''}</td>
+                <td class=\"px-3 py-2\">${r.valor}</td>
+                <td class=\"px-3 py-2\">${r.data_lancamento}</td>
+              </tr>
+            `).join('');
+            tbody.innerHTML = rows || `<tr><td colspan=\"5\" class=\"px-3 py-2 text-center\">${gettext('Nenhum repasse')}</td></tr>`;
+          } catch (e) {
+            tbody.innerHTML = `<tr><td colspan=\"5\" class=\"px-3 py-2 text-center\">${gettext('Erro ao carregar')}</td></tr>`;
+          }
+        }
+        document.addEventListener('DOMContentLoaded', () => {
+          htmx.trigger('#filtros', 'submit');
+        });
+      </script>
+    </div>
   </div>
-  <script src="{% url 'javascript-catalog' %}"></script>
-  <script>
-    function renderRepasses(evt) {
-      const tbody = document.querySelector('#lista tbody');
-      tbody.innerHTML = '';
-      try {
-        const data = JSON.parse(evt.detail.xhr.response);
-        const itens = data.results || data;
-        const rows = itens.map(r => `
-          <tr>
-            <td class=\"px-3 py-2\">${r.id}</td>
-            <td class=\"px-3 py-2\">${r.centro_custo || ''}</td>
-            <td class=\"px-3 py-2\">${r.conta_associado || ''}</td>
-            <td class=\"px-3 py-2\">${r.valor}</td>
-            <td class=\"px-3 py-2\">${r.data_lancamento}</td>
-          </tr>
-        `).join('');
-        tbody.innerHTML = rows || `<tr><td colspan=\"5\" class=\"px-3 py-2 text-center\">${gettext('Nenhum repasse')}</td></tr>`;
-      } catch (e) {
-        tbody.innerHTML = `<tr><td colspan=\"5\" class=\"px-3 py-2 text-center\">${gettext('Erro ao carregar')}</td></tr>`;
-      }
-    }
-    document.addEventListener('DOMContentLoaded', () => {
-      htmx.trigger('#filtros', 'submit');
-    });
-  </script>
-</main>
+</div>
 {% endblock %}

--- a/nucleos/templates/nucleos/list.html
+++ b/nucleos/templates/nucleos/list.html
@@ -4,38 +4,35 @@
 {% block title %}{% trans "Núcleos" %}{% endblock %}
 
 {% block content %}
-<section class="max-w-6xl mx-auto py-8 px-4">
-  <h1 class="text-2xl font-bold mb-4">{% trans "Núcleos" %}</h1>
-  {% include 'components/search_form.html' with q=request.GET.q %}
-  {% if request.user.user_type != 'admin' %}
-  <div class="mb-4">
-    <a href="{% url 'nucleos:meus' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100" aria-label="{% trans 'Ver meus núcleos' %}">{% trans 'Meus Núcleos' %}</a>
-  </div>
-  {% endif %}
-  {% if request.user.user_type == 'admin' %}
-  <div class="mb-4">
-    <a href="{% url 'nucleos:create' %}" class="px-3 py-2 bg-green-600 text-white rounded" aria-label="{% trans 'Criar novo núcleo' %}">{% trans 'Novo' %}</a>
-  </div>
-  {% endif %}
-
-  <!-- Cards de totais (organização) -->
-  <div class="mb-6 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-    {% include "partials/cards/total_card.html" with label=_('Núcleos') valor=total_nucleos %}
-    {% include "partials/cards/total_card.html" with label=_('Membros (todos os núcleos)') valor=total_membros_org %}
-    {% include "partials/cards/total_card.html" with label=_('Eventos (todos)') valor=total_eventos_org %}
-    {% include "partials/cards/total_card.html" with label=_('Eventos ativos') valor=total_eventos_ativos_org %}
-    {% include "partials/cards/total_card.html" with label=_('Eventos concluídos') valor=total_eventos_concluidos_org %}
-  </div>
-
-  <main>
-    <div role="list" aria-label="{% trans 'Lista de núcleos' %}" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-      {% for nucleo in object_list %}
-        {% include 'nucleos/partials/card.html' with nucleo=nucleo %}
-      {% empty %}
-        <p class="col-span-full text-center text-neutral-500">{% trans "Nenhum núcleo encontrado." %}</p>
-      {% endfor %}
+{% include 'components/hero.html' with title=_('Núcleos') %}
+<div class="container mx-auto p-6">
+  <div class="card">
+    <div class="card-header space-y-4">
+      {% include 'components/search_form.html' with q=request.GET.q %}
+      {% if request.user.user_type != 'admin' %}
+      <a href="{% url 'nucleos:meus' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100" aria-label="{% trans 'Ver meus núcleos' %}">{% trans 'Meus Núcleos' %}</a>
+      {% endif %}
+      {% if request.user.user_type == 'admin' %}
+      <a href="{% url 'nucleos:create' %}" class="px-3 py-2 bg-green-600 text-white rounded" aria-label="{% trans 'Criar novo núcleo' %}">{% trans 'Novo' %}</a>
+      {% endif %}
     </div>
-  </main>
-  {% include 'components/pagination.html' with page_obj=page_obj querystring=querystring %}
-</section>
+    <div class="card-body">
+      <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6 mb-6">
+        {% include "partials/cards/total_card.html" with label=_('Núcleos') valor=total_nucleos %}
+        {% include "partials/cards/total_card.html" with label=_('Membros (todos os núcleos)') valor=total_membros_org %}
+        {% include "partials/cards/total_card.html" with label=_('Eventos (todos)') valor=total_eventos_org %}
+        {% include "partials/cards/total_card.html" with label=_('Eventos ativos') valor=total_eventos_ativos_org %}
+        {% include "partials/cards/total_card.html" with label=_('Eventos concluídos') valor=total_eventos_concluidos_org %}
+      </div>
+      <div role="list" aria-label="{% trans 'Lista de núcleos' %}" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+        {% for nucleo in object_list %}
+          {% include 'nucleos/partials/card.html' with nucleo=nucleo %}
+        {% empty %}
+          <p class="col-span-full text-center text-neutral-500">{% trans "Nenhum núcleo encontrado." %}</p>
+        {% endfor %}
+      </div>
+      {% include 'components/pagination.html' with page_obj=page_obj querystring=querystring %}
+    </div>
+  </div>
+</div>
 {% endblock %}

--- a/tokens/templates/tokens/ativar_2fa.html
+++ b/tokens/templates/tokens/ativar_2fa.html
@@ -4,55 +4,46 @@
 {% block title %}{% trans "Ativar 2FA" %} | HubX{% endblock %}
 
 {% block content %}
-
-<section class="max-w-md mx-auto px-4 py-12">
-  <header class="text-center mb-6">
-    <h1 class="text-2xl font-bold">{% trans "Ativar Autenticação de Dois Fatores" %}</h1>
-    <p class="text-sm text-neutral-600 mt-2">{% trans "Escaneie o QR Code no aplicativo autenticador ou digite o código exibido." %}</p>
-  </header>
-
-  {% if messages %}
-    <div class="mb-4 space-y-2">
-      {% for message in messages %}
-        <p role="alert" class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-green-100 text-green-700{% else %}bg-red-100 text-red-700{% endif %}">
-          {{ message }}
-        </p>
-      {% endfor %}
-    </div>
+{% include 'components/hero.html' with title=_('Ativar Autenticação de Dois Fatores') %}
+<div class="container mx-auto p-6">
+  <div class="card">
     <div class="card-body">
       {% if messages %}
-        <div class="mb-4 space-y-2">
+        <div class="mb-4 space-y-2 text-center">
           {% for message in messages %}
-            <p class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-green-100 text-green-700{% else %}bg-red-100 text-red-700{% endif %}">
+            <p role="alert" class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-green-100 text-green-700{% else %}bg-red-100 text-red-700{% endif %}">
               {{ message }}
             </p>
           {% endfor %}
-      </div>
+        </div>
       {% endif %}
-  <main>
-    {% if qr_code %}
-      <div class="flex flex-col items-center mb-4">
-        <img src="data:image/png;base64,{{ qr_code }}" alt="{% trans 'QR Code' %}" class="w-40 h-40" />
-        <p class="mt-2 text-sm font-mono">{{ secret }}</p>
-      </div>
-    {% endif %}
-    <form method="post" action="{% url 'tokens:ativar_2fa' %}" class="bg-white rounded-2xl shadow p-6 space-y-4">
-      {% csrf_token %}
-      <div class="relative">
-        <label for="{{ form.codigo_totp.id_for_label }}" class="label-float">{{ form.codigo_totp.label }}</label>
-        {{ form.codigo_totp|add_class:"peer placeholder-transparent form-input"|attr:"autofocus required pattern=\\d+ inputmode=numeric" }}
-        {% if form.codigo_totp.errors %}
-          <p role="alert" class="text-sm text-red-600 mt-1">{{ form.codigo_totp.errors.0 }}</p>
-        {% endif %}
-      </div>
-      <div class="text-right">
-        <button type="submit" class="btn btn-primary">{% trans "Ativar" %}</button>
-      </div>
-    </form>
-  </main>
-  <footer class="mt-6 text-center">
-    <a href="{% url 'configuracoes' %}" class="text-sm text-blue-600 hover:underline">{% trans "Voltar ao perfil de segurança" %}</a>
-  </footer>
 
-</section>
+      {% if qr_code %}
+        <div class="flex flex-col items-center mb-4">
+          <img src="data:image/png;base64,{{ qr_code }}" alt="{% trans 'QR Code' %}" class="w-40 h-40" />
+          <p class="mt-2 text-sm font-mono">{{ secret }}</p>
+        </div>
+        <p class="text-sm text-neutral-600 mb-4 text-center">{% trans "Escaneie o QR Code no aplicativo autenticador ou digite o código exibido." %}</p>
+      {% endif %}
+
+      <form method="post" action="{% url 'tokens:ativar_2fa' %}" class="bg-white rounded-2xl shadow p-6 space-y-4">
+        {% csrf_token %}
+        <div class="relative">
+          <label for="{{ form.codigo_totp.id_for_label }}" class="label-float">{{ form.codigo_totp.label }}</label>
+          {{ form.codigo_totp|add_class:"peer placeholder-transparent form-input"|attr:"autofocus required pattern=\\d+ inputmode=numeric" }}
+          {% if form.codigo_totp.errors %}
+            <p role="alert" class="text-sm text-red-600 mt-1">{{ form.codigo_totp.errors.0 }}</p>
+          {% endif %}
+        </div>
+        <div class="text-right">
+          <button type="submit" class="btn btn-primary">{% trans "Ativar" %}</button>
+        </div>
+      </form>
+
+      <footer class="mt-6 text-center">
+        <a href="{% url 'configuracoes' %}" class="text-sm text-blue-600 hover:underline">{% trans "Voltar ao perfil de segurança" %}</a>
+      </footer>
+    </div>
+  </div>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- standardize templates to use hero include and card-based layout
- remove legacy `<main>` wrappers and manual `<h1>` headers
- unify spacing with `container` and responsive grid utilities

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'silk')*


------
https://chatgpt.com/codex/tasks/task_e_68bd84349cdc8325a890a127375cc7e5