### PR TITLE
feat: improve accessibility in account templates

### DIFF
--- a/accounts/templates/account_inactive.html
+++ b/accounts/templates/account_inactive.html
@@ -4,13 +4,13 @@
 {% block title %}{% trans "Conta inativa" %} | Hubx{% endblock %}
 
 {% block content %}
-<section class="max-w-md mx-auto px-4 py-12 text-center">
-  <div class="rounded-2xl border border-neutral-200 bg-white p-8 shadow-sm">
-    <h1 class="mb-4 text-3xl font-bold text-neutral-900">{% trans "Conta inativa" %}</h1>
-    <p class="mb-6 text-neutral-600">{% trans "Sua conta ainda não foi ativada. Verifique seu e-mail para continuar." %}</p>
+<section class="max-w-md mx-auto px-4 py-12 text-center bg-white dark:bg-neutral-900">
+  <div class="rounded-2xl border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800 p-8 shadow-sm">
+    <h1 class="mb-4 text-3xl font-bold text-neutral-900 dark:text-neutral-100">{% trans "Conta inativa" %}</h1>
+    <p class="mb-6 text-neutral-600 dark:text-neutral-400">{% trans "Sua conta ainda não foi ativada. Verifique seu e-mail para continuar." %}</p>
     <a
       href="{% url 'accounts:login' %}"
-      class="rounded-xl bg-primary-600 px-4 py-2 text-white hover:bg-primary-700"
+      class="rounded-xl bg-primary-600 hover:bg-primary-700 text-white dark:bg-primary-700 dark:hover:bg-primary-600 px-4 py-2"
     >{% trans "Ir para login" %}</a>
   </div>
 </section>

--- a/accounts/templates/accounts/cancel_delete.html
+++ b/accounts/templates/accounts/cancel_delete.html
@@ -2,13 +2,13 @@
 {% load i18n %}
 {% block title %}{% trans "Cancelar exclusão" %} - HubX{% endblock %}
 {% block content %}
-<section class="max-w-md mx-auto px-4 py-12">
+<section class="max-w-md mx-auto px-4 py-12 bg-white dark:bg-neutral-900">
   {% if status == 'sucesso' %}
-    <div class="bg-green-100 text-green-700 rounded-xl px-4 py-3 text-center">
+    <div class="bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-300 rounded-xl px-4 py-3 text-center">
       {% trans "Sua conta foi reativada." %}
     </div>
   {% else %}
-    <div class="bg-red-100 text-red-700 rounded-xl px-4 py-3 text-center">
+    <div class="bg-red-100 dark:bg-red-900 text-red-700 dark:text-red-300 rounded-xl px-4 py-3 text-center">
       {% trans "Link inválido ou expirado." %}
     </div>
   {% endif %}

--- a/accounts/templates/accounts/delete_account_confirm.html
+++ b/accounts/templates/accounts/delete_account_confirm.html
@@ -2,27 +2,30 @@
 {% load i18n %}
 {% block title %}{% trans "Excluir Conta" %} - HubX{% endblock %}
 {% block content %}
-<section class="max-w-md mx-auto px-4 py-12">
-  <h1 class="text-2xl font-bold text-center mb-6">{% trans "Excluir Conta" %}</h1>
-  <p class="text-red-700 bg-red-100 rounded-xl px-4 py-2 mb-4 text-sm">
+<section class="max-w-md mx-auto px-4 py-12 bg-white dark:bg-neutral-900">
+  <h1 class="text-2xl font-bold text-center mb-6 text-neutral-900 dark:text-neutral-100">{% trans "Excluir Conta" %}</h1>
+  <p class="text-red-700 dark:text-red-300 bg-red-100 dark:bg-red-900 rounded-xl px-4 py-2 mb-4 text-sm">
     {% trans "A exclusão da conta é permanente e você perderá acesso aos seus dados." %}
   </p>
-  <form method="post" class="bg-white rounded-2xl shadow p-6 space-y-4">
+  <form method="post" class="bg-white dark:bg-neutral-800 rounded-2xl shadow p-6 space-y-4">
     {% csrf_token %}
     <div>
-      <label for="confirm" class="block text-sm font-medium text-neutral-700">{% trans "Digite EXCLUIR para confirmar" %}</label>
+      <label for="confirm" class="block text-sm font-medium text-neutral-700 dark:text-neutral-300">{% trans "Digite EXCLUIR para confirmar" %}</label>
       <input
         type="text"
         name="confirm"
         id="confirm"
         required
-        class="w-full rounded-md border border-neutral-300 px-3 py-2"
+        class="w-full rounded-md border border-neutral-300 dark:border-neutral-600 dark:bg-neutral-700 dark:text-neutral-100 px-3 py-2"
+        placeholder="EXCLUIR"
+        aria-label="{% trans 'Confirmação' %}"
+        aria-invalid="false"
       />
     </div>
     <div class="text-right">
       <button
         type="submit"
-        class="rounded-xl bg-red-600 px-4 py-2 text-white hover:bg-red-700"
+        class="rounded-xl bg-red-600 hover:bg-red-700 px-4 py-2 text-white"
       >
         {% trans "Confirmar exclusão" %}
       </button>

--- a/accounts/templates/accounts/email_confirm.html
+++ b/accounts/templates/accounts/email_confirm.html
@@ -2,13 +2,13 @@
 {% load i18n %}
 {% block title %}{% trans "Confirmação de Email" %} - HubX{% endblock %}
 {% block content %}
-<section class="max-w-md mx-auto px-4 py-12">
+<section class="max-w-md mx-auto px-4 py-12 bg-white dark:bg-neutral-900">
   {% if status == 'sucesso' %}
-    <div class="bg-green-100 text-green-700 rounded-xl px-4 py-3 text-center">
+    <div class="bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-300 rounded-xl px-4 py-3 text-center">
       {% trans "Seu e-mail foi confirmado com sucesso." %}
     </div>
   {% else %}
-    <div class="bg-red-100 text-red-700 rounded-xl px-4 py-3 text-center">
+    <div class="bg-red-100 dark:bg-red-900 text-red-700 dark:text-red-300 rounded-xl px-4 py-3 text-center">
       {% trans "Link inválido ou expirado." %}
     </div>
   {% endif %}

--- a/accounts/templates/accounts/password_reset.html
+++ b/accounts/templates/accounts/password_reset.html
@@ -2,17 +2,18 @@
 {% load i18n %}
 {% block title %}{% trans "Recuperar Senha" %} - HubX{% endblock %}
 {% block content %}
-<div class="flex items-center justify-center min-h-screen">
-    <div class="max-w-md mx-auto p-6 rounded-2xl shadow bg-white w-full">
-        <h1 class="text-2xl font-bold mb-6 text-center">{% trans "Recuperar Senha" %}</h1>
-        <p class="text-center text-neutral-600 mb-4">{% trans "Informe o e-mail cadastrado para receber instruções." %}</p>
+<div class="flex items-center justify-center min-h-screen bg-white dark:bg-neutral-900">
+    <div class="max-w-md mx-auto p-6 rounded-2xl shadow bg-white dark:bg-neutral-800 w-full">
+        <h1 class="text-2xl font-bold mb-6 text-center text-neutral-900 dark:text-neutral-100">{% trans "Recuperar Senha" %}</h1>
+        <p class="text-center text-neutral-600 dark:text-neutral-400 mb-4">{% trans "Informe o e-mail cadastrado para receber instruções." %}</p>
         <form method="post" class="space-y-4">
             {% csrf_token %}
             <div>
-                <label for="id_email" class="block mb-1 font-medium">{% trans "E-mail" %}</label>
-                <input type="email" name="email" id="id_email" required class="w-full p-3 border rounded-md focus:ring-2 focus:ring-primary">
+                <label for="id_email" class="block mb-1 font-medium text-neutral-700 dark:text-neutral-300">{% trans "E-mail" %}</label>
+                <input type="email" name="email" id="id_email" required class="w-full p-3 border rounded-md focus:ring-2 focus:ring-primary dark:bg-neutral-700 dark:border-neutral-600 dark:text-neutral-100" placeholder="{% trans 'Seu e-mail' %}" aria-label="{% trans 'E-mail' %}" aria-invalid="false" aria-describedby="email_help">
+                <small id="email_help" class="text-sm text-neutral-500 dark:text-neutral-400">{% trans "Digite o e-mail utilizado no cadastro" %}</small>
             </div>
