### PR TITLE
Use CSS variables for form field text colors

### DIFF
--- a/templates/_forms/field.html
+++ b/templates/_forms/field.html
@@ -4,12 +4,12 @@
   {% if field|widget_type == 'checkboxinput' %}
   <div class="flex items-center gap-2">
     {% render_field field class+="form-checkbox" %}
-    <label for="{{ field.id_for_label }}" class="text-sm text-neutral-700">
+    <label for="{{ field.id_for_label }}" class="text-sm text-[var(--text-primary)]">
       {{ field.label }}{% if field.field.required %} *{% endif %}
     </label>
   </div>
   {% else %}
-  <label for="{{ field.id_for_label }}" class="block text-sm font-medium text-neutral-700">
+  <label for="{{ field.id_for_label }}" class="block text-sm font-medium text-[var(--text-primary)]">
     {{ field.label }}{% if field.field.required %} *{% endif %}
   </label>
   {% if field|widget_type == 'select' %}
@@ -24,7 +24,7 @@
   </ul>
   {% endif %}
   {% if field.help_text %}
-  <p class="text-xs text-neutral-500">{{ field.help_text }}</p>
+  <p class="text-xs text-[var(--text-secondary)]">{{ field.help_text }}</p>
   {% endif %}
 
 </div>


### PR DESCRIPTION
## Summary
- replace hard-coded neutral text colors in shared form field template with CSS variables

## Testing
- `python - <<'PY'
import os, django
os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'Hubx.settings')
django.setup()
from django import forms
from django.template.loader import render_to_string
class TestForm(forms.Form):
    checkbox = forms.BooleanField(label="Checkbox label", required=False)
    select = forms.ChoiceField(label="Select label", choices=[('1','Option 1'), ('2','Option 2')])
    input = forms.CharField(label="Input label")
form = TestForm()
for name in ('checkbox','select','input'):
    html = render_to_string('_forms/field.html', {'field': form[name]})
    print(f'--- {name} ---')
    print(html)
    print()
PY`
- `pytest tests/configuracoes/test_forms.py tests/nucleos/test_forms.py tests/tokens/test_forms.py tests/organizacoes/test_forms.py tests/empresas/test_forms.py tests/feed/test_forms.py -q` *(fails: ModuleNotFoundError: No module named 'factory')*


------
https://chatgpt.com/codex/tasks/task_e_68c09eafbaa88325a4e5919eceac05a6