### PR TITLE
style: update background palette

### DIFF
--- a/app/static/css/hubx.css
+++ b/app/static/css/hubx.css
@@ -105,8 +105,8 @@
   --transition-slow: 350ms ease-in-out;
 
   /* Light Theme (Default) */
-  --bg-primary: var(--color-neutral-50);
-  --bg-secondary: #ffffff;
+  --bg-primary: #ffffff;
+  --bg-secondary: #f1f5f9;
   --bg-tertiary: var(--color-neutral-100);
   --bg-accent: var(--color-primary-50);
 

--- a/core/templates/core/home.html
+++ b/core/templates/core/home.html
@@ -10,12 +10,12 @@
   {% if user.is_authenticated %}
   <div class="flex justify-center gap-4">
     <a href="{% url 'dashboard:dashboard' %}" class="bg-primary text-white px-5 py-3 rounded-xl shadow hover:bg-primary/90">{% trans "Ir para Dashboard" %}</a>
-    <a href="{% url 'feed:listar' %}" class="bg-white border border-primary text-primary px-5 py-3 rounded-xl hover:bg-primary/5">{% trans "Ver Feed" %}</a>
+    <a href="{% url 'feed:listar' %}" class="bg-secondary border border-primary text-primary px-5 py-3 rounded-xl hover:bg-primary/5">{% trans "Ver Feed" %}</a>
   </div>
   {% else %}
   <div class="flex justify-center gap-4">
     <a href="{% url 'accounts:onboarding' %}" class="bg-primary text-white px-5 py-3 rounded-xl shadow hover:bg-primary/90">{% trans "Criar conta" %}</a>
-    <a href="{% url 'accounts:login' %}" class="bg-white border border-primary text-primary px-5 py-3 rounded-xl hover:bg-primary/5">{% trans "Entrar" %}</a>
+    <a href="{% url 'accounts:login' %}" class="bg-secondary border border-primary text-primary px-5 py-3 rounded-xl hover:bg-primary/5">{% trans "Entrar" %}</a>
   </div>
   {% endif %}
 </div>

--- a/financeiro/templates/financeiro/importar_pagamentos.html
+++ b/financeiro/templates/financeiro/importar_pagamentos.html
@@ -48,7 +48,7 @@
                 hx-target="#messages"
                 hx-include="#confirm-form"
                 hx-indicator="#loading"
-                class="bg-secondary text-white px-4 py-2 rounded">
+                class="bg-primary text-white px-4 py-2 rounded">
           {% trans "Confirmar Importação" %}
         </button>
         <span id="loading" class="htmx-indicator text-sm">{% trans "Processando..." %}</span>

--- a/templates/base.html
+++ b/templates/base.html
@@ -67,7 +67,7 @@
   {% endif %}
 
   <div id="content" class="flex flex-col flex-1 {% if not hide_nav %}ml-64{% else %}ml-0{% endif %} transition-all">
-    <header class="bg-white border-b">
+    <header class="bg-secondary border-b">
       <div class="container mx-auto p-4 flex items-center gap-4 justify-between">
         <a href="/" class="text-xl font-bold text-primary" aria-label="{% trans 'Página inicial' %}">HubX</a>
         <form action="#" method="get" role="search" class="flex-1 max-w-md">
@@ -113,7 +113,7 @@
       {% block content %}{% endblock %}
     </main>
 
-    <footer class="bg-white border-t mt-10">
+    <footer class="bg-secondary border-t mt-10">
       <div class="container mx-auto px-4 py-6 text-sm text-gray-500 flex flex-col items-center gap-2 md:flex-row md:justify-between">
         <p>{% blocktrans with year=now|date:"Y" %}© {{ year }} HubX. Todos os direitos reservados.{% endblocktrans %}</p>
         <nav class="flex gap-4">