-            <button type="submit" class="bg-primary text-white font-semibold py-2 px-4 rounded-xl w-full">{% trans "Enviar" %}</button>
+            <button type="submit" class="bg-primary dark:bg-primary text-white font-semibold py-2 px-4 rounded-xl w-full">{% trans "Enviar" %}</button>
         </form>
     </div>
 </div>

--- a/accounts/templates/accounts/password_reset_confirm.html
+++ b/accounts/templates/accounts/password_reset_confirm.html
@@ -2,34 +2,42 @@
 {% load i18n %}
 {% block title %}{% trans "Definir Nova Senha" %} - HubX{% endblock %}
 {% block content %}
-<div class="flex items-center justify-center min-h-screen">
-    <div class="max-w-md mx-auto p-6 rounded-2xl shadow bg-white w-full">
-        <h1 class="text-2xl font-bold mb-6 text-center">{% trans "Definir Nova Senha" %}</h1>
+<div class="flex items-center justify-center min-h-screen bg-white dark:bg-neutral-900">
+    <div class="max-w-md mx-auto p-6 rounded-2xl shadow bg-white dark:bg-neutral-800 w-full">
+        <h1 class="text-2xl font-bold mb-6 text-center text-neutral-900 dark:text-neutral-100">{% trans "Definir Nova Senha" %}</h1>
         <form method="post" class="space-y-4">
             {% csrf_token %}
             <div>
-                <label for="{{ form.new_password1.id_for_label }}" class="block mb-1 font-medium">{{ form.new_password1.label }}</label>
+                <label for="{{ form.new_password1.id_for_label }}" class="block mb-1 font-medium text-neutral-700 dark:text-neutral-300">{{ form.new_password1.label }}</label>
                 <input type="password"
                        name="{{ form.new_password1.html_name }}"
                        id="{{ form.new_password1.id_for_label }}"
-                       class="w-full p-3 border rounded-md focus:ring-2 focus:ring-primary"
+                       class="w-full p-3 border rounded-md focus:ring-2 focus:ring-primary dark:bg-neutral-700 dark:border-neutral-600 dark:text-neutral-100"
+                       placeholder="{% trans 'Nova senha' %}"
+                       aria-label="{{ form.new_password1.label }}"
+                       aria-describedby="{{ form.new_password1.id_for_label }}_error"
+                       {% if form.new_password1.errors %}aria-invalid="true"{% else %}aria-invalid="false"{% endif %}
                        required />
                 {% if form.new_password1.errors %}
-                    <div class="text-red-600 text-sm">{{ form.new_password1.errors }}</div>
+                    <div id="{{ form.new_password1.id_for_label }}_error" class="text-red-600 text-sm" role="alert">{{ form.new_password1.errors }}</div>
                 {% endif %}
             </div>
             <div>
-                <label for="{{ form.new_password2.id_for_label }}" class="block mb-1 font-medium">{{ form.new_password2.label }}</label>
+                <label for="{{ form.new_password2.id_for_label }}" class="block mb-1 font-medium text-neutral-700 dark:text-neutral-300">{{ form.new_password2.label }}</label>
                 <input type="password"
                        name="{{ form.new_password2.html_name }}"
                        id="{{ form.new_password2.id_for_label }}"
-                       class="w-full p-3 border rounded-md focus:ring-2 focus:ring-primary"
+                       class="w-full p-3 border rounded-md focus:ring-2 focus:ring-primary dark:bg-neutral-700 dark:border-neutral-600 dark:text-neutral-100"
+                       placeholder="{% trans 'Confirme a senha' %}"
+                       aria-label="{{ form.new_password2.label }}"
+                       aria-describedby="{{ form.new_password2.id_for_label }}_error"
+                       {% if form.new_password2.errors %}aria-invalid="true"{% else %}aria-invalid="false"{% endif %}
                        required />
                 {% if form.new_password2.errors %}
-                    <div class="text-red-600 text-sm">{{ form.new_password2.errors }}</div>
+                    <div id="{{ form.new_password2.id_for_label }}_error" class="text-red-600 text-sm" role="alert">{{ form.new_password2.errors }}</div>
                 {% endif %}
             </div>
-            <button type="submit" class="bg-primary text-white font-semibold py-2 px-4 rounded-xl w-full">{% trans "Alterar Senha" %}</button>
+            <button type="submit" class="bg-primary dark:bg-primary text-white font-semibold py-2 px-4 rounded-xl w-full">{% trans "Alterar Senha" %}</button>
         </form>
     </div>
 </div>

--- a/accounts/templates/accounts/resend_confirmation.html
+++ b/accounts/templates/accounts/resend_confirmation.html
@@ -2,13 +2,14 @@
 {% load i18n %}
 {% block title %}{% trans "Reenviar confirmação" %}{% endblock %}
 {% block content %}
-<section class="max-w-md mx-auto px-4 py-12 text-center">
-  <div class="rounded-2xl border border-neutral-200 bg-white p-8 shadow-sm">
-    <h1 class="mb-4 text-2xl font-bold text-neutral-900">{% trans "Reenviar confirmação" %}</h1>
+<section class="max-w-md mx-auto px-4 py-12 text-center bg-white dark:bg-neutral-900">
+  <div class="rounded-2xl border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800 p-8 shadow-sm">
+    <h1 class="mb-4 text-2xl font-bold text-neutral-900 dark:text-neutral-100">{% trans "Reenviar confirmação" %}</h1>
     <form method="post" class="space-y-4">
       {% csrf_token %}
-      <input type="email" name="email" required class="w-full p-3 border border-gray-300 rounded-lg" placeholder="{% trans 'Seu e-mail' %}">
-      <button type="submit" class="w-full bg-primary text-white py-2 rounded-lg">{% trans "Enviar" %}</button>
+      <input type="email" name="email" required class="w-full p-3 border border-gray-300 dark:border-neutral-600 dark:bg-neutral-700 dark:text-neutral-100 rounded-lg" placeholder="{% trans 'Seu e-mail' %}" aria-label="{% trans 'E-mail' %}" aria-invalid="false" aria-describedby="email_info">
+      <small id="email_info" class="text-sm text-neutral-500 dark:text-neutral-400">{% trans "Informe o e-mail cadastrado" %}</small>
+      <button type="submit" class="w-full bg-primary dark:bg-primary text-white py-2 rounded-lg">{% trans "Enviar" %}</button>
     </form>
   </div>
 </section>

--- a/accounts/templates/login/login.html
+++ b/accounts/templates/login/login.html
@@ -9,7 +9,7 @@
 <div class="bg-muted min-h-screen flex items-center justify-center px-4">
   <div class="card max-w-md w-full mx-auto" role="dialog">
     <div class="card-body">
-      <p class="text-center text-sm text-gray-600 mb-6">
+      <p class="text-center text-sm text-gray-600 dark:text-gray-300 mb-6">
         {% trans "Entre para acessar sua conta e conectar-se à sua rede" %}
       </p>
 
@@ -25,12 +25,13 @@
                  value="{{ form.email.value|default_if_none:'' }}"
                  autocomplete="email"
                  class="peer w-full p-3 border border-gray-300 rounded-lg text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
-                 placeholder=" "
+                 placeholder="{% trans 'Email' %}"
                  required
+                 aria-label="{% trans 'Email' %}"
                  aria-describedby="email-error"
-                 {% if form.email.errors %}aria-invalid="true"{% endif %}>
+                 {% if form.email.errors %}aria-invalid="true"{% else %}aria-invalid="false"{% endif %}>
           <label for="id_email"
-                 class="absolute left-3 -top-2 text-xs text-gray-700 transition-all peer-placeholder-shown:top-3 peer-placeholder-shown:text-sm peer-placeholder-shown:text-gray-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary">{% trans "Email" %}</label>
+                 class="absolute left-3 -top-2 text-xs text-gray-700 dark:text-gray-300 transition-all peer-placeholder-shown:top-3 peer-placeholder-shown:text-sm peer-placeholder-shown:text-gray-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary">{% trans "Email" %}</label>
         </div>
         {% if form.email.errors %}
           <div id="email-error" class="text-red-600 text-xs mt-1" role="alert">{{ form.email.errors }}</div>
