### PR TITLE
Refine aria attribute handling in profile templates

### DIFF
--- a/accounts/templates/perfil/informacoes_pessoais.html
+++ b/accounts/templates/perfil/informacoes_pessoais.html
@@ -1,5 +1,5 @@
 {% extends 'perfil/perfil.html' %}
-{% load static i18n custom_filters %}
+{% load widget_tweaks custom_filters %}
 
 {% block title %}{% trans "Informações Pessoais" %} | HubX{% endblock %}
 
@@ -17,12 +17,16 @@
 
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div class="relative">
-            {{ form.first_name|add_class:'peer form-input placeholder-transparent'|attr:'placeholder: '|attr:('aria-label:'|add:form.first_name.label)|attr:('aria-required:'|add:(form.first_name.field.required|yesno:'true,false')) }}
+            {% with label_attr='aria-label:'|add:form.first_name.label required_attr='aria-required:'|add:(form.first_name.field.required|yesno:'true,false') %}
+              {{ form.first_name|add_class:'peer form-input placeholder-transparent'|attr:'placeholder: '|attr:label_attr|attr:required_attr }}
+            {% endwith %}
             <label for="{{ form.first_name.id_for_label }}" class="label-float">{{ form.first_name.label }}</label>
             {{ form.first_name.errors }}
           </div>
           <div class="relative">
-            {{ form.last_name|add_class:'peer form-input placeholder-transparent'|attr:'placeholder: '|attr:('aria-label:'|add:form.last_name.label)|attr:('aria-required:'|add:(form.last_name.field.required|yesno:'true,false')) }}
+            {% with label_attr='aria-label:'|add:form.last_name.label required_attr='aria-required:'|add:(form.last_name.field.required|yesno:'true,false') %}
+              {{ form.last_name|add_class:'peer form-input placeholder-transparent'|attr:'placeholder: '|attr:label_attr|attr:required_attr }}
+            {% endwith %}
             <label for="{{ form.last_name.id_for_label }}" class="label-float">{{ form.last_name.label }}</label>
             {{ form.last_name.errors }}
           </div>
@@ -30,38 +34,50 @@
 
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div class="relative">
-            {{ form.username|add_class:'peer form-input placeholder-transparent'|attr:'placeholder: '|attr:('aria-label:'|add:form.username.label)|attr:('aria-required:'|add:(form.username.field.required|yesno:'true,false')) }}
+            {% with label_attr='aria-label:'|add:form.username.label required_attr='aria-required:'|add:(form.username.field.required|yesno:'true,false') %}
+              {{ form.username|add_class:'peer form-input placeholder-transparent'|attr:'placeholder: '|attr:label_attr|attr:required_attr }}
+            {% endwith %}
             <label for="{{ form.username.id_for_label }}" class="label-float">{{ form.username.label }}</label>
             {{ form.username.errors }}
           </div>
 
           <div class="relative">
-            {{ form.email|add_class:'peer form-input placeholder-transparent'|attr:'placeholder: '|attr:('aria-label:'|add:form.email.label)|attr:('aria-required:'|add:(form.email.field.required|yesno:'true,false')) }}
+            {% with label_attr='aria-label:'|add:form.email.label required_attr='aria-required:'|add:(form.email.field.required|yesno:'true,false') %}
+              {{ form.email|add_class:'peer form-input placeholder-transparent'|attr:'placeholder: '|attr:label_attr|attr:required_attr }}
+            {% endwith %}
             <label for="{{ form.email.id_for_label }}" class="label-float">{{ form.email.label }}</label>
             {{ form.email.errors }}
           </div>
         </div>
 
         <div class="relative">
-          {{ form.cpf|add_class:'peer form-input placeholder-transparent'|attr:'placeholder: '|attr:('aria-label:'|add:form.cpf.label)|attr:('aria-required:'|add:(form.cpf.field.required|yesno:'true,false')) }}
+          {% with label_attr='aria-label:'|add:form.cpf.label required_attr='aria-required:'|add:(form.cpf.field.required|yesno:'true,false') %}
+            {{ form.cpf|add_class:'peer form-input placeholder-transparent'|attr:'placeholder: '|attr:label_attr|attr:required_attr }}
+          {% endwith %}
           <label for="{{ form.cpf.id_for_label }}" class="label-float">{{ form.cpf.label }}</label>
           {{ form.cpf.errors }}
         </div>
 
         <div class="relative">
