### PR TITLE
refactor: update profile template styles

### DIFF
--- a/accounts/templates/perfil/perfil.html
+++ b/accounts/templates/perfil/perfil.html
@@ -10,13 +10,13 @@
 {% include 'components/hero.html' with title=block.hero_title|default:_('Meu Perfil') subtitle=block.hero_subtitle %}
 <div class="container mx-auto p-6">
   <div class="grid grid-cols-1 gap-6">
-    <div class="bg-white dark:bg-slate-800 p-6 rounded-lg shadow">
+    <div class="bg-[var(--bg-secondary)] p-6 rounded-lg shadow">
       {% with perfil|default:user as profile %}
       <div class="profile-cover relative h-48 w-full overflow-hidden">
         {% if profile.cover %}
           <img src="{{ profile.cover.url }}" alt="{% trans "Capa do usuário" %}" class="absolute inset-0 w-full h-full object-cover z-0" aria-hidden="true">
         {% else %}
-          <div class="absolute inset-0 w-full h-full bg-neutral-200 dark:bg-slate-700 z-0" role="img" aria-label="{% trans "Capa padrão" %}"></div>
+          <div class="absolute inset-0 w-full h-full bg-[var(--bg-tertiary)] z-0" role="img" aria-label="{% trans "Capa padrão" %}"></div>
         {% endif %}
 
         <div class="absolute inset-0 z-50 flex items-center justify-center text-center text-white drop-shadow">
@@ -29,10 +29,10 @@
                 {{ profile.username|first|upper }}
               </div>
             {% endif %}
-            <h2 class="mb-0.5 text-lg font-bold text-gray-900 dark:text-gray-100">{{ profile.get_full_name }}</h2>
-            <p class="mt-0 text-sm text-gray-600 dark:text-gray-400">@{{ profile.username }}</p>
+            <h2 class="mb-0.5 text-lg font-bold text-[var(--text-primary)]">{{ profile.get_full_name }}</h2>
+            <p class="mt-0 text-sm text-[var(--text-secondary)]">@{{ profile.username }}</p>
             {% if profile == request.user %}
-            <button class="text-sm text-gray-700 dark:text-gray-300 hover:underline">{% trans "Alterar foto" %}</button>
+            <button class="text-sm text-[var(--text-secondary)] hover:underline">{% trans "Alterar foto" %}</button>
             {% endif %}
           </div>
         </div>
@@ -42,7 +42,7 @@
 
       {% if request.resolver_match.url_name == 'informacoes_pessoais' or request.resolver_match.url_name == 'redes_sociais' %}
 
-        <nav class="mt-6 border-b flex space-x-4 text-sm font-medium text-gray-600 dark:text-gray-400 border-gray-200 dark:border-gray-700" role="tablist">
+        <nav class="mt-6 border-b flex space-x-4 text-sm font-medium text-[var(--text-secondary)] border-[var(--border)]" role="tablist">
           <a href="{% url 'accounts:informacoes_pessoais' %}"
              class="px-3 py-2 -mb-px border-b-2 {% if request.resolver_match.url_name == 'informacoes_pessoais' %}border-primary text-primary dark:text-primary{% else %}border-transparent hover:text-primary dark:hover:text-primary{% endif %}"
              role="tab"


### PR DESCRIPTION
## Summary
- use CSS variables for profile background colors
- align profile text and tab colors with theme variables

## Testing
- `pytest -m "not slow"` *(fails: 81 errors in tokens tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bf06969cbc83258d6576746d7ba640