@@ -41,12 +42,13 @@
           <input type="password" id="id_password" name="password"
                  autocomplete="current-password"
                  class="peer w-full p-3 border border-gray-300 rounded-lg text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
-                 placeholder=" "
+                 placeholder="{% trans 'Senha' %}"
                  required
+                 aria-label="{% trans 'Senha' %}"
                  aria-describedby="password-error"
-                 {% if form.password.errors %}aria-invalid="true"{% endif %}>
+                 {% if form.password.errors %}aria-invalid="true"{% else %}aria-invalid="false"{% endif %}>
           <label for="id_password"
-                 class="absolute left-3 -top-2 text-xs text-gray-700 transition-all peer-placeholder-shown:top-3 peer-placeholder-shown:text-sm peer-placeholder-shown:text-gray-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary">{% trans "Senha" %}</label>
+                 class="absolute left-3 -top-2 text-xs text-gray-700 dark:text-gray-300 transition-all peer-placeholder-shown:top-3 peer-placeholder-shown:text-sm peer-placeholder-shown:text-gray-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary">{% trans "Senha" %}</label>
         </div>
         {% if form.password.errors %}
           <div id="password-error" class="text-red-600 text-xs mt-1" role="alert">{{ form.password.errors }}</div>
@@ -58,13 +60,14 @@
                  value="{{ form.totp.value|default_if_none:'' }}"
                  autocomplete="one-time-code"
                  class="peer w-full p-3 border border-gray-300 rounded-lg text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
-                 placeholder=" "
+                 placeholder="{% trans 'TOTP' %}"
+                 aria-label="{% trans 'TOTP' %}"
                  aria-describedby="totp-error"
-                 {% if form.totp.errors %}aria-invalid="true"{% endif %}>
+                 {% if form.totp.errors %}aria-invalid="true"{% else %}aria-invalid="false"{% endif %}>
           <label for="id_totp"
-                 class="absolute left-3 -top-2 text-xs text-gray-700 transition-all peer-placeholder-shown:top-3 peer-placeholder-shown:text-sm peer-placeholder-shown:text-gray-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary">{% trans "TOTP" %}</label>
+                 class="absolute left-3 -top-2 text-xs text-gray-700 dark:text-gray-300 transition-all peer-placeholder-shown:top-3 peer-placeholder-shown:text-sm peer-placeholder-shown:text-gray-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary">{% trans "TOTP" %}</label>
         </div>
-        <p class="text-xs text-gray-500 mt-1">{% trans "Deixe em branco se não tiver 2FA" %}</p>
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">{% trans "Deixe em branco se não tiver 2FA" %}</p>
         {% if form.totp.errors %}
           <div id="totp-error" class="text-red-600 text-xs mt-1" role="alert">{{ form.totp.errors }}</div>
         {% endif %}
@@ -86,9 +89,9 @@
       </div>
     </div>
 
-    <div class="text-center mt-4 text-sm text-gray-600">
+    <div class="text-center mt-4 text-sm text-gray-600 dark:text-gray-300">
       {% trans "Não tem uma conta?" %}
-      <a href="{% url 'accounts:onboarding' %}" class="text-primary hover:underline">
+      <a href="{% url 'accounts:onboarding' %}" class="text-primary dark:text-primary hover:underline">
         {% trans "Cadastre-se gratuitamente" %}
       </a>
     </div>

--- a/accounts/templates/perfil/conexoes.html
+++ b/accounts/templates/perfil/conexoes.html
@@ -6,14 +6,14 @@
 {% block perfil_content %}
 <section id="conexoes" class="space-y-6">
   <div>
-    <h2 class="text-xl font-semibold">{% trans "Minhas Conexões" %}</h2>
-    <p class="text-sm text-gray-500">{% trans "Gerencie sua rede de contatos" %}</p>
+    <h2 class="text-xl font-semibold text-neutral-900 dark:text-neutral-100">{% trans "Minhas Conexões" %}</h2>
+    <p class="text-sm text-gray-500 dark:text-gray-400">{% trans "Gerencie sua rede de contatos" %}</p>
   </div>
 
   <!-- Abas -->
   <div class="flex gap-4 border-b">
     <button class="tab-btn py-2 px-4 text-sm border-b-2 border-primary text-primary font-medium" data-tab="minhas-conexoes">{% trans "Minhas Conexões" %}</button>
-    <button class="tab-btn py-2 px-4 text-sm text-gray-600 hover:text-primary" data-tab="solicitacoes">{% trans "Solicitações" %}</button>
+    <button class="tab-btn py-2 px-4 text-sm text-gray-600 dark:text-gray-400 hover:text-primary" data-tab="solicitacoes">{% trans "Solicitações" %}</button>
   </div>
 
   <!-- Conteúdo das abas -->
@@ -27,7 +27,8 @@
           name="q"
           value="{{ q }}"
           placeholder="{% trans 'Buscar conexões...' %}"
-          class="flex-grow border rounded-lg p-2 text-sm"
+          class="flex-grow border rounded-lg p-2 text-sm dark:bg-neutral-700 dark:border-neutral-600 dark:text-neutral-100"
+          aria-label="{% trans 'Buscar conexões' %}" aria-invalid="false"
         />
         <button type="submit" class="btn-secondary btn-sm" aria-label="{% trans 'Buscar' %}">
           {% lucide 'search' class='w-4 h-4' aria_hidden='true' %}
@@ -36,19 +37,19 @@
 
       <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
         {% for connection in connections %}
-        <div class="bg-white dark:bg-slate-800 p-6 rounded-lg shadow">
+        <div class="bg-white dark:bg-slate-800 p-6 rounded-lg shadow border border-neutral-200 dark:border-neutral-700">
           <div class="flex items-center justify-between">
             <div class="flex items-center gap-3">
               {% if connection.avatar %}
                 <img src="{{ connection.avatar.url }}" alt="{{ connection.username }}" class="w-10 h-10 rounded-full object-cover" />
               {% else %}
-                <div class="w-10 h-10 rounded-full bg-gray-200 flex items-center justify-center text-sm font-semibold text-gray-600" role="img" aria-label="{{ connection.username }}">
+                <div class="w-10 h-10 rounded-full bg-gray-200 dark:bg-gray-700 flex items-center justify-center text-sm font-semibold text-gray-600 dark:text-gray-300" role="img" aria-label="{{ connection.username }}">
                   {{ connection.username|first|upper }}
                 </div>
               {% endif %}
               <div>
-                <p class="font-medium">{{ connection.get_full_name }}</p>
-                <p class="text-sm text-gray-500">@{{ connection.username }}</p>
+                <p class="font-medium text-neutral-900 dark:text-neutral-100">{{ connection.get_full_name }}</p>
+                <p class="text-sm text-gray-500 dark:text-gray-400">@{{ connection.username }}</p>
               </div>
             </div>
             <div class="flex gap-2">
@@ -62,7 +63,7 @@
           </div>
         </div>
         {% empty %}
-        <div class="text-center text-sm text-gray-500 col-span-full">
+        <div class="text-center text-sm text-gray-500 dark:text-gray-400 col-span-full">
           <p>{% trans "Você ainda não tem conexões." %}</p>
           <a href="#" class="mt-2 inline-block bg-gray-100 px-4 py-2 rounded hover:bg-gray-200 text-sm">{% trans "Encontrar Pessoas" %}</a>
         </div>
@@ -74,33 +75,33 @@
     <div class="tab-pane hidden" id="solicitacoes">
       <div class="space-y-4">
         {% for solicitante in connection_requests %}
-        <div class="flex items-start justify-between p-4 border rounded-xl bg-white shadow-sm">
+        <div class="flex items-start justify-between p-4 border rounded-xl bg-white dark:bg-neutral-800 border-neutral-200 dark:border-neutral-700 shadow-sm">
           <div class="flex items-center gap-3">
             {% if solicitante.avatar %}
               <img src="{{ solicitante.avatar.url }}" alt="{{ solicitante.username }}" class="w-10 h-10 rounded-full object-cover" />
             {% else %}
