### PR TITLE
refactor: align personal info form with floating label pattern

### DIFF
--- a/accounts/templates/perfil/informacoes_pessoais.html
+++ b/accounts/templates/perfil/informacoes_pessoais.html
@@ -16,77 +16,101 @@
 
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div class="relative">
-            {% with
-                label_attr="aria-label:"|add:form.first_name.label
-                required_attr="aria-required:"|add:(form.first_name.field.required|yesno:'true,false')
-            %}
-            {% with label_attr="aria-label:"|add:form.first_name.label required_flag=form.first_name.field.required|yesno:'true,false' required_attr="aria-required:"|add:required_flag %}
-            {{ form.first_name|add_class:'peer form-input placeholder-transparent' |attr:'placeholder: ' |attr:label_attr |attr:required_attr }}
+            {% with invalid_flag=form.first_name.errors|yesno:'true,false' %}
+              {% with label_attr='aria-label:'|add:form.first_name.label required_flag=form.first_name.field.required|yesno:'true,false' required_attr='aria-required:'|add:required_flag aria_invalid='aria-invalid:'|add:invalid_flag desc_attr='aria-describedby:'|add:form.first_name.id_for_label|add:'_error' placeholder_attr='placeholder:'|add:form.first_name.label %}
+                {{ form.first_name|add_class:'peer form-input placeholder-transparent'|attr:placeholder_attr|attr:label_attr|attr:required_attr|attr:aria_invalid|attr:desc_attr }}
+              {% endwith %}
             {% endwith %}
             <label for="{{ form.first_name.id_for_label }}" class="label-float">{{ form.first_name.label }}</label>
-            {{ form.first_name.errors }}
+            {% if form.first_name.errors %}
+              <div id="{{ form.first_name.id_for_label }}_error" class="text-red-600 text-xs mt-1" role="alert">{{ form.first_name.errors }}</div>
+            {% endif %}
           </div>
           <div class="relative">
-            {% with
-                label_attr="aria-label:"|add:form.last_name.label
-                required_attr="aria-required:"|add:(form.last_name.field.required|yesno:'true,false')
-            %}
-            {% with label_attr="aria-label:"|add:form.last_name.label required_flag=form.last_name.field.required|yesno:'true,false' required_attr="aria-required:"|add:required_flag %}
-            {{ form.last_name|add_class:'peer form-input placeholder-transparent' |attr:'placeholder: ' |attr:label_attr |attr:required_attr }}
+            {% with invalid_flag=form.last_name.errors|yesno:'true,false' %}
+              {% with label_attr='aria-label:'|add:form.last_name.label required_flag=form.last_name.field.required|yesno:'true,false' required_attr='aria-required:'|add:required_flag aria_invalid='aria-invalid:'|add:invalid_flag desc_attr='aria-describedby:'|add:form.last_name.id_for_label|add:'_error' placeholder_attr='placeholder:'|add:form.last_name.label %}
+                {{ form.last_name|add_class:'peer form-input placeholder-transparent'|attr:placeholder_attr|attr:label_attr|attr:required_attr|attr:aria_invalid|attr:desc_attr }}
+              {% endwith %}
             {% endwith %}
             <label for="{{ form.last_name.id_for_label }}" class="label-float">{{ form.last_name.label }}</label>
-            {{ form.last_name.errors }}
+            {% if form.last_name.errors %}
+              <div id="{{ form.last_name.id_for_label }}_error" class="text-red-600 text-xs mt-1" role="alert">{{ form.last_name.errors }}</div>
+            {% endif %}
           </div>
         </div>
 
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div class="relative">
-            {% with label_attr="aria-label:"|add:form.username.label required_attr="aria-required:"|add:(form.username.field.required|yesno:'true,false') %}
-            {{ form.username|add_class:'peer form-input placeholder-transparent' |attr:'placeholder: ' |attr:label_attr |attr:required_attr }}
+            {% with invalid_flag=form.username.errors|yesno:'true,false' %}
+              {% with label_attr='aria-label:'|add:form.username.label required_flag=form.username.field.required|yesno:'true,false' required_attr='aria-required:'|add:required_flag aria_invalid='aria-invalid:'|add:invalid_flag desc_attr='aria-describedby:'|add:form.username.id_for_label|add:'_error' placeholder_attr='placeholder:'|add:form.username.label %}
+                {{ form.username|add_class:'peer form-input placeholder-transparent'|attr:placeholder_attr|attr:label_attr|attr:required_attr|attr:aria_invalid|attr:desc_attr }}
+              {% endwith %}
             {% endwith %}
             <label for="{{ form.username.id_for_label }}" class="label-float">{{ form.username.label }}</label>
