### PR TITLE
Padroniza grids de cards no perfil

### DIFF
--- a/accounts/templates/perfil/detail.html
+++ b/accounts/templates/perfil/detail.html
@@ -58,7 +58,7 @@
     {% if user.get_tipo_usuario != 'admin' %}
     <!-- Painel: Empresas -->
     <div class="tab-panel hidden" data-tab="empresas">
-      <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+        <div class="card-grid">
         {% for empresa in empresas %}
           {% include '_components/card_empresa.html' with empresa=empresa %}
         {% empty %}
@@ -80,7 +80,7 @@
 
     <!-- Painel: Eventos -->
     <div class="tab-panel hidden" data-tab="eventos">
-      <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+        <div class="card-grid">
         {% for ins in inscricoes %}
           {% include '_components/card_evento.html' with evento=ins.evento %}
         {% empty %}

--- a/accounts/templates/perfil/midias.html
+++ b/accounts/templates/perfil/midias.html
@@ -54,10 +54,10 @@
            class="w-full border border-gray-300 dark:border-neutral-600 dark:bg-neutral-700 dark:text-neutral-100 rounded-lg px-4 py-2 text-sm" aria-label="{% trans 'Buscar' %}" aria-invalid="false">
   </form>
 
-  <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6 mt-6">
-    {% for media in medias %}
-    <div class="bg-white dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 rounded-lg shadow p-3 relative">
-      <div class="absolute top-2 right-2 flex gap-2">
+    <div class="card-grid mt-6">
+      {% for media in medias %}
+      <article class="card relative p-3">
+        <div class="absolute top-2 right-2 flex gap-2">
         <a href="{% url 'accounts:midia_edit' media.pk %}" class="btn-secondary btn-sm" aria-label="{% trans 'Editar' %}">
           {% lucide 'edit' class='w-4 h-4' aria_hidden='true' %}
         </a>
@@ -65,7 +65,7 @@
           {% lucide 'trash' class='w-4 h-4' aria_hidden='true' %}
         </a>
       </div>
-      <a href="{% url 'accounts:midia_detail' media.pk %}">
+        <a href="{% url 'accounts:midia_detail' media.pk %}">
         {% if media.media_type == 'image' %}
           <img src="{{ media.file.url }}" alt="{{ media.descricao }}" class="w-full h-40 object-cover rounded">
         {% elif media.media_type == 'video' %}
@@ -75,22 +75,22 @@
         {% else %}
           <span class="text-sm text-gray-500">{{ media.file.name }}</span>
         {% endif %}
-      </a>
-      <div class="mt-2">
-        <p class="text-sm font-medium text-gray-700 dark:text-gray-200">{{ media.descricao }}</p>
-        <p class="text-xs text-gray-400 dark:text-gray-500">{{ media.created_at|date:"SHORT_DATETIME_FORMAT" }}</p>
-        <div class="flex flex-wrap gap-1 mt-1">
-          {% for tag in media.tags.all %}
-            <span class="bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 text-xs px-2 py-0.5 rounded">{{ tag.nome }}</span>
-          {% endfor %}
+        </a>
+        <div class="card-body mt-2">
+          <p class="text-sm font-medium text-gray-700 dark:text-gray-200">{{ media.descricao }}</p>
+          <p class="text-xs text-gray-400 dark:text-gray-500">{{ media.created_at|date:"SHORT_DATETIME_FORMAT" }}</p>
+          <div class="flex flex-wrap gap-1 mt-1">
+            {% for tag in media.tags.all %}
+              <span class="bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 text-xs px-2 py-0.5 rounded">{{ tag.nome }}</span>
+            {% endfor %}
+          </div>
         </div>
-      </div>
-    </div>
+      </article>
     {% empty %}
       <p class="text-sm text-gray-500 dark:text-gray-400">{% trans "Nenhum arquivo enviado." %}</p>
     {% endfor %}
-  </div>
-</section>
+    </div>
+  </section>
 
 <div class="mt-8 text-center">
   <a href="{% url 'accounts:perfil' %}" class="text-sm text-primary hover:underline">← {% trans "Voltar" %}</a>

