### PR TITLE
Refactor personal info template to use reusable form field partial

### DIFF
--- a/accounts/templates/perfil/informacoes_pessoais.html
+++ b/accounts/templates/perfil/informacoes_pessoais.html
@@ -16,77 +16,37 @@
 
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div class="relative">
-            {% with
-                label_attr="aria-label:"|add:form.first_name.label
-                required_attr="aria-required:"|add:(form.first_name.field.required|yesno:'true,false')
-            %}
-            {% with label_attr="aria-label:"|add:form.first_name.label required_flag=form.first_name.field.required|yesno:'true,false' required_attr="aria-required:"|add:required_flag %}
-            {{ form.first_name|add_class:'peer form-input placeholder-transparent' |attr:'placeholder: ' |attr:label_attr |attr:required_attr }}
-            {% endwith %}
-            <label for="{{ form.first_name.id_for_label }}" class="label-float">{{ form.first_name.label }}</label>
-            {{ form.first_name.errors }}
+            {% include 'perfil/partials/form_field.html' with field=form.first_name %}
           </div>
           <div class="relative">
-            {% with
-                label_attr="aria-label:"|add:form.last_name.label
-                required_attr="aria-required:"|add:(form.last_name.field.required|yesno:'true,false')
-            %}
-            {% with label_attr="aria-label:"|add:form.last_name.label required_flag=form.last_name.field.required|yesno:'true,false' required_attr="aria-required:"|add:required_flag %}
-            {{ form.last_name|add_class:'peer form-input placeholder-transparent' |attr:'placeholder: ' |attr:label_attr |attr:required_attr }}
-            {% endwith %}
-            <label for="{{ form.last_name.id_for_label }}" class="label-float">{{ form.last_name.label }}</label>
-            {{ form.last_name.errors }}
+            {% include 'perfil/partials/form_field.html' with field=form.last_name %}
           </div>
         </div>
 
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div class="relative">
-            {% with label_attr="aria-label:"|add:form.username.label required_attr="aria-required:"|add:(form.username.field.required|yesno:'true,false') %}
-            {{ form.username|add_class:'peer form-input placeholder-transparent' |attr:'placeholder: ' |attr:label_attr |attr:required_attr }}
-            {% endwith %}
-            <label for="{{ form.username.id_for_label }}" class="label-float">{{ form.username.label }}</label>
-            {{ form.username.errors }}
+            {% include 'perfil/partials/form_field.html' with field=form.username %}
           </div>
 
           <div class="relative">
-            {% with label_attr="aria-label:"|add:form.email.label required_attr="aria-required:"|add:(form.email.field.required|yesno:'true,false') %}
-            {{ form.email|add_class:'peer form-input placeholder-transparent' |attr:'placeholder: ' |attr:label_attr |attr:required_attr }}
-            {% endwith %}
-            <label for="{{ form.email.id_for_label }}" class="label-float">{{ form.email.label }}</label>
-            {{ form.email.errors }}
+            {% include 'perfil/partials/form_field.html' with field=form.email %}
           </div>
         </div>
 
         <div class="relative">
-          {% with label_attr="aria-label:"|add:form.cpf.label required_attr="aria-required:"|add:(form.cpf.field.required|yesno:'true,false') %}
-          {{ form.cpf|add_class:'peer form-input placeholder-transparent' |attr:'placeholder: ' |attr:label_attr |attr:required_attr }}
-          {% endwith %}
-          <label for="{{ form.cpf.id_for_label }}" class="label-float">{{ form.cpf.label }}</label>
-          {{ form.cpf.errors }}
+          {% include 'perfil/partials/form_field.html' with field=form.cpf %}
         </div>
 
         <div class="relative">
-          {% with label_attr="aria-label:"|add:form.biografia.label required_attr="aria-required:"|add:(form.biografia.field.required|yesno:'true,false')%}
-          {{ form.biografia|add_class:'peer form-input placeholder-transparent' |attr:'placeholder: ' |attr:label_attr |attr:required_attr }}
-          {% endwith %}
-          <label for="{{ form.biografia.id_for_label }}" class="label-float">{{ form.biografia.label }}</label>
-          {{ form.biografia.errors }}
+          {% include 'perfil/partials/form_field.html' with field=form.biografia %}
         </div>
 
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div class="relative">
-            {% with label_attr="aria-label:"|add:form.avatar.label required_attr="aria-required:"|add:(form.avatar.field.required|yesno:'true,false') %}
-            {{ form.avatar|add_class:'peer form-input placeholder-transparent' |attr:'placeholder: ' |attr:label_attr |attr:required_attr }}
-            {% endwith %}
-            <label for="{{ form.avatar.id_for_label }}" class="label-float">{{ form.avatar.label }}</label>
-            {{ form.avatar.errors }}
+            {% include 'perfil/partials/form_field.html' with field=form.avatar %}
           </div>
           <div class="relative">
-            {% with label_attr="aria-label:"|add:form.cover.label required_attr="aria-required:"|add:(form.cover.field.required|yesno:'true,false') %}
-            {{ form.cover|add_class:'peer form-input placeholder-transparent' |attr:'placeholder: ' |attr:label_attr |attr:required_attr }}
-            {% endwith %}
-            <label for="{{ form.cover.id_for_label }}" class="label-float">{{ form.cover.label }}</label>
-            {{ form.cover.errors }}
+            {% include 'perfil/partials/form_field.html' with field=form.cover %}
           </div>
         </div>
       </div>
