### PR TITLE
refactor: unify card grids

### DIFF
--- a/accounts/templates/associados/associado_list.html
+++ b/accounts/templates/associados/associado_list.html
@@ -15,12 +15,12 @@
   {% include '_components/search_form.html' with q=request.GET.q %}
 
   <!-- Cards de totais -->
-  <div class="mb-6 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+  <div class="mb-6 card-grid gap-4">
     {% include "_partials/cards/total_card.html" with label=_('Usuários') valor=total_usuarios %}
     {% include "_partials/cards/total_card.html" with label=_('Associados') valor=total_associados %}
     {% include "_partials/cards/total_card.html" with label=_('Nucleados') valor=total_nucleados %}
   </div>
-  <div role="list" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+  <div role="list" class="card-grid">
     {% for user in associados %}
       <div role="listitem">
         {% include "associados/partials/card.html" with user=user %}

--- a/accounts/templates/perfil/conexoes.html
+++ b/accounts/templates/perfil/conexoes.html
@@ -35,7 +35,7 @@
         </button>
       </form>
 
-      <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+      <div class="card-grid">
         {% for connection in connections %}
         <div class="bg-white dark:bg-slate-800 p-6 rounded-lg shadow border border-neutral-200 dark:border-neutral-700">
           <div class="flex items-center justify-between">

--- a/core/templates/core/about.html
+++ b/core/templates/core/about.html
@@ -9,7 +9,7 @@
 
 {% block content %}
 <div class="container mx-auto p-6">
-<section class="max-w-3xl mx-auto px-4 py-12 grid grid-cols-1 gap-6">
+<div class="max-w-3xl mx-auto px-4 py-12 card-grid">
   <div class="card">
     <div class="card-header">
       <h2 class="text-xl font-semibold">{% trans "Sobre o HubX" %}</h2>
@@ -19,6 +19,6 @@
       <p>{% trans "Nosso objetivo é facilitar a comunicação, gestão de eventos e colaboração entre membros." %}</p>
     </div>
   </div>
-</section>
+</div>
 </div>
 {% endblock %}

--- a/core/templates/core/home.html
+++ b/core/templates/core/home.html
@@ -28,7 +28,7 @@
       <h2 class="text-2xl font-bold text-neutral-900 mb-8">{% trans "Principais Funcionalidades" %}</h2>
     </div>
     <div class="card-body">
-      <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+      <div class="card-grid">
         <div class="card text-center flex flex-col items-center">
           <div class="card-body">
             {% lucide 'rss' class='text-indigo-600 w-8 h-8 mb-4' %}

--- a/core/templates/core/privacy.html
+++ b/core/templates/core/privacy.html
@@ -9,7 +9,7 @@
 
 {% block content %}
 <div class="container mx-auto p-6">
-<section class="max-w-3xl mx-auto px-4 py-12 grid grid-cols-1 gap-6">
+<div class="max-w-3xl mx-auto px-4 py-12 card-grid">
   <div class="card">
     <div class="card-header">
       <h2 class="text-xl font-semibold">{% trans "Política de Privacidade" %}</h2>
@@ -18,6 +18,6 @@
       <p>{% trans "Seus dados pessoais são tratados com segurança e apenas para fins da plataforma." %}</p>
     </div>
   </div>
-</section>
+</div>
 </div>
 {% endblock %}

--- a/core/templates/core/terms.html
+++ b/core/templates/core/terms.html
@@ -9,7 +9,7 @@
 
 {% block content %}
 <div class="container mx-auto p-6">
-<section class="max-w-3xl mx-auto px-4 py-12 grid grid-cols-1 gap-6">
+<div class="max-w-3xl mx-auto px-4 py-12 card-grid">
   <div class="card">
     <div class="card-header">
       <h2 class="text-xl font-semibold">{% trans "Termos de Uso" %}</h2>
@@ -18,6 +18,6 @@
       <p>{% trans "Ao utilizar o HubX, você concorda com nossas políticas de uso e privacidade." %}</p>
     </div>
   </div>
-</section>
+</div>
 </div>
 {% endblock %}

--- a/dashboard/templates/dashboard/admin.html
+++ b/dashboard/templates/dashboard/admin.html
@@ -9,7 +9,7 @@
 
 {% block content %}
 <div class="container mx-auto p-6">
-<section class="max-w-7xl mx-auto px-4 py-10 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6" aria-label="{% trans 'Dashboard' %}">
+<div class="max-w-7xl mx-auto px-4 py-10 card-grid" aria-label="{% trans 'Dashboard' %}">
   <div class="card col-span-full">
     <div class="card-header">
       <h2 class="text-xl font-semibold text-center">{% trans "Dashboard Administrativo" %}</h2>
