### PR TITLE
refactor: unify eventos templates

### DIFF
--- a/eventos/templates/eventos/inscricao_list.html
+++ b/eventos/templates/eventos/inscricao_list.html
@@ -19,9 +19,9 @@
       {% url 'eventos:inscricao_list' as inscricao_list_url %}
       {% include 'components/search_form.html' with q=request.GET.q hx_get=inscricao_list_url hx_target='#inscricao-container' hx_push_url='true' %}
 
-      <div class="overflow-x-auto bg-white border border-[var(--border)] rounded-2xl shadow-sm mt-6">
+      <div class="overflow-x-auto bg-[var(--bg-secondary)] border border-[var(--border)] rounded-2xl shadow-sm mt-6">
         <table class="min-w-full divide-y divide-[var(--border)] table-auto text-sm">
-          <thead class="bg-neutral-50">
+          <thead class="bg-[var(--bg-secondary)]">
             <tr>
               <th class="px-4 py-2 text-left font-semibold text-[var(--text-secondary)]">{% trans "Usuário" %}</th>
               <th class="px-4 py-2 text-left font-semibold text-[var(--text-secondary)]">{% trans "Evento" %}</th>

--- a/eventos/templates/eventos/parceria_form.html
+++ b/eventos/templates/eventos/parceria_form.html
@@ -6,21 +6,17 @@
 {% block content %}
 <section class="max-w-screen-xl mx-auto pt-8 px-6 lg:px-8">
   <h1 class="text-2xl font-bold text-neutral-900 mb-6">{% trans "Parceria" %}</h1>
-  <form method="post" enctype="multipart/form-data" class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 space-y-6">
+  <form method="post" enctype="multipart/form-data" class="bg-[var(--bg-secondary)] border border-[var(--border)] rounded-2xl shadow-sm p-6 space-y-6">
     {% csrf_token %}
     {{ form.non_field_errors }}
     {% for field in form %}
-    <div>
-      {{ field.label_tag }}
-  {% if field.name == 'acordo' %}
-  {{ field|attr:'accept:.pdf' }}
+      {% if field.name == 'acordo' %}
+        {% include 'components/form_field.html' with field=field|attr:'accept:.pdf' %}
       {% else %}
-      {{ field }}
+        {% include 'components/form_field.html' with field=field %}
       {% endif %}
-      {{ field.errors }}
-    </div>
     {% endfor %}
-    <div class="flex justify-end gap-3 pt-4 border-t border-neutral-100">
+    <div class="flex justify-end gap-3 pt-4 border-t border-[var(--border)]">
       <a href="{% url 'eventos:parceria_list' %}" class="btn-secondary" aria-label="{% trans 'Cancelar' %}">{% trans "Cancelar" %}</a>
       <button type="submit" class="btn-primary" aria-label="{% trans 'Salvar' %}">{% trans "Salvar" %}</button>
     </div>

--- a/eventos/templates/eventos/parceria_list.html
+++ b/eventos/templates/eventos/parceria_list.html
@@ -11,19 +11,19 @@
       <a href="{% url 'eventos:parceria_criar' %}" class="btn-primary">{% trans "Nova Parceria" %}</a>
     </div>
     <div class="card-body">
-      <div class="overflow-x-auto bg-white border border-neutral-200 rounded-2xl shadow-sm">
-        <table class="min-w-full divide-y divide-neutral-200 table-auto text-sm">
-          <thead class="bg-neutral-50">
+      <div class="overflow-x-auto bg-[var(--bg-secondary)] border border-[var(--border)] rounded-2xl shadow-sm">
+        <table class="min-w-full divide-y divide-[var(--border)] table-auto text-sm">
+          <thead class="bg-[var(--bg-secondary)]">
             <tr>