-          {{ form.biografia|add_class:'peer form-input placeholder-transparent'|attr:'placeholder: '|attr:('aria-label:'|add:form.biografia.label)|attr:('aria-required:'|add:(form.biografia.field.required|yesno:'true,false')) }}
+          {% with label_attr='aria-label:'|add:form.biografia.label required_attr='aria-required:'|add:(form.biografia.field.required|yesno:'true,false') %}
+            {{ form.biografia|add_class:'peer form-input placeholder-transparent'|attr:'placeholder: '|attr:label_attr|attr:required_attr }}
+          {% endwith %}
           <label for="{{ form.biografia.id_for_label }}" class="label-float">{{ form.biografia.label }}</label>
           {{ form.biografia.errors }}
         </div>
 
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div class="relative">
-            {{ form.avatar|add_class:'peer form-input placeholder-transparent'|attr:'placeholder: '|attr:('aria-label:'|add:form.avatar.label)|attr:('aria-required:'|add:(form.avatar.field.required|yesno:'true,false')) }}
+            {% with label_attr='aria-label:'|add:form.avatar.label required_attr='aria-required:'|add:(form.avatar.field.required|yesno:'true,false') %}
+              {{ form.avatar|add_class:'peer form-input placeholder-transparent'|attr:'placeholder: '|attr:label_attr|attr:required_attr }}
+            {% endwith %}
             <label for="{{ form.avatar.id_for_label }}" class="label-float">{{ form.avatar.label }}</label>
             {{ form.avatar.errors }}
           </div>
           <div class="relative">
-            {{ form.cover|add_class:'peer form-input placeholder-transparent'|attr:'placeholder: '|attr:('aria-label:'|add:form.cover.label)|attr:('aria-required:'|add:(form.cover.field.required|yesno:'true,false')) }}
+            {% with label_attr='aria-label:'|add:form.cover.label required_attr='aria-required:'|add:(form.cover.field.required|yesno:'true,false') %}
+              {{ form.cover|add_class:'peer form-input placeholder-transparent'|attr:'placeholder: '|attr:label_attr|attr:required_attr }}
+            {% endwith %}
             <label for="{{ form.cover.id_for_label }}" class="label-float">{{ form.cover.label }}</label>
             {{ form.cover.errors }}
           </div>
@@ -73,12 +89,16 @@
 
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div class="relative">
-            {{ form.phone_number|add_class:'peer form-input placeholder-transparent'|attr:'placeholder: '|attr:('aria-label:'|add:form.phone_number.label)|attr:('aria-required:'|add:(form.phone_number.field.required|yesno:'true,false')) }}
+            {% with label_attr='aria-label:'|add:form.phone_number.label required_attr='aria-required:'|add:(form.phone_number.field.required|yesno:'true,false') %}
+              {{ form.phone_number|add_class:'peer form-input placeholder-transparent'|attr:'placeholder: '|attr:label_attr|attr:required_attr }}
+            {% endwith %}
             <label for="{{ form.phone_number.id_for_label }}" class="label-float">{{ form.phone_number.label }}</label>
             {{ form.phone_number.errors }}
           </div>
           <div class="relative">
-            {{ form.whatsapp|add_class:'peer form-input placeholder-transparent'|attr:'placeholder: '|attr:('aria-label:'|add:form.whatsapp.label)|attr:('aria-required:'|add:(form.whatsapp.field.required|yesno:'true,false')) }}
+            {% with label_attr='aria-label:'|add:form.whatsapp.label required_attr='aria-required:'|add:(form.whatsapp.field.required|yesno:'true,false') %}
+              {{ form.whatsapp|add_class:'peer form-input placeholder-transparent'|attr:'placeholder: '|attr:label_attr|attr:required_attr }}
+            {% endwith %}
             <label for="{{ form.whatsapp.id_for_label }}" class="label-float">{{ form.whatsapp.label }}</label>
             {{ form.whatsapp.errors }}
           </div>