@@ -52,7 +52,7 @@
 
       <section id="feed-metrics" class="my-8" aria-labelledby="feed-metrics-title" data-feed-metrics-url="{% url 'dashboard_api:feed-metrics' %}">
         <h2 id="feed-metrics-title" class="text-xl font-semibold mb-4">{% trans "Métricas do Feed" %}</h2>
-        <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+        <div class="card-grid">
           <canvas id="feed-type-chart" aria-label="{% trans 'Posts por tipo' %}" role="img"></canvas>
           <canvas id="feed-tag-chart" aria-label="{% trans 'Top tags' %}" role="img"></canvas>
           <canvas id="feed-author-chart" aria-label="{% trans 'Top autores' %}" role="img"></canvas>
@@ -61,7 +61,7 @@
 
       <section class="mb-8">
         <h2 class="text-xl font-semibold mb-4">{% trans "Ações Rápidas" %}</h2>
-        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        <div class="card-grid gap-4">
           <a href="{% url 'dashboard:custom-metrics' %}" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50" aria-label="{% trans 'Métricas Personalizadas' %}">
             {% lucide 'chart-line' class='mb-2 mx-auto w-6 h-6' %}
             <span class="block">{% trans "Métricas Personalizadas" %}</span>
@@ -82,6 +82,6 @@
       </section>
     </div>
   </div>
-</section>
+</div>
 </div>
 {% endblock %}

--- a/dashboard/templates/dashboard/cliente.html
+++ b/dashboard/templates/dashboard/cliente.html
@@ -40,7 +40,7 @@
         ></section>
         <section class="mb-8">
           <h2 class="text-xl font-semibold mb-4">{% trans "Atalhos" %}</h2>
-          <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          <div class="card-grid gap-4">
             <a href="{% url 'eventos:calendario' %}" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50" aria-label="{% trans 'Inscrever-se em Eventos' %}">
               {% lucide 'calendar-plus' class='mb-2 mx-auto w-6 h-6' %}
               <span class="block">{% trans "Inscrever-se em Eventos" %}</span>

--- a/dashboard/templates/dashboard/coordenador.html
+++ b/dashboard/templates/dashboard/coordenador.html
@@ -34,7 +34,7 @@
         ></section>
         <section class="mb-8">
           <h2 class="text-xl font-semibold mb-4">{% trans "Ações Rápidas" %}</h2>
-          <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          <div class="card-grid gap-4">
           </div>
         </section>
       </div>

--- a/dashboard/templates/dashboard/partials/metrics_list.html
+++ b/dashboard/templates/dashboard/partials/metrics_list.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 <section class="mb-8" id="metrics">
-  <div id="dashboard-cards" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4" data-save-url="{{ layout_save_url|default:'' }}">
+  <div id="dashboard-cards" class="card-grid gap-4" data-save-url="{{ layout_save_url|default:'' }}">
     {% for m in metricas_iter %}
       {% include "dashboard/partials/metric_card.html" with title=m.label value=m.data.total icon=m.icon crescimento=m.data.crescimento id=m.key %}
     {% endfor %}

--- a/dashboard/templates/dashboard/root.html
+++ b/dashboard/templates/dashboard/root.html
@@ -22,7 +22,7 @@
         {% endwith %}
         <section class="mb-8">
           <h2 class="text-xl font-semibold mb-4">{% trans "Status dos Serviços" %}</h2>
-          <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div class="card-grid gap-4">
             <div class="p-4 bg-white rounded-lg shadow">
               <span class="block font-medium">{% trans "Celery" %}</span>
               <span>{{ service_status.celery }}</span>
@@ -39,7 +39,7 @@
         </section>
         <section class="mb-8">
           <h2 class="text-xl font-semibold mb-4">{% trans "Métricas de Segurança" %}</h2>
-          <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div class="card-grid gap-4">
             <div class="p-4 bg-white rounded-lg shadow">
               <span class="block font-medium">{% trans "Tentativas de Login Bloqueadas" %}</span>
               <span>{{ security_metrics.login_bloqueados }}</span>
@@ -48,7 +48,7 @@
         </section>
         <section class="mb-8">
           <h2 class="text-xl font-semibold mb-4">{% trans "Organizações" %}</h2>
-          <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          <div class="card-grid gap-4">
             {% include 'dashboard/partials/org_cards.html' %}
           </div>
         </section>
@@ -61,7 +61,7 @@
         ></section>
         <section class="mb-8">
           <h2 class="text-xl font-semibold mb-4">{% trans "Ações Rápidas" %}</h2>
-          <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          <div class="card-grid gap-4">
             <a href="{% url 'admin:index' %}" class="p-4 bg-white rounded-lg shadow text-center hover:bg-neutral-50" aria-label="{% trans 'Django Admin' %}">
               {% lucide 'wrench' class='mb-2 mx-auto w-6 h-6' %}
               <span class="block">{% trans "Django Admin" %}</span>

