### PR TITLE
style: update repasses template colors

### DIFF
--- a/financeiro/templates/financeiro/repasses.html
+++ b/financeiro/templates/financeiro/repasses.html
@@ -10,7 +10,7 @@
     <div class="card-header">
       <form id="filtros" class="flex gap-4" hx-get="/api/financeiro/repasses/" hx-target="#lista" hx-swap="none" hx-trigger="change from:select,change from:input, submit" hx-on="htmx:afterRequest: renderRepasses(event)">
         <div>
-          <label for="filtro-evento" class="block text-sm font-medium text-gray-700">{% trans "Evento" %}</label>
+          <label for="filtro-evento" class="block text-sm font-medium text-[var(--text-secondary)]">{% trans "Evento" %}</label>
           <select id="filtro-evento" name="evento" class="border p-2 rounded">
             <option value="">{% trans "Todos" %}</option>
             {% for e in eventos %}
@@ -22,14 +22,14 @@
     </div>
     <div class="card-body">
       <div id="lista" aria-live="polite">
-        <table class="min-w-full divide-y divide-gray-200">
+        <table class="min-w-full divide-y divide-[var(--border)]">
           <thead>
-            <tr class="bg-gray-50">
-              <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{% trans "ID" %}</th>
-              <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{% trans "Centro de Custo" %}</th>
-              <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{% trans "Conta Associada" %}</th>
-              <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{% trans "Valor" %}</th>
-              <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{% trans "Data de Lançamento" %}</th>
+            <tr class="bg-[var(--bg-tertiary)]">
+              <th class="px-3 py-2 text-left text-xs font-medium text-[var(--text-secondary)]">{% trans "ID" %}</th>
+              <th class="px-3 py-2 text-left text-xs font-medium text-[var(--text-secondary)]">{% trans "Centro de Custo" %}</th>
+              <th class="px-3 py-2 text-left text-xs font-medium text-[var(--text-secondary)]">{% trans "Conta Associada" %}</th>
+              <th class="px-3 py-2 text-left text-xs font-medium text-[var(--text-secondary)]">{% trans "Valor" %}</th>
+              <th class="px-3 py-2 text-left text-xs font-medium text-[var(--text-secondary)]">{% trans "Data de Lançamento" %}</th>
             </tr>
           </thead>
           <tbody></tbody>


### PR DESCRIPTION
## Summary
- use color variables for repasses filter label and table

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'freezegun', 'factory', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bf0696cf588325b9b09e33d5e8a317