-              <div class="w-10 h-10 rounded-full bg-gray-200 flex items-center justify-center text-sm font-semibold text-gray-600" role="img" aria-label="{{ solicitante.username }}">
+              <div class="w-10 h-10 rounded-full bg-gray-200 dark:bg-gray-700 flex items-center justify-center text-sm font-semibold text-gray-600 dark:text-gray-300" role="img" aria-label="{{ solicitante.username }}">
                 {{ solicitante.username|first|upper }}
               </div>
             {% endif %}
             <div>
-              <p class="font-medium">{{ solicitante.get_full_name }}</p>
-              <p class="text-sm text-gray-500">@{{ solicitante.username }}</p>
+              <p class="font-medium text-neutral-900 dark:text-neutral-100">{{ solicitante.get_full_name }}</p>
+              <p class="text-sm text-gray-500 dark:text-gray-400">@{{ solicitante.username }}</p>
             </div>
           </div>
           <div class="flex flex-col gap-1">
             <form method="post" action="{% url 'accounts:aceitar_conexao' solicitante.id %}">
               {% csrf_token %}
-              <button class="text-sm bg-green-100 text-green-700 px-3 py-1 rounded">{% trans "Aceitar" %}</button>
+              <button class="text-sm bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-300 px-3 py-1 rounded">{% trans "Aceitar" %}</button>
             </form>
             <form method="post" action="{% url 'accounts:recusar_conexao' solicitante.id %}">
               {% csrf_token %}
-              <button class="text-sm bg-red-100 text-red-600 px-3 py-1 rounded">{% trans "Recusar" %}</button>
+              <button class="text-sm bg-red-100 dark:bg-red-900 text-red-600 dark:text-red-300 px-3 py-1 rounded">{% trans "Recusar" %}</button>
             </form>
           </div>
         </div>
         {% empty %}
-        <div class="text-center text-sm text-gray-500">
+        <div class="text-center text-sm text-gray-500 dark:text-gray-400">
           <p>{% trans "Você não tem solicitações de conexão pendentes." %}</p>
         </div>
         {% endfor %}

--- a/accounts/templates/perfil/detail.html
+++ b/accounts/templates/perfil/detail.html
@@ -4,13 +4,13 @@
 {% block perfil_content %}
 
 <div class="card-header">
-  <div class="mt-2 border-b border-neutral-200">
+  <div class="mt-2 border-b border-neutral-200 dark:border-neutral-700">
     <nav class="-mb-px flex gap-6" aria-label="Tabs">
-      <button type="button" class="tab-btn py-3 text-sm font-medium border-b-2 border-transparent text-neutral-600 data-[active=true]:border-blue-600 data-[active=true]:text-blue-600" data-tab="informacoes">{% trans 'Informações' %}</button>
+      <button type="button" class="tab-btn py-3 text-sm font-medium border-b-2 border-transparent text-neutral-600 dark:text-neutral-400 data-[active=true]:border-blue-600 data-[active=true]:text-blue-600" data-tab="informacoes">{% trans 'Informações' %}</button>
       {% if user.get_tipo_usuario != 'admin' %}
-        <button type="button" class="tab-btn py-3 text-sm font-medium border-b-2 border-transparent text-neutral-600 data-[active=true]:border-blue-600 data-[active=true]:text-blue-600" data-tab="empresas">{% trans 'Empresas' %}</button>
-        <button type="button" class="tab-btn py-3 text-sm font-medium border-b-2 border-transparent text-neutral-600 data-[active=true]:border-blue-600 data-[active=true]:text-blue-600" data-tab="nucleos">{% trans 'Núcleos' %}</button>
-        <button type="button" class="tab-btn py-3 text-sm font-medium border-b-2 border-transparent text-neutral-600 data-[active=true]:border-blue-600 data-[active=true]:text-blue-600" data-tab="eventos">{% trans 'Eventos' %}</button>
+        <button type="button" class="tab-btn py-3 text-sm font-medium border-b-2 border-transparent text-neutral-600 dark:text-neutral-400 data-[active=true]:border-blue-600 data-[active=true]:text-blue-600" data-tab="empresas">{% trans 'Empresas' %}</button>
+        <button type="button" class="tab-btn py-3 text-sm font-medium border-b-2 border-transparent text-neutral-600 dark:text-neutral-400 data-[active=true]:border-blue-600 data-[active=true]:text-blue-600" data-tab="nucleos">{% trans 'Núcleos' %}</button>
+        <button type="button" class="tab-btn py-3 text-sm font-medium border-b-2 border-transparent text-neutral-600 dark:text-neutral-400 data-[active=true]:border-blue-600 data-[active=true]:text-blue-600" data-tab="eventos">{% trans 'Eventos' %}</button>
       {% endif %}
     </nav>
   </div>
@@ -23,11 +23,11 @@
 
         {% if user.biografia %}
           <div class="mb-6">
-            <p class="text-gray-700 italic border-l-4 border-primary pl-4">{{ user.biografia }}</p>
+            <p class="text-gray-700 dark:text-gray-300 italic border-l-4 border-primary pl-4">{{ user.biografia }}</p>
           </div>
         {% endif %}
 
-        <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6 text-sm text-gray-700">
+        <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6 text-sm text-gray-700 dark:text-gray-300">
           <div>
             <h4 class="font-medium mb-1">{% trans "Contato" %}</h4>
             <p>{% trans "Email" %}: {{ user.email }}</p>
@@ -62,7 +62,7 @@
         {% for empresa in empresas %}
           {% include 'partials/cards/empresa_card.html' with empresa=empresa %}
         {% empty %}
-          <p class="text-sm text-neutral-500">{% trans "Nenhuma empresa encontrada." %}</p>
+          <p class="text-sm text-neutral-500 dark:text-neutral-400">{% trans "Nenhuma empresa encontrada." %}</p>
         {% endfor %}
       </div>
     </div>
@@ -73,7 +73,7 @@
         {% for nucleo in nucleos %}
           {% include 'partials/cards/nucleo_card.html' with nucleo=nucleo %}
         {% empty %}
-          <p class="text-sm text-neutral-500">{% trans "Nenhum núcleo encontrado." %}</p>
+          <p class="text-sm text-neutral-500 dark:text-neutral-400">{% trans "Nenhum núcleo encontrado." %}</p>
         {% endfor %}
       </div>
     </div>
@@ -84,7 +84,7 @@
         {% for ins in inscricoes %}
           {% include 'partials/cards/evento_card.html' with evento=ins.evento %}
         {% empty %}
-          <p class="text-sm text-neutral-500">{% trans "Nenhum evento encontrado." %}</p>
+          <p class="text-sm text-neutral-500 dark:text-neutral-400">{% trans "Nenhum evento encontrado." %}</p>
         {% endfor %}
       </div>
     </div>

--- a/accounts/templates/perfil/disable_2fa.html
+++ b/accounts/templates/perfil/disable_2fa.html
@@ -7,12 +7,14 @@
 <form method="post" class="space-y-4">
   {% csrf_token %}
   <div class="relative">
-    <input type="text" name="code" id="code" class="peer form-input placeholder-transparent" placeholder=" " required />
+    <input type="text" name="code" id="code" class="peer form-input placeholder-transparent" placeholder="{% trans 'Código' %}" aria-label="{% trans 'Código 2FA' %}" aria-invalid="false" aria-describedby="code_help" required />
     <label for="code" class="label-float">{% trans "Código" %}</label>
+    <small id="code_help" class="text-sm text-neutral-500 dark:text-neutral-400">{% trans "Código gerado pelo aplicativo" %}</small>
   </div>
   <div class="relative">
-    <input type="password" name="password" id="password" class="peer form-input placeholder-transparent" placeholder=" " required />
+    <input type="password" name="password" id="password" class="peer form-input placeholder-transparent" placeholder="{% trans 'Senha' %}" aria-label="{% trans 'Senha' %}" aria-invalid="false" aria-describedby="password_help" required />
     <label for="password" class="label-float">{% trans "Senha" %}</label>