--- a/empresas/templates/empresas/busca.html
+++ b/empresas/templates/empresas/busca.html
@@ -17,7 +17,7 @@
 
   <div
     id="empresas-grid"
-  class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6"
+  class="card-grid"
     role="list"
     aria-label="{% translate 'Lista de empresas' %}"
   >

--- a/empresas/templates/empresas/empresa_list.html
+++ b/empresas/templates/empresas/empresa_list.html
@@ -14,7 +14,7 @@
     {% include '_components/search_form.html' with q=request.GET.q hx_get=empresas_lista_url hx_target='#empresas-grid' hx_push_url='true' %}
 
     <!-- Cards de totais -->
-    <div class="mb-6 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+    <div class="mb-6 card-grid gap-4">
       {% include "_partials/cards/total_card.html" with label=_('Empresas') valor=total_empresas %}
     </div>
 

--- a/eventos/templates/eventos/_lista_eventos_dia.html
+++ b/eventos/templates/eventos/_lista_eventos_dia.html
@@ -7,7 +7,7 @@
   <p class="sr-only">{% trans 'Lista de eventos do dia' %}</p>
 </header>
 
-<div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+<div class="card-grid">
   {% for ev in eventos %}
     {% include 'eventos/partials/card.html' with evento=ev %}
   {% empty %}

--- a/eventos/templates/eventos/evento_list.html
+++ b/eventos/templates/eventos/evento_list.html
@@ -16,13 +16,13 @@
       {% include '_components/search_form.html' with q=request.GET.q %}
     </div>
     <div class="card-body">
-      <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6 mb-6">
+      <div class="card-grid mb-6">
         {% include "_partials/cards/total_card.html" with label=_('Eventos') valor=total_eventos %}
         {% include "_partials/cards/total_card.html" with label=_('Ativos') valor=total_eventos_ativos %}
         {% include "_partials/cards/total_card.html" with label=_('Concluídos') valor=total_eventos_concluidos %}
         {% include "_partials/cards/total_card.html" with label=_('Inscritos (total)') valor=total_inscritos %}
       </div>
-      <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6" role="list" aria-label="{% trans 'Lista de eventos' %}">
+      <div class="card-grid" role="list" aria-label="{% trans 'Lista de eventos' %}">
         {% for evento in eventos %}
           {% include '_components/card_evento.html' %}
         {% empty %}

--- a/eventos/templates/eventos/eventos_lista.html
+++ b/eventos/templates/eventos/eventos_lista.html
@@ -15,13 +15,13 @@
       {% include '_components/search_form.html' with q=request.GET.q %}
     </div>
     <div class="card-body">
-      <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6 mb-6">
+      <div class="card-grid mb-6">
         {% include "_partials/cards/total_card.html" with label=_('Eventos') valor=total_eventos %}
         {% include "_partials/cards/total_card.html" with label=_('Ativos') valor=total_eventos_ativos %}
         {% include "_partials/cards/total_card.html" with label=_('Concluídos') valor=total_eventos_concluidos %}
         {% include "_partials/cards/total_card.html" with label=_('Inscritos (total)') valor=total_inscritos %}
       </div>
-      <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6" role="list" aria-label="{% trans 'Lista de eventos' %}">
+      <div class="card-grid" role="list" aria-label="{% trans 'Lista de eventos' %}">
         {% for evento in eventos %}
           {% include '_components/card_evento.html' %}
         {% empty %}

--- a/tokens/templates/tokens/api_tokens.html
+++ b/tokens/templates/tokens/api_tokens.html
@@ -8,7 +8,7 @@
 
 {% block content %}
 <div class="container mx-auto p-6">
-<section class="max-w-3xl mx-auto px-4 py-12 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+<div class="max-w-3xl mx-auto px-4 py-12 card-grid">
   <div class="card">
     <div class="card-header">
       <h2 class="text-xl font-semibold">{% trans "Tokens de API" %}</h2>
@@ -83,6 +83,6 @@
       </div>
     </div>
   </div>
-</section>
+</div>
 </div>
 {% endblock %}

--- a/tokens/templates/tokens/listar_convites.html
+++ b/tokens/templates/tokens/listar_convites.html
@@ -19,7 +19,7 @@
     </a>
   </div>
 
-  <div class="mb-6 grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-4">
+  <div class="mb-6 card-grid gap-4">
     <div class="p-4 rounded-2xl border border-neutral-200 bg-white shadow-sm">
       <div class="text-sm text-neutral-500">{% trans "Total" %}</div>
       <div class="mt-1 text-2xl font-bold text-neutral-900">{{ totais.total }}</div>


### PR DESCRIPTION
## Summary
- use card-grid utility for company search layout
- refactor event list templates to card-grid
- apply card-grid to dashboards and token pages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_benchmark' and other modules)*

------
https://chatgpt.com/codex/tasks/task_e_68c0aa7651e4832594b3d81086daf503