@@ -89,24 +109,32 @@
         <h4 class="text-lg font-semibold">{% trans "Endereço" %}</h4>
 
         <div class="relative">
-          {{ form.endereco|add_class:'w-full peer form-input placeholder-transparent'|attr:'placeholder: '|attr:('aria-label:'|add:form.endereco.label)|attr:('aria-required:'|add:(form.endereco.field.required|yesno:'true,false')) }}
+          {% with label_attr='aria-label:'|add:form.endereco.label required_attr='aria-required:'|add:(form.endereco.field.required|yesno:'true,false') %}
+            {{ form.endereco|add_class:'w-full peer form-input placeholder-transparent'|attr:'placeholder: '|attr:label_attr|attr:required_attr }}
+          {% endwith %}
           <label for="{{ form.endereco.id_for_label }}" class="label-float">{{ form.endereco.label }}</label>
           {{ form.endereco.errors }}
         </div>
 
         <div class="grid md:grid-cols-3 gap-4">
           <div class="relative">
-            {{ form.cidade|add_class:'peer form-input placeholder-transparent'|attr:'placeholder: '|attr:('aria-label:'|add:form.cidade.label)|attr:('aria-required:'|add:(form.cidade.field.required|yesno:'true,false')) }}
+            {% with label_attr='aria-label:'|add:form.cidade.label required_attr='aria-required:'|add:(form.cidade.field.required|yesno:'true,false') %}
+              {{ form.cidade|add_class:'peer form-input placeholder-transparent'|attr:'placeholder: '|attr:label_attr|attr:required_attr }}
+            {% endwith %}
             <label for="{{ form.cidade.id_for_label }}" class="label-float">{{ form.cidade.label }}</label>
             {{ form.cidade.errors }}
           </div>
           <div class="relative">
-            {{ form.estado|add_class:'peer form-input placeholder-transparent'|attr:'placeholder: '|attr:('aria-label:'|add:form.estado.label)|attr:('aria-required:'|add:(form.estado.field.required|yesno:'true,false')) }}
+            {% with label_attr='aria-label:'|add:form.estado.label required_attr='aria-required:'|add:(form.estado.field.required|yesno:'true,false') %}
+              {{ form.estado|add_class:'peer form-input placeholder-transparent'|attr:'placeholder: '|attr:label_attr|attr:required_attr }}
+            {% endwith %}
             <label for="{{ form.estado.id_for_label }}" class="label-float">{{ form.estado.label }}</label>
             {{ form.estado.errors }}
           </div>
           <div class="relative">
-            {{ form.cep|add_class:'peer form-input placeholder-transparent'|attr:'placeholder: '|attr:('aria-label:'|add:form.cep.label)|attr:('aria-required:'|add:(form.cep.field.required|yesno:'true,false')) }}
+            {% with label_attr='aria-label:'|add:form.cep.label required_attr='aria-required:'|add:(form.cep.field.required|yesno:'true,false') %}
+              {{ form.cep|add_class:'peer form-input placeholder-transparent'|attr:'placeholder: '|attr:label_attr|attr:required_attr }}
+            {% endwith %}
             <label for="{{ form.cep.id_for_label }}" class="label-float">{{ form.cep.label }}</label>
             {{ form.cep.errors }}
           </div>

--- a/accounts/templates/perfil/redes_sociais.html
+++ b/accounts/templates/perfil/redes_sociais.html
@@ -1,5 +1,5 @@
 {% extends 'perfil/perfil.html' %}
-{% load static i18n custom_filters %}
+{% load widget_tweaks custom_filters %}
 
 {% block title %}{% trans "Redes Sociais" %} | HubX{% endblock %}
 
@@ -16,28 +16,36 @@
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div class="relative">
             {% with invalid=form.facebook.errors|yesno:'true,false' %}