--- a/templates/components/nav_sidebar.html
+++ b/templates/components/nav_sidebar.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-<aside id="sidebar" class="fixed inset-y-0 left-0 z-20 w-64 bg-white border-r flex flex-col transition-all">
+<aside id="sidebar" class="fixed inset-y-0 left-0 z-20 w-64 bg-secondary border-r flex flex-col transition-all">
   <div class="flex items-center justify-between p-4 border-b">
     <a href="/" class="text-2xl font-bold text-primary" aria-label="{% trans 'Página inicial' %}" aria-current="{% if request.path == '/' %}page{% endif %}"><span class="sidebar-label">HubX</span></a>
     <button id="sidebar-toggle" class="text-gray-800" aria-label="{% trans 'Alternar menu' %}" aria-controls="sidebar" aria-expanded="true">

--- a/templates/partials/cards/base_card.html
+++ b/templates/partials/cards/base_card.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 <a href="{{ url }}"
-  class="group block rounded-2xl border border-neutral-200 bg-white shadow-sm hover:shadow-lg transition-shadow focus:outline-none focus:ring-2 focus:ring-primary/40"
+  class="group block rounded-2xl border border-neutral-200 bg-secondary shadow-sm hover:shadow-lg transition-shadow focus:outline-none focus:ring-2 focus:ring-primary/40"
   aria-label="{{ title }}">
   <article class="overflow-hidden rounded-2xl" role="article">
     <header class="relative">

--- a/templates/partials/cards/empresa_card.html
+++ b/templates/partials/cards/empresa_card.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 {# Card de Empresa #}
 <a href="{% url 'empresas:detail' empresa.pk %}"
-   class="group block rounded-2xl border border-neutral-200 bg-white shadow-sm hover:shadow-lg transition-shadow focus:outline-none focus:ring-2 focus:ring-primary/40">
+   class="group block rounded-2xl border border-neutral-200 bg-secondary shadow-sm hover:shadow-lg transition-shadow focus:outline-none focus:ring-2 focus:ring-primary/40">
   <article class="overflow-hidden rounded-2xl" role="article" aria-label="{{ empresa.nome }}">
     <header class="relative">
       {% if empresa.cover %}

--- a/templates/partials/cards/nucleo_card.html
+++ b/templates/partials/cards/nucleo_card.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 {# Card de Núcleo #}
 <a href="{% url 'nucleos:detail_uuid' nucleo.public_id %}"
-   class="group block rounded-2xl border border-neutral-200 bg-white shadow-sm hover:shadow-lg hover:scale-[1.01] transition-transform focus:outline-none focus:ring-2 focus:ring-primary/40">
+   class="group block rounded-2xl border border-neutral-200 bg-secondary shadow-sm hover:shadow-lg hover:scale-[1.01] transition-transform focus:outline-none focus:ring-2 focus:ring-primary/40">
   <article class="overflow-hidden rounded-2xl" role="article" aria-label="{{ nucleo.nome }}">
     <header class="relative">
       {% if nucleo.cover %}

--- a/templates/partials/cards/total_card.html
+++ b/templates/partials/cards/total_card.html
@@ -1,5 +1,5 @@
 {# Card de total #}
-<div class="p-4 rounded-2xl border border-neutral-200 bg-white shadow-sm">
+<div class="p-4 rounded-2xl border border-neutral-200 bg-secondary shadow-sm">
   <div class="text-sm text-neutral-500">{{ label }}</div>
   <div class="mt-1 text-2xl font-bold text-neutral-900">{{ valor }}</div>
 </div>


### PR DESCRIPTION
## Summary
- set light theme background variables to white and soft gray
- align sidebar, layout, cards and home buttons with new palette
- fix finance import confirmation button contrast

## Testing
- `pytest -m "not slow"` *(fails: ModuleNotFoundError: No module named 'silk', many tests error)*

------
https://chatgpt.com/codex/tasks/task_e_68bed32d41a483258ae5fb83105baa87