-              <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Empresa" %}</th>
-              <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Evento" %}</th>
-              <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Tipo" %}</th>
-              <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Avaliação" %}</th>
-              <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Comentário" %}</th>
-              <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Ações" %}</th>
+              <th class="px-4 py-2 text-left font-semibold text-[var(--text-secondary)]">{% trans "Empresa" %}</th>
+              <th class="px-4 py-2 text-left font-semibold text-[var(--text-secondary)]">{% trans "Evento" %}</th>
+              <th class="px-4 py-2 text-left font-semibold text-[var(--text-secondary)]">{% trans "Tipo" %}</th>
+              <th class="px-4 py-2 text-left font-semibold text-[var(--text-secondary)]">{% trans "Avaliação" %}</th>
+              <th class="px-4 py-2 text-left font-semibold text-[var(--text-secondary)]">{% trans "Comentário" %}</th>
+              <th class="px-4 py-2 text-left font-semibold text-[var(--text-secondary)]">{% trans "Ações" %}</th>
             </tr>
           </thead>
-          <tbody class="divide-y divide-neutral-200">
+          <tbody class="divide-y divide-[var(--border)]">
             {% for parceria in parcerias %}
               <tr>
                 <td class="px-4 py-2">{{ parceria.empresa.nome }}</td>
@@ -46,7 +46,7 @@
               </tr>
             {% empty %}
               <tr>
-                <td colspan="6" class="px-4 py-4 text-center text-neutral-500">{% trans "Nenhuma parceria encontrada." %}</td>
+                <td colspan="6" class="px-4 py-4 text-center text-[var(--text-secondary)]">{% trans "Nenhuma parceria encontrada." %}</td>
               </tr>
             {% endfor %}
           </tbody>

--- a/eventos/templates/eventos/tarefa_detail.html
+++ b/eventos/templates/eventos/tarefa_detail.html
@@ -29,21 +29,21 @@
       </div>
       <div class="card-body">
         {% if logs %}
-          <div class="overflow-x-auto">
-            <table class="min-w-full divide-y">
-              <thead>
+          <div class="overflow-x-auto bg-[var(--bg-secondary)] border border-[var(--border)] rounded-2xl shadow-sm">
+            <table class="min-w-full divide-y divide-[var(--border)] text-sm">
+              <thead class="bg-[var(--bg-secondary)]">
                 <tr>
-                  <th class="px-4 py-2 text-left text-xs font-medium">{% trans "Data" %}</th>
-                  <th class="px-4 py-2 text-left text-xs font-medium">{% trans "Usuário" %}</th>
-                  <th class="px-4 py-2 text-left text-xs font-medium">{% trans "Ação" %}</th>
+                  <th class="px-4 py-2 text-left font-semibold text-[var(--text-secondary)] text-xs">{% trans "Data" %}</th>
+                  <th class="px-4 py-2 text-left font-semibold text-[var(--text-secondary)] text-xs">{% trans "Usuário" %}</th>
+                  <th class="px-4 py-2 text-left font-semibold text-[var(--text-secondary)] text-xs">{% trans "Ação" %}</th>
                 </tr>
               </thead>
-              <tbody class="divide-y">
+              <tbody class="divide-y divide-[var(--border)]">
                 {% for log in logs %}
                 <tr>
-                  <td class="px-4 py-2 text-sm">{{ log.created_at|date:'SHORT_DATETIME_FORMAT' }}</td>
-                  <td class="px-4 py-2 text-sm">{{ log.usuario }}</td>
-                  <td class="px-4 py-2 text-sm">{{ log.acao }}</td>
+                  <td class="px-4 py-2">{{ log.created_at|date:'SHORT_DATETIME_FORMAT' }}</td>
+                  <td class="px-4 py-2">{{ log.usuario }}</td>
+                  <td class="px-4 py-2">{{ log.acao }}</td>
                 </tr>
                 {% endfor %}
               </tbody>


### PR DESCRIPTION
## Summary
- update inscricao list table wrapper to use design tokens
- apply shared form field component and tokens in parceria form
- unify parceria list and tarefa detail tables with design tokens

## Testing
- `pytest eventos/tests -q` *(fails: Required test coverage of 90% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_68c057dc2dcc8325bec61a6e29cd992c