-            {{ form.username.errors }}
+            {% if form.username.errors %}
+              <div id="{{ form.username.id_for_label }}_error" class="text-red-600 text-xs mt-1" role="alert">{{ form.username.errors }}</div>
+            {% endif %}
           </div>
 
           <div class="relative">
-            {% with label_attr="aria-label:"|add:form.email.label required_attr="aria-required:"|add:(form.email.field.required|yesno:'true,false') %}
-            {{ form.email|add_class:'peer form-input placeholder-transparent' |attr:'placeholder: ' |attr:label_attr |attr:required_attr }}
+            {% with invalid_flag=form.email.errors|yesno:'true,false' %}
+              {% with label_attr='aria-label:'|add:form.email.label required_flag=form.email.field.required|yesno:'true,false' required_attr='aria-required:'|add:required_flag aria_invalid='aria-invalid:'|add:invalid_flag desc_attr='aria-describedby:'|add:form.email.id_for_label|add:'_error' placeholder_attr='placeholder:'|add:form.email.label %}
+                {{ form.email|add_class:'peer form-input placeholder-transparent'|attr:placeholder_attr|attr:label_attr|attr:required_attr|attr:aria_invalid|attr:desc_attr }}
+              {% endwith %}
             {% endwith %}
             <label for="{{ form.email.id_for_label }}" class="label-float">{{ form.email.label }}</label>
-            {{ form.email.errors }}
+            {% if form.email.errors %}
+              <div id="{{ form.email.id_for_label }}_error" class="text-red-600 text-xs mt-1" role="alert">{{ form.email.errors }}</div>
+            {% endif %}
           </div>
         </div>
 
         <div class="relative">
-          {% with label_attr="aria-label:"|add:form.cpf.label required_attr="aria-required:"|add:(form.cpf.field.required|yesno:'true,false') %}
-          {{ form.cpf|add_class:'peer form-input placeholder-transparent' |attr:'placeholder: ' |attr:label_attr |attr:required_attr }}
+          {% with invalid_flag=form.cpf.errors|yesno:'true,false' %}
+            {% with label_attr='aria-label:'|add:form.cpf.label required_flag=form.cpf.field.required|yesno:'true,false' required_attr='aria-required:'|add:required_flag aria_invalid='aria-invalid:'|add:invalid_flag desc_attr='aria-describedby:'|add:form.cpf.id_for_label|add:'_error' placeholder_attr='placeholder:'|add:form.cpf.label %}
+              {{ form.cpf|add_class:'peer form-input placeholder-transparent'|attr:placeholder_attr|attr:label_attr|attr:required_attr|attr:aria_invalid|attr:desc_attr }}
+            {% endwith %}
           {% endwith %}
           <label for="{{ form.cpf.id_for_label }}" class="label-float">{{ form.cpf.label }}</label>
-          {{ form.cpf.errors }}
+          {% if form.cpf.errors %}
+            <div id="{{ form.cpf.id_for_label }}_error" class="text-red-600 text-xs mt-1" role="alert">{{ form.cpf.errors }}</div>
+          {% endif %}
         </div>
 
         <div class="relative">
-          {% with label_attr="aria-label:"|add:form.biografia.label required_attr="aria-required:"|add:(form.biografia.field.required|yesno:'true,false')%}
-          {{ form.biografia|add_class:'peer form-input placeholder-transparent' |attr:'placeholder: ' |attr:label_attr |attr:required_attr }}
+          {% with invalid_flag=form.biografia.errors|yesno:'true,false' %}
+            {% with label_attr='aria-label:'|add:form.biografia.label required_flag=form.biografia.field.required|yesno:'true,false' required_attr='aria-required:'|add:required_flag aria_invalid='aria-invalid:'|add:invalid_flag desc_attr='aria-describedby:'|add:form.biografia.id_for_label|add:'_error' placeholder_attr='placeholder:'|add:form.biografia.label %}
+              {{ form.biografia|add_class:'peer form-input placeholder-transparent'|attr:placeholder_attr|attr:label_attr|attr:required_attr|attr:aria_invalid|attr:desc_attr }}
+            {% endwith %}
           {% endwith %}
           <label for="{{ form.biografia.id_for_label }}" class="label-float">{{ form.biografia.label }}</label>