--- a/accounts/templates/perfil/partials/conexoes_minhas.html
+++ b/accounts/templates/perfil/partials/conexoes_minhas.html
@@ -12,10 +12,10 @@
   </button>
 </form>
 
-<div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+  <div class="card-grid">
   {% for connection in connections %}
-  <div class="connection-card bg-[var(--bg-secondary)] p-6 rounded-lg shadow">
-    <div class="flex items-center justify-between">
+    <article class="card connection-card">
+      <div class="card-body flex items-center justify-between">
       <div class="flex items-center gap-3">
         {% if connection.avatar %}
           <img src="{{ connection.avatar.url }}" alt="{{ connection.username }}" class="w-10 h-10 rounded-full object-cover" />
@@ -42,10 +42,9 @@
           </button>
         </form>
       </div>
-    </div>
-  </div>
-  {% empty %}
-  <div class="text-center text-sm text-[var(--text-secondary)] col-span-full">
+      </article>
+    {% empty %}
+    <div class="text-center text-sm text-[var(--text-secondary)] col-span-full">
     <p>{% trans "Você ainda não tem conexões." %}</p>
     <a href="#" class="mt-2 inline-block btn btn-primary btn-sm">{% trans "Encontrar Pessoas" %}</a>
   </div>

--- a/accounts/templates/perfil/partials/detail_empresas.html
+++ b/accounts/templates/perfil/partials/detail_empresas.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-<div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+<div class="card-grid">
   {% for empresa in empresas %}
     {% include '_components/card_empresa.html' with empresa=empresa %}
   {% empty %}

--- a/accounts/templates/perfil/partials/detail_eventos.html
+++ b/accounts/templates/perfil/partials/detail_eventos.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-<div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+<div class="card-grid">
   {% for ins in inscricoes %}
     {% include '_components/card_evento.html' with evento=ins.evento %}
   {% empty %}

--- a/accounts/templates/perfil/partials/publico_empresas.html
+++ b/accounts/templates/perfil/partials/publico_empresas.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 {% if empresas %}
-<div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6" role="list" aria-label="{% translate 'Lista de empresas' %}">
+<div class="card-grid" role="list" aria-label="{% translate 'Lista de empresas' %}">
   {% for empresa in empresas %}
     <div role="listitem">
       {% include '_components/card_empresa.html' with empresa=empresa %}

--- a/accounts/templates/perfil/partials/publico_eventos.html
+++ b/accounts/templates/perfil/partials/publico_eventos.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-<div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6" role="list" aria-label="{% trans 'Lista de eventos' %}">
+<div class="card-grid" role="list" aria-label="{% trans 'Lista de eventos' %}">
   {% for ins in inscricoes %}
     {% include '_components/card_evento.html' with evento=ins.evento %}
   {% empty %}

--- a/accounts/templates/perfil/publico.html
+++ b/accounts/templates/perfil/publico.html
@@ -85,7 +85,7 @@
     {% if not profile.is_superuser %}
     <div id="tab-empresas" role="tabpanel" data-tab-panel class="hidden">
       {% if empresas %}
-      <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6" role="list" aria-label="{% translate 'Lista de empresas' %}">
+        <div class="card-grid" role="list" aria-label="{% translate 'Lista de empresas' %}">
         {% for empresa in empresas %}
           <div role="listitem">
             {% include '_components/card_empresa.html' with empresa=empresa %}
@@ -110,7 +110,7 @@
     </div>
 
     <div id="tab-eventos" role="tabpanel" data-tab-panel class="hidden">
-      <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6" role="list" aria-label="{% trans 'Lista de eventos' %}">
+        <div class="card-grid" role="list" aria-label="{% trans 'Lista de eventos' %}">
         {% for ins in inscricoes %}
           {% include '_components/card_evento.html' with evento=ins.evento %}
         {% empty %}


### PR DESCRIPTION
## Resumo
- substitui grades de cards por `card-grid` nos templates de perfil
- ajusta marcação dos itens para utilizar `article.card` e `card-body`

## Testes
- `pytest` *(falhou: ModuleNotFoundError: No module named 'silk')*
- `pytest` *(falhou: Interrupted: 81 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c0b38a9998832580e29791af4f1ec1