@@ -96,19 +56,10 @@
 
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div class="relative">
-            {% with label_attr="aria-label:"|add:form.phone_number.label required_attr="aria-required:"|add:(form.phone_number.field.required|yesno:'true,false') %}
-            {{ form.phone_number|add_class:'peer form-input placeholder-transparent' |attr:'placeholder: ' |attr:label_attr |attr:required_attr }}
-            {% endwith %}
-            <label for="{{ form.phone_number.id_for_label }}" class="label-float">{{ form.phone_number.label }}</label>
-            {{ form.phone_number.errors }}
+            {% include 'perfil/partials/form_field.html' with field=form.phone_number %}
           </div>
           <div class="relative">
-            {% with
-                label_attr="aria-label:"|add:form.whatsapp.label required_attr="aria-required:"|add:(form.whatsapp.field.required|yesno:'true,false') %}
-            {{ form.whatsapp|add_class:'peer form-input placeholder-transparent' |attr:'placeholder: ' |attr:label_attr |attr:required_attr }}
-            {% endwith %}
-            <label for="{{ form.whatsapp.id_for_label }}" class="label-float">{{ form.whatsapp.label }}</label>
-            {{ form.whatsapp.errors }}
+            {% include 'perfil/partials/form_field.html' with field=form.whatsapp %}
           </div>
         </div>
       </div>
@@ -117,35 +68,18 @@
         <h4 class="text-lg font-semibold">{% trans "Endereço" %}</h4>
 
         <div class="relative">
-          {% with
-            label_attr="aria-label:"|add:form.endereco.label required_attr="aria-required:"|add:(form.endereco.field.required|yesno:'true,false')%}
-          {{ form.endereco|add_class:'w-full peer form-input placeholder-transparent' |attr:'placeholder: ' |attr:label_attr |attr:required_attr }}
-          {% endwith %}
-          <label for="{{ form.endereco.id_for_label }}" class="label-float">{{ form.endereco.label }}</label>
-          {{ form.endereco.errors }}
+          {% include 'perfil/partials/form_field.html' with field=form.endereco %}
         </div>
 
         <div class="grid md:grid-cols-3 gap-4">
           <div class="relative">
-            {% with label_attr="aria-label:"|add:form.cidade.label required_attr="aria-required:"|add:(form.cidade.field.required|yesno:'true,false') %}
-            {{ form.cidade|add_class:'peer form-input placeholder-transparent' |attr:'placeholder: ' |attr:label_attr |attr:required_attr }}
-            {% endwith %}
-            <label for="{{ form.cidade.id_for_label }}" class="label-float">{{ form.cidade.label }}</label>
-            {{ form.cidade.errors }}
+            {% include 'perfil/partials/form_field.html' with field=form.cidade %}
           </div>
           <div class="relative">
-            {% with label_attr="aria-label:"|add:form.estado.label required_attr="aria-required:"|add:(form.estado.field.required|yesno:'true,false') %}
-            {{ form.estado|add_class:'peer form-input placeholder-transparent' |attr:'placeholder: ' |attr:label_attr |attr:required_attr }}
-            {% endwith %}
-            <label for="{{ form.estado.id_for_label }}" class="label-float">{{ form.estado.label }}</label>
-            {{ form.estado.errors }}
+            {% include 'perfil/partials/form_field.html' with field=form.estado %}
           </div>
           <div class="relative">
-            {% with label_attr="aria-label:"|add:form.cep.label required_attr="aria-required:"|add:(form.cep.field.required|yesno:'true,false') %}
-            {{ form.cep|add_class:'peer form-input placeholder-transparent' |attr:'placeholder: ' |attr:label_attr |attr:required_attr }}
-            {% endwith %}
-            <label for="{{ form.cep.id_for_label }}" class="label-float">{{ form.cep.label }}</label>
-            {{ form.cep.errors }}
+            {% include 'perfil/partials/form_field.html' with field=form.cep %}
           </div>
         </div>
       </div>
@@ -163,6 +97,4 @@
 </div>
 
 {% endblock %}
-
-
 

--- a/accounts/templates/perfil/partials/form_field.html
+++ b/accounts/templates/perfil/partials/form_field.html
@@ -1,0 +1,18 @@
+{% with
+   label_attr="aria-label:"|add:field.label
+   required_attr="aria-required:"|add:(field.field.required|yesno:'true,false')
+   invalid_attr="aria-invalid:"|add:(field.errors|yesno:'true,false')
+   desc_attr="aria-describedby:"|add:field.id_for_label|add:'_error'
+%}
+  {{ field|add_class:'peer form-input placeholder-transparent'
+           |attr:'placeholder:'
+           |attr:label_attr
+           |attr:required_attr
+           |attr:invalid_attr
+           |attr:desc_attr }}
+{% endwith %}
+<label for="{{ field.id_for_label }}" class="label-float">{{ field.label }}</label>
+{% if field.errors %}
+  <p id="{{ field.id_for_label }}_error" class="text-[var(--error)] text-sm mt-1" role="alert">{{ field.errors }}</p>
+{% endif %}
+


### PR DESCRIPTION
## Summary
- add reusable `form_field.html` partial to handle labels, aria attributes, and error messages
- simplify personal info template by including the new partial for each form field

## Testing
- `pytest -q` *(fails: 14 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bf52ac09dc83258866ec581a6d1e7c