### PR TITLE
feat: add accent color token

### DIFF
--- a/app/static/css/hubx.css
+++ b/app/static/css/hubx.css
@@ -124,6 +124,10 @@
   --primary-hover: var(--color-primary-700);
   --primary-light: var(--color-primary-100);
 
+  --accent: #a855f7;
+  --accent-light: #f3e8ff;
+  --accent-dark: #7e22ce;
+
   --success: var(--color-success-600);
   --success-light: var(--color-success-100);
   --warning: var(--color-warning-600);
@@ -170,6 +174,10 @@
     --primary-hover: var(--color-primary-400);
     --primary-light: var(--color-primary-900);
 
+    --accent: #a855f7;
+    --accent-light: #f3e8ff;
+    --accent-dark: #7e22ce;
+
     --success: var(--color-success-500);
     --success-light: var(--color-success-900);
     --warning: var(--color-warning-500);
@@ -203,6 +211,10 @@
   --primary: var(--color-primary-500);
   --primary-hover: var(--color-primary-400);
   --primary-light: var(--color-primary-900);
+
+  --accent: #a855f7;
+  --accent-light: #f3e8ff;
+  --accent-dark: #7e22ce;
 
   --success: var(--color-success-500);
   --success-light: var(--color-success-900);

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -28,6 +28,11 @@ const config: Config = {
                                 900: '#1e3a8a',
                                 DEFAULT: '#3b82f6',
                                 foreground: '#ffffff'
+                        },
+                        accent: {
+                                DEFAULT: 'var(--accent)',
+                                light: 'var(--accent-light)',
+                                dark: 'var(--accent-dark)'
                         }
                 },
                 fontFamily: {


### PR DESCRIPTION
## Summary
- add accent color CSS variables with light and dark variants
- expose accent token in Tailwind config for `text-accent` and `bg-accent`

## Testing
- `npm run lint` *(fails: requires interactive ESLint setup)*
- `pytest -q` *(fails: No module named 'silk')*

------
https://chatgpt.com/codex/tasks/task_e_68bed34b804483259f01708d44a95b93