### PR TITLE
Add active class and aria updates to sidebar navigation

### DIFF
--- a/app/static/css/hubx.css
+++ b/app/static/css/hubx.css
@@ -567,7 +567,7 @@
 
   /* Sidebar */
   .sidebar-item { @apply flex items-center gap-3 rounded-lg px-3 py-2 text-[var(--text-secondary)] hover:bg-[var(--bg-accent)] transition; }
-  .sidebar-item[aria-current="page"] { @apply bg-[var(--bg-accent)] text-[var(--text-primary)] font-medium; }
+  .sidebar-item-active { @apply bg-[var(--bg-accent)] text-[var(--text-primary)] font-medium; }
 
   /* Tabelas */
   .table           { @apply w-full text-sm; }

--- a/static/tailwind.css
+++ b/static/tailwind.css
@@ -1421,7 +1421,7 @@ a:focus {
   background-color: var(--bg-accent);
 }
 
-.sidebar-item[aria-current="page"] {
+.sidebar-item-active {
   background-color: var(--bg-accent);
   font-weight: 500;
   color: var(--text-primary);

--- a/templates/components/nav_sidebar.html
+++ b/templates/components/nav_sidebar.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 <aside id="sidebar" class="fixed inset-y-0 left-0 z-20 w-64 bg-[var(--bg-secondary)] border-r border-[var(--border)] flex flex-col transition-all">
   <div class="flex items-center justify-between p-4 border-b border-[var(--border)]">
-    <a href="/" class="text-2xl font-bold text-primary" aria-label="{% trans 'Página inicial' %}" aria-current="{% if request.path == '/' %}page{% endif %}">
+    <a href="/" class="text-2xl font-bold text-primary" aria-label="{% trans 'Página inicial' %}" {% if request.path == '/' %}aria-current="page"{% endif %}>
       {% trans 'Hubx' %}
     </a>
     <button id="sidebar-toggle" class="text-[var(--text-primary)]" aria-label="{% trans 'Alternar menu' %}" aria-controls="sidebar" aria-expanded="true">
@@ -12,7 +12,7 @@
   </div>
   <nav class="flex-1 overflow-y-auto px-4 py-4" role="navigation" aria-label="{% trans 'Menu' %}">
     {% for item in NAV_MENU %}
-      <a href="{{ item.path }}" class="sidebar-item" aria-current="{% if request.path == item.path %}page{% else %}false{% endif %}">
+      <a href="{{ item.path }}" class="sidebar-item{% if request.path == item.path %} sidebar-item-active{% endif %}" {% if request.path == item.path %}aria-current="page"{% endif %}>
         {% if item.id == 'perfil' and user.avatar %}
           <img src="{{ user.avatar.url }}" alt="{{ user.username }}" class="w-6 h-6 rounded-full object-cover" />
         {% else %}


### PR DESCRIPTION
## Summary
- mark active sidebar links with `.sidebar-item-active`
- show `aria-current="page"` only on the active navigation item
- style new active sidebar class in CSS

## Testing
- `pytest -m "not slow"` *(fails: KeyboardInterrupt during import)*

------
https://chatgpt.com/codex/tasks/task_e_68c057f2c314832591bee0f0788ef6c0