-          {{ form.biografia.errors }}
+          {% if form.biografia.errors %}
+            <div id="{{ form.biografia.id_for_label }}_error" class="text-red-600 text-xs mt-1" role="alert">{{ form.biografia.errors }}</div>
+          {% endif %}
         </div>
 
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div class="relative">
-            {% with label_attr="aria-label:"|add:form.avatar.label required_attr="aria-required:"|add:(form.avatar.field.required|yesno:'true,false') %}
-            {{ form.avatar|add_class:'peer form-input placeholder-transparent' |attr:'placeholder: ' |attr:label_attr |attr:required_attr }}
+            {% with invalid_flag=form.avatar.errors|yesno:'true,false' %}
+              {% with label_attr='aria-label:'|add:form.avatar.label required_flag=form.avatar.field.required|yesno:'true,false' required_attr='aria-required:'|add:required_flag aria_invalid='aria-invalid:'|add:invalid_flag desc_attr='aria-describedby:'|add:form.avatar.id_for_label|add:'_error' placeholder_attr='placeholder:'|add:form.avatar.label %}
+                {{ form.avatar|add_class:'peer form-input placeholder-transparent'|attr:placeholder_attr|attr:label_attr|attr:required_attr|attr:aria_invalid|attr:desc_attr }}
+              {% endwith %}
             {% endwith %}
             <label for="{{ form.avatar.id_for_label }}" class="label-float">{{ form.avatar.label }}</label>
-            {{ form.avatar.errors }}
+            {% if form.avatar.errors %}
+              <div id="{{ form.avatar.id_for_label }}_error" class="text-red-600 text-xs mt-1" role="alert">{{ form.avatar.errors }}</div>
+            {% endif %}
           </div>
           <div class="relative">
-            {% with label_attr="aria-label:"|add:form.cover.label required_attr="aria-required:"|add:(form.cover.field.required|yesno:'true,false') %}
-            {{ form.cover|add_class:'peer form-input placeholder-transparent' |attr:'placeholder: ' |attr:label_attr |attr:required_attr }}
+            {% with invalid_flag=form.cover.errors|yesno:'true,false' %}
+              {% with label_attr='aria-label:'|add:form.cover.label required_flag=form.cover.field.required|yesno:'true,false' required_attr='aria-required:'|add:required_flag aria_invalid='aria-invalid:'|add:invalid_flag desc_attr='aria-describedby:'|add:form.cover.id_for_label|add:'_error' placeholder_attr='placeholder:'|add:form.cover.label %}
+                {{ form.cover|add_class:'peer form-input placeholder-transparent'|attr:placeholder_attr|attr:label_attr|attr:required_attr|attr:aria_invalid|attr:desc_attr }}
+              {% endwith %}
             {% endwith %}
             <label for="{{ form.cover.id_for_label }}" class="label-float">{{ form.cover.label }}</label>
-            {{ form.cover.errors }}
+            {% if form.cover.errors %}
+              <div id="{{ form.cover.id_for_label }}_error" class="text-red-600 text-xs mt-1" role="alert">{{ form.cover.errors }}</div>
+            {% endif %}
           </div>
         </div>
       </div>
@@ -96,19 +120,26 @@
 
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div class="relative">
-            {% with label_attr="aria-label:"|add:form.phone_number.label required_attr="aria-required:"|add:(form.phone_number.field.required|yesno:'true,false') %}
-            {{ form.phone_number|add_class:'peer form-input placeholder-transparent' |attr:'placeholder: ' |attr:label_attr |attr:required_attr }}
+            {% with invalid_flag=form.phone_number.errors|yesno:'true,false' %}
+              {% with label_attr='aria-label:'|add:form.phone_number.label required_flag=form.phone_number.field.required|yesno:'true,false' required_attr='aria-required:'|add:required_flag aria_invalid='aria-invalid:'|add:invalid_flag desc_attr='aria-describedby:'|add:form.phone_number.id_for_label|add:'_error' placeholder_attr='placeholder:'|add:form.phone_number.label %}
+                {{ form.phone_number|add_class:'peer form-input placeholder-transparent'|attr:placeholder_attr|attr:label_attr|attr:required_attr|attr:aria_invalid|attr:desc_attr }}
+              {% endwith %}
             {% endwith %}
             <label for="{{ form.phone_number.id_for_label }}" class="label-float">{{ form.phone_number.label }}</label>