-              {{ form.facebook|add_class:'w-full peer form-input placeholder-transparent border border-neutral-300 dark:border-neutral-700 dark:text-neutral-100'|attr:'placeholder: '|attr:'aria-label:'|add:form.facebook.label|attr:'aria-invalid:'|add:invalid }}
+              {% with label_attr='aria-label:'|add:form.facebook.label invalid_attr='aria-invalid:'|add:invalid %}
+                {{ form.facebook|add_class:'w-full peer form-input placeholder-transparent border border-neutral-300 dark:border-neutral-700 dark:text-neutral-100'|attr:'placeholder: '|attr:label_attr|attr:invalid_attr }}
+              {% endwith %}
             {% endwith %}
             <label for="{{ form.facebook.id_for_label }}" class="label-float dark:text-neutral-300">{{ form.facebook.label }}</label>
             {{ form.facebook.errors }}
           </div>
           <div class="relative">
             {% with invalid=form.twitter.errors|yesno:'true,false' %}
-              {{ form.twitter|add_class:'w-full peer form-input placeholder-transparent border border-neutral-300 dark:border-neutral-700 dark:text-neutral-100'|attr:'placeholder: '|attr:'aria-label:'|add:form.twitter.label|attr:'aria-invalid:'|add:invalid }}
+              {% with label_attr='aria-label:'|add:form.twitter.label invalid_attr='aria-invalid:'|add:invalid %}
+                {{ form.twitter|add_class:'w-full peer form-input placeholder-transparent border border-neutral-300 dark:border-neutral-700 dark:text-neutral-100'|attr:'placeholder: '|attr:label_attr|attr:invalid_attr }}
+              {% endwith %}
             {% endwith %}
             <label for="{{ form.twitter.id_for_label }}" class="label-float dark:text-neutral-300">{{ form.twitter.label }}</label>
             {{ form.twitter.errors }}
           </div>
           <div class="relative">
             {% with invalid=form.instagram.errors|yesno:'true,false' %}
-              {{ form.instagram|add_class:'w-full peer form-input placeholder-transparent border border-neutral-300 dark:border-neutral-700 dark:text-neutral-100'|attr:'placeholder: '|attr:'aria-label:'|add:form.instagram.label|attr:'aria-invalid:'|add:invalid }}
+              {% with label_attr='aria-label:'|add:form.instagram.label invalid_attr='aria-invalid:'|add:invalid %}
+                {{ form.instagram|add_class:'w-full peer form-input placeholder-transparent border border-neutral-300 dark:border-neutral-700 dark:text-neutral-100'|attr:'placeholder: '|attr:label_attr|attr:invalid_attr }}
+              {% endwith %}
             {% endwith %}
             <label for="{{ form.instagram.id_for_label }}" class="label-float dark:text-neutral-300">{{ form.instagram.label }}</label>
             {{ form.instagram.errors }}
           </div>
           <div class="relative">
             {% with invalid=form.linkedin.errors|yesno:'true,false' %}
-              {{ form.linkedin|add_class:'w-full peer form-input placeholder-transparent border border-neutral-300 dark:border-neutral-700 dark:text-neutral-100'|attr:'placeholder: '|attr:'aria-label:'|add:form.linkedin.label|attr:'aria-invalid:'|add:invalid }}
+              {% with label_attr='aria-label:'|add:form.linkedin.label invalid_attr='aria-invalid:'|add:invalid %}
+                {{ form.linkedin|add_class:'w-full peer form-input placeholder-transparent border border-neutral-300 dark:border-neutral-700 dark:text-neutral-100'|attr:'placeholder: '|attr:label_attr|attr:invalid_attr }}
+              {% endwith %}
             {% endwith %}
             <label for="{{ form.linkedin.id_for_label }}" class="label-float dark:text-neutral-300">{{ form.linkedin.label }}</label>
             {{ form.linkedin.errors }}


### PR DESCRIPTION
## Summary
- Load `widget_tweaks` in personal info and social network templates
- Build aria attribute strings with `with` before applying `attr`

## Testing
- `pytest --no-cov tests/test_i18n_templates.py::test_no_untranslated_pt_strings -k informacoes_pessoais -q`
- `pytest --no-cov tests/test_i18n_templates.py::test_no_untranslated_pt_strings -k redes_sociais -q`

------
https://chatgpt.com/codex/tasks/task_e_68bed221cdb48325b0d66d10d0ffd1d0