### PR TITLE
Fix empresa card include path and remove duplicate markup

### DIFF
--- a/templates/_components/card_empresa.html
+++ b/templates/_components/card_empresa.html
@@ -5,50 +5,9 @@
   {% if empresa.deleted %}
     {% trans 'excluída' as excluida %}
     {% with title=base_title|add:' ('|add:excluida|add:')' %}
-      {% include 'partials/cards/base_card.html' with url=detail_url cover=empresa.cover avatar=empresa.avatar title=title details='empresas/partials/card_details.html' sr_label=sr_label %}
+      {% include '_partials/cards/base_card.html' with url=detail_url cover=empresa.cover avatar=empresa.avatar title=title details='empresas/partials/card_details.html' sr_label=sr_label %}
     {% endwith %}
   {% else %}
-      {% include 'partials/cards/base_card.html' with url=detail_url cover=empresa.cover avatar=empresa.avatar title=base_title details='empresas/partials/card_details.html' sr_label=sr_label %}
+      {% include '_partials/cards/base_card.html' with url=detail_url cover=empresa.cover avatar=empresa.avatar title=base_title details='empresas/partials/card_details.html' sr_label=sr_label %}
   {% endif %}
 {% endwith %}
-{# Card de Empresa #}
-<a href="{% url 'empresas:detail' empresa.pk %}"
-   class="group block rounded-2xl border border-[var(--border)] bg-[var(--bg-secondary)] shadow-sm hover:shadow-lg transition-shadow focus:outline-none focus:ring-2 focus:ring-primary/40">
-  <article class="overflow-hidden rounded-2xl" role="article" aria-label="{{ empresa.nome }}">
-    <header class="relative">
-      {% if empresa.cover %}
-        <img src="{{ empresa.cover.url }}" alt="{% trans 'Capa da empresa' %}"
-             class="h-24 w-full object-cover" />
-      {% else %}
-        <div class="h-24 w-full bg-gradient-to-r from-primary-500 to-primary-700"></div>
-      {% endif %}
-      <div class="absolute -bottom-8 left-4">
-        {% if empresa.avatar %}
-          <img src="{{ empresa.avatar.url }}" alt="{{ empresa.nome }}"
-               class="h-16 w-16 rounded-full ring-4 ring-[var(--bg-primary)] object-cover" />
-        {% else %}
-          <div class="h-16 w-16 rounded-full ring-4 ring-[var(--bg-primary)] bg-[var(--bg-tertiary)] flex items-center justify-center text-lg font-semibold text-primary" role="img" aria-label="{{ empresa.nome }}">
-            {{ empresa.nome|first|upper }}
-          </div>
-        {% endif %}
-      </div>
-    </header>
-    <div class="px-4 pt-10 pb-4">
-      <h3 class="text-base font-semibold text-[var(--text-primary)] group-hover:underline">{{ empresa.nome }}</h3>
-      <dl class="mt-3 grid grid-cols-2 gap-2 text-xs text-[var(--text-secondary)]">
-        <div>
-          <dt class="text-[var(--text-secondary)]">CNPJ</dt>
-          <dd class="font-medium">{{ empresa.cnpj }}</dd>
-        </div>
-        <div>
-          <dt class="text-[var(--text-secondary)]">{% trans 'Proprietário' %}</dt>
-          <dd class="font-medium">
-            <a href="{% url 'accounts:perfil_publico_uuid' empresa.usuario.public_id %}" class="text-primary hover:underline">
-              {{ empresa.usuario.get_full_name|default:empresa.usuario.username }}
-            </a>
-          </dd>
-        </div>
-      </dl>
-    </div>
-  </article>
-</a>


### PR DESCRIPTION
## Summary
- point card include to `_partials` directory
- remove redundant hard-coded empresa card markup

## Testing
- `curl -I localhost:8000/empresas/` (fails: OperationalError no such table: silk_request)
- `pytest -q` (fails: import twilio -> KeyboardInterrupt)


------
https://chatgpt.com/codex/tasks/task_e_68c094c4655c8325a23c9ef08d71decb