+    <small id="password_help" class="text-sm text-neutral-500 dark:text-neutral-400">{% trans "Informe sua senha para confirmar" %}</small>
   </div>
   <button type="submit" class="btn btn-primary">{% trans "Desativar" %}</button>
 </form>

--- a/accounts/templates/perfil/enable_2fa.html
+++ b/accounts/templates/perfil/enable_2fa.html
@@ -8,12 +8,14 @@
 <form method="post" class="space-y-4">
   {% csrf_token %}
   <div class="relative">
-    <input type="text" name="code" id="code" class="peer form-input placeholder-transparent" placeholder=" " required />
+    <input type="text" name="code" id="code" class="peer form-input placeholder-transparent" placeholder="{% trans 'Código' %}" aria-label="{% trans 'Código 2FA' %}" aria-invalid="false" aria-describedby="code_help" required />
     <label for="code" class="label-float">{% trans "Código" %}</label>
+    <small id="code_help" class="text-sm text-neutral-500 dark:text-neutral-400">{% trans "Código gerado pelo aplicativo" %}</small>
   </div>
   <div class="relative">
-    <input type="password" name="password" id="password" class="peer form-input placeholder-transparent" placeholder=" " required />
+    <input type="password" name="password" id="password" class="peer form-input placeholder-transparent" placeholder="{% trans 'Senha' %}" aria-label="{% trans 'Senha' %}" aria-invalid="false" aria-describedby="password_help" required />
     <label for="password" class="label-float">{% trans "Senha" %}</label>
+    <small id="password_help" class="text-sm text-neutral-500 dark:text-neutral-400">{% trans "Informe sua senha para confirmar" %}</small>
   </div>
   <button type="submit" class="btn btn-primary">{% trans "Ativar" %}</button>
 </form>

--- a/accounts/templates/perfil/midia_confirm_delete.html
+++ b/accounts/templates/perfil/midia_confirm_delete.html
@@ -4,8 +4,8 @@
 
 {% block perfil_content %}
 <section class="space-y-4">
-  <h2 class="text-xl font-semibold text-red-600">{% trans "Remover Mídia" %}</h2>
-  <p class="text-gray-600">{% trans "Tem certeza que deseja remover esta mídia?" %}</p>
+  <h2 class="text-xl font-semibold text-red-600 dark:text-red-300">{% trans "Remover Mídia" %}</h2>
+  <p class="text-gray-600 dark:text-gray-400">{% trans "Tem certeza que deseja remover esta mídia?" %}</p>
   <form method="post" class="flex justify-end gap-2">
     {% csrf_token %}
     <a href="{% url 'accounts:midias' %}" class="btn-secondary btn-sm inline-flex items-center gap-1">

--- a/accounts/templates/perfil/midia_detail.html
+++ b/accounts/templates/perfil/midia_detail.html
@@ -30,9 +30,9 @@
       </a>
     </p>
   {% endif %}
-  <p class="text-center text-gray-700">{{ media.descricao }}</p>
+  <p class="text-center text-gray-700 dark:text-gray-200">{{ media.descricao }}</p>
   <div class="text-center">
-    <a href="{% url 'accounts:midias' %}" class="inline-flex items-center gap-1 text-sm text-primary hover:underline">
+    <a href="{% url 'accounts:midias' %}" class="inline-flex items-center gap-1 text-sm text-primary dark:text-primary hover:underline">
       {% lucide 'arrow-left' class='w-4 h-4' aria_hidden='true' %}
       {% trans "Voltar para mídias" %}
     </a>

--- a/accounts/templates/perfil/midia_form.html
+++ b/accounts/templates/perfil/midia_form.html
@@ -15,8 +15,8 @@
         {% csrf_token %}
 
         <div class="relative">
-          {% with label_attr='aria-label:'|add:form.file.label invalid_attr='aria-invalid:'|add:(form.file.errors|yesno:'true,false') desc_attr='aria-describedby:'|add:form.file.id_for_label|add:'_error' %}
-            {{ form.file|add_class:'peer form-input placeholder-transparent'|attr:'placeholder: '|attr:label_attr|attr:invalid_attr|attr:desc_attr }}
+          {% with label_attr='aria-label:'|add:form.file.label invalid_attr='aria-invalid:'|add:(form.file.errors|yesno:'true,false') desc_attr='aria-describedby:'|add:form.file.id_for_label|add:'_error' placeholder_attr='placeholder:'|add:form.file.label %}
+            {{ form.file|add_class:'peer form-input placeholder-transparent'|attr:placeholder_attr|attr:label_attr|attr:invalid_attr|attr:desc_attr }}
           {% endwith %}
           <label for="{{ form.file.id_for_label }}" class="label-float">{{ form.file.label }}</label>
           {% if form.file.errors %}
@@ -25,8 +25,8 @@
         </div>
 
         <div class="relative">
-          {% with label_attr='aria-label:'|add:form.descricao.label invalid_attr='aria-invalid:'|add:(form.descricao.errors|yesno:'true,false') desc_attr='aria-describedby:'|add:form.descricao.id_for_label|add:'_error' %}
-            {{ form.descricao|add_class:'peer form-input placeholder-transparent'|attr:'placeholder: '|attr:label_attr|attr:invalid_attr|attr:desc_attr }}
+          {% with label_attr='aria-label:'|add:form.descricao.label invalid_attr='aria-invalid:'|add:(form.descricao.errors|yesno:'true,false') desc_attr='aria-describedby:'|add:form.descricao.id_for_label|add:'_error' placeholder_attr='placeholder:'|add:form.descricao.label %}
+            {{ form.descricao|add_class:'peer form-input placeholder-transparent'|attr:placeholder_attr|attr:label_attr|attr:invalid_attr|attr:desc_attr }}
           {% endwith %}
           <label for="{{ form.descricao.id_for_label }}" class="label-float">{{ form.descricao.label }}</label>
           {% if form.descricao.errors %}
@@ -35,8 +35,8 @@
         </div>
 
         <div class="relative">
-          {% with label_attr='aria-label:'|add:form.tags_field.label invalid_attr='aria-invalid:'|add:(form.tags_field.errors|yesno:'true,false') desc_attr='aria-describedby:'|add:form.tags_field.id_for_label|add:'_error' %}
-            {{ form.tags_field|add_class:'peer form-input placeholder-transparent'|attr:'placeholder: '|attr:label_attr|attr:invalid_attr|attr:desc_attr }}
+          {% with label_attr='aria-label:'|add:form.tags_field.label invalid_attr='aria-invalid:'|add:(form.tags_field.errors|yesno:'true,false') desc_attr='aria-describedby:'|add:form.tags_field.id_for_label|add:'_error' placeholder_attr='placeholder:'|add:form.tags_field.label %}
+            {{ form.tags_field|add_class:'peer form-input placeholder-transparent'|attr:placeholder_attr|attr:label_attr|attr:invalid_attr|attr:desc_attr }}
           {% endwith %}
           <label for="{{ form.tags_field.id_for_label }}" class="label-float">{{ form.tags_field.label }}</label>
           {% if form.tags_field.errors %}

--- a/accounts/templates/perfil/midias.html
+++ b/accounts/templates/perfil/midias.html
@@ -6,30 +6,32 @@
 {% block perfil_content %}
 <section id="midias" class="perfil-section active">
   <div class="section-header mb-6">
-    <h2 class="text-xl font-semibold">{% trans "Mídias" %}</h2>
-    <p class="text-sm text-gray-500">{% trans "Gerencie suas imagens, vídeos e documentos" %}</p>
+    <h2 class="text-xl font-semibold text-neutral-900 dark:text-neutral-100">{% trans "Mídias" %}</h2>
+    <p class="text-sm text-gray-500 dark:text-gray-400">{% trans "Gerencie suas imagens, vídeos e documentos" %}</p>
   </div>
 
   {% if show_form %}
   <form id="formMidias" class="space-y-6" method="post" action="{% url 'accounts:midias' %}" enctype="multipart/form-data">
     {% csrf_token %}
     <div>
