### PR TITLE
refactor: modernize register templates with design tokens

### DIFF
--- a/accounts/templates/register/cpf.html
+++ b/accounts/templates/register/cpf.html
@@ -4,32 +4,30 @@
 {% block title %}{% trans "Registro - CPF" %} | Hubx{% endblock %}
 
 {% block content %}
-{% include 'components/nav_sidebar.html' %}
-{% include 'components/hero.html' %}
 <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
-  <div class="bg-white dark:bg-slate-800 p-6 rounded-lg shadow">
+  <div class="card">
     <div class="mb-8">
       {% with step=4 total=8 %}
       <div class="mb-2 flex items-center justify-between">
-        <span class="text-sm font-medium text-primary-600">{% blocktrans with step=step total=total %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
+        <span class="text-sm font-medium text-[var(--primary)]">{% blocktrans with step=step total=total %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
         {% widthratio step total 100 as progress %}
-        <span class="text-sm text-neutral-500 dark:text-neutral-400">{{ progress }}%</span>
+        <span class="text-sm text-[var(--text-secondary)]">{{ progress }}%</span>
       </div>
-      <div class="h-2 w-full rounded-xl bg-neutral-200 dark:bg-slate-700">
-        <div class="h-full rounded-xl bg-primary-600" style="width: {{ progress }}%;"></div>
+      <div class="h-2 w-full rounded-xl bg-[var(--bg-tertiary)]">
+        <div class="h-full rounded-xl bg-[var(--primary)]" style="width: {{ progress }}%;"></div>
       </div>
       {% endwith %}
     </div>
 
     <div class="mb-8 text-center">
-      <h1 class="mb-2 text-3xl font-bold text-neutral-900 dark:text-neutral-100">{% trans "Qual seu CPF?" %}</h1>
-      <p class="text-neutral-600 dark:text-neutral-400">{% trans "Precisamos para validar sua identidade e segurança" %}</p>
+      <h1 class="mb-2 text-3xl font-bold text-[var(--text-primary)]">{% trans "Qual seu CPF?" %}</h1>
+      <p class="text-[var(--text-secondary)]">{% trans "Precisamos para validar sua identidade e segurança" %}</p>
     </div>
 
     {% if messages %}
     <div class="mb-4 space-y-2">
       {% for message in messages %}
-        <p class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-300{% else %}bg-red-100 dark:bg-red-900 text-red-700 dark:text-red-300{% endif %}">{{ message }}</p>
+        <p class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-[var(--success-light)] text-[var(--success)]{% else %}bg-[var(--error-light)] text-[var(--error)]{% endif %}">{{ message }}</p>
       {% endfor %}
     </div>
     {% endif %}
@@ -37,32 +35,14 @@
     <form id="cpfForm" method="post" action="{% url 'accounts:cpf' %}" class="space-y-6">
       {% csrf_token %}
       <div>
-        <div class="relative">
-          <input
-            type="text"
-            id="cpf"
-            name="cpf"
-            maxlength="14"
-            class="peer w-full rounded-lg border border-neutral-300 dark:border-slate-600 px-4 py-2 placeholder-transparent focus:outline-none focus:ring-2 focus:ring-primary-500 dark:bg-slate-700 dark:text-neutral-100"
-            placeholder="{% trans 'CPF' %}"
-            required
-            autofocus
-            aria-label="CPF"
-            aria-invalid="false"
-            aria-describedby="cpf_help cpf_validation"
-          />
-          <label
-            for="cpf"
-            class="absolute left-4 -top-2 text-xs text-neutral-700 dark:text-neutral-300 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600"
-          >{% trans "CPF" %}</label>
-        </div>
-        <div class="text-sm text-red-600" id="cpf_validation"></div>
-        <small id="cpf_help" class="text-sm text-neutral-500 dark:text-neutral-400">{% trans "Formato 000.000.000-00" %}</small>
+        {% include "_forms/field.html" with id="cpf" name="cpf" label=_("CPF") placeholder=_("CPF") maxlength="14" required=True autofocus=True describedby="cpf_help cpf_validation" %}
+        <div class="text-sm text-[var(--error)]" id="cpf_validation"></div>
+        <small id="cpf_help" class="text-sm text-[var(--text-secondary)]">{% trans "Formato 000.000.000-00" %}</small>
       </div>
 
       <div class="flex gap-4">
-        <a href="{% url 'accounts:nome' %}" class="flex-1 rounded-xl border border-neutral-300 dark:border-slate-600 px-4 py-2 text-center text-neutral-700 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-slate-700">{% trans "Voltar" %}</a>
-        <button type="submit" id="submitButton" class="flex-1 rounded-xl bg-primary-600 px-4 py-2 text-white hover:bg-primary-700">{% trans "Continuar" %}</button>
+        <a href="{% url 'accounts:nome' %}" class="btn btn-secondary flex-1">{% trans "Voltar" %}</a>
+        <button type="submit" id="submitButton" class="btn btn-primary flex-1">{% trans "Continuar" %}</button>
       </div>
     </form>
   </div>

--- a/accounts/templates/register/email.html
+++ b/accounts/templates/register/email.html
@@ -4,32 +4,30 @@
 {% block title %}{% trans "Registro - Email" %} | Hubx{% endblock %}
 
 {% block content %}
-{% include 'components/nav_sidebar.html' %}
-{% include 'components/hero.html' %}
 <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
-  <div class="bg-white dark:bg-slate-800 p-6 rounded-lg shadow">
+  <div class="card">
     <div class="mb-8">
       {% with step=5 total=8 %}
       <div class="mb-2 flex items-center justify-between">
-        <span class="text-sm font-medium text-primary-600">{% blocktrans with step=step total=total %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
+        <span class="text-sm font-medium text-[var(--primary)]">{% blocktrans with step=step total=total %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
         {% widthratio step total 100 as progress %}
-        <span class="text-sm text-neutral-500 dark:text-neutral-400">{{ progress }}%</span>
+        <span class="text-sm text-[var(--text-secondary)]">{{ progress }}%</span>
       </div>
-      <div class="h-2 w-full rounded-xl bg-neutral-200 dark:bg-slate-700">
-        <div class="h-full rounded-xl bg-primary-600" style="width: {{ progress }}%;"></div>
+      <div class="h-2 w-full rounded-xl bg-[var(--bg-tertiary)]">
+        <div class="h-full rounded-xl bg-[var(--primary)]" style="width: {{ progress }}%;"></div>
       </div>
       {% endwith %}
     </div>
 
     <div class="mb-8 text-center">
-      <h1 class="mb-2 text-3xl font-bold text-neutral-900 dark:text-neutral-100">{% trans "Qual seu email?" %}</h1>
-      <p class="text-neutral-600 dark:text-neutral-400">{% trans "Usaremos para comunicação e recuperação de conta" %}</p>
+      <h1 class="mb-2 text-3xl font-bold text-[var(--text-primary)]">{% trans "Qual seu email?" %}</h1>
+      <p class="text-[var(--text-secondary)]">{% trans "Usaremos para comunicação e recuperação de conta" %}</p>
     </div>
 
     {% if messages %}
     <div class="mb-4 space-y-2">
       {% for message in messages %}
-        <p class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-300{% else %}bg-red-100 dark:bg-red-900 text-red-700 dark:text-red-300{% endif %}">{{ message }}</p>
+        <p class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-[var(--success-light)] text-[var(--success)]{% else %}bg-[var(--error-light)] text-[var(--error)]{% endif %}">{{ message }}</p>
       {% endfor %}
     </div>
     {% endif %}
@@ -37,31 +35,14 @@
     <form id="emailForm" method="post" action="{% url 'accounts:email' %}" class="space-y-6">
       {% csrf_token %}
       <div>
-        <div class="relative">
-          <input
-            type="email"
-            id="email"
-            name="email"
-            class="peer w-full rounded-lg border border-neutral-300 dark:border-slate-600 px-4 py-2 placeholder-transparent focus:outline-none focus:ring-2 focus:ring-primary-500 dark:bg-slate-700 dark:text-neutral-100"
-            placeholder="{% trans 'Seu e-mail' %}"
-            required
-            autofocus
-            aria-label="Email"
-            aria-invalid="false"
-            aria-describedby="email_help email_validation"
-          />
-          <label
-            for="email"
-            class="absolute left-4 -top-2 text-xs text-neutral-700 dark:text-neutral-300 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600"
-          >{% trans "Email" %}</label>
-        </div>
-        <div class="text-sm text-red-600" id="email_validation"></div>
-        <small id="email_help" class="text-sm text-neutral-500 dark:text-neutral-400">{% trans "Enviaremos um link de confirmação" %}</small>
+        {% include "_forms/field.html" with id="email" name="email" type="email" label=_("Email") placeholder=_("Seu e-mail") required=True autofocus=True describedby="email_help email_validation" %}
+        <div class="text-sm text-[var(--error)]" id="email_validation"></div>
+        <small id="email_help" class="text-sm text-[var(--text-secondary)]">{% trans "Enviaremos um link de confirmação" %}</small>
       </div>
 
       <div class="flex gap-4">
-        <a href="{% url 'accounts:cpf' %}" class="flex-1 rounded-xl border border-neutral-300 dark:border-slate-600 px-4 py-2 text-center text-neutral-700 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-slate-700">{% trans "Voltar" %}</a>
-        <button type="submit" id="submitButton" class="flex-1 rounded-xl bg-primary-600 px-4 py-2 text-white hover:bg-primary-700">{% trans "Continuar" %}</button>
+        <a href="{% url 'accounts:cpf' %}" class="btn btn-secondary flex-1">{% trans "Voltar" %}</a>
+        <button type="submit" id="submitButton" class="btn btn-primary flex-1">{% trans "Continuar" %}</button>
       </div>
     </form>
   </div>

--- a/accounts/templates/register/foto.html
+++ b/accounts/templates/register/foto.html
@@ -4,32 +4,30 @@
 {% block title %}{% trans "Registro - Foto" %} | Hubx{% endblock %}
 
 {% block content %}
-{% include 'components/nav_sidebar.html' %}
-{% include 'components/hero.html' %}
 <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
-  <div class="bg-white dark:bg-slate-800 p-6 rounded-lg shadow">
+  <div class="card">
     <div class="mb-8">
       {% with step=7 total=8 %}
       <div class="mb-2 flex items-center justify-between">
-        <span class="text-sm font-medium text-primary-600">{% blocktrans with step=step total=total %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
+        <span class="text-sm font-medium text-[var(--primary)]">{% blocktrans with step=step total=total %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
         {% widthratio step total 100 as progress %}
-        <span class="text-sm text-neutral-500 dark:text-neutral-400">{{ progress }}%</span>
+        <span class="text-sm text-[var(--text-secondary)]">{{ progress }}%</span>
       </div>
-      <div class="h-2 w-full rounded-xl bg-neutral-200 dark:bg-slate-700">
-        <div class="h-full rounded-xl bg-primary-600" style="width: {{ progress }}%;"></div>
+      <div class="h-2 w-full rounded-xl bg-[var(--bg-tertiary)]">
+        <div class="h-full rounded-xl bg-[var(--primary)]" style="width: {{ progress }}%;"></div>
       </div>
       {% endwith %}
     </div>
 
     <div class="mb-8 text-center">
-      <h1 class="mb-2 text-3xl font-bold text-neutral-900 dark:text-neutral-100">{% trans "Adicione uma foto de perfil" %}</h1>
-      <p class="text-neutral-600 dark:text-neutral-400">{% trans "Personalize sua presença na comunidade" %}</p>
+      <h1 class="mb-2 text-3xl font-bold text-[var(--text-primary)]">{% trans "Adicione uma foto de perfil" %}</h1>
+      <p class="text-[var(--text-secondary)]">{% trans "Personalize sua presença na comunidade" %}</p>
     </div>
 
     {% if messages %}
     <div class="mb-4 space-y-2">
       {% for message in messages %}
-        <p class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-300{% else %}bg-red-100 dark:bg-red-900 text-red-700 dark:text-red-300{% endif %}">{{ message }}</p>
+        <p class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-[var(--success-light)] text-[var(--success)]{% else %}bg-[var(--error-light)] text-[var(--error)]{% endif %}">{{ message }}</p>
       {% endfor %}
     </div>
     {% endif %}
@@ -37,30 +35,14 @@
     <form id="fotoForm" method="post" action="{% url 'accounts:foto' %}" enctype="multipart/form-data" class="space-y-6">
       {% csrf_token %}
       <div>
-        <div class="relative">
-          <input
-            type="file"
-            id="foto"
-            name="foto"
-            accept="image/*"
-            class="peer w-full rounded-lg border border-neutral-300 dark:border-slate-600 px-4 py-2 placeholder-transparent focus:outline-none focus:ring-2 focus:ring-primary-500 dark:bg-slate-700 dark:text-neutral-100"
-            placeholder="{% trans 'Selecione uma foto' %}"
-            aria-label="{% trans 'Foto' %}"
-            aria-invalid="false"
-            aria-describedby="foto_validation"
-          />
-          <label
-            for="foto"
-            class="absolute left-4 -top-2 text-xs text-neutral-700 dark:text-neutral-300 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600"
-          >{% trans "Escolher Foto" %}</label>
-        </div>
-        <div class="text-sm text-red-600" id="foto_validation"></div>
-        <small class="text-sm text-neutral-500 dark:text-neutral-400">{% trans "Formatos aceitos: JPG, PNG. Tamanho máximo: 5MB" %}</small>
+        {% include "_forms/field.html" with id="foto" name="foto" type="file" label=_("Escolher Foto") placeholder=_("Selecione uma foto") describedby="foto_validation" attrs="accept='image/*'" %}
+        <div class="text-sm text-[var(--error)]" id="foto_validation"></div>
+        <small class="text-sm text-[var(--text-secondary)]">{% trans "Formatos aceitos: JPG, PNG. Tamanho máximo: 5MB" %}</small>
       </div>
 
       <div class="flex gap-4">
-        <a href="{% url 'accounts:senha' %}" class="flex-1 rounded-xl border border-neutral-300 dark:border-slate-600 px-4 py-2 text-center text-neutral-700 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-slate-700">{% trans "Voltar" %}</a>
-        <button type="submit" id="submitButton" class="flex-1 rounded-xl bg-primary-600 px-4 py-2 text-white hover:bg-primary-700">{% trans "Continuar" %}</button>
+        <a href="{% url 'accounts:senha' %}" class="btn btn-secondary flex-1">{% trans "Voltar" %}</a>
+        <button type="submit" id="submitButton" class="btn btn-primary flex-1">{% trans "Continuar" %}</button>
       </div>
     </form>
   </div>

--- a/accounts/templates/register/nome.html
+++ b/accounts/templates/register/nome.html
@@ -4,32 +4,30 @@
 {% block title %}{% trans "Registro - Nome" %} | Hubx{% endblock %}
 
 {% block content %}
-{% include 'components/nav_sidebar.html' %}
-{% include 'components/hero.html' %}
 <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
-  <div class="bg-white dark:bg-slate-800 p-6 rounded-lg shadow">
+  <div class="card">
     <div class="mb-8">
       {% with step=3 total=8 %}
       <div class="mb-2 flex items-center justify-between">
-        <span class="text-sm font-medium text-primary-600">{% blocktrans with step=step total=total %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
+        <span class="text-sm font-medium text-[var(--primary)]">{% blocktrans with step=step total=total %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
         {% widthratio step total 100 as progress %}
-        <span class="text-sm text-neutral-500 dark:text-neutral-400">{{ progress }}%</span>
+        <span class="text-sm text-[var(--text-secondary)]">{{ progress }}%</span>
       </div>
-      <div class="h-2 w-full rounded-xl bg-neutral-200 dark:bg-slate-700">
-        <div class="h-full rounded-xl bg-primary-600" style="width: {{ progress }}%;"></div>
+      <div class="h-2 w-full rounded-xl bg-[var(--bg-tertiary)]">
+        <div class="h-full rounded-xl bg-[var(--primary)]" style="width: {{ progress }}%;"></div>
       </div>
       {% endwith %}
     </div>
 
     <div class="mb-8 text-center">
-      <h1 class="mb-2 text-3xl font-bold text-neutral-900 dark:text-neutral-100">{% trans "Como podemos te chamar?" %}</h1>
-      <p class="text-neutral-600 dark:text-neutral-400">{% trans "Digite seu nome completo" %}</p>
+      <h1 class="mb-2 text-3xl font-bold text-[var(--text-primary)]">{% trans "Como podemos te chamar?" %}</h1>
+      <p class="text-[var(--text-secondary)]">{% trans "Digite seu nome completo" %}</p>
     </div>
 
     {% if messages %}
     <div class="mb-4 space-y-2">
       {% for message in messages %}
-        <p class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-300{% else %}bg-red-100 dark:bg-red-900 text-red-700 dark:text-red-300{% endif %}">{{ message }}</p>
+        <p class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-[var(--success-light)] text-[var(--success)]{% else %}bg-[var(--error-light)] text-[var(--error)]{% endif %}">{{ message }}</p>
       {% endfor %}
     </div>
     {% endif %}
@@ -37,30 +35,13 @@
     <form id="nomeForm" method="post" action="{% url 'accounts:nome' %}" class="space-y-6">
       {% csrf_token %}
       <div>
-        <div class="relative">
-          <input
-            type="text"
-            id="nome"
-            name="nome"
-            class="peer w-full rounded-lg border border-neutral-300 dark:border-slate-600 px-4 py-2 placeholder-transparent focus:outline-none focus:ring-2 focus:ring-primary-500 dark:bg-slate-700 dark:text-neutral-100"
-            placeholder="{% trans 'Nome completo' %}"
-            required
-            autofocus
-            aria-label="Nome"
-            aria-invalid="false"
-            aria-describedby="nome_validation"
-          />
-          <label
-            for="nome"
-            class="absolute left-4 -top-2 text-xs text-neutral-700 dark:text-neutral-300 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600"
-          >{% trans "Nome Completo" %}</label>
-        </div>
-        <div class="text-sm text-red-600" id="nome_validation"></div>
+        {% include "_forms/field.html" with id="nome" name="nome" label=_("Nome Completo") placeholder=_("Nome completo") required=True autofocus=True describedby="nome_validation" %}
+        <div class="text-sm text-[var(--error)]" id="nome_validation"></div>
       </div>
 
       <div class="flex gap-4">
-        <a href="{% url 'accounts:usuario' %}" class="flex-1 rounded-xl border border-neutral-300 dark:border-slate-600 px-4 py-2 text-center text-neutral-700 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-slate-700">{% trans "Voltar" %}</a>
-        <button type="submit" id="submitButton" class="flex-1 rounded-xl bg-primary-600 px-4 py-2 text-white hover:bg-primary-700">{% trans "Continuar" %}</button>
+        <a href="{% url 'accounts:usuario' %}" class="btn btn-secondary flex-1">{% trans "Voltar" %}</a>
+        <button type="submit" id="submitButton" class="btn btn-primary flex-1">{% trans "Continuar" %}</button>
       </div>
     </form>
   </div>

--- a/accounts/templates/register/onboarding.html
+++ b/accounts/templates/register/onboarding.html
@@ -4,12 +4,10 @@
 {% block title %}{% trans "Cadastre-se" %} - HubX{% endblock %}
 
 {% block content %}
-{% include 'components/nav_sidebar.html' %}
-{% include 'components/hero.html' %}
 <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
-  <div class="bg-white dark:bg-slate-800 p-6 rounded-lg shadow text-center">
+  <div class="card text-center">
         <div class="mb-8">
-            <div class="w-20 h-20 bg-primary-100 dark:bg-primary-900 rounded-full flex items-center justify-center mx-auto mb-4">
+            <div class="w-20 h-20 bg-[var(--primary-light)] rounded-full flex items-center justify-center mx-auto mb-4">
                 <svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="var(--primary-600)" stroke-width="2" aria-hidden="true">
                     <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/>
                     <circle cx="9" cy="7" r="4"/>
@@ -17,10 +15,10 @@
                     <path d="M16 3.13a4 4 0 0 1 0 7.75"/>
                 </svg>
             </div>
-            <h1 class="text-2xl font-bold mb-6 text-center text-neutral-900 dark:text-neutral-100">
+            <h1 class="text-2xl font-bold mb-6 text-[var(--text-primary)]">
                 {% trans "Junte-se ao HubX" %}
             </h1>
-            <p class="text-neutral-600 dark:text-neutral-400 mb-6">
+            <p class="text-[var(--text-secondary)] mb-6">
                 {% trans "Conecte-se com comunidades, empresas e organizações em uma única plataforma" %}
             </p>
         </div>
@@ -28,27 +26,27 @@
         {% if messages %}
         <div class="mb-4 space-y-2">
             {% for message in messages %}
-            <p class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-300{% else %}bg-red-100 dark:bg-red-900 text-red-700 dark:text-red-300{% endif %}">{{ message }}</p>
+            <p class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-[var(--success-light)] text-[var(--success)]{% else %}bg-[var(--error-light)] text-[var(--error)]{% endif %}">{{ message }}</p>
             {% endfor %}
         </div>
         {% endif %}
 
         <div class="grid md:grid-cols-3 gap-6 mb-8">
             <div class="text-center">
-                <div class="w-15 h-15 bg-success-100 dark:bg-success-900 rounded-full flex items-center justify-center mx-auto mb-3">
+                <div class="w-15 h-15 bg-[var(--success-light)] rounded-full flex items-center justify-center mx-auto mb-3">
                     <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--success-600)" stroke-width="2" aria-hidden="true">
                         <path d="M9 11H5a2 2 0 0 0-2 2v7a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7a2 2 0 0 0-2-2h-4"/>
                         <polyline points="9,11 12,14 15,11"/>
                         <line x1="12" y1="14" x2="12" y2="3"/>
                     </svg>
                 </div>
-                <h3 class="font-semibold text-neutral-900 dark:text-neutral-100 mb-2">{% trans "Compartilhe" %}</h3>
-                <p class="text-sm text-neutral-600 dark:text-neutral-400">
+                <h3 class="font-semibold text-[var(--text-primary)] mb-2">{% trans "Compartilhe" %}</h3>
+                <p class="text-sm text-[var(--text-secondary)]">
                     {% trans "Publique conteúdo e mantenha sua comunidade informada" %}
                 </p>
             </div>
             <div class="text-center">
-                <div class="w-15 h-15 bg-primary-100 dark:bg-primary-900 rounded-full flex items-center justify-center mx-auto mb-3">
+                <div class="w-15 h-15 bg-[var(--primary-light)] rounded-full flex items-center justify-center mx-auto mb-3">
                     <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--primary-600)" stroke-width="2" aria-hidden="true">
                         <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/>
                         <circle cx="9" cy="7" r="4"/>
@@ -56,13 +54,13 @@
                         <path d="M16 3.13a4 4 0 0 1 0 7.75"/>
                     </svg>
                 </div>
-                <h3 class="font-semibold text-neutral-900 dark:text-neutral-100 mb-2">{% trans "Conecte" %}</h3>
-                <p class="text-sm text-neutral-600 dark:text-neutral-400">
+                <h3 class="font-semibold text-[var(--text-primary)] mb-2">{% trans "Conecte" %}</h3>
+                <p class="text-sm text-[var(--text-secondary)]">
                     {% trans "Encontre e conecte-se com pessoas e organizações" %}
                 </p>
             </div>
             <div class="text-center">
-                <div class="w-15 h-15 bg-warning-100 dark:bg-warning-900 rounded-full flex items-center justify-center mx-auto mb-3">
+                <div class="w-15 h-15 bg-[var(--warning-light)] rounded-full flex items-center justify-center mx-auto mb-3">
                     <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--warning)" stroke-width="2" aria-hidden="true">
                         <rect x="3" y="4" width="18" height="18" rx="2" ry="2"/>
                         <line x1="16" y1="2" x2="16" y2="6"/>
@@ -70,15 +68,15 @@
                         <line x1="3" y1="10" x2="21" y2="10"/>
                     </svg>
                 </div>
-                <h3 class="font-semibold text-neutral-900 dark:text-neutral-100 mb-2">{% trans "Organize" %}</h3>
-                <p class="text-sm text-neutral-600 dark:text-neutral-400">
+                <h3 class="font-semibold text-[var(--text-primary)] mb-2">{% trans "Organize" %}</h3>
+                <p class="text-sm text-[var(--text-secondary)]">
                     {% trans "Crie e participe de eventos da sua comunidade" %}
                 </p>
             </div>
         </div>
 
         <div class="flex flex-col sm:flex-row gap-4 justify-center">
-            <a href="{% url 'tokens:token' %}" class="bg-primary dark:bg-primary text-white font-semibold py-2 px-4 rounded-xl">
+            <a href="{% url 'tokens:token' %}" class="btn btn-primary inline-flex items-center gap-2">
                 <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
                     <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/>
                     <circle cx="9" cy="7" r="4"/>
@@ -87,14 +85,14 @@
                 </svg>
                 {% trans "Começar Cadastro" %}
             </a>
-            <a href="{% url 'accounts:login' %}" class="bg-gray-100 text-neutral-700 dark:bg-slate-700 dark:text-neutral-300 font-semibold py-2 px-4 rounded-xl">
+            <a href="{% url 'accounts:login' %}" class="btn btn-secondary">
                 {% trans "Já tenho conta" %}
             </a>
         </div>
 
-        <div class="mt-8 pt-6 border-t border-neutral-200 dark:border-slate-700">
-            <p class="text-xs text-neutral-500 dark:text-neutral-400">
-                {% blocktrans trimmed %}Ao se cadastrar, você concorda com nossos <a href="#" class="text-primary-600 hover:text-primary-700">Termos de Uso</a> e <a href="#" class="text-primary-600 hover:text-primary-700">Política de Privacidade</a>{% endblocktrans %}
+        <div class="mt-8 pt-6 border-t border-[var(--border)]">
+            <p class="text-xs text-[var(--text-secondary)]">
+                {% blocktrans trimmed %}Ao se cadastrar, você concorda com nossos <a href="#" class="text-[var(--primary)] hover:underline">Termos de Uso</a> e <a href="#" class="text-[var(--primary)] hover:underline">Política de Privacidade</a>{% endblocktrans %}
             </p>
         </div>
   </div>

--- a/accounts/templates/register/registro_sucesso.html
+++ b/accounts/templates/register/registro_sucesso.html
@@ -4,23 +4,18 @@
 {% block title %}{% trans "Registro Concluído" %} | Hubx{% endblock %}
 
 {% block content %}
-{% include 'components/nav_sidebar.html' %}
-{% include 'components/hero.html' %}
 <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
-  <div class="bg-white dark:bg-slate-800 p-8 rounded-lg shadow text-center">
+  <div class="card p-8 text-center">
     {% if messages %}
     <div class="mb-4 space-y-2">
       {% for message in messages %}
-        <p class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-300{% else %}bg-red-100 dark:bg-red-900 text-red-700 dark:text-red-300{% endif %}">{{ message }}</p>
+        <p class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-[var(--success-light)] text-[var(--success)]{% else %}bg-[var(--error-light)] text-[var(--error)]{% endif %}">{{ message }}</p>
       {% endfor %}
     </div>
     {% endif %}
-    <h1 class="mb-4 text-3xl font-bold text-neutral-900 dark:text-neutral-100">{% trans "Bem-vindo ao HubX!" %}</h1>
-    <p class="mb-6 text-neutral-600 dark:text-neutral-400">{% trans "Seu cadastro foi concluído. Verifique seu e-mail para ativar sua conta." %}</p>
-    <a
-      href="{% url 'accounts:login' %}"
-      class="rounded-xl bg-primary-600 px-4 py-2 text-white hover:bg-primary-700"
-    >{% trans "Ir para login" %}</a>
+    <h1 class="mb-4 text-3xl font-bold text-[var(--text-primary)]">{% trans "Bem-vindo ao HubX!" %}</h1>
+    <p class="mb-6 text-[var(--text-secondary)]">{% trans "Seu cadastro foi concluído. Verifique seu e-mail para ativar sua conta." %}</p>
+    <a href="{% url 'accounts:login' %}" class="btn btn-primary">{% trans "Ir para login" %}</a>
   </div>
 </div>
 {% endblock %}

--- a/accounts/templates/register/senha.html
+++ b/accounts/templates/register/senha.html
@@ -4,32 +4,30 @@
 {% block title %}{% trans "Registro - Senha" %} | Hubx{% endblock %}
 
 {% block content %}
-{% include 'components/nav_sidebar.html' %}
-{% include 'components/hero.html' %}
 <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
-  <div class="bg-white dark:bg-slate-800 p-6 rounded-lg shadow">
+  <div class="card">
     <div class="mb-8">
       {% with step=6 total=8 %}
       <div class="mb-2 flex items-center justify-between">
-        <span class="text-sm font-medium text-primary-600">{% blocktrans with step=step total=total %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
+        <span class="text-sm font-medium text-[var(--primary)]">{% blocktrans with step=step total=total %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
         {% widthratio step total 100 as progress %}
-        <span class="text-sm text-neutral-500 dark:text-neutral-400">{{ progress }}%</span>
+        <span class="text-sm text-[var(--text-secondary)]">{{ progress }}%</span>
       </div>
-      <div class="h-2 w-full rounded-xl bg-neutral-200 dark:bg-slate-700">
-        <div class="h-full rounded-xl bg-primary-600" style="width: {{ progress }}%;"></div>
+      <div class="h-2 w-full rounded-xl bg-[var(--bg-tertiary)]">
+        <div class="h-full rounded-xl bg-[var(--primary)]" style="width: {{ progress }}%;"></div>
       </div>
       {% endwith %}
     </div>
 
     <div class="mb-8 text-center">
-      <h1 class="mb-2 text-3xl font-bold text-neutral-900 dark:text-neutral-100">{% trans "Crie uma senha segura" %}</h1>
-      <p class="text-neutral-600 dark:text-neutral-400">{% trans "Proteja sua conta com uma senha forte" %}</p>
+      <h1 class="mb-2 text-3xl font-bold text-[var(--text-primary)]">{% trans "Crie uma senha segura" %}</h1>
+      <p class="text-[var(--text-secondary)]">{% trans "Proteja sua conta com uma senha forte" %}</p>
     </div>
 
     {% if messages %}
     <div class="mb-4 space-y-2">
       {% for message in messages %}
-        <p class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-300{% else %}bg-red-100 dark:bg-red-900 text-red-700 dark:text-red-300{% endif %}">{{ message }}</p>
+        <p class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-[var(--success-light)] text-[var(--success)]{% else %}bg-[var(--error-light)] text-[var(--error)]{% endif %}">{{ message }}</p>
       {% endfor %}
     </div>
     {% endif %}
@@ -37,53 +35,20 @@
     <form id="senhaForm" method="post" action="{% url 'accounts:senha' %}" class="space-y-6">
       {% csrf_token %}
       <div>
-        <div class="relative">
-          <input
-            type="password"
-            id="senha"
-            name="senha"
-            class="peer w-full rounded-lg border border-neutral-300 dark:border-slate-600 px-4 py-2 placeholder-transparent focus:outline-none focus:ring-2 focus:ring-primary-500 dark:bg-slate-700 dark:text-neutral-100"
-            placeholder="{% trans 'Senha' %}"
-            required
-            autofocus
-            aria-label="Senha"
-            aria-invalid="false"
-            aria-describedby="senha_help senha_validation"
-          />
-          <label
-            for="senha"
-            class="absolute left-4 -top-2 text-xs text-neutral-700 dark:text-neutral-300 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600"
-          >{% trans "Senha" %}</label>
-        </div>
-        <div class="text-sm text-red-600" id="senha_validation"></div>
-        <small id="senha_help" class="text-sm text-neutral-500 dark:text-neutral-400">{% trans "Use ao menos 8 caracteres com letras e números" %}</small>
+        {% include "_forms/field.html" with id="senha" name="senha" type="password" label=_("Senha") placeholder=_("Senha") required=True autofocus=True describedby="senha_help senha_validation" %}
+        <div class="text-sm text-[var(--error)]" id="senha_validation"></div>
+        <small id="senha_help" class="text-sm text-[var(--text-secondary)]">{% trans "Use ao menos 8 caracteres com letras e números" %}</small>
       </div>
 
       <div>
-        <div class="relative">
-          <input
-            type="password"
-            id="confirmar_senha"
-            name="confirmar_senha"
-            class="peer w-full rounded-lg border border-neutral-300 dark:border-slate-600 px-4 py-2 placeholder-transparent focus:outline-none focus:ring-2 focus:ring-primary-500 dark:bg-slate-700 dark:text-neutral-100"
-            placeholder="{% trans 'Confirme a senha' %}"
-            required
-            aria-label="Confirmar senha"
-            aria-invalid="false"
-            aria-describedby="confirmar_senha_help confirmar_senha_validation"
-          />
-          <label
-            for="confirmar_senha"
-            class="absolute left-4 -top-2 text-xs text-neutral-700 dark:text-neutral-300 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600"
-          >{% trans "Confirmar Senha" %}</label>
-        </div>
-        <div class="text-sm text-red-600" id="confirmar_senha_validation"></div>
-        <small id="confirmar_senha_help" class="text-sm text-neutral-500 dark:text-neutral-400">{% trans "Repita a senha para confirmação" %}</small>
+        {% include "_forms/field.html" with id="confirmar_senha" name="confirmar_senha" type="password" label=_("Confirmar Senha") placeholder=_("Confirme a senha") required=True describedby="confirmar_senha_help confirmar_senha_validation" %}
+        <div class="text-sm text-[var(--error)]" id="confirmar_senha_validation"></div>
+        <small id="confirmar_senha_help" class="text-sm text-[var(--text-secondary)]">{% trans "Repita a senha para confirmação" %}</small>
       </div>
 
       <div class="flex gap-4">
-        <a href="{% url 'accounts:email' %}" class="flex-1 rounded-xl border border-neutral-300 dark:border-slate-600 px-4 py-2 text-center text-neutral-700 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-slate-700">{% trans "Voltar" %}</a>
-        <button type="submit" id="submitButton" class="flex-1 rounded-xl bg-primary-600 px-4 py-2 text-white hover:bg-primary-700">{% trans "Continuar" %}</button>
+        <a href="{% url 'accounts:email' %}" class="btn btn-secondary flex-1">{% trans "Voltar" %}</a>
+        <button type="submit" id="submitButton" class="btn btn-primary flex-1">{% trans "Continuar" %}</button>
       </div>
     </form>
   </div>

--- a/accounts/templates/register/termos.html
+++ b/accounts/templates/register/termos.html
@@ -4,64 +4,62 @@
 {% block title %}{% trans "Registro - Termos" %} | Hubx{% endblock %}
 
 {% block content %}
-{% include 'components/nav_sidebar.html' %}
-{% include 'components/hero.html' %}
 <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
-  <div class="bg-white dark:bg-slate-800 p-6 rounded-lg shadow">
+  <div class="card">
     <div class="mb-8">
       {% with step=8 total=8 %}
       <div class="mb-2 flex items-center justify-between">
-        <span class="text-sm font-medium text-primary-600">{% blocktrans with step=step total=total %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
+        <span class="text-sm font-medium text-[var(--primary)]">{% blocktrans with step=step total=total %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
         {% widthratio step total 100 as progress %}
-        <span class="text-sm text-neutral-500 dark:text-neutral-400">{{ progress }}%</span>
+        <span class="text-sm text-[var(--text-secondary)]">{{ progress }}%</span>
       </div>
-      <div class="h-2 w-full rounded-xl bg-neutral-200 dark:bg-slate-700">
-        <div class="h-full rounded-xl bg-primary-600" style="width: {{ progress }}%;"></div>
+      <div class="h-2 w-full rounded-xl bg-[var(--bg-tertiary)]">
+        <div class="h-full rounded-xl bg-[var(--primary)]" style="width: {{ progress }}%;"></div>
       </div>
       {% endwith %}
     </div>
 
     <div class="mb-8 text-center">
-      <h1 class="mb-2 text-3xl font-bold text-neutral-900 dark:text-neutral-100">{% trans "Quase lá!" %}</h1>
-      <p class="text-neutral-600 dark:text-neutral-400">{% trans "Revise e aceite os termos para finalizar" %}</p>
+      <h1 class="mb-2 text-3xl font-bold text-[var(--text-primary)]">{% trans "Quase lá!" %}</h1>
+      <p class="text-[var(--text-secondary)]">{% trans "Revise e aceite os termos para finalizar" %}</p>
     </div>
 
     {% if messages %}
     <div class="mb-4 space-y-2">
       {% for message in messages %}
-        <p class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-300{% else %}bg-red-100 dark:bg-red-900 text-red-700 dark:text-red-300{% endif %}">{{ message }}</p>
+        <p class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-[var(--success-light)] text-[var(--success)]{% else %}bg-[var(--error-light)] text-[var(--error)]{% endif %}">{{ message }}</p>
       {% endfor %}
     </div>
     {% endif %}
 
     <form id="termosForm" method="post" action="{% url 'accounts:termos' %}" class="space-y-6">
       {% csrf_token %}
-      <div class="space-y-4 max-h-64 overflow-y-auto p-4 border border-neutral-200 dark:border-slate-700 rounded-lg">
-        <h3 class="font-semibold">{% trans "Termos de Uso e Política de Privacidade" %}</h3>
-        <p>{% trans "Ao utilizar o HubX, você concorda com nossos termos de uso e política de privacidade. Abaixo estão os principais pontos:" %}</p>
-        <h4 class="font-medium">{% trans "1. Uso da Plataforma" %}</h4>
-        <p>{% trans "O HubX é uma plataforma para comunidades, entidades e associações. Você concorda em utilizar a plataforma de acordo com as leis aplicáveis e não violar os direitos de outros usuários." %}</p>
-        <h4 class="font-medium">{% trans "2. Privacidade" %}</h4>
-        <p>{% trans "Respeitamos sua privacidade. Seus dados serão utilizados apenas para os fins especificados em nossa política de privacidade." %}</p>
-        <h4 class="font-medium">{% trans "3. Conteúdo" %}</h4>
-        <p>{% trans "Você é responsável pelo conteúdo que compartilha na plataforma. Não toleramos conteúdo ofensivo, ilegal ou que viole direitos de terceiros." %}</p>
-        <h4 class="font-medium">{% trans "4. Segurança" %}</h4>
-        <p>{% trans "Você é responsável por manter a segurança de sua conta e senha. Notifique-nos imediatamente sobre qualquer uso não autorizado." %}</p>
+      <div class="space-y-4 max-h-64 overflow-y-auto p-4 border border-[var(--border)] rounded-lg">
+        <h3 class="font-semibold text-[var(--text-primary)]">{% trans "Termos de Uso e Política de Privacidade" %}</h3>
+        <p class="text-[var(--text-secondary)]">{% trans "Ao utilizar o HubX, você concorda com nossos termos de uso e política de privacidade. Abaixo estão os principais pontos:" %}</p>
+        <h4 class="font-medium text-[var(--text-primary)]">{% trans "1. Uso da Plataforma" %}</h4>
+        <p class="text-[var(--text-secondary)]">{% trans "O HubX é uma plataforma para comunidades, entidades e associações. Você concorda em utilizar a plataforma de acordo com as leis aplicáveis e não violar os direitos de outros usuários." %}</p>
+        <h4 class="font-medium text-[var(--text-primary)]">{% trans "2. Privacidade" %}</h4>
+        <p class="text-[var(--text-secondary)]">{% trans "Respeitamos sua privacidade. Seus dados serão utilizados apenas para os fins especificados em nossa política de privacidade." %}</p>
+        <h4 class="font-medium text-[var(--text-primary)]">{% trans "3. Conteúdo" %}</h4>
+        <p class="text-[var(--text-secondary)]">{% trans "Você é responsável pelo conteúdo que compartilha na plataforma. Não toleramos conteúdo ofensivo, ilegal ou que viole direitos de terceiros." %}</p>
+        <h4 class="font-medium text-[var(--text-primary)]">{% trans "4. Segurança" %}</h4>
+        <p class="text-[var(--text-secondary)]">{% trans "Você é responsável por manter a segurança de sua conta e senha. Notifique-nos imediatamente sobre qualquer uso não autorizado." %}</p>
       </div>
 
       <div class="flex items-start gap-2">
-        <input type="checkbox" id="aceitar_termos" name="aceitar_termos" class="mt-1 rounded border-neutral-300 dark:border-slate-600 text-primary-600 focus:ring-primary-500" required aria-label="Aceitar termos" aria-invalid="false" aria-describedby="aceitar_termos_desc">
-        <label for="aceitar_termos" class="text-sm text-neutral-700 dark:text-neutral-300" id="aceitar_termos_desc">{% blocktrans trimmed %}Eu li e concordo com os <a href="/termos/" class="text-primary-600 hover:text-primary-700" target="_blank">Termos de Uso</a> e <a href="/privacidade/" class="text-primary-600 hover:text-primary-700" target="_blank">Política de Privacidade</a>{% endblocktrans %}</label>
+        <input type="checkbox" id="aceitar_termos" name="aceitar_termos" class="mt-1 rounded border-[var(--border)] text-[var(--primary)] focus:ring-[var(--primary)]" required aria-label="Aceitar termos" aria-invalid="false" aria-describedby="aceitar_termos_desc">
+        <label for="aceitar_termos" class="text-sm text-[var(--text-primary)]" id="aceitar_termos_desc">{% blocktrans trimmed %}Eu li e concordo com os <a href="/termos/" class="text-[var(--primary)] hover:underline" target="_blank">Termos de Uso</a> e <a href="/privacidade/" class="text-[var(--primary)] hover:underline" target="_blank">Política de Privacidade</a>{% endblocktrans %}</label>
       </div>
 
       <div class="flex items-start gap-2">
-        <input type="checkbox" id="newsletter" name="newsletter" class="mt-1 rounded border-neutral-300 dark:border-slate-600 text-primary-600 focus:ring-primary-500" aria-label="Receber novidades" aria-invalid="false" aria-describedby="newsletter_desc">
-        <label for="newsletter" class="text-sm text-neutral-700 dark:text-neutral-300" id="newsletter_desc">{% trans "Quero receber atualizações e novidades do HubX" %}</label>
+        <input type="checkbox" id="newsletter" name="newsletter" class="mt-1 rounded border-[var(--border)] text-[var(--primary)] focus:ring-[var(--primary)]" aria-label="Receber novidades" aria-invalid="false" aria-describedby="newsletter_desc">
+        <label for="newsletter" class="text-sm text-[var(--text-primary)]" id="newsletter_desc">{% trans "Quero receber atualizações e novidades do HubX" %}</label>
       </div>
 
       <div class="flex gap-4">
-        <a href="{% url 'accounts:foto' %}" class="flex-1 rounded-xl border border-neutral-300 dark:border-slate-600 px-4 py-2 text-center text-neutral-700 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-slate-700">{% trans "Voltar" %}</a>
-        <button type="submit" id="submitButton" class="flex-1 rounded-xl bg-primary-600 px-4 py-2 text-white hover:bg-primary-700">{% trans "Finalizar Cadastro" %}</button>
+        <a href="{% url 'accounts:foto' %}" class="btn btn-secondary flex-1">{% trans "Voltar" %}</a>
+        <button type="submit" id="submitButton" class="btn btn-primary flex-1">{% trans "Finalizar Cadastro" %}</button>
       </div>
     </form>
   </div>

--- a/accounts/templates/register/token.html
+++ b/accounts/templates/register/token.html
@@ -4,39 +4,37 @@
 {% block title %}{% trans "Token de Convite" %} - HubX{% endblock %}
 
 {% block content %}
-{% include 'components/nav_sidebar.html' %}
-{% include 'components/hero.html' %}
 <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
-  <div class="bg-white dark:bg-slate-800 p-6 rounded-lg shadow">
+  <div class="card">
     <div class="mb-8">
       {% with step=1 total=8 %}
       <div class="mb-2 flex items-center justify-between">
-        <span class="text-sm font-medium text-primary-600">{% blocktrans with step=step total=total %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
+        <span class="text-sm font-medium text-[var(--primary)]">{% blocktrans with step=step total=total %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
         {% widthratio step total 100 as progress %}
-        <span class="text-sm text-neutral-500 dark:text-neutral-400">{{ progress }}%</span>
+        <span class="text-sm text-[var(--text-secondary)]">{{ progress }}%</span>
       </div>
-      <div class="h-2 w-full rounded-xl bg-neutral-200 dark:bg-slate-700">
-        <div class="h-full rounded-xl bg-primary-600" style="width: {{ progress }}%;"></div>
+      <div class="h-2 w-full rounded-xl bg-[var(--bg-tertiary)]">
+        <div class="h-full rounded-xl bg-[var(--primary)]" style="width: {{ progress }}%;"></div>
       </div>
       {% endwith %}
     </div>
 
     <div class="mb-8 text-center">
-      <div class="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-primary-100 dark:bg-primary-900">
+      <div class="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-[var(--primary-light)]">
         <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="var(--primary-600)" stroke-width="2" aria-hidden="true">
           <rect x="3" y="11" width="18" height="11" rx="2" ry="2"/>
           <circle cx="12" cy="16" r="1"/>
           <path d="M7 11V7a5 5 0 0 1 10 0v4"/>
         </svg>
       </div>
-      <h1 class="mb-2 text-3xl font-bold text-neutral-900 dark:text-neutral-100">{% trans "Token de Convite" %}</h1>
-      <p class="text-neutral-600 dark:text-neutral-400">{% trans "Digite seu token de convite para começar o cadastro" %}</p>
+      <h1 class="mb-2 text-3xl font-bold text-[var(--text-primary)]">{% trans "Token de Convite" %}</h1>
+      <p class="text-[var(--text-secondary)]">{% trans "Digite seu token de convite para começar o cadastro" %}</p>
     </div>
 
     {% if messages %}
     <div class="mb-4 space-y-2">
       {% for message in messages %}
-        <p class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-300{% else %}bg-red-100 dark:bg-red-900 text-red-700 dark:text-red-300{% endif %}">{{ message }}</p>
+        <p class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-[var(--success-light)] text-[var(--success)]{% else %}bg-[var(--error-light)] text-[var(--error)]{% endif %}">{{ message }}</p>
       {% endfor %}
     </div>
     {% endif %}
@@ -44,37 +42,20 @@
     <form method="post" action="{% url 'tokens:token' %}" class="space-y-6">
       {% csrf_token %}
       <div>
-        <div class="relative">
-          <input
-            type="text"
-            id="token"
-            name="token"
-            class="peer w-full rounded-lg border border-neutral-300 dark:border-slate-600 px-4 py-2 placeholder-transparent text-center font-mono tracking-widest focus:outline-none focus:ring-2 focus:ring-primary-500 dark:bg-slate-700 dark:text-neutral-100"
-            placeholder="{% trans 'Token de convite' %}"
-            required
-            autofocus
-            aria-label="Token"
-            aria-invalid="false"
-            aria-describedby="token_help"
-          />
-          <label
-            for="token"
-            class="absolute left-4 -top-2 text-xs text-neutral-700 dark:text-neutral-300 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600"
-          >{% trans "Token de Convite" %}</label>
-        </div>
-        <p id="token_help" class="mt-1 text-sm text-neutral-500 dark:text-neutral-400">{% trans "O token é necessário para continuar o cadastro na plataforma" %}</p>
+        {% include "_forms/field.html" with id="token" name="token" label=_("Token de Convite") placeholder=_("Token de convite") required=True autofocus=True describedby="token_help" extra_classes="text-center font-mono tracking-widest" %}
+        <p id="token_help" class="mt-1 text-sm text-[var(--text-secondary)]">{% trans "O token é necessário para continuar o cadastro na plataforma" %}</p>
       </div>
 
       <div class="flex gap-4">
-        <a href="{% url 'accounts:login' %}" class="flex-1 rounded-xl border border-neutral-300 dark:border-slate-600 px-4 py-2 text-center text-neutral-700 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-slate-700">{% trans "Voltar" %}</a>
-        <button type="submit" class="flex-1 rounded-xl bg-primary-600 px-4 py-2 text-white hover:bg-primary-700">{% trans "Continuar" %}</button>
+        <a href="{% url 'accounts:login' %}" class="btn btn-secondary flex-1">{% trans "Voltar" %}</a>
+        <button type="submit" class="btn btn-primary flex-1">{% trans "Continuar" %}</button>
       </div>
     </form>
 
     <div class="mt-8 text-center">
-      <p class="text-sm text-neutral-600 dark:text-neutral-400">
+      <p class="text-sm text-[var(--text-secondary)]">
         {% trans "Já tem uma conta?" %}
-        <a href="{% url 'accounts:login' %}" class="font-medium text-primary-600 hover:text-primary-700">{% trans "Entrar" %}</a>
+        <a href="{% url 'accounts:login' %}" class="font-medium text-[var(--primary)] hover:underline">{% trans "Entrar" %}</a>
       </p>
     </div>
   </div>

--- a/accounts/templates/register/usuario.html
+++ b/accounts/templates/register/usuario.html
@@ -4,35 +4,33 @@
 {% block title %}{% trans "Registro - Usuário" %} | Hubx{% endblock %}
 
 {% block content %}
-{% include 'components/nav_sidebar.html' %}
-{% include 'components/hero.html' %}
 <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
-  <div class="bg-white dark:bg-slate-800 p-6 rounded-lg shadow">
+  <div class="card">
     <div class="mb-8">
       {% with step=2 total=8 %}
       <div class="mb-2 flex items-center justify-between">
-        <span class="text-sm font-medium text-primary-600">{% blocktrans with step=step total=total %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
+        <span class="text-sm font-medium text-[var(--primary)]">{% blocktrans with step=step total=total %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
         {% widthratio step total 100 as progress %}
-        <span class="text-sm text-neutral-500 dark:text-neutral-400">{{ progress }}%</span>
+        <span class="text-sm text-[var(--text-secondary)]">{{ progress }}%</span>
       </div>
-      <div class="h-2 w-full rounded-xl bg-neutral-200 dark:bg-slate-700">
-        <div class="h-full rounded-xl bg-primary-600" style="width: {{ progress }}%;"></div>
+      <div class="h-2 w-full rounded-xl bg-[var(--bg-tertiary)]">
+        <div class="h-full rounded-xl bg-[var(--primary)]" style="width: {{ progress }}%;"></div>
       </div>
       {% endwith %}
     </div>
 
     <div class="mb-8 text-center">
-      <h1 class="mb-2 text-3xl font-bold text-neutral-900 dark:text-neutral-100">{% trans "Escolha seu nome de usuário" %}</h1>
-      <p class="text-neutral-600 dark:text-neutral-400">{% trans "Como você será identificado na plataforma" %}</p>
+      <h1 class="mb-2 text-3xl font-bold text-[var(--text-primary)]">{% trans "Escolha seu nome de usuário" %}</h1>
+      <p class="text-[var(--text-secondary)]">{% trans "Como você será identificado na plataforma" %}</p>
     </div>
 
     {% if messages %}
     <div class="mb-4 space-y-2">
       {% for message in messages %}
         {% if message.tags == 'success' %}
-        <p class="rounded-xl px-4 py-2 text-sm bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-300">{{ message }}</p>
+        <p class="rounded-xl px-4 py-2 text-sm bg-[var(--success-light)] text-[var(--success)]">{{ message }}</p>
         {% else %}
-        <p class="rounded-xl px-4 py-2 text-sm bg-red-100 dark:bg-red-900 text-red-700 dark:text-red-300">{{ message }}</p>
+        <p class="rounded-xl px-4 py-2 text-sm bg-[var(--error-light)] text-[var(--error)]">{{ message }}</p>
         {% endif %}
       {% endfor %}
     </div>
@@ -41,31 +39,14 @@
     <form id="usuarioForm" method="post" action="{% url 'accounts:usuario' %}" class="space-y-6">
       {% csrf_token %}
       <div>
-        <div class="relative">
-          <input
-            type="text"
-            id="usuario"
-            name="usuario"
-            class="peer w-full rounded-lg border border-neutral-300 dark:border-slate-600 px-4 py-2 placeholder-transparent focus:outline-none focus:ring-2 focus:ring-primary-500 dark:bg-slate-700 dark:text-neutral-100"
-            placeholder="{% trans 'Nome de usuário' %}"
-            required
-            autofocus
-            aria-label="Usuário"
-            aria-invalid="false"
-            aria-describedby="usuario_help usuario_validation"
-          />
-          <label
-            for="usuario"
-            class="absolute left-4 -top-2 text-xs text-neutral-700 dark:text-neutral-300 transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-neutral-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary-600"
-          >{% trans "Nome de Usuário" %}</label>
-        </div>
-        <div class="text-sm text-red-600" id="usuario_validation"></div>
-        <small id="usuario_help" class="text-sm text-neutral-500 dark:text-neutral-400">{% trans "Use apenas letras, números e underscore (_)" %}</small>
+        {% include "_forms/field.html" with id="usuario" name="usuario" label=_("Nome de Usuário") placeholder=_("Nome de usuário") required=True autofocus=True describedby="usuario_help usuario_validation" %}
+        <div class="text-sm text-[var(--error)]" id="usuario_validation"></div>
+        <small id="usuario_help" class="text-sm text-[var(--text-secondary)]">{% trans "Use apenas letras, números e underscore (_)" %}</small>
       </div>
 
       <div class="flex gap-4">
-        <a href="{% url 'tokens:token' %}" class="flex-1 rounded-xl border border-neutral-300 dark:border-slate-600 px-4 py-2 text-center text-neutral-700 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-slate-700">{% trans "Voltar" %}</a>
-        <button type="submit" id="submitButton" class="flex-1 rounded-xl bg-primary-600 px-4 py-2 text-white hover:bg-primary-700">{% trans "Continuar" %}</button>
+        <a href="{% url 'tokens:token' %}" class="btn btn-secondary flex-1">{% trans "Voltar" %}</a>
+        <button type="submit" id="submitButton" class="btn btn-primary flex-1">{% trans "Continuar" %}</button>
       </div>
     </form>
   </div>

--- a/templates/_forms/field.html
+++ b/templates/_forms/field.html
@@ -1,0 +1,23 @@
+{% comment %}Generic form field using tailwindcss forms plugin and design tokens.
+Expects: id, name, label, type (default 'text'), value, placeholder, required, autofocus, describedby, attrs.
+{% endcomment %}
+<div class="space-y-1">
+  <div class="relative">
+    <input
+      type="{{ type|default:'text' }}"
+      id="{{ id }}"
+      name="{{ name }}"
+      {% if value is not None %}value="{{ value }}"{% endif %}
+      class="peer w-full rounded-lg border border-[var(--border)] bg-[var(--bg-secondary)] px-4 py-2 placeholder-transparent focus:outline-none focus:ring-2 focus:ring-[var(--primary)] text-[var(--text-primary)] {{ extra_classes }}"
+      placeholder="{{ placeholder|default:label }}"
+      {% if maxlength %}maxlength="{{ maxlength }}"{% endif %}
+      {% if required %}required{% endif %}
+      {% if autofocus %}autofocus{% endif %}
+      aria-label="{{ label }}"
+      aria-invalid="false"
+      {% if describedby %}aria-describedby="{{ describedby }}"{% endif %}
+      {{ attrs|safe }}
+    />
+    <label for="{{ id }}" class="absolute left-4 -top-2 text-xs text-[var(--text-secondary)] transition-all peer-placeholder-shown:top-2 peer-placeholder-shown:text-sm peer-placeholder-shown:text-[var(--text-secondary)] peer-focus:-top-2 peer-focus:text-xs peer-focus:text-[var(--primary)]">{{ label }}</label>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- add reusable `_forms/field.html` leveraging design tokens and tailwind form styles
- refactor register templates to drop redundant includes, use new field partial, and update buttons to `.btn` variants

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'silk' -> after installing dependencies, tests error during collection: 81 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c057e917648325bb5bf9b7bfe9a58c