### PR TITLE
refactor(cards): use CSS variable-based colors

### DIFF
--- a/static/tailwind.css
+++ b/static/tailwind.css
@@ -1094,24 +1094,6 @@ a:focus {
   border-color: var(--color-error-700);
 }
 
-.btn-danger {
-  border-width: 1px;
-  --tw-text-opacity: 1;
-  color: rgb(255 255 255 / var(--tw-text-opacity, 1));
-  background-color: var(--error);
-  border-color: var(--error);
-}
-
-.btn-danger:hover:not(:disabled) {
-  --tw-translate-y: -1px;
-  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
-  --tw-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
-  --tw-shadow-colored: 0 4px 6px -1px var(--tw-shadow-color), 0 2px 4px -2px var(--tw-shadow-color);
-  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
-  background-color: var(--color-error-700);
-  border-color: var(--color-error-700);
-}
-
 .btn-sm {
   padding-left: 0.75rem;
   padding-right: 0.75rem;
@@ -1704,6 +1686,10 @@ a:focus {
   border-top-width: 1px;
 }
 
+.border-\[var\(--border\)\] {
+  border-color: var(--border);
+}
+
 .border-gray-200 {
   --tw-border-opacity: 1;
   border-color: rgb(229 231 235 / var(--tw-border-opacity, 1));
@@ -1738,9 +1724,24 @@ a:focus {
   border-color: transparent;
 }
 
-.bg-blue-500 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(59 130 246 / var(--tw-bg-opacity, 1));
+.bg-\[var\(--bg-secondary\)\] {
+  background-color: var(--bg-secondary);
+}
+
+.bg-\[var\(--bg-tertiary\)\] {
+  background-color: var(--bg-tertiary);
+}
+
+.bg-\[var\(--error\)\] {
+  background-color: var(--error);
+}
+
+.bg-\[var\(--primary\)\] {
+  background-color: var(--primary);
+}
+
+.bg-\[var\(--success\)\] {
+  background-color: var(--success);
 }
 
 .bg-gray-100 {
@@ -1761,11 +1762,6 @@ a:focus {
 .bg-green-100 {
   --tw-bg-opacity: 1;
   background-color: rgb(220 252 231 / var(--tw-bg-opacity, 1));
-}
-
-.bg-green-500 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(34 197 94 / var(--tw-bg-opacity, 1));
 }
 
 .bg-neutral-100 {
@@ -1803,14 +1799,17 @@ a:focus {
   background-color: rgb(254 242 242 / var(--tw-bg-opacity, 1));
 }
 
-.bg-red-500 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(239 68 68 / var(--tw-bg-opacity, 1));
-}
-
 .bg-red-600 {
   --tw-bg-opacity: 1;
   background-color: rgb(220 38 38 / var(--tw-bg-opacity, 1));
+}
+
+.bg-success-100 {
+  background-color: var(--color-success-100);
+}
+
+.bg-warning-100 {
+  background-color: var(--color-warning-100);
 }
 
 .bg-white {
@@ -2037,6 +2036,10 @@ a:focus {
   letter-spacing: 0.1em;
 }
 
+.text-\[var\(--text-primary\)\] {
+  color: var(--text-primary);
+}
+
 .text-\[var\(--text-secondary\)\] {
   color: var(--text-secondary);
 }
@@ -2182,9 +2185,8 @@ a:focus {
   box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
 }
 
-.ring-white {
-  --tw-ring-opacity: 1;
-  --tw-ring-color: rgb(255 255 255 / var(--tw-ring-opacity, 1));
+.ring-\[var\(--bg-primary\)\] {
+  --tw-ring-color: var(--bg-primary);
 }
 
 .drop-shadow {
@@ -2260,6 +2262,17 @@ a:focus {
   --color-primary-700: #1d4ed8;
   --color-primary-800: #1e40af;
   --color-primary-900: #1e3a8a;
+  /* Accent Colors */
+  --color-accent-50: #faf5ff;
+  --color-accent-100: #f3e8ff;
+  --color-accent-200: #e9d5ff;
+  --color-accent-300: #d8b4fe;
+  --color-accent-400: #c084fc;
+  --color-accent-500: #a855f7;
+  --color-accent-600: #9333ea;
+  --color-accent-700: #7e22ce;
+  --color-accent-800: #6b21a8;
+  --color-accent-900: #581c87;
   /* Neutral Colors - Light */
   --color-neutral-50: #f8fafc;
   --color-neutral-100: #f1f5f9;
@@ -2274,9 +2287,14 @@ a:focus {
   /* Semantic Colors */
   --color-success-50: #f0fdf4;
   --color-success-100: #dcfce7;
+  --color-success-200: #bbf7d0;
+  --color-success-300: #86efac;
+  --color-success-400: #4ade80;
   --color-success-500: #22c55e;
   --color-success-600: #16a34a;
   --color-success-700: #15803d;
+  --color-success-800: #166534;
+  --color-success-900: #14532d;
   --color-warning-50: #fefce8;
   --color-warning-100: #fef9c3;
   --color-warning-200: #fef08a;
@@ -2286,9 +2304,14 @@ a:focus {
   --color-warning-900: #713f12;
   --color-error-50: #fef2f2;
   --color-error-100: #fee2e2;
+  --color-error-200: #fecaca;
+  --color-error-300: #fca5a5;
+  --color-error-400: #f87171;
   --color-error-500: #ef4444;
   --color-error-600: #dc2626;
   --color-error-700: #b91c1c;
+  --color-error-800: #991b1b;
+  --color-error-900: #7f1d1d;
   /* Typography */
   --font-family-sans: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   --font-family-mono: "JetBrains Mono", "Fira Code", Consolas, monospace;
@@ -2337,8 +2360,8 @@ a:focus {
   --transition-normal: 250ms ease-in-out;
   --transition-slow: 350ms ease-in-out;
   /* Light Theme (Default) */
-  --bg-primary: var(--color-neutral-50);
-  --bg-secondary: #ffffff;
+  --bg-primary: #ffffff;
+  --bg-secondary: #f1f5f9;
   --bg-tertiary: var(--color-neutral-100);
   --bg-accent: var(--color-primary-50);
   --text-primary: var(--color-neutral-900);
@@ -2349,10 +2372,13 @@ a:focus {
   --border: var(--color-neutral-200);
   --border-primary: var(--color-neutral-200);
   --border-secondary: var(--color-neutral-300);
-  --border-focus: var(--color-primary-500);
+  --border-focus: var(--color-primary-600);
   --primary: var(--color-primary-600);
-  --primary-hover: var(--color-primary-700);
+  --primary-hover: var(--color-primary-800);
   --primary-light: var(--color-primary-100);
+  --accent: var(--color-accent-500);
+  --accent-light: var(--color-accent-100);
+  --accent-dark: var(--color-accent-700);
   --success: var(--color-success-600);
   --success-light: var(--color-success-100);
   --warning: var(--color-warning-600);
@@ -2366,9 +2392,9 @@ a:focus {
   --shadow-heavy: 0 10px 15px -3px var(--shadow-color);
   /* Legacy Matrix theme variable mappings */
   --primary-dark: var(--color-neutral-900);
-  --matrix-green: var(--color-primary-500);
-  --matrix-light: var(--color-primary-300);
-  --matrix-dark: var(--color-primary-700);
+  --matrix-green: var(--color-primary-600);
+  --matrix-light: var(--color-primary-400);
+  --matrix-dark: var(--color-primary-800);
   --white: var(--color-neutral-50);
   --glass-border: var(--color-neutral-200);
   --glass-bg: rgba(255, 255, 255, 0.1);
@@ -2392,9 +2418,12 @@ a:focus {
     --border-primary: var(--color-neutral-700);
     --border-secondary: var(--color-neutral-600);
     --border-focus: var(--color-primary-400);
-    --primary: var(--color-primary-500);
-    --primary-hover: var(--color-primary-400);
+    --primary: var(--color-primary-600);
+    --primary-hover: var(--color-primary-800);
     --primary-light: var(--color-primary-900);
+    --accent: var(--color-accent-500);
+    --accent-light: var(--color-accent-100);
+    --accent-dark: var(--color-accent-700);
     --success: var(--color-success-500);
     --success-light: var(--color-success-900);
     --warning: var(--color-warning-500);
@@ -2423,9 +2452,12 @@ a:focus {
   --border-primary: var(--color-neutral-700);
   --border-secondary: var(--color-neutral-600);
   --border-focus: var(--color-primary-400);
-  --primary: var(--color-primary-500);
-  --primary-hover: var(--color-primary-400);
+  --primary: var(--color-primary-600);
+  --primary-hover: var(--color-primary-800);
   --primary-light: var(--color-primary-900);
+  --accent: var(--color-accent-500);
+  --accent-light: var(--color-accent-100);
+  --accent-dark: var(--color-accent-700);
   --success: var(--color-success-500);
   --success-light: var(--color-success-900);
   --warning: var(--color-warning-500);
@@ -2784,6 +2816,14 @@ a:focus {
 .dark\:bg-slate-800:is(.dark *) {
   --tw-bg-opacity: 1;
   background-color: rgb(30 41 59 / var(--tw-bg-opacity, 1));
+}
+
+.dark\:bg-success-900:is(.dark *) {
+  background-color: var(--color-success-900);
+}
+
+.dark\:bg-warning-900:is(.dark *) {
+  background-color: var(--color-warning-900);
 }
 
 .dark\:text-gray-100:is(.dark *) {

--- a/templates/partials/cards/base_card.html
+++ b/templates/partials/cards/base_card.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 <a href="{{ url }}"
-  class="group block rounded-2xl border border-neutral-200 bg-secondary shadow-sm hover:shadow-lg transition-shadow focus:outline-none focus:ring-2 focus:ring-primary/40"
+  class="group block rounded-2xl border border-[var(--border)] bg-[var(--bg-secondary)] shadow-sm hover:shadow-lg transition-shadow focus:outline-none focus:ring-2 focus:ring-primary/40"
   aria-label="{{ title }}">
   <article class="overflow-hidden rounded-2xl" role="article">
     <header class="relative">
@@ -11,16 +11,16 @@
       {% endif %}
       <div class="absolute -bottom-8 left-4">
         {% if avatar %}
-          <img src="{{ avatar.url|default:avatar }}" alt="{{ title }}" class="h-16 w-16 rounded-full ring-4 ring-white object-cover" />
+          <img src="{{ avatar.url|default:avatar }}" alt="{{ title }}" class="h-16 w-16 rounded-full ring-4 ring-[var(--bg-primary)] object-cover" />
         {% else %}
-          <div class="h-16 w-16 rounded-full ring-4 ring-white bg-neutral-200 flex items-center justify-center text-lg font-semibold text-primary" role="img" aria-label="{{ title }}">
+          <div class="h-16 w-16 rounded-full ring-4 ring-[var(--bg-primary)] bg-[var(--bg-tertiary)] flex items-center justify-center text-lg font-semibold text-primary" role="img" aria-label="{{ title }}">
             {{ title|first|upper }}
           </div>
         {% endif %}
       </div>
     </header>
   <div class="px-4 pt-10 pb-4">
-      <h3 class="text-base font-semibold text-neutral-900 group-hover:underline">{{ title }}</h3>
+      <h3 class="text-base font-semibold text-[var(--text-primary)] group-hover:underline">{{ title }}</h3>
       {% include details %}
     </div>
   </article>

--- a/templates/partials/cards/empresa_card.html
+++ b/templates/partials/cards/empresa_card.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 {# Card de Empresa #}
 <a href="{% url 'empresas:detail' empresa.pk %}"
-   class="group block rounded-2xl border border-neutral-200 bg-secondary shadow-sm hover:shadow-lg transition-shadow focus:outline-none focus:ring-2 focus:ring-primary/40">
+   class="group block rounded-2xl border border-[var(--border)] bg-[var(--bg-secondary)] shadow-sm hover:shadow-lg transition-shadow focus:outline-none focus:ring-2 focus:ring-primary/40">
   <article class="overflow-hidden rounded-2xl" role="article" aria-label="{{ empresa.nome }}">
     <header class="relative">
       {% if empresa.cover %}
@@ -13,23 +13,23 @@
       <div class="absolute -bottom-8 left-4">
         {% if empresa.avatar %}
           <img src="{{ empresa.avatar.url }}" alt="{{ empresa.nome }}"
-               class="h-16 w-16 rounded-full ring-4 ring-white object-cover" />
+               class="h-16 w-16 rounded-full ring-4 ring-[var(--bg-primary)] object-cover" />
         {% else %}
-          <div class="h-16 w-16 rounded-full ring-4 ring-white bg-neutral-200 flex items-center justify-center text-lg font-semibold text-primary" role="img" aria-label="{{ empresa.nome }}">
+          <div class="h-16 w-16 rounded-full ring-4 ring-[var(--bg-primary)] bg-[var(--bg-tertiary)] flex items-center justify-center text-lg font-semibold text-primary" role="img" aria-label="{{ empresa.nome }}">
             {{ empresa.nome|first|upper }}
           </div>
         {% endif %}
       </div>
     </header>
     <div class="px-4 pt-10 pb-4">
-      <h3 class="text-base font-semibold text-neutral-900 group-hover:underline">{{ empresa.nome }}</h3>
-      <dl class="mt-3 grid grid-cols-2 gap-2 text-xs text-neutral-600">
+      <h3 class="text-base font-semibold text-[var(--text-primary)] group-hover:underline">{{ empresa.nome }}</h3>
+      <dl class="mt-3 grid grid-cols-2 gap-2 text-xs text-[var(--text-secondary)]">
         <div>
-          <dt class="text-neutral-500">CNPJ</dt>
+          <dt class="text-[var(--text-secondary)]">CNPJ</dt>
           <dd class="font-medium">{{ empresa.cnpj }}</dd>
         </div>
         <div>
-          <dt class="text-neutral-500">{% trans 'Proprietário' %}</dt>
+          <dt class="text-[var(--text-secondary)]">{% trans 'Proprietário' %}</dt>
           <dd class="font-medium">
             <a href="{% url 'accounts:perfil_publico_uuid' empresa.usuario.public_id %}" class="text-primary hover:underline">
               {{ empresa.usuario.get_full_name|default:empresa.usuario.username }}

--- a/templates/partials/cards/evento_card_details.html
+++ b/templates/partials/cards/evento_card_details.html
@@ -1,19 +1,19 @@
 {% load i18n %}
-<dl class="mt-3 grid grid-cols-4 gap-2 text-xs text-neutral-600">
+<dl class="mt-3 grid grid-cols-4 gap-2 text-xs text-[var(--text-secondary)]">
   <div>
-    <dt class="text-neutral-500">{% trans 'Inscritos' %}</dt>
+    <dt class="text-[var(--text-secondary)]">{% trans 'Inscritos' %}</dt>
     <dd class="font-medium">{{ evento.num_inscritos|default:0 }}</dd>
   </div>
   <div>
-    <dt class="text-neutral-500">{% trans 'Núcleo' %}</dt>
+    <dt class="text-[var(--text-secondary)]">{% trans 'Núcleo' %}</dt>
     <dd class="font-medium">{% if evento.nucleo %}{{ evento.nucleo.nome }}{% else %}-{% endif %}</dd>
   </div>
   <div>
-    <dt class="text-neutral-500">{% trans 'Coordenador' %}</dt>
+    <dt class="text-[var(--text-secondary)]">{% trans 'Coordenador' %}</dt>
     <dd class="font-medium">{{ evento.coordenador.get_full_name|default:evento.coordenador.username }}</dd>
   </div>
   <div>
-    <dt class="text-neutral-500">{% trans 'Status' %}</dt>
+    <dt class="text-[var(--text-secondary)]">{% trans 'Status' %}</dt>
     <dd class="font-medium">
       {% if evento.status == 0 %}{% trans 'Ativo' %}{% elif evento.status == 1 %}{% trans 'Concluído' %}{% else %}{% trans 'Cancelado' %}{% endif %}
     </dd>

--- a/templates/partials/cards/nucleo_card.html
+++ b/templates/partials/cards/nucleo_card.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 {# Card de Núcleo #}
 <a href="{% url 'nucleos:detail_uuid' nucleo.public_id %}"
-   class="group block rounded-2xl border border-neutral-200 bg-secondary shadow-sm hover:shadow-lg hover:scale-[1.01] transition-transform focus:outline-none focus:ring-2 focus:ring-primary/40">
+   class="group block rounded-2xl border border-[var(--border)] bg-[var(--bg-secondary)] shadow-sm hover:shadow-lg hover:scale-[1.01] transition-transform focus:outline-none focus:ring-2 focus:ring-primary/40">
   <article class="overflow-hidden rounded-2xl" role="article" aria-label="{{ nucleo.nome }}">
     <header class="relative">
       {% if nucleo.cover %}
@@ -13,23 +13,23 @@
       <div class="absolute -bottom-8 left-4">
         {% if nucleo.avatar %}
           <img src="{{ nucleo.avatar.url }}" alt="{{ nucleo.nome }}"
-               class="h-16 w-16 rounded-full ring-4 ring-white object-cover" />
+               class="h-16 w-16 rounded-full ring-4 ring-[var(--bg-primary)] object-cover" />
         {% else %}
-          <div class="h-16 w-16 rounded-full ring-4 ring-white bg-neutral-200 flex items-center justify-center text-lg font-semibold text-primary" role="img" aria-label="{{ nucleo.nome }}">
+          <div class="h-16 w-16 rounded-full ring-4 ring-[var(--bg-primary)] bg-[var(--bg-tertiary)] flex items-center justify-center text-lg font-semibold text-primary" role="img" aria-label="{{ nucleo.nome }}">
             {{ nucleo.nome|first|upper }}
           </div>
         {% endif %}
       </div>
     </header>
     <div class="px-4 pt-10 pb-4">
-      <h3 class="text-base font-semibold text-neutral-900 group-hover:underline">{{ nucleo.nome }}</h3>
-      <dl class="mt-3 grid grid-cols-3 gap-2 text-xs text-neutral-600">
+      <h3 class="text-base font-semibold text-[var(--text-primary)] group-hover:underline">{{ nucleo.nome }}</h3>
+      <dl class="mt-3 grid grid-cols-3 gap-2 text-xs text-[var(--text-secondary)]">
         <div>
-          <dt class="text-neutral-500">{% trans 'Membros' %}</dt>
+          <dt class="text-[var(--text-secondary)]">{% trans 'Membros' %}</dt>
           <dd class="font-medium">{{ nucleo.num_membros|default:nucleo.membros.count }}</dd>
         </div>
         <div>
-          <dt class="text-neutral-500">{% trans 'Coordenador' %}</dt>
+          <dt class="text-[var(--text-secondary)]">{% trans 'Coordenador' %}</dt>
           <dd class="font-medium">
             {% with coord=nucleo.coordenadores.first %}
               {% if coord %}{{ coord.get_full_name|default:coord.username }}{% else %}-{% endif %}
@@ -37,7 +37,7 @@
           </dd>
         </div>
         <div>
-          <dt class="text-neutral-500">{% trans 'Eventos' %}</dt>
+          <dt class="text-[var(--text-secondary)]">{% trans 'Eventos' %}</dt>
           <dd class="font-medium">{{ nucleo.num_eventos|default:0 }}</dd>
         </div>
       </dl>

--- a/templates/partials/cards/total_card.html
+++ b/templates/partials/cards/total_card.html
@@ -1,5 +1,5 @@
 {# Card de total #}
-<div class="p-4 rounded-2xl border border-neutral-200 bg-secondary shadow-sm">
-  <div class="text-sm text-neutral-500">{{ label }}</div>
-  <div class="mt-1 text-2xl font-bold text-neutral-900">{{ valor }}</div>
+<div class="p-4 rounded-2xl border border-[var(--border)] bg-[var(--bg-secondary)] shadow-sm">
+  <div class="text-sm text-[var(--text-secondary)]">{{ label }}</div>
+  <div class="mt-1 text-2xl font-bold text-[var(--text-primary)]">{{ valor }}</div>
 </div>


### PR DESCRIPTION
## Summary
- replace neutral color classes in card templates with CSS variable-based equivalents
- rebuild Tailwind to compile new variable classes

## Testing
- `npm run build:css`
- `pytest` *(fails: ModuleNotFoundError: No module named 'silk'; later, 81 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bee40f9f78832584ed20f65b4ee33b