### PR TITLE
refactor: clean register templates

### DIFF
--- a/accounts/templates/register/cpf.html
+++ b/accounts/templates/register/cpf.html
@@ -8,8 +8,7 @@
 {% endblock %}
 
 {% block content %}
-{% include '_partials/sidebar.html' %}
-<div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+<div class="card-grid">
   <div class="card">
     <div class="mb-8">
       {% with step=4 total=8 %}

--- a/accounts/templates/register/email.html
+++ b/accounts/templates/register/email.html
@@ -8,11 +8,7 @@
 {% endblock %}
 
 {% block content %}
-<<<<<<< HEAD
-=======
-{% include '_partials/sidebar.html' %}
->>>>>>> main
-<div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+<div class="card-grid">
   <div class="card">
     <div class="mb-8">
       {% with step=5 total=8 %}

--- a/accounts/templates/register/foto.html
+++ b/accounts/templates/register/foto.html
@@ -8,11 +8,7 @@
 {% endblock %}
 
 {% block content %}
-<<<<<<< HEAD
-=======
-{% include '_partials/sidebar.html' %}
->>>>>>> main
-<div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+<div class="card-grid">
   <div class="card">
     <div class="mb-8">
       {% with step=7 total=8 %}

--- a/accounts/templates/register/nome.html
+++ b/accounts/templates/register/nome.html
@@ -8,11 +8,7 @@
 {% endblock %}
 
 {% block content %}
-<<<<<<< HEAD
-=======
-{% include '_partials/sidebar.html' %}
->>>>>>> main
-<div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+<div class="card-grid">
   <div class="card">
     <div class="mb-8">
       {% with step=3 total=8 %}

--- a/accounts/templates/register/onboarding.html
+++ b/accounts/templates/register/onboarding.html
@@ -8,11 +8,7 @@
 {% endblock %}
 
 {% block content %}
-<<<<<<< HEAD
-=======
-{% include '_partials/sidebar.html' %}
->>>>>>> main
-<div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+<div class="card-grid">
   <div class="card text-center">
         <div class="mb-8">
             <div class="w-20 h-20 bg-[var(--primary-light)] rounded-full flex items-center justify-center mx-auto mb-4">

--- a/accounts/templates/register/registro_sucesso.html
+++ b/accounts/templates/register/registro_sucesso.html
@@ -8,11 +8,7 @@
 {% endblock %}
 
 {% block content %}
-<<<<<<< HEAD
-=======
-{% include '_partials/sidebar.html' %}
->>>>>>> main
-<div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+<div class="card-grid">
   <div class="card p-8 text-center">
     {% if messages %}
     <div class="mb-4 space-y-2">

--- a/accounts/templates/register/senha.html
+++ b/accounts/templates/register/senha.html
@@ -8,11 +8,7 @@
 {% endblock %}
 
 {% block content %}
-<<<<<<< HEAD
-=======
-{% include '_partials/sidebar.html' %}
->>>>>>> main
-<div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+<div class="card-grid">
   <div class="card">
     <div class="mb-8">
       {% with step=6 total=8 %}

--- a/accounts/templates/register/termos.html
+++ b/accounts/templates/register/termos.html
@@ -8,11 +8,7 @@
 {% endblock %}
 
 {% block content %}
-<<<<<<< HEAD
-=======
-{% include '_partials/sidebar.html' %}
->>>>>>> main
-<div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+<div class="card-grid">
   <div class="card">
     <div class="mb-8">
       {% with step=8 total=8 %}

--- a/accounts/templates/register/token.html
+++ b/accounts/templates/register/token.html
@@ -8,11 +8,7 @@
 {% endblock %}
 
 {% block content %}
-<<<<<<< HEAD
-=======
-{% include '_partials/sidebar.html' %}
->>>>>>> main
-<div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+<div class="card-grid">
   <div class="card">
     <div class="mb-8">
       {% with step=1 total=8 %}

--- a/accounts/templates/register/usuario.html
+++ b/accounts/templates/register/usuario.html
@@ -8,11 +8,7 @@
 {% endblock %}
 
 {% block content %}
-<<<<<<< HEAD
-=======
-{% include '_partials/sidebar.html' %}
->>>>>>> main
-<div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+<div class="card-grid">
   <div class="card">
     <div class="mb-8">
       {% with step=2 total=8 %}


### PR DESCRIPTION
## Summary
- clean registration templates by removing leftover merge markers and sidebar includes
- use `card-grid` container instead of grid columns for registration cards

## Testing
- `pytest` *(fails: ModuleNotFoundError and collection errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c0ae4121b4832587930af235956efd