-      <label for="id_file" class="block text-sm font-medium text-gray-700">{% trans "Enviar arquivo" %}</label>
-      <input type="file" id="id_file" name="file" class="mt-1 block w-full border rounded-lg p-2 text-sm" required accept="{{ allowed_exts|join:',' }}">
+      <label for="id_file" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{% trans "Enviar arquivo" %}</label>
+      <input type="file" id="id_file" name="file" class="mt-1 block w-full border rounded-lg p-2 text-sm dark:bg-neutral-700 dark:border-neutral-600 dark:text-neutral-100" required accept="{{ allowed_exts|join:',' }}" aria-label="{% trans 'Arquivo' %}" aria-invalid="false" aria-describedby="file_help">
       {% if form.file.errors %}
         <div class="text-sm text-red-600">{{ form.file.errors }}</div>
       {% endif %}
+      <small id="file_help" class="text-sm text-neutral-500 dark:text-neutral-400">{% trans "Selecione um arquivo" %}</small>
     </div>
     <div>
-      <label for="id_descricao" class="block text-sm font-medium text-gray-700">{% trans "Descrição" %}</label>
-      <input type="text" id="id_descricao" name="descricao" class="mt-1 block w-full border rounded-lg p-2 text-sm">
+      <label for="id_descricao" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{% trans "Descrição" %}</label>
+      <input type="text" id="id_descricao" name="descricao" class="mt-1 block w-full border rounded-lg p-2 text-sm dark:bg-neutral-700 dark:border-neutral-600 dark:text-neutral-100" aria-label="{% trans 'Descrição' %}" aria-invalid="false" aria-describedby="descricao_help" placeholder="{% trans 'Descrição' %}">
+      <small id="descricao_help" class="text-sm text-neutral-500 dark:text-neutral-400">{% trans "Breve descrição da mídia" %}</small>
       {% if form.descricao.errors %}
         <div class="text-sm text-red-600">{{ form.descricao.errors }}</div>
       {% endif %}
     </div>
     <div>
-      <label for="id_tags_field" class="block text-sm font-medium text-gray-700">{% trans "Tags" %}</label>
-      <input type="text" id="id_tags_field" name="tags_field" class="mt-1 block w-full border rounded-lg p-2 text-sm" placeholder="{% trans 'paisagem, viagem' %}">
+      <label for="id_tags_field" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{% trans "Tags" %}</label>
+      <input type="text" id="id_tags_field" name="tags_field" class="mt-1 block w-full border rounded-lg p-2 text-sm dark:bg-neutral-700 dark:border-neutral-600 dark:text-neutral-100" placeholder="{% trans 'paisagem, viagem' %}" aria-label="{% trans 'Tags' %}" aria-invalid="false">
       {% if form.tags_field.errors %}
         <div class="text-sm text-red-600">{{ form.tags_field.errors }}</div>
       {% endif %}
@@ -49,12 +51,12 @@
 
   <form method="get" class="mt-6">
     <input type="text" name="q" value="{{ q }}" placeholder="{% trans 'Buscar por descrição ou tags...' %}"
-           class="w-full border border-gray-300 rounded-lg px-4 py-2 text-sm">
+           class="w-full border border-gray-300 dark:border-neutral-600 dark:bg-neutral-700 dark:text-neutral-100 rounded-lg px-4 py-2 text-sm" aria-label="{% trans 'Buscar' %}" aria-invalid="false">
   </form>
 
   <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6 mt-6">
     {% for media in medias %}
-    <div class="bg-white border rounded-lg shadow p-3 relative">
+    <div class="bg-white dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 rounded-lg shadow p-3 relative">
       <div class="absolute top-2 right-2 flex gap-2">
         <a href="{% url 'accounts:midia_edit' media.pk %}" class="btn-secondary btn-sm" aria-label="{% trans 'Editar' %}">
           {% lucide 'edit' class='w-4 h-4' aria_hidden='true' %}
@@ -75,17 +77,17 @@
         {% endif %}
       </a>
       <div class="mt-2">
-        <p class="text-sm font-medium text-gray-700">{{ media.descricao }}</p>
-  <p class="text-xs text-gray-400">{{ media.created_at|date:"SHORT_DATETIME_FORMAT" }}</p>
+        <p class="text-sm font-medium text-gray-700 dark:text-gray-200">{{ media.descricao }}</p>
+        <p class="text-xs text-gray-400 dark:text-gray-500">{{ media.created_at|date:"SHORT_DATETIME_FORMAT" }}</p>
         <div class="flex flex-wrap gap-1 mt-1">
           {% for tag in media.tags.all %}
-            <span class="bg-gray-100 text-gray-700 text-xs px-2 py-0.5 rounded">{{ tag.nome }}</span>
+            <span class="bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 text-xs px-2 py-0.5 rounded">{{ tag.nome }}</span>
           {% endfor %}
         </div>
       </div>
     </div>
     {% empty %}
-      <p class="text-sm text-gray-500">{% trans "Nenhum arquivo enviado." %}</p>
+      <p class="text-sm text-gray-500 dark:text-gray-400">{% trans "Nenhum arquivo enviado." %}</p>
     {% endfor %}
   </div>
 </section>

--- a/accounts/templates/perfil/publico.html
+++ b/accounts/templates/perfil/publico.html
@@ -6,18 +6,18 @@
 
 {% block perfil_content %}
 <div class="card-header">
-  <nav class="border-b border-gray-200">
+  <nav class="border-b border-gray-200 dark:border-gray-700">
     <ul class="-mb-px flex flex-wrap gap-2" role="tablist" aria-label="{% trans 'Navegação de abas do perfil' %}">
       <li>
         <a href="#tab-informacoes" data-tab-target="tab-informacoes" role="tab" aria-selected="true"
-           class="inline-flex items-center gap-2 rounded-t px-3 py-2 text-sm font-medium border-b-2 border-transparent text-gray-600 hover:text-primary hover:border-primary data-[active=true]:border-primary data-[active=true]:text-primary">
+           class="inline-flex items-center gap-2 rounded-t px-3 py-2 text-sm font-medium border-b-2 border-transparent text-gray-600 dark:text-gray-400 hover:text-primary hover:border-primary data-[active=true]:border-primary data-[active=true]:text-primary">
           {% trans "Informações" %}
         </a>
       </li>
       {% if not profile.is_superuser %}
       <li>
         <a href="#tab-empresas" data-tab-target="tab-empresas" role="tab" aria-selected="false"
-           class="inline-flex items-center gap-2 rounded-t px-3 py-2 text-sm font-medium border-b-2 border-transparent text-gray-600 hover:text-primary hover:border-primary">
+           class="inline-flex items-center gap-2 rounded-t px-3 py-2 text-sm font-medium border-b-2 border-transparent text-gray-600 dark:text-gray-400 hover:text-primary hover:border-primary">
           {% trans "Empresas" %}
         </a>
       </li>
@@ -43,36 +43,36 @@
     <div id="tab-informacoes" role="tabpanel" data-tab-panel class="block">
       <dl class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6 text-sm">
         <div>
-          <dt class="text-gray-500">{% trans "Nome completo" %}</dt>
+          <dt class="text-gray-500 dark:text-gray-400">{% trans "Nome completo" %}</dt>
           <dd class="font-medium">{{ profile.get_full_name|default:profile.username }}</dd>
         </div>
         <div>
-          <dt class="text-gray-500">{% trans "Usuário" %}</dt>
+          <dt class="text-gray-500 dark:text-gray-400">{% trans "Usuário" %}</dt>
           <dd class="font-medium">@{{ profile.username }}</dd>
         </div>
         {% if profile.email %}
         <div>
-          <dt class="text-gray-500">{% trans "E-mail" %}</dt>
+          <dt class="text-gray-500 dark:text-gray-400">{% trans "E-mail" %}</dt>
           <dd class="font-medium">{{ profile.email }}</dd>
         </div>
         {% endif %}
         {% if profile.date_joined %}
         <div>
-          <dt class="text-gray-500">{% trans "Membro desde" %}</dt>
+          <dt class="text-gray-500 dark:text-gray-400">{% trans "Membro desde" %}</dt>
           <dd class="font-medium">{{ profile.date_joined|date:"d/m/Y H:i" }}</dd>
         </div>
         {% endif %}
         {% if profile.last_login %}
         <div>
