### PR TITLE
Refactor template colors to CSS tokens

### DIFF
--- a/dashboard/templates/dashboard/export_pdf.html
+++ b/dashboard/templates/dashboard/export_pdf.html
@@ -8,7 +8,7 @@
   <style>
     body { font-family: sans-serif; }
     table { width: 100%; border-collapse: collapse; }
-    th, td { border: 1px solid #ccc; padding: 4px; text-align: left; }
+    th, td { border: 1px solid var(--border-secondary); padding: 4px; text-align: left; }
   </style>
 </head>
 <body>

--- a/dashboard/templates/dashboard/partials/chart.html
+++ b/dashboard/templates/dashboard/partials/chart.html
@@ -8,9 +8,10 @@
   (function(){
     const ctx = document.getElementById('{{ chart_id }}');
     if(ctx){
+      const primaryColor = getComputedStyle(document.documentElement).getPropertyValue('--primary').trim();
       new Chart(ctx, {
         type: '{{ type|default:"bar" }}',
-        data: {labels: {{ labels|safe }}, datasets:[{label: '{{ title }}', data: {{ data|safe }}, backgroundColor: '#3b82f6'}]},
+        data: {labels: {{ labels|safe }}, datasets:[{label: '{{ title }}', data: {{ data|safe }}, backgroundColor: primaryColor}]},
         options: {responsive: true, maintainAspectRatio: false}
       });
     }

--- a/financeiro/templates/financeiro/forecast.html
+++ b/financeiro/templates/financeiro/forecast.html
@@ -28,7 +28,7 @@
         <input type="range" name="reducao_despesa" id="reducao" min="0" max="100" value="0" class="w-full" />
       </div>
     </div>
-    <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">{% trans "Atualizar" %}</button>
+    <button type="submit" class="bg-[var(--primary)] text-white px-4 py-2 rounded hover:opacity-90">{% trans "Atualizar" %}</button>
   </form>
   <div id="forecast-result" class="mt-6">
     <!-- gráfico e tabela serão inseridos aqui -->
@@ -73,13 +73,18 @@ function renderForecast(xhr){
       canvas.className = 'mt-4';
       container.appendChild(canvas);
       const ctx = canvas.getContext('2d');
+      const styles = getComputedStyle(document.documentElement);
+      const successColor = styles.getPropertyValue('--success').trim();
+      const errorColor = styles.getPropertyValue('--error').trim();
+      const successBg = successColor + '33';
+      const errorBg = errorColor + '33';
       new Chart(ctx, {
         type: 'line',
         data: {
           labels: rows.map(r => r.mes),
           datasets: [
-            {label: '{% trans "Receita" %}', data: rows.map(r => r.receita), borderColor: '#16a34a', backgroundColor: 'rgba(22,163,74,0.2)'},
-            {label: '{% trans "Despesa" %}', data: rows.map(r => r.despesa), borderColor: '#dc2626', backgroundColor: 'rgba(220,38,38,0.2)'}
+            {label: '{% trans "Receita" %}', data: rows.map(r => r.receita), borderColor: successColor, backgroundColor: successBg},
+            {label: '{% trans "Despesa" %}', data: rows.map(r => r.despesa), borderColor: errorColor, backgroundColor: errorBg}
           ]
         },
         options: {responsive: true}

--- a/templates/base.html
+++ b/templates/base.html
@@ -6,7 +6,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="manifest" href="{% static 'manifest.json' %}">
-  <meta name="theme-color" content="#0f172a">
+  <meta name="theme-color" content="">
   <script>
     (function () {
       const stored = localStorage.getItem('tema');
@@ -21,6 +21,12 @@
       const langMatch = document.cookie.match(/(?:^|; )django_language=([^;]+)/);
       if (langMatch) {
         document.documentElement.setAttribute('lang', langMatch[1]);
+      }
+
+      const metaTheme = document.querySelector('meta[name="theme-color"]');
+      if (metaTheme) {
+        const color = getComputedStyle(document.documentElement).getPropertyValue('--primary-dark').trim();
+        if (color) metaTheme.setAttribute('content', color);
       }
     })();
   </script>
@@ -40,7 +46,7 @@
 <body class="preload min-h-screen flex font-sans text-gray-800" data-is-authenticated="{{ request.user.is_authenticated|yesno:'true,false' }}">
   <noscript>
     <style>body.preload { opacity: 1; }</style>
-    <div class="p-4 text-center bg-red-500 text-white">
+    <div class="p-4 text-center bg-[var(--error)] text-white">
       {% trans "Este site requer JavaScript. Por favor, habilite-o para continuar." %}
     </div>
   </noscript>
@@ -49,7 +55,7 @@
   {% if messages %}
   <div id="messages" class="fixed top-4 right-4 space-y-2 z-50">
     {% for message in messages %}
-      <div class="px-4 py-2 rounded shadow text-white {% if 'error' in message.tags %}bg-red-500{% elif 'success' in message.tags %}bg-green-500{% else %}bg-blue-500{% endif %}">
+      <div class="px-4 py-2 rounded shadow text-white {% if 'error' in message.tags %}bg-[var(--error)]{% elif 'success' in message.tags %}bg-[var(--success)]{% else %}bg-[var(--primary)]{% endif %}">
         {{ message }}
       </div>
     {% endfor %}

--- a/tokens/templates/tokens/desativar_2fa.html
+++ b/tokens/templates/tokens/desativar_2fa.html
@@ -14,13 +14,13 @@
   <form method="post" action="" class="bg-white rounded-2xl shadow p-6 space-y-4">
     {% csrf_token %}
     <div class="text-right">
-      <button type="submit" class="rounded-xl bg-red-500 px-4 py-2 text-white hover:bg-red-600">
+      <button type="submit" class="rounded-xl bg-[var(--error)] px-4 py-2 text-white hover:opacity-90">
         {% trans "Desativar" %}
       </button>
     </div>
   </form>
   <footer class="mt-6 text-center">
-    <a href="{% url 'configuracoes' %}" class="text-sm text-blue-600 hover:underline">
+    <a href="{% url 'configuracoes' %}" class="text-sm text-[var(--primary)] hover:underline">
       {% trans "Voltar ao perfil de segurança" %}
     </a>
   </footer>


### PR DESCRIPTION
## Summary
- Use CSS variable tokens for Chart.js colors
- Replace fixed colors in forecast and base templates with design tokens
- Switch PDF export and 2FA templates to token-based colors

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and missing test dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68bed348ef948325959b6576a1c2ca54