### PR TITLE
Refatora hero em base_list

### DIFF
--- a/templates/base_list.html
+++ b/templates/base_list.html
@@ -1,11 +1,8 @@
 {% extends 'base.html' %}
 {% load i18n %}
 
-{% include "_components/hero.html" with title=title subtitle=subtitle breadcrumb=breadcrumb actions=actions %}
-
-
 {% block hero %}
-  {% include "templates/components/hero.html" with title=title subtitle=subtitle breadcrumb=breadcrumb actions=actions %}
+  {% include '_components/hero.html' with title=title subtitle=subtitle breadcrumb=breadcrumb actions=actions %}
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
## Summary
- remove include redundante de hero em `base_list.html`
- referencia componente `_components/hero.html` dentro do bloco `hero`

## Testing
- `pytest` *(falhou: ModuleNotFoundError: No module named 'silk')*


------
https://chatgpt.com/codex/tasks/task_e_68c09c093cb88325a6a1c92c617d008e