-          <dt class="text-gray-500">{% trans "Último acesso" %}</dt>
+          <dt class="text-gray-500 dark:text-gray-400">{% trans "Último acesso" %}</dt>
           <dd class="font-medium">{{ profile.last_login|date:"d/m/Y H:i" }}</dd>
         </div>
         {% endif %}
       </dl>
       {% if profile.biografia %}
         <div class="mt-4">
-          <h3 class="text-sm font-semibold mb-1">{% trans "Biografia" %}</h3>
-          <p class="text-gray-700 whitespace-pre-line">{{ profile.biografia }}</p>
+          <h3 class="text-sm font-semibold mb-1 text-neutral-900 dark:text-neutral-100">{% trans "Biografia" %}</h3>
+          <p class="text-gray-700 dark:text-gray-300 whitespace-pre-line">{{ profile.biografia }}</p>
         </div>
       {% endif %}
     </div>
@@ -89,7 +89,7 @@
       </div>
       {% else %}
       <div class="grid grid-cols-1">
-        <p class="col-span-full text-center text-neutral-500 py-10">{% translate 'Nenhuma empresa encontrada.' %}</p>
+        <p class="col-span-full text-center text-neutral-500 dark:text-neutral-400 py-10">{% translate 'Nenhuma empresa encontrada.' %}</p>
       </div>
       {% endif %}
     </div>
@@ -99,7 +99,7 @@
         {% for nucleo in nucleos %}
           {% include 'nucleos/partials/card.html' with nucleo=nucleo %}
         {% empty %}
-          <p class="col-span-full text-center text-neutral-500">{% trans "Nenhum núcleo encontrado." %}</p>
+          <p class="col-span-full text-center text-neutral-500 dark:text-neutral-400">{% trans "Nenhum núcleo encontrado." %}</p>
         {% endfor %}
       </div>
     </div>
@@ -109,7 +109,7 @@
         {% for ins in inscricoes %}
           {% include 'partials/cards/evento_card.html' with evento=ins.evento %}
         {% empty %}
-          <p class="col-span-full text-center text-neutral-500">{% trans "Nenhum evento encontrado." %}</p>
+          <p class="col-span-full text-center text-neutral-500 dark:text-neutral-400">{% trans "Nenhum evento encontrado." %}</p>
         {% endfor %}
       </div>
     </div>

--- a/accounts/templates/register/cpf.html
+++ b/accounts/templates/register/cpf.html
@@ -29,7 +29,7 @@
     {% if messages %}
     <div class="mb-4 space-y-2">
       {% for message in messages %}
-        <p class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-green-100 text-green-700{% else %}bg-red-100 text-red-700{% endif %}">{{ message }}</p>
+        <p class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-300{% else %}bg-red-100 dark:bg-red-900 text-red-700 dark:text-red-300{% endif %}">{{ message }}</p>
       {% endfor %}
     </div>
     {% endif %}
@@ -44,7 +44,7 @@
             name="cpf"
             maxlength="14"
             class="peer w-full rounded-lg border border-neutral-300 dark:border-slate-600 px-4 py-2 placeholder-transparent focus:outline-none focus:ring-2 focus:ring-primary-500 dark:bg-slate-700 dark:text-neutral-100"
-            placeholder=" "
+            placeholder="{% trans 'CPF' %}"
             required
             autofocus
             aria-label="CPF"

--- a/accounts/templates/register/email.html
+++ b/accounts/templates/register/email.html
@@ -29,7 +29,7 @@
     {% if messages %}
     <div class="mb-4 space-y-2">
       {% for message in messages %}
-        <p class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-green-100 text-green-700{% else %}bg-red-100 text-red-700{% endif %}">{{ message }}</p>
+        <p class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-300{% else %}bg-red-100 dark:bg-red-900 text-red-700 dark:text-red-300{% endif %}">{{ message }}</p>
       {% endfor %}
     </div>
     {% endif %}
@@ -43,7 +43,7 @@
             id="email"
             name="email"
             class="peer w-full rounded-lg border border-neutral-300 dark:border-slate-600 px-4 py-2 placeholder-transparent focus:outline-none focus:ring-2 focus:ring-primary-500 dark:bg-slate-700 dark:text-neutral-100"
-            placeholder=" "
+            placeholder="{% trans 'Seu e-mail' %}"
             required
             autofocus
             aria-label="Email"

--- a/accounts/templates/register/foto.html
+++ b/accounts/templates/register/foto.html
@@ -29,7 +29,7 @@
     {% if messages %}
     <div class="mb-4 space-y-2">
       {% for message in messages %}
-        <p class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-green-100 text-green-700{% else %}bg-red-100 text-red-700{% endif %}">{{ message }}</p>
+        <p class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-300{% else %}bg-red-100 dark:bg-red-900 text-red-700 dark:text-red-300{% endif %}">{{ message }}</p>
       {% endfor %}
     </div>
     {% endif %}
@@ -44,8 +44,8 @@
             name="foto"
             accept="image/*"
             class="peer w-full rounded-lg border border-neutral-300 dark:border-slate-600 px-4 py-2 placeholder-transparent focus:outline-none focus:ring-2 focus:ring-primary-500 dark:bg-slate-700 dark:text-neutral-100"
-            placeholder=" "
-            aria-label="Foto"
+            placeholder="{% trans 'Selecione uma foto' %}"
+            aria-label="{% trans 'Foto' %}"
             aria-invalid="false"
             aria-describedby="foto_validation"
           />

--- a/accounts/templates/register/nome.html
+++ b/accounts/templates/register/nome.html
@@ -29,7 +29,7 @@
     {% if messages %}
     <div class="mb-4 space-y-2">
       {% for message in messages %}
-        <p class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-green-100 text-green-700{% else %}bg-red-100 text-red-700{% endif %}">{{ message }}</p>
+        <p class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-300{% else %}bg-red-100 dark:bg-red-900 text-red-700 dark:text-red-300{% endif %}">{{ message }}</p>
       {% endfor %}
     </div>
     {% endif %}
@@ -43,7 +43,7 @@
             id="nome"
             name="nome"
             class="peer w-full rounded-lg border border-neutral-300 dark:border-slate-600 px-4 py-2 placeholder-transparent focus:outline-none focus:ring-2 focus:ring-primary-500 dark:bg-slate-700 dark:text-neutral-100"
-            placeholder=" "
+            placeholder="{% trans 'Nome completo' %}"
             required
             autofocus
             aria-label="Nome"

--- a/accounts/templates/register/onboarding.html
+++ b/accounts/templates/register/onboarding.html
@@ -9,8 +9,8 @@
 <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
   <div class="bg-white dark:bg-slate-800 p-6 rounded-lg shadow text-center">
         <div class="mb-8">
-            <div class="w-20 h-20 bg-primary-100 rounded-full flex items-center justify-center mx-auto mb-4">
-                <svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="var(--primary-600)" stroke-width="2">
+            <div class="w-20 h-20 bg-primary-100 dark:bg-primary-900 rounded-full flex items-center justify-center mx-auto mb-4">
+                <svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="var(--primary-600)" stroke-width="2" aria-hidden="true">
                     <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/>
                     <circle cx="9" cy="7" r="4"/>
                     <path d="M23 21v-2a4 4 0 0 0-3-3.87"/>
@@ -28,15 +28,15 @@
         {% if messages %}
         <div class="mb-4 space-y-2">
             {% for message in messages %}
-            <p class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-green-100 text-green-700{% else %}bg-red-100 text-red-700{% endif %}">{{ message }}</p>
+            <p class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-300{% else %}bg-red-100 dark:bg-red-900 text-red-700 dark:text-red-300{% endif %}">{{ message }}</p>
             {% endfor %}
         </div>
         {% endif %}
 
         <div class="grid md:grid-cols-3 gap-6 mb-8">
             <div class="text-center">
