### PR TITLE
feat: improve register templates

### DIFF
--- a/accounts/templates/register/cpf.html
+++ b/accounts/templates/register/cpf.html
@@ -4,24 +4,26 @@
 {% block title %}{% trans "Registro - CPF" %} | Hubx{% endblock %}
 
 {% block content %}
-<section class="max-w-md mx-auto px-4 py-12">
-  <div class="rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
+{% include 'components/nav_sidebar.html' %}
+{% include 'components/hero.html' %}
+<div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+  <div class="bg-white dark:bg-slate-800 p-6 rounded-lg shadow">
     <div class="mb-8">
       {% with step=4 total=8 %}
       <div class="mb-2 flex items-center justify-between">
         <span class="text-sm font-medium text-primary-600">{% blocktrans with step=step total=total %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
         {% widthratio step total 100 as progress %}
-        <span class="text-sm text-neutral-500">{{ progress }}%</span>
+        <span class="text-sm text-neutral-500 dark:text-neutral-400">{{ progress }}%</span>
       </div>
-      <div class="h-2 w-full rounded-xl bg-neutral-200">
+      <div class="h-2 w-full rounded-xl bg-neutral-200 dark:bg-slate-700">
         <div class="h-full rounded-xl bg-primary-600" style="width: {{ progress }}%;"></div>
       </div>
       {% endwith %}
     </div>
 
     <div class="mb-8 text-center">
-      <h1 class="mb-2 text-3xl font-bold text-neutral-900">{% trans "Qual seu CPF?" %}</h1>
-      <p class="text-neutral-600">{% trans "Precisamos para validar sua identidade e segurança" %}</p>
+      <h1 class="mb-2 text-3xl font-bold text-neutral-900 dark:text-neutral-100">{% trans "Qual seu CPF?" %}</h1>
+      <p class="text-neutral-600 dark:text-neutral-400">{% trans "Precisamos para validar sua identidade e segurança" %}</p>
     </div>
 
     {% if messages %}
@@ -41,26 +43,28 @@
             id="cpf"
             name="cpf"
             maxlength="14"
-            class="peer w-full rounded-lg border border-neutral-300 px-4 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500"
+            class="peer w-full rounded-lg border border-neutral-300 dark:border-slate-600 px-4 py-2 placeholder-transparent focus:outline-none focus:ring-2 focus:ring-primary-500 dark:bg-slate-700 dark:text-neutral-100"
             placeholder=" "
             required
             autofocus
+            aria-label="CPF"
+            aria-invalid="false"
             aria-describedby="cpf_help cpf_validation"
           />
           <label
             for="cpf"
-            class="absolute left-4 -top-2 text-xs text-neutral-700 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600"
+            class="absolute left-4 -top-2 text-xs text-neutral-700 dark:text-neutral-300 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600"
           >{% trans "CPF" %}</label>
         </div>
         <div class="text-sm text-red-600" id="cpf_validation"></div>
-        <small id="cpf_help" class="text-sm text-neutral-500">{% trans "Formato 000.000.000-00" %}</small>
+        <small id="cpf_help" class="text-sm text-neutral-500 dark:text-neutral-400">{% trans "Formato 000.000.000-00" %}</small>
       </div>
 
       <div class="flex gap-4">
-        <a href="{% url 'accounts:nome' %}" class="flex-1 rounded-xl border border-neutral-300 px-4 py-2 text-center text-neutral-700 hover:bg-neutral-100">{% trans "Voltar" %}</a>
+        <a href="{% url 'accounts:nome' %}" class="flex-1 rounded-xl border border-neutral-300 dark:border-slate-600 px-4 py-2 text-center text-neutral-700 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-slate-700">{% trans "Voltar" %}</a>
         <button type="submit" id="submitButton" class="flex-1 rounded-xl bg-primary-600 px-4 py-2 text-white hover:bg-primary-700">{% trans "Continuar" %}</button>
       </div>
     </form>
   </div>
-</section>
+</div>
 {% endblock %}

--- a/accounts/templates/register/email.html
+++ b/accounts/templates/register/email.html
@@ -4,24 +4,26 @@
 {% block title %}{% trans "Registro - Email" %} | Hubx{% endblock %}
 
 {% block content %}
-<section class="max-w-md mx-auto px-4 py-12">
-  <div class="rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
+{% include 'components/nav_sidebar.html' %}
+{% include 'components/hero.html' %}
+<div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+  <div class="bg-white dark:bg-slate-800 p-6 rounded-lg shadow">
     <div class="mb-8">
       {% with step=5 total=8 %}
       <div class="mb-2 flex items-center justify-between">
         <span class="text-sm font-medium text-primary-600">{% blocktrans with step=step total=total %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
         {% widthratio step total 100 as progress %}
-        <span class="text-sm text-neutral-500">{{ progress }}%</span>
+        <span class="text-sm text-neutral-500 dark:text-neutral-400">{{ progress }}%</span>
       </div>
-      <div class="h-2 w-full rounded-xl bg-neutral-200">
+      <div class="h-2 w-full rounded-xl bg-neutral-200 dark:bg-slate-700">
         <div class="h-full rounded-xl bg-primary-600" style="width: {{ progress }}%;"></div>
       </div>
       {% endwith %}
     </div>
 
     <div class="mb-8 text-center">
-      <h1 class="mb-2 text-3xl font-bold text-neutral-900">{% trans "Qual seu email?" %}</h1>
-      <p class="text-neutral-600">{% trans "Usaremos para comunicação e recuperação de conta" %}</p>
+      <h1 class="mb-2 text-3xl font-bold text-neutral-900 dark:text-neutral-100">{% trans "Qual seu email?" %}</h1>
+      <p class="text-neutral-600 dark:text-neutral-400">{% trans "Usaremos para comunicação e recuperação de conta" %}</p>
     </div>
 
     {% if messages %}
@@ -40,26 +42,28 @@
             type="email"
             id="email"
             name="email"
-            class="peer w-full rounded-lg border border-neutral-300 px-4 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500"
+            class="peer w-full rounded-lg border border-neutral-300 dark:border-slate-600 px-4 py-2 placeholder-transparent focus:outline-none focus:ring-2 focus:ring-primary-500 dark:bg-slate-700 dark:text-neutral-100"
             placeholder=" "
             required
             autofocus
+            aria-label="Email"
+            aria-invalid="false"
             aria-describedby="email_help email_validation"
           />
           <label
             for="email"
-            class="absolute left-4 -top-2 text-xs text-neutral-700 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600"
+            class="absolute left-4 -top-2 text-xs text-neutral-700 dark:text-neutral-300 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600"
           >{% trans "Email" %}</label>
         </div>
         <div class="text-sm text-red-600" id="email_validation"></div>
-        <small id="email_help" class="text-sm text-neutral-500">{% trans "Enviaremos um link de confirmação" %}</small>
+        <small id="email_help" class="text-sm text-neutral-500 dark:text-neutral-400">{% trans "Enviaremos um link de confirmação" %}</small>
       </div>
 
       <div class="flex gap-4">
-        <a href="{% url 'accounts:cpf' %}" class="flex-1 rounded-xl border border-neutral-300 px-4 py-2 text-center text-neutral-700 hover:bg-neutral-100">{% trans "Voltar" %}</a>
+        <a href="{% url 'accounts:cpf' %}" class="flex-1 rounded-xl border border-neutral-300 dark:border-slate-600 px-4 py-2 text-center text-neutral-700 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-slate-700">{% trans "Voltar" %}</a>
         <button type="submit" id="submitButton" class="flex-1 rounded-xl bg-primary-600 px-4 py-2 text-white hover:bg-primary-700">{% trans "Continuar" %}</button>
       </div>
     </form>
   </div>
-</section>
+</div>
 {% endblock %}

--- a/accounts/templates/register/foto.html
+++ b/accounts/templates/register/foto.html
@@ -4,24 +4,26 @@
 {% block title %}{% trans "Registro - Foto" %} | Hubx{% endblock %}
 
 {% block content %}
-<section class="max-w-md mx-auto px-4 py-12">
-  <div class="rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
+{% include 'components/nav_sidebar.html' %}
+{% include 'components/hero.html' %}
+<div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+  <div class="bg-white dark:bg-slate-800 p-6 rounded-lg shadow">
     <div class="mb-8">
       {% with step=7 total=8 %}
       <div class="mb-2 flex items-center justify-between">
         <span class="text-sm font-medium text-primary-600">{% blocktrans with step=step total=total %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
         {% widthratio step total 100 as progress %}
-        <span class="text-sm text-neutral-500">{{ progress }}%</span>
+        <span class="text-sm text-neutral-500 dark:text-neutral-400">{{ progress }}%</span>
       </div>
-      <div class="h-2 w-full rounded-xl bg-neutral-200">
+      <div class="h-2 w-full rounded-xl bg-neutral-200 dark:bg-slate-700">
         <div class="h-full rounded-xl bg-primary-600" style="width: {{ progress }}%;"></div>
       </div>
       {% endwith %}
     </div>
 
     <div class="mb-8 text-center">
-      <h1 class="mb-2 text-3xl font-bold text-neutral-900">{% trans "Adicione uma foto de perfil" %}</h1>
-      <p class="text-neutral-600">{% trans "Personalize sua presença na comunidade" %}</p>
+      <h1 class="mb-2 text-3xl font-bold text-neutral-900 dark:text-neutral-100">{% trans "Adicione uma foto de perfil" %}</h1>
+      <p class="text-neutral-600 dark:text-neutral-400">{% trans "Personalize sua presença na comunidade" %}</p>
     </div>
 
     {% if messages %}
@@ -41,23 +43,26 @@
             id="foto"
             name="foto"
             accept="image/*"
-            class="peer w-full rounded-lg border border-neutral-300 px-4 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500"
+            class="peer w-full rounded-lg border border-neutral-300 dark:border-slate-600 px-4 py-2 placeholder-transparent focus:outline-none focus:ring-2 focus:ring-primary-500 dark:bg-slate-700 dark:text-neutral-100"
             placeholder=" "
+            aria-label="Foto"
+            aria-invalid="false"
+            aria-describedby="foto_validation"
           />
           <label
             for="foto"
-            class="absolute left-4 -top-2 text-xs text-neutral-700 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600"
+            class="absolute left-4 -top-2 text-xs text-neutral-700 dark:text-neutral-300 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600"
           >{% trans "Escolher Foto" %}</label>
         </div>
         <div class="text-sm text-red-600" id="foto_validation"></div>
-        <small class="text-sm text-neutral-500">{% trans "Formatos aceitos: JPG, PNG. Tamanho máximo: 5MB" %}</small>
+        <small class="text-sm text-neutral-500 dark:text-neutral-400">{% trans "Formatos aceitos: JPG, PNG. Tamanho máximo: 5MB" %}</small>
       </div>
 
       <div class="flex gap-4">
-        <a href="{% url 'accounts:senha' %}" class="flex-1 rounded-xl border border-neutral-300 px-4 py-2 text-center text-neutral-700 hover:bg-neutral-100">{% trans "Voltar" %}</a>
+        <a href="{% url 'accounts:senha' %}" class="flex-1 rounded-xl border border-neutral-300 dark:border-slate-600 px-4 py-2 text-center text-neutral-700 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-slate-700">{% trans "Voltar" %}</a>
         <button type="submit" id="submitButton" class="flex-1 rounded-xl bg-primary-600 px-4 py-2 text-white hover:bg-primary-700">{% trans "Continuar" %}</button>
       </div>
     </form>
   </div>
-</section>
+</div>
 {% endblock %}

--- a/accounts/templates/register/nome.html
+++ b/accounts/templates/register/nome.html
@@ -4,24 +4,26 @@
 {% block title %}{% trans "Registro - Nome" %} | Hubx{% endblock %}
 
 {% block content %}
-<section class="max-w-md mx-auto px-4 py-12">
-  <div class="rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
+{% include 'components/nav_sidebar.html' %}
+{% include 'components/hero.html' %}
+<div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+  <div class="bg-white dark:bg-slate-800 p-6 rounded-lg shadow">
     <div class="mb-8">
       {% with step=3 total=8 %}
       <div class="mb-2 flex items-center justify-between">
         <span class="text-sm font-medium text-primary-600">{% blocktrans with step=step total=total %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
         {% widthratio step total 100 as progress %}
-        <span class="text-sm text-neutral-500">{{ progress }}%</span>
+        <span class="text-sm text-neutral-500 dark:text-neutral-400">{{ progress }}%</span>
       </div>
-      <div class="h-2 w-full rounded-xl bg-neutral-200">
+      <div class="h-2 w-full rounded-xl bg-neutral-200 dark:bg-slate-700">
         <div class="h-full rounded-xl bg-primary-600" style="width: {{ progress }}%;"></div>
       </div>
       {% endwith %}
     </div>
 
     <div class="mb-8 text-center">
-      <h1 class="mb-2 text-3xl font-bold text-neutral-900">{% trans "Como podemos te chamar?" %}</h1>
-      <p class="text-neutral-600">{% trans "Digite seu nome completo" %}</p>
+      <h1 class="mb-2 text-3xl font-bold text-neutral-900 dark:text-neutral-100">{% trans "Como podemos te chamar?" %}</h1>
+      <p class="text-neutral-600 dark:text-neutral-400">{% trans "Digite seu nome completo" %}</p>
     </div>
 
     {% if messages %}
@@ -40,24 +42,27 @@
             type="text"
             id="nome"
             name="nome"
-            class="peer w-full rounded-lg border border-neutral-300 px-4 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500"
+            class="peer w-full rounded-lg border border-neutral-300 dark:border-slate-600 px-4 py-2 placeholder-transparent focus:outline-none focus:ring-2 focus:ring-primary-500 dark:bg-slate-700 dark:text-neutral-100"
             placeholder=" "
             required
             autofocus
+            aria-label="Nome"
+            aria-invalid="false"
+            aria-describedby="nome_validation"
           />
           <label
             for="nome"
-            class="absolute left-4 -top-2 text-xs text-neutral-700 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600"
+            class="absolute left-4 -top-2 text-xs text-neutral-700 dark:text-neutral-300 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600"
           >{% trans "Nome Completo" %}</label>
         </div>
         <div class="text-sm text-red-600" id="nome_validation"></div>
       </div>
 
       <div class="flex gap-4">
-        <a href="{% url 'accounts:usuario' %}" class="flex-1 rounded-xl border border-neutral-300 px-4 py-2 text-center text-neutral-700 hover:bg-neutral-100">{% trans "Voltar" %}</a>
+        <a href="{% url 'accounts:usuario' %}" class="flex-1 rounded-xl border border-neutral-300 dark:border-slate-600 px-4 py-2 text-center text-neutral-700 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-slate-700">{% trans "Voltar" %}</a>
         <button type="submit" id="submitButton" class="flex-1 rounded-xl bg-primary-600 px-4 py-2 text-white hover:bg-primary-700">{% trans "Continuar" %}</button>
       </div>
     </form>
   </div>
-</section>
+</div>
 {% endblock %}

--- a/accounts/templates/register/onboarding.html
+++ b/accounts/templates/register/onboarding.html
@@ -4,8 +4,10 @@
 {% block title %}{% trans "Cadastre-se" %} - HubX{% endblock %}
 
 {% block content %}
-<div class="flex items-center justify-center min-h-screen">
-    <div class="max-w-md mx-auto p-6 rounded-2xl shadow bg-white text-center w-full">
+{% include 'components/nav_sidebar.html' %}
+{% include 'components/hero.html' %}
+<div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+  <div class="bg-white dark:bg-slate-800 p-6 rounded-lg shadow text-center">
         <div class="mb-8">
             <div class="w-20 h-20 bg-primary-100 rounded-full flex items-center justify-center mx-auto mb-4">
                 <svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="var(--primary-600)" stroke-width="2">
@@ -15,10 +17,10 @@
                     <path d="M16 3.13a4 4 0 0 1 0 7.75"/>
                 </svg>
             </div>
-            <h1 class="text-2xl font-bold mb-6 text-center">
+            <h1 class="text-2xl font-bold mb-6 text-center text-neutral-900 dark:text-neutral-100">
                 {% trans "Junte-se ao HubX" %}
             </h1>
-            <p class="text-neutral-600 mb-6">
+            <p class="text-neutral-600 dark:text-neutral-400 mb-6">
                 {% trans "Conecte-se com comunidades, empresas e organizações em uma única plataforma" %}
             </p>
         </div>
@@ -40,8 +42,8 @@
                         <line x1="12" y1="14" x2="12" y2="3"/>
                     </svg>
                 </div>
-                <h3 class="font-semibold text-neutral-900 mb-2">{% trans "Compartilhe" %}</h3>
-                <p class="text-sm text-neutral-600">
+                <h3 class="font-semibold text-neutral-900 dark:text-neutral-100 mb-2">{% trans "Compartilhe" %}</h3>
+                <p class="text-sm text-neutral-600 dark:text-neutral-400">
                     {% trans "Publique conteúdo e mantenha sua comunidade informada" %}
                 </p>
             </div>
@@ -54,8 +56,8 @@
                         <path d="M16 3.13a4 4 0 0 1 0 7.75"/>
                     </svg>
                 </div>
-                <h3 class="font-semibold text-neutral-900 mb-2">{% trans "Conecte" %}</h3>
-                <p class="text-sm text-neutral-600">
+                <h3 class="font-semibold text-neutral-900 dark:text-neutral-100 mb-2">{% trans "Conecte" %}</h3>
+                <p class="text-sm text-neutral-600 dark:text-neutral-400">
                     {% trans "Encontre e conecte-se com pessoas e organizações" %}
                 </p>
             </div>
@@ -68,8 +70,8 @@
                         <line x1="3" y1="10" x2="21" y2="10"/>
                     </svg>
                 </div>
-                <h3 class="font-semibold text-neutral-900 mb-2">{% trans "Organize" %}</h3>
-                <p class="text-sm text-neutral-600">
+                <h3 class="font-semibold text-neutral-900 dark:text-neutral-100 mb-2">{% trans "Organize" %}</h3>
+                <p class="text-sm text-neutral-600 dark:text-neutral-400">
                     {% trans "Crie e participe de eventos da sua comunidade" %}
                 </p>
             </div>
@@ -85,17 +87,16 @@
                 </svg>
                 {% trans "Começar Cadastro" %}
             </a>
-            <a href="{% url 'accounts:login' %}" class="bg-gray-100 text-neutral-700 font-semibold py-2 px-4 rounded-xl">
+            <a href="{% url 'accounts:login' %}" class="bg-gray-100 text-neutral-700 dark:bg-slate-700 dark:text-neutral-300 font-semibold py-2 px-4 rounded-xl">
                 {% trans "Já tenho conta" %}
             </a>
         </div>
 
-        <div class="mt-8 pt-6 border-t border-neutral-200">
-            <p class="text-xs text-neutral-500">
+        <div class="mt-8 pt-6 border-t border-neutral-200 dark:border-slate-700">
+            <p class="text-xs text-neutral-500 dark:text-neutral-400">
                 {% blocktrans trimmed %}Ao se cadastrar, você concorda com nossos <a href="#" class="text-primary-600 hover:text-primary-700">Termos de Uso</a> e <a href="#" class="text-primary-600 hover:text-primary-700">Política de Privacidade</a>{% endblocktrans %}
             </p>
-            </div>
         </div>
-    </div>
+  </div>
 </div>
 {% endblock %}

--- a/accounts/templates/register/registro_sucesso.html
+++ b/accounts/templates/register/registro_sucesso.html
@@ -4,8 +4,10 @@
 {% block title %}{% trans "Registro Concluído" %} | Hubx{% endblock %}
 
 {% block content %}
-<section class="max-w-md mx-auto px-4 py-12 text-center">
-  <div class="rounded-2xl border border-neutral-200 bg-white p-8 shadow-sm">
+{% include 'components/nav_sidebar.html' %}
+{% include 'components/hero.html' %}
+<div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+  <div class="bg-white dark:bg-slate-800 p-8 rounded-lg shadow text-center">
     {% if messages %}
     <div class="mb-4 space-y-2">
       {% for message in messages %}
@@ -13,12 +15,12 @@
       {% endfor %}
     </div>
     {% endif %}
-    <h1 class="mb-4 text-3xl font-bold text-neutral-900">{% trans "Bem-vindo ao HubX!" %}</h1>
-    <p class="mb-6 text-neutral-600">{% trans "Seu cadastro foi concluído. Verifique seu e-mail para ativar sua conta." %}</p>
+    <h1 class="mb-4 text-3xl font-bold text-neutral-900 dark:text-neutral-100">{% trans "Bem-vindo ao HubX!" %}</h1>
+    <p class="mb-6 text-neutral-600 dark:text-neutral-400">{% trans "Seu cadastro foi concluído. Verifique seu e-mail para ativar sua conta." %}</p>
     <a
       href="{% url 'accounts:login' %}"
       class="rounded-xl bg-primary-600 px-4 py-2 text-white hover:bg-primary-700"
     >{% trans "Ir para login" %}</a>
   </div>
-</section>
+</div>
 {% endblock %}

--- a/accounts/templates/register/senha.html
+++ b/accounts/templates/register/senha.html
@@ -4,24 +4,26 @@
 {% block title %}{% trans "Registro - Senha" %} | Hubx{% endblock %}
 
 {% block content %}
-<section class="max-w-md mx-auto px-4 py-12">
-  <div class="rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
+{% include 'components/nav_sidebar.html' %}
+{% include 'components/hero.html' %}
+<div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+  <div class="bg-white dark:bg-slate-800 p-6 rounded-lg shadow">
     <div class="mb-8">
       {% with step=6 total=8 %}
       <div class="mb-2 flex items-center justify-between">
         <span class="text-sm font-medium text-primary-600">{% blocktrans with step=step total=total %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
         {% widthratio step total 100 as progress %}
-        <span class="text-sm text-neutral-500">{{ progress }}%</span>
+        <span class="text-sm text-neutral-500 dark:text-neutral-400">{{ progress }}%</span>
       </div>
-      <div class="h-2 w-full rounded-xl bg-neutral-200">
+      <div class="h-2 w-full rounded-xl bg-neutral-200 dark:bg-slate-700">
         <div class="h-full rounded-xl bg-primary-600" style="width: {{ progress }}%;"></div>
       </div>
       {% endwith %}
     </div>
 
     <div class="mb-8 text-center">
-      <h1 class="mb-2 text-3xl font-bold text-neutral-900">{% trans "Crie uma senha segura" %}</h1>
-      <p class="text-neutral-600">{% trans "Proteja sua conta com uma senha forte" %}</p>
+      <h1 class="mb-2 text-3xl font-bold text-neutral-900 dark:text-neutral-100">{% trans "Crie uma senha segura" %}</h1>
+      <p class="text-neutral-600 dark:text-neutral-400">{% trans "Proteja sua conta com uma senha forte" %}</p>
     </div>
 
     {% if messages %}
@@ -40,19 +42,21 @@
             type="password"
             id="senha"
             name="senha"
-            class="peer w-full rounded-lg border border-neutral-300 px-4 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500"
+            class="peer w-full rounded-lg border border-neutral-300 dark:border-slate-600 px-4 py-2 placeholder-transparent focus:outline-none focus:ring-2 focus:ring-primary-500 dark:bg-slate-700 dark:text-neutral-100"
             placeholder=" "
             required
             autofocus
+            aria-label="Senha"
+            aria-invalid="false"
             aria-describedby="senha_help senha_validation"
           />
           <label
             for="senha"
-            class="absolute left-4 -top-2 text-xs text-neutral-700 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600"
+            class="absolute left-4 -top-2 text-xs text-neutral-700 dark:text-neutral-300 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600"
           >{% trans "Senha" %}</label>
         </div>
         <div class="text-sm text-red-600" id="senha_validation"></div>
-        <small id="senha_help" class="text-sm text-neutral-500">{% trans "Use ao menos 8 caracteres com letras e números" %}</small>
+        <small id="senha_help" class="text-sm text-neutral-500 dark:text-neutral-400">{% trans "Use ao menos 8 caracteres com letras e números" %}</small>
       </div>
 
       <div>
@@ -61,25 +65,27 @@
             type="password"
             id="confirmar_senha"
             name="confirmar_senha"
-            class="peer w-full rounded-lg border border-neutral-300 px-4 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500"
+            class="peer w-full rounded-lg border border-neutral-300 dark:border-slate-600 px-4 py-2 placeholder-transparent focus:outline-none focus:ring-2 focus:ring-primary-500 dark:bg-slate-700 dark:text-neutral-100"
             placeholder=" "
             required
+            aria-label="Confirmar senha"
+            aria-invalid="false"
             aria-describedby="confirmar_senha_help confirmar_senha_validation"
           />
           <label
             for="confirmar_senha"
-            class="absolute left-4 -top-2 text-xs text-neutral-700 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600"
+            class="absolute left-4 -top-2 text-xs text-neutral-700 dark:text-neutral-300 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600"
           >{% trans "Confirmar Senha" %}</label>
         </div>
         <div class="text-sm text-red-600" id="confirmar_senha_validation"></div>
-        <small id="confirmar_senha_help" class="text-sm text-neutral-500">{% trans "Repita a senha para confirmação" %}</small>
+        <small id="confirmar_senha_help" class="text-sm text-neutral-500 dark:text-neutral-400">{% trans "Repita a senha para confirmação" %}</small>
       </div>
 
       <div class="flex gap-4">
-        <a href="{% url 'accounts:email' %}" class="flex-1 rounded-xl border border-neutral-300 px-4 py-2 text-center text-neutral-700 hover:bg-neutral-100">{% trans "Voltar" %}</a>
+        <a href="{% url 'accounts:email' %}" class="flex-1 rounded-xl border border-neutral-300 dark:border-slate-600 px-4 py-2 text-center text-neutral-700 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-slate-700">{% trans "Voltar" %}</a>
         <button type="submit" id="submitButton" class="flex-1 rounded-xl bg-primary-600 px-4 py-2 text-white hover:bg-primary-700">{% trans "Continuar" %}</button>
       </div>
     </form>
   </div>
-</section>
+</div>
 {% endblock %}

--- a/accounts/templates/register/termos.html
+++ b/accounts/templates/register/termos.html
@@ -4,24 +4,26 @@
 {% block title %}{% trans "Registro - Termos" %} | Hubx{% endblock %}
 
 {% block content %}
-<section class="max-w-md mx-auto px-4 py-12">
-  <div class="rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
+{% include 'components/nav_sidebar.html' %}
+{% include 'components/hero.html' %}
+<div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+  <div class="bg-white dark:bg-slate-800 p-6 rounded-lg shadow">
     <div class="mb-8">
       {% with step=8 total=8 %}
       <div class="mb-2 flex items-center justify-between">
         <span class="text-sm font-medium text-primary-600">{% blocktrans with step=step total=total %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
         {% widthratio step total 100 as progress %}
-        <span class="text-sm text-neutral-500">{{ progress }}%</span>
+        <span class="text-sm text-neutral-500 dark:text-neutral-400">{{ progress }}%</span>
       </div>
-      <div class="h-2 w-full rounded-xl bg-neutral-200">
+      <div class="h-2 w-full rounded-xl bg-neutral-200 dark:bg-slate-700">
         <div class="h-full rounded-xl bg-primary-600" style="width: {{ progress }}%;"></div>
       </div>
       {% endwith %}
     </div>
 
     <div class="mb-8 text-center">
-      <h1 class="mb-2 text-3xl font-bold text-neutral-900">{% trans "Quase lá!" %}</h1>
-      <p class="text-neutral-600">{% trans "Revise e aceite os termos para finalizar" %}</p>
+      <h1 class="mb-2 text-3xl font-bold text-neutral-900 dark:text-neutral-100">{% trans "Quase lá!" %}</h1>
+      <p class="text-neutral-600 dark:text-neutral-400">{% trans "Revise e aceite os termos para finalizar" %}</p>
     </div>
 
     {% if messages %}
@@ -34,7 +36,7 @@
 
     <form id="termosForm" method="post" action="{% url 'accounts:termos' %}" class="space-y-6">
       {% csrf_token %}
-      <div class="space-y-4 max-h-64 overflow-y-auto p-4 border border-neutral-200 rounded-lg">
+      <div class="space-y-4 max-h-64 overflow-y-auto p-4 border border-neutral-200 dark:border-slate-700 rounded-lg">
         <h3 class="font-semibold">{% trans "Termos de Uso e Política de Privacidade" %}</h3>
         <p>{% trans "Ao utilizar o HubX, você concorda com nossos termos de uso e política de privacidade. Abaixo estão os principais pontos:" %}</p>
         <h4 class="font-medium">{% trans "1. Uso da Plataforma" %}</h4>
@@ -48,20 +50,20 @@
       </div>
 
       <div class="flex items-start gap-2">
-        <input type="checkbox" id="aceitar_termos" name="aceitar_termos" class="mt-1 rounded border-neutral-300 text-primary-600 focus:ring-primary-500" required>
-        <label for="aceitar_termos" class="text-sm text-neutral-700">{% blocktrans trimmed %}Eu li e concordo com os <a href="/termos/" class="text-primary-600 hover:text-primary-700" target="_blank">Termos de Uso</a> e <a href="/privacidade/" class="text-primary-600 hover:text-primary-700" target="_blank">Política de Privacidade</a>{% endblocktrans %}</label>
+        <input type="checkbox" id="aceitar_termos" name="aceitar_termos" class="mt-1 rounded border-neutral-300 dark:border-slate-600 text-primary-600 focus:ring-primary-500" required aria-label="Aceitar termos" aria-invalid="false" aria-describedby="aceitar_termos_desc">
+        <label for="aceitar_termos" class="text-sm text-neutral-700 dark:text-neutral-300" id="aceitar_termos_desc">{% blocktrans trimmed %}Eu li e concordo com os <a href="/termos/" class="text-primary-600 hover:text-primary-700" target="_blank">Termos de Uso</a> e <a href="/privacidade/" class="text-primary-600 hover:text-primary-700" target="_blank">Política de Privacidade</a>{% endblocktrans %}</label>
       </div>
 
       <div class="flex items-start gap-2">
-        <input type="checkbox" id="newsletter" name="newsletter" class="mt-1 rounded border-neutral-300 text-primary-600 focus:ring-primary-500">
-        <label for="newsletter" class="text-sm text-neutral-700">{% trans "Quero receber atualizações e novidades do HubX" %}</label>
+        <input type="checkbox" id="newsletter" name="newsletter" class="mt-1 rounded border-neutral-300 dark:border-slate-600 text-primary-600 focus:ring-primary-500" aria-label="Receber novidades" aria-invalid="false" aria-describedby="newsletter_desc">
+        <label for="newsletter" class="text-sm text-neutral-700 dark:text-neutral-300" id="newsletter_desc">{% trans "Quero receber atualizações e novidades do HubX" %}</label>
       </div>
 
       <div class="flex gap-4">
-        <a href="{% url 'accounts:foto' %}" class="flex-1 rounded-xl border border-neutral-300 px-4 py-2 text-center text-neutral-700 hover:bg-neutral-100">{% trans "Voltar" %}</a>
+        <a href="{% url 'accounts:foto' %}" class="flex-1 rounded-xl border border-neutral-300 dark:border-slate-600 px-4 py-2 text-center text-neutral-700 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-slate-700">{% trans "Voltar" %}</a>
         <button type="submit" id="submitButton" class="flex-1 rounded-xl bg-primary-600 px-4 py-2 text-white hover:bg-primary-700">{% trans "Finalizar Cadastro" %}</button>
       </div>
     </form>
   </div>
-</section>
+</div>
 {% endblock %}

--- a/accounts/templates/register/token.html
+++ b/accounts/templates/register/token.html
@@ -4,16 +4,18 @@
 {% block title %}{% trans "Token de Convite" %} - HubX{% endblock %}
 
 {% block content %}
-<section class="max-w-md mx-auto px-4 py-12">
-  <div class="rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
+{% include 'components/nav_sidebar.html' %}
+{% include 'components/hero.html' %}
+<div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+  <div class="bg-white dark:bg-slate-800 p-6 rounded-lg shadow">
     <div class="mb-8">
       {% with step=1 total=8 %}
       <div class="mb-2 flex items-center justify-between">
         <span class="text-sm font-medium text-primary-600">{% blocktrans with step=step total=total %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
         {% widthratio step total 100 as progress %}
-        <span class="text-sm text-neutral-500">{{ progress }}%</span>
+        <span class="text-sm text-neutral-500 dark:text-neutral-400">{{ progress }}%</span>
       </div>
-      <div class="h-2 w-full rounded-xl bg-neutral-200">
+      <div class="h-2 w-full rounded-xl bg-neutral-200 dark:bg-slate-700">
         <div class="h-full rounded-xl bg-primary-600" style="width: {{ progress }}%;"></div>
       </div>
       {% endwith %}
@@ -27,8 +29,8 @@
           <path d="M7 11V7a5 5 0 0 1 10 0v4"/>
         </svg>
       </div>
-      <h1 class="mb-2 text-3xl font-bold text-neutral-900">{% trans "Token de Convite" %}</h1>
-      <p class="text-neutral-600">{% trans "Digite seu token de convite para começar o cadastro" %}</p>
+      <h1 class="mb-2 text-3xl font-bold text-neutral-900 dark:text-neutral-100">{% trans "Token de Convite" %}</h1>
+      <p class="text-neutral-600 dark:text-neutral-400">{% trans "Digite seu token de convite para começar o cadastro" %}</p>
     </div>
 
     {% if messages %}
@@ -47,31 +49,34 @@
             type="text"
             id="token"
             name="token"
-            class="peer w-full rounded-lg border border-neutral-300 px-4 py-2 text-center font-mono tracking-widest focus:outline-none focus:ring-2 focus:ring-primary-500"
+            class="peer w-full rounded-lg border border-neutral-300 dark:border-slate-600 px-4 py-2 placeholder-transparent text-center font-mono tracking-widest focus:outline-none focus:ring-2 focus:ring-primary-500 dark:bg-slate-700 dark:text-neutral-100"
             placeholder=" "
             required
             autofocus
+            aria-label="Token"
+            aria-invalid="false"
+            aria-describedby="token_help"
           />
           <label
             for="token"
-            class="absolute left-4 -top-2 text-xs text-neutral-700 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600"
+            class="absolute left-4 -top-2 text-xs text-neutral-700 dark:text-neutral-300 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600"
           >{% trans "Token de Convite" %}</label>
         </div>
-        <p class="mt-1 text-sm text-neutral-500">{% trans "O token é necessário para continuar o cadastro na plataforma" %}</p>
+        <p id="token_help" class="mt-1 text-sm text-neutral-500 dark:text-neutral-400">{% trans "O token é necessário para continuar o cadastro na plataforma" %}</p>
       </div>
 
       <div class="flex gap-4">
-        <a href="{% url 'accounts:login' %}" class="flex-1 rounded-xl border border-neutral-300 px-4 py-2 text-center text-neutral-700 hover:bg-neutral-100">{% trans "Voltar" %}</a>
+        <a href="{% url 'accounts:login' %}" class="flex-1 rounded-xl border border-neutral-300 dark:border-slate-600 px-4 py-2 text-center text-neutral-700 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-slate-700">{% trans "Voltar" %}</a>
         <button type="submit" class="flex-1 rounded-xl bg-primary-600 px-4 py-2 text-white hover:bg-primary-700">{% trans "Continuar" %}</button>
       </div>
     </form>
 
     <div class="mt-8 text-center">
-      <p class="text-sm text-neutral-600">
+      <p class="text-sm text-neutral-600 dark:text-neutral-400">
         {% trans "Já tem uma conta?" %}
         <a href="{% url 'accounts:login' %}" class="font-medium text-primary-600 hover:text-primary-700">{% trans "Entrar" %}</a>
       </p>
     </div>
   </div>
-</section>
+</div>
 {% endblock %}

--- a/accounts/templates/register/usuario.html
+++ b/accounts/templates/register/usuario.html
@@ -4,24 +4,26 @@
 {% block title %}{% trans "Registro - Usuário" %} | Hubx{% endblock %}
 
 {% block content %}
-<section class="max-w-md mx-auto px-4 py-12">
-  <div class="rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
+{% include 'components/nav_sidebar.html' %}
+{% include 'components/hero.html' %}
+<div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+  <div class="bg-white dark:bg-slate-800 p-6 rounded-lg shadow">
     <div class="mb-8">
       {% with step=2 total=8 %}
       <div class="mb-2 flex items-center justify-between">
         <span class="text-sm font-medium text-primary-600">{% blocktrans with step=step total=total %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
         {% widthratio step total 100 as progress %}
-        <span class="text-sm text-neutral-500">{{ progress }}%</span>
+        <span class="text-sm text-neutral-500 dark:text-neutral-400">{{ progress }}%</span>
       </div>
-      <div class="h-2 w-full rounded-xl bg-neutral-200">
+      <div class="h-2 w-full rounded-xl bg-neutral-200 dark:bg-slate-700">
         <div class="h-full rounded-xl bg-primary-600" style="width: {{ progress }}%;"></div>
       </div>
       {% endwith %}
     </div>
 
     <div class="mb-8 text-center">
-      <h1 class="mb-2 text-3xl font-bold text-neutral-900">{% trans "Escolha seu nome de usuário" %}</h1>
-      <p class="text-neutral-600">{% trans "Como você será identificado na plataforma" %}</p>
+      <h1 class="mb-2 text-3xl font-bold text-neutral-900 dark:text-neutral-100">{% trans "Escolha seu nome de usuário" %}</h1>
+      <p class="text-neutral-600 dark:text-neutral-400">{% trans "Como você será identificado na plataforma" %}</p>
     </div>
 
     {% if messages %}
@@ -44,26 +46,28 @@
             type="text"
             id="usuario"
             name="usuario"
-            class="peer w-full rounded-lg border border-neutral-300 px-4 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500"
+            class="peer w-full rounded-lg border border-neutral-300 dark:border-slate-600 px-4 py-2 placeholder-transparent focus:outline-none focus:ring-2 focus:ring-primary-500 dark:bg-slate-700 dark:text-neutral-100"
             placeholder=" "
             required
             autofocus
+            aria-label="Usuário"
+            aria-invalid="false"
             aria-describedby="usuario_help usuario_validation"
           />
           <label
             for="usuario"
-            class="absolute left-4 -top-2 text-xs text-neutral-700 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600"
+            class="absolute left-4 -top-2 text-xs text-neutral-700 dark:text-neutral-300 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600"
           >{% trans "Nome de Usuário" %}</label>
         </div>
         <div class="text-sm text-red-600" id="usuario_validation"></div>
-        <small id="usuario_help" class="text-sm text-neutral-500">{% trans "Use apenas letras, números e underscore (_)" %}</small>
+        <small id="usuario_help" class="text-sm text-neutral-500 dark:text-neutral-400">{% trans "Use apenas letras, números e underscore (_)" %}</small>
       </div>
 
       <div class="flex gap-4">
-        <a href="{% url 'tokens:token' %}" class="flex-1 rounded-xl border border-neutral-300 px-4 py-2 text-center text-neutral-700 hover:bg-neutral-100">{% trans "Voltar" %}</a>
+        <a href="{% url 'tokens:token' %}" class="flex-1 rounded-xl border border-neutral-300 dark:border-slate-600 px-4 py-2 text-center text-neutral-700 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-slate-700">{% trans "Voltar" %}</a>
         <button type="submit" id="submitButton" class="flex-1 rounded-xl bg-primary-600 px-4 py-2 text-white hover:bg-primary-700">{% trans "Continuar" %}</button>
       </div>
     </form>
   </div>
-</section>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- include navigation and hero components in registration templates
- add responsive grid layout with dark-themed cards
- enhance form inputs with floating labels and accessibility attrs

## Testing
- `pytest -m "not slow"` *(fails: ModuleNotFoundError: No module named 'factory'; KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68bdceadd4248325b3d274c1b165a6e4