-            {{ form.phone_number.errors }}
+            {% if form.phone_number.errors %}
+              <div id="{{ form.phone_number.id_for_label }}_error" class="text-red-600 text-xs mt-1" role="alert">{{ form.phone_number.errors }}</div>
+            {% endif %}
           </div>
           <div class="relative">
-            {% with
-                label_attr="aria-label:"|add:form.whatsapp.label required_attr="aria-required:"|add:(form.whatsapp.field.required|yesno:'true,false') %}
-            {{ form.whatsapp|add_class:'peer form-input placeholder-transparent' |attr:'placeholder: ' |attr:label_attr |attr:required_attr }}
+            {% with invalid_flag=form.whatsapp.errors|yesno:'true,false' %}
+              {% with label_attr='aria-label:'|add:form.whatsapp.label required_flag=form.whatsapp.field.required|yesno:'true,false' required_attr='aria-required:'|add:required_flag aria_invalid='aria-invalid:'|add:invalid_flag desc_attr='aria-describedby:'|add:form.whatsapp.id_for_label|add:'_error' placeholder_attr='placeholder:'|add:form.whatsapp.label %}
+                {{ form.whatsapp|add_class:'peer form-input placeholder-transparent'|attr:placeholder_attr|attr:label_attr|attr:required_attr|attr:aria_invalid|attr:desc_attr }}
+              {% endwith %}
             {% endwith %}
             <label for="{{ form.whatsapp.id_for_label }}" class="label-float">{{ form.whatsapp.label }}</label>
-            {{ form.whatsapp.errors }}
+            {% if form.whatsapp.errors %}
+              <div id="{{ form.whatsapp.id_for_label }}_error" class="text-red-600 text-xs mt-1" role="alert">{{ form.whatsapp.errors }}</div>
+            {% endif %}
           </div>
         </div>
       </div>
@@ -117,35 +148,50 @@
         <h4 class="text-lg font-semibold">{% trans "Endereço" %}</h4>
 
         <div class="relative">
-          {% with
-            label_attr="aria-label:"|add:form.endereco.label required_attr="aria-required:"|add:(form.endereco.field.required|yesno:'true,false')%}
-          {{ form.endereco|add_class:'w-full peer form-input placeholder-transparent' |attr:'placeholder: ' |attr:label_attr |attr:required_attr }}
+          {% with invalid_flag=form.endereco.errors|yesno:'true,false' %}
+            {% with label_attr='aria-label:'|add:form.endereco.label required_flag=form.endereco.field.required|yesno:'true,false' required_attr='aria-required:'|add:required_flag aria_invalid='aria-invalid:'|add:invalid_flag desc_attr='aria-describedby:'|add:form.endereco.id_for_label|add:'_error' placeholder_attr='placeholder:'|add:form.endereco.label %}
+              {{ form.endereco|add_class:'w-full peer form-input placeholder-transparent'|attr:placeholder_attr|attr:label_attr|attr:required_attr|attr:aria_invalid|attr:desc_attr }}
+            {% endwith %}
           {% endwith %}
           <label for="{{ form.endereco.id_for_label }}" class="label-float">{{ form.endereco.label }}</label>
-          {{ form.endereco.errors }}
+          {% if form.endereco.errors %}
+            <div id="{{ form.endereco.id_for_label }}_error" class="text-red-600 text-xs mt-1" role="alert">{{ form.endereco.errors }}</div>
+          {% endif %}
         </div>
 
         <div class="grid md:grid-cols-3 gap-4">
           <div class="relative">