-                <div class="w-15 h-15 bg-success-100 rounded-full flex items-center justify-center mx-auto mb-3">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--success-600)" stroke-width="2">
+                <div class="w-15 h-15 bg-success-100 dark:bg-success-900 rounded-full flex items-center justify-center mx-auto mb-3">
+                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--success-600)" stroke-width="2" aria-hidden="true">
                         <path d="M9 11H5a2 2 0 0 0-2 2v7a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7a2 2 0 0 0-2-2h-4"/>
                         <polyline points="9,11 12,14 15,11"/>
                         <line x1="12" y1="14" x2="12" y2="3"/>
@@ -48,8 +48,8 @@
                 </p>
             </div>
             <div class="text-center">
-                <div class="w-15 h-15 bg-primary-100 rounded-full flex items-center justify-center mx-auto mb-3">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--primary-600)" stroke-width="2">
+                <div class="w-15 h-15 bg-primary-100 dark:bg-primary-900 rounded-full flex items-center justify-center mx-auto mb-3">
+                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--primary-600)" stroke-width="2" aria-hidden="true">
                         <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/>
                         <circle cx="9" cy="7" r="4"/>
                         <path d="M23 21v-2a4 4 0 0 0-3-3.87"/>
@@ -62,8 +62,8 @@
                 </p>
             </div>
             <div class="text-center">
-                <div class="w-15 h-15 bg-warning-100 rounded-full flex items-center justify-center mx-auto mb-3">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--warning-600)" stroke-width="2">
+                <div class="w-15 h-15 bg-warning-100 dark:bg-warning-900 rounded-full flex items-center justify-center mx-auto mb-3">
+                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--warning-600)" stroke-width="2" aria-hidden="true">
                         <rect x="3" y="4" width="18" height="18" rx="2" ry="2"/>
                         <line x1="16" y1="2" x2="16" y2="6"/>
                         <line x1="8" y1="2" x2="8" y2="6"/>
@@ -78,8 +78,8 @@
         </div>
 
         <div class="flex flex-col sm:flex-row gap-4 justify-center">
-            <a href="{% url 'tokens:token' %}" class="bg-primary text-white font-semibold py-2 px-4 rounded-xl">
-                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <a href="{% url 'tokens:token' %}" class="bg-primary dark:bg-primary text-white font-semibold py-2 px-4 rounded-xl">
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
                     <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/>
                     <circle cx="9" cy="7" r="4"/>
                     <line x1="19" y1="8" x2="19" y2="14"/>

--- a/accounts/templates/register/registro_sucesso.html
+++ b/accounts/templates/register/registro_sucesso.html
@@ -11,7 +11,7 @@
     {% if messages %}
     <div class="mb-4 space-y-2">
       {% for message in messages %}
-        <p class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-green-100 text-green-700{% else %}bg-red-100 text-red-700{% endif %}">{{ message }}</p>
+        <p class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-300{% else %}bg-red-100 dark:bg-red-900 text-red-700 dark:text-red-300{% endif %}">{{ message }}</p>
       {% endfor %}
     </div>
     {% endif %}

--- a/accounts/templates/register/senha.html
+++ b/accounts/templates/register/senha.html
@@ -29,7 +29,7 @@
     {% if messages %}
     <div class="mb-4 space-y-2">
       {% for message in messages %}
-        <p class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-green-100 text-green-700{% else %}bg-red-100 text-red-700{% endif %}">{{ message }}</p>
+        <p class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-300{% else %}bg-red-100 dark:bg-red-900 text-red-700 dark:text-red-300{% endif %}">{{ message }}</p>
       {% endfor %}
     </div>
     {% endif %}
@@ -43,7 +43,7 @@
             id="senha"
             name="senha"
             class="peer w-full rounded-lg border border-neutral-300 dark:border-slate-600 px-4 py-2 placeholder-transparent focus:outline-none focus:ring-2 focus:ring-primary-500 dark:bg-slate-700 dark:text-neutral-100"
-            placeholder=" "
+            placeholder="{% trans 'Senha' %}"
             required
             autofocus
             aria-label="Senha"
@@ -66,7 +66,7 @@
             id="confirmar_senha"
             name="confirmar_senha"
             class="peer w-full rounded-lg border border-neutral-300 dark:border-slate-600 px-4 py-2 placeholder-transparent focus:outline-none focus:ring-2 focus:ring-primary-500 dark:bg-slate-700 dark:text-neutral-100"
-            placeholder=" "
+            placeholder="{% trans 'Confirme a senha' %}"
             required
             aria-label="Confirmar senha"
             aria-invalid="false"

--- a/accounts/templates/register/termos.html
+++ b/accounts/templates/register/termos.html
@@ -29,7 +29,7 @@
     {% if messages %}
     <div class="mb-4 space-y-2">
       {% for message in messages %}
-        <p class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-green-100 text-green-700{% else %}bg-red-100 text-red-700{% endif %}">{{ message }}</p>
+        <p class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-300{% else %}bg-red-100 dark:bg-red-900 text-red-700 dark:text-red-300{% endif %}">{{ message }}</p>
       {% endfor %}
     </div>
     {% endif %}

--- a/accounts/templates/register/token.html
+++ b/accounts/templates/register/token.html
@@ -22,8 +22,8 @@
     </div>
 
     <div class="mb-8 text-center">
-      <div class="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-primary-100">
-        <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="var(--primary-600)" stroke-width="2">
+      <div class="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-primary-100 dark:bg-primary-900">
+        <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="var(--primary-600)" stroke-width="2" aria-hidden="true">
           <rect x="3" y="11" width="18" height="11" rx="2" ry="2"/>
           <circle cx="12" cy="16" r="1"/>
           <path d="M7 11V7a5 5 0 0 1 10 0v4"/>
@@ -36,7 +36,7 @@
     {% if messages %}
     <div class="mb-4 space-y-2">
       {% for message in messages %}
-        <p class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-green-100 text-green-700{% else %}bg-red-100 text-red-700{% endif %}">{{ message }}</p>
+        <p class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-300{% else %}bg-red-100 dark:bg-red-900 text-red-700 dark:text-red-300{% endif %}">{{ message }}</p>
       {% endfor %}
     </div>
     {% endif %}
@@ -50,7 +50,7 @@
             id="token"
             name="token"
             class="peer w-full rounded-lg border border-neutral-300 dark:border-slate-600 px-4 py-2 placeholder-transparent text-center font-mono tracking-widest focus:outline-none focus:ring-2 focus:ring-primary-500 dark:bg-slate-700 dark:text-neutral-100"
-            placeholder=" "
+            placeholder="{% trans 'Token de convite' %}"
             required
             autofocus
             aria-label="Token"

--- a/accounts/templates/register/usuario.html
+++ b/accounts/templates/register/usuario.html
@@ -30,9 +30,9 @@
     <div class="mb-4 space-y-2">
       {% for message in messages %}
         {% if message.tags == 'success' %}
-        <p class="rounded-xl px-4 py-2 text-sm bg-green-100 text-green-700">{{ message }}</p>
+        <p class="rounded-xl px-4 py-2 text-sm bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-300">{{ message }}</p>
         {% else %}
-        <p class="rounded-xl px-4 py-2 text-sm bg-red-100 text-red-700">{{ message }}</p>
+        <p class="rounded-xl px-4 py-2 text-sm bg-red-100 dark:bg-red-900 text-red-700 dark:text-red-300">{{ message }}</p>
         {% endif %}
       {% endfor %}
     </div>
@@ -47,7 +47,7 @@
             id="usuario"
             name="usuario"
             class="peer w-full rounded-lg border border-neutral-300 dark:border-slate-600 px-4 py-2 placeholder-transparent focus:outline-none focus:ring-2 focus:ring-primary-500 dark:bg-slate-700 dark:text-neutral-100"
-            placeholder=" "
+            placeholder="{% trans 'Nome de usuário' %}"
             required
             autofocus
             aria-label="Usuário"


### PR DESCRIPTION
## Summary
- improve accessibility in login and account templates with aria attributes
- ensure dark mode styles and placeholders in registration flow
- mark decorative svg icons as hidden from screen readers

## Testing
- `pytest accounts -q -c /dev/null`


------
https://chatgpt.com/codex/tasks/task_e_68bec94ad07c8325beab78c0467a7660