-            {% with label_attr="aria-label:"|add:form.cidade.label required_attr="aria-required:"|add:(form.cidade.field.required|yesno:'true,false') %}
-            {{ form.cidade|add_class:'peer form-input placeholder-transparent' |attr:'placeholder: ' |attr:label_attr |attr:required_attr }}
+            {% with invalid_flag=form.cidade.errors|yesno:'true,false' %}
+              {% with label_attr='aria-label:'|add:form.cidade.label required_flag=form.cidade.field.required|yesno:'true,false' required_attr='aria-required:'|add:required_flag aria_invalid='aria-invalid:'|add:invalid_flag desc_attr='aria-describedby:'|add:form.cidade.id_for_label|add:'_error' placeholder_attr='placeholder:'|add:form.cidade.label %}
+                {{ form.cidade|add_class:'peer form-input placeholder-transparent'|attr:placeholder_attr|attr:label_attr|attr:required_attr|attr:aria_invalid|attr:desc_attr }}
+              {% endwith %}
             {% endwith %}
             <label for="{{ form.cidade.id_for_label }}" class="label-float">{{ form.cidade.label }}</label>
-            {{ form.cidade.errors }}
+            {% if form.cidade.errors %}
+              <div id="{{ form.cidade.id_for_label }}_error" class="text-red-600 text-xs mt-1" role="alert">{{ form.cidade.errors }}</div>
+            {% endif %}
           </div>
           <div class="relative">
-            {% with label_attr="aria-label:"|add:form.estado.label required_attr="aria-required:"|add:(form.estado.field.required|yesno:'true,false') %}
-            {{ form.estado|add_class:'peer form-input placeholder-transparent' |attr:'placeholder: ' |attr:label_attr |attr:required_attr }}
+            {% with invalid_flag=form.estado.errors|yesno:'true,false' %}
+              {% with label_attr='aria-label:'|add:form.estado.label required_flag=form.estado.field.required|yesno:'true,false' required_attr='aria-required:'|add:required_flag aria_invalid='aria-invalid:'|add:invalid_flag desc_attr='aria-describedby:'|add:form.estado.id_for_label|add:'_error' placeholder_attr='placeholder:'|add:form.estado.label %}
+                {{ form.estado|add_class:'peer form-input placeholder-transparent'|attr:placeholder_attr|attr:label_attr|attr:required_attr|attr:aria_invalid|attr:desc_attr }}
+              {% endwith %}
             {% endwith %}
             <label for="{{ form.estado.id_for_label }}" class="label-float">{{ form.estado.label }}</label>
-            {{ form.estado.errors }}
+            {% if form.estado.errors %}
+              <div id="{{ form.estado.id_for_label }}_error" class="text-red-600 text-xs mt-1" role="alert">{{ form.estado.errors }}</div>
+            {% endif %}
           </div>
           <div class="relative">
-            {% with label_attr="aria-label:"|add:form.cep.label required_attr="aria-required:"|add:(form.cep.field.required|yesno:'true,false') %}
-            {{ form.cep|add_class:'peer form-input placeholder-transparent' |attr:'placeholder: ' |attr:label_attr |attr:required_attr }}
+            {% with invalid_flag=form.cep.errors|yesno:'true,false' %}
+              {% with label_attr='aria-label:'|add:form.cep.label required_flag=form.cep.field.required|yesno:'true,false' required_attr='aria-required:'|add:required_flag aria_invalid='aria-invalid:'|add:invalid_flag desc_attr='aria-describedby:'|add:form.cep.id_for_label|add:'_error' placeholder_attr='placeholder:'|add:form.cep.label %}
+                {{ form.cep|add_class:'peer form-input placeholder-transparent'|attr:placeholder_attr|attr:label_attr|attr:required_attr|attr:aria_invalid|attr:desc_attr }}
+              {% endwith %}
             {% endwith %}
             <label for="{{ form.cep.id_for_label }}" class="label-float">{{ form.cep.label }}</label>
-            {{ form.cep.errors }}
+            {% if form.cep.errors %}
+              <div id="{{ form.cep.id_for_label }}_error" class="text-red-600 text-xs mt-1" role="alert">{{ form.cep.errors }}</div>
+            {% endif %}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- apply floating-label `invalid_flag` structure to personal info form fields
- add error blocks and `aria-describedby` for accessibility

## Testing
- `pytest` *(fails: 81 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bf52dab00c8325a31c044de168c087