### PR TITLE
refactor event templates

### DIFF
--- a/eventos/templates/eventos/briefing_list.html
+++ b/eventos/templates/eventos/briefing_list.html
@@ -24,10 +24,10 @@
 
       <form hx-get="{% url 'eventos:briefing_list' %}" hx-target="#briefing-container" hx-push-url="true" class="mb-6 flex gap-2">
         <input type="text" name="q" value="{{ request.GET.q }}" placeholder="{% trans 'Buscar por evento' %}" class="w-full rounded-md border-gray-300 px-3 py-2" />
-        <button type="submit" class="rounded-md bg-primary px-4 py-2 text-white hover:bg-primary/90">{% trans "Filtrar" %}</button>
+        <button type="submit" class="btn-primary">{% trans "Filtrar" %}</button>
       </form>
 
-      <div class="overflow-x-auto bg-white border border-neutral-200 rounded-2xl shadow-sm">
+      <div class="overflow-x-auto bg-[var(--bg-secondary)] border border-[var(--border)] rounded-2xl shadow-sm">
         <table class="min-w-full divide-y divide-neutral-200 table-auto text-sm">
           <thead class="bg-neutral-50">
             <tr>
@@ -52,20 +52,20 @@
                 <td class="px-4 py-2">{{ briefing.conteudo_programatico }}</td>
                 <td class="px-4 py-2">{{ briefing.observacoes }}</td>
                 <td class="px-4 py-2 space-x-2">
-                  <a href="{% url 'eventos:briefing_editar' briefing.pk %}" class="text-blue-600 hover:underline">{% trans "Editar" %}</a>
+                  <a href="{% url 'eventos:briefing_editar' briefing.pk %}" class="btn-secondary">{% trans "Editar" %}</a>
                   <form method="post" action="{% url 'eventos:briefing_status' briefing.pk 'orcamentado' %}" class="inline space-x-1">
                     {% csrf_token %}
                     <input type="datetime-local" name="prazo_limite_resposta" required class="rounded-md border-gray-300 px-2 py-1 text-xs" />
-                    <button type="submit" class="text-green-600 hover:underline">{% trans "Orçar" %}</button>
+                    <button type="submit" class="btn-secondary">{% trans "Orçar" %}</button>
                   </form>
                   <form method="post" action="{% url 'eventos:briefing_status' briefing.pk 'aprovado' %}" class="inline">
                     {% csrf_token %}
-                    <button type="submit" class="text-primary hover:underline">{% trans "Aprovar" %}</button>
+                    <button type="submit" class="btn-primary">{% trans "Aprovar" %}</button>
                   </form>
                   <form method="post" action="{% url 'eventos:briefing_status' briefing.pk 'recusado' %}" class="inline space-x-1">
                     {% csrf_token %}
                     <input type="text" name="motivo_recusa" placeholder="{% trans 'Motivo' %}" required class="rounded-md border-gray-300 px-2 py-1 text-xs" />
-                    <button type="submit" class="text-red-600 hover:underline">{% trans "Recusar" %}</button>
+                    <button type="submit" class="btn-secondary">{% trans "Recusar" %}</button>
                   </form>
                 </td>
               </tr>

--- a/eventos/templates/eventos/create.html
+++ b/eventos/templates/eventos/create.html
@@ -6,47 +6,17 @@
 <section class="max-w-screen-xl mx-auto pt-8 px-6 lg:px-8">
   <h1 class="text-2xl font-bold text-neutral-900 mb-6">{% trans "Cadastrar Evento" %}</h1>
 
-  <form method="post" enctype="multipart/form-data" class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 space-y-6">
+  <form method="post" enctype="multipart/form-data" class="bg-[var(--bg-secondary)] border border-[var(--border)] rounded-2xl shadow-sm p-6 space-y-6">
     {% csrf_token %}
 
     {{ form.non_field_errors }}
     {% for field in form %}
-      {% if field.name != 'participantes_maximo' and field.name != 'espera_habilitada' and field.name != 'numero_presentes' %}
-        <div>
-          <label for="{{ field.id_for_label }}" class="block text-sm font-medium text-neutral-700 mb-1">
-            {{ field.label }}
-          </label>
-          {% if field.name == 'avatar' or field.name == 'cover' %}
-            {{ field|add_class:'mt-1 block w-full'|attr:'accept:image/*' }}
-          {% else %}
-            {{ field }}
-          {% endif %}
-          {% if field.errors %}
-            <p class="text-sm text-red-600 mt-1">{{ field.errors }}</p>
-          {% endif %}
-        </div>
+      {% if field.name == 'avatar' or field.name == 'cover' %}
+        {% include '_forms/field.html' with field=field|attr:'accept:image/*' %}
+      {% else %}
+        {% include '_forms/field.html' with field=field %}
       {% endif %}
     {% endfor %}
-
-    <div>
-      <label for="{{ form.participantes_maximo.id_for_label }}" class="block text-sm font-medium text-neutral-700 mb-1">
-        {{ form.participantes_maximo.label }}
-      </label>
-      {{ form.participantes_maximo }}
-      {% if form.participantes_maximo.errors %}
-        <p class="text-sm text-red-600 mt-1">{{ form.participantes_maximo.errors }}</p>
-      {% endif %}
-    </div>
-
-    <div>
-      <label for="{{ form.espera_habilitada.id_for_label }}" class="block text-sm font-medium text-neutral-700 mb-1">
-        {{ form.espera_habilitada.label }}
-      </label>
-      {{ form.espera_habilitada }}
-      {% if form.espera_habilitada.errors %}
-        <p class="text-sm text-red-600 mt-1">{{ form.espera_habilitada.errors }}</p>
-      {% endif %}
-    </div>
 
     <div class="flex justify-end gap-3 pt-4 border-t border-neutral-100">
       <a href="{% url 'eventos:calendario' %}" class="btn-secondary" aria-label="{% trans 'Cancelar' %}">{% trans "Cancelar" %}</a>

--- a/eventos/templates/eventos/delete.html
+++ b/eventos/templates/eventos/delete.html
@@ -4,14 +4,14 @@
 
 {% block content %}
 <section class="max-w-screen-xl mx-auto pt-8 px-6 lg:px-8">
-  <div class="bg-white border border-red-200 rounded-2xl shadow-sm p-6 text-center">
+  <div class="bg-[var(--bg-secondary)] border border-red-200 rounded-2xl shadow-sm p-6 text-center">
     <h2 class="text-xl font-semibold text-red-700 mb-4">{% trans "Remover Evento" %}</h2>
     <p class="text-sm text-neutral-700">{% blocktrans with title=object.titulo %}Tem certeza que deseja remover <strong>{{ title }}</strong>?{% endblocktrans %}</p>
 
     <form method="post" class="mt-6 flex justify-center gap-3">
       {% csrf_token %}
       <a href="{% url 'eventos:calendario' %}" class="btn-secondary" aria-label="{% trans 'Cancelar' %}">{% trans "Cancelar" %}</a>
-      <button type="submit" class="btn-danger" aria-label="{% trans 'Remover' %}">{% trans "Remover" %}</button>
+      <button type="submit" class="btn-primary" aria-label="{% trans 'Remover' %}">{% trans "Remover" %}</button>
     </form>
   </div>
 </section>

--- a/eventos/templates/eventos/inscricao_form.html
+++ b/eventos/templates/eventos/inscricao_form.html
@@ -6,29 +6,16 @@
 {% block content %}
 <section class="max-w-screen-xl mx-auto pt-8 px-6 lg:px-8">
   <h1 class="text-2xl font-bold text-neutral-900 mb-6">{% trans "Inscrição" %}</h1>
-  <form method="post" enctype="multipart/form-data" class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 space-y-6">
+  <form method="post" enctype="multipart/form-data" class="bg-[var(--bg-secondary)] border border-[var(--border)] rounded-2xl shadow-sm p-6 space-y-6">
     {% csrf_token %}
     {{ form.non_field_errors }}
-    <div>
-      {{ form.metodo_pagamento.label_tag }}
-      {{ form.metodo_pagamento }}
-      {{ form.metodo_pagamento.errors }}
-    </div>
-    <div>
-      {{ form.valor_pago.label_tag }}
-      {{ form.valor_pago }}
-      {{ form.valor_pago.errors }}
-    </div>
-    <div>
-  {{ form.comprovante_pagamento.label_tag }}
-  {{ form.comprovante_pagamento|attr:'accept:.jpg,.jpeg,.png,.pdf' }}
-      {{ form.comprovante_pagamento.errors }}
-    </div>
-    <div>
-      {{ form.observacao.label_tag }}
-      {{ form.observacao }}
-      {{ form.observacao.errors }}
-    </div>
+    {% for field in form %}
+      {% if field.name == 'comprovante_pagamento' %}
+        {% include '_forms/field.html' with field=field|attr:'accept:.jpg,.jpeg,.png,.pdf' %}
+      {% else %}
+        {% include '_forms/field.html' with field=field %}
+      {% endif %}
+    {% endfor %}
     <div class="flex justify-end gap-3 pt-4 border-t border-neutral-100">
       <a href="{% url 'eventos:evento_detalhe' evento.pk %}" class="btn-secondary" aria-label="{% trans 'Cancelar' %}">{% trans "Cancelar" %}</a>
       <button type="submit" class="btn-primary" aria-label="{% trans 'Salvar' %}">{% trans "Salvar" %}</button>

--- a/eventos/templates/eventos/material_form.html
+++ b/eventos/templates/eventos/material_form.html
@@ -7,21 +7,17 @@
   <h1 class="text-2xl font-bold text-neutral-900 mb-6">
     {% if object %}{% trans "Editar Material" %}{% else %}{% trans "Novo Material" %}{% endif %}
   </h1>
-  <form method="post" enctype="multipart/form-data" class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 space-y-6">
+  <form method="post" enctype="multipart/form-data" class="bg-[var(--bg-secondary)] border border-[var(--border)] rounded-2xl shadow-sm p-6 space-y-6">
     {% csrf_token %}
     {{ form.non_field_errors }}
     {% for field in form %}
-    <div>
-      {{ field.label_tag }}
-  {% if field.name == 'arquivo' %}
-  {{ field|attr:'accept:.jpg,.jpeg,.png,.pdf' }}
-  {% elif field.name == 'imagem_thumb' %}
-  {{ field|attr:'accept:.jpg,.jpeg,.png' }}
+      {% if field.name == 'arquivo' %}
+        {% include '_forms/field.html' with field=field|attr:'accept:.jpg,.jpeg,.png,.pdf' %}
+      {% elif field.name == 'imagem_thumb' %}
+        {% include '_forms/field.html' with field=field|attr:'accept:.jpg,.jpeg,.png' %}
       {% else %}
-      {{ field }}
+        {% include '_forms/field.html' with field=field %}
       {% endif %}
-      {{ field.errors }}
-    </div>
     {% endfor %}
     <div class="flex justify-end gap-3 pt-4 border-t border-neutral-100">
       <a href="{% url 'eventos:material_list' %}" class="btn-secondary" aria-label="{% trans 'Cancelar' %}">{% trans "Cancelar" %}</a>

--- a/eventos/templates/eventos/material_list.html
+++ b/eventos/templates/eventos/material_list.html
@@ -18,10 +18,10 @@
 
       <form method="get" class="mb-6 flex gap-2">
         <input type="text" name="q" value="{{ request.GET.q }}" placeholder="{% trans 'Buscar por título' %}" class="w-full rounded-md border-gray-300 px-3 py-2" />
-        <button type="submit" class="rounded-md bg-primary px-4 py-2 text-white hover:bg-primary/90">{% trans "Filtrar" %}</button>
+        <button type="submit" class="btn-primary">{% trans "Filtrar" %}</button>
       </form>
 
-      <div class="overflow-x-auto bg-white border border-neutral-200 rounded-2xl shadow-sm">
+      <div class="overflow-x-auto bg-[var(--bg-secondary)] border border-[var(--border)] rounded-2xl shadow-sm">
         <table class="min-w-full divide-y divide-neutral-200 table-auto text-sm">
           <thead class="bg-neutral-50">
             <tr>

--- a/eventos/templates/eventos/parceria_confirm_delete.html
+++ b/eventos/templates/eventos/parceria_confirm_delete.html
@@ -5,13 +5,13 @@
 
 {% block content %}
 <section class="max-w-screen-xl mx-auto pt-8 px-6 lg:px-8">
-  <div class="bg-white border border-red-200 rounded-2xl shadow-sm p-6 text-center">
+  <div class="bg-[var(--bg-secondary)] border border-red-200 rounded-2xl shadow-sm p-6 text-center">
     <h2 class="text-xl font-semibold text-red-700 mb-4">{% trans 'Remover Parceria' %}</h2>
     <p class="text-sm text-neutral-700">{% blocktrans %}Tem certeza que deseja remover <strong>{{ object.empresa.nome }}</strong>?{% endblocktrans %}</p>
     <form method="post" class="mt-6 flex justify-center gap-3">
       {% csrf_token %}
       <a href="{% url 'eventos:parceria_list' %}" class="btn-secondary" aria-label="{% trans 'Cancelar' %}">{% trans 'Cancelar' %}</a>
-      <button type="submit" class="btn-danger" aria-label="{% trans 'Remover' %}">{% trans 'Remover' %}</button>
+      <button type="submit" class="btn-primary" aria-label="{% trans 'Remover' %}">{% trans 'Remover' %}</button>
     </form>
   </div>
 </section>

--- a/eventos/templates/eventos/tarefa_form.html
+++ b/eventos/templates/eventos/tarefa_form.html
@@ -7,39 +7,12 @@
   <h1 class="text-2xl font-bold text-neutral-900 mb-6">
     {% if object %}{% trans "Editar Tarefa" %}{% else %}{% trans "Cadastrar Tarefa" %}{% endif %}
   </h1>
-  <form method="post" class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 space-y-6">
+  <form method="post" class="bg-[var(--bg-secondary)] border border-[var(--border)] rounded-2xl shadow-sm p-6 space-y-6">
     {% csrf_token %}
     {{ form.non_field_errors }}
-    <div>
-      {{ form.titulo.label_tag }}
-      {{ form.titulo }}
-      {{ form.titulo.errors }}
-    </div>
-    <div>
-      {{ form.descricao.label_tag }}
-      {{ form.descricao }}
-      {{ form.descricao.errors }}
-    </div>
-    <div>
-      {{ form.data_inicio.label_tag }}
-      {{ form.data_inicio }}
-      {{ form.data_inicio.errors }}
-    </div>
-    <div>
-      {{ form.data_fim.label_tag }}
-      {{ form.data_fim }}
-      {{ form.data_fim.errors }}
-    </div>
-    <div>
-      {{ form.responsavel.label_tag }}
-      {{ form.responsavel }}
-      {{ form.responsavel.errors }}
-    </div>
-    <div>
-      {{ form.status.label_tag }}
-      {{ form.status }}
-      {{ form.status.errors }}
-    </div>
+    {% for field in form %}
+      {% include '_forms/field.html' with field=field %}
+    {% endfor %}
     <div class="flex justify-end gap-3 pt-4 border-t border-neutral-100">
       <a href="{% url 'eventos:tarefa_list' %}" class="btn-secondary" aria-label="{% trans 'Cancelar' %}">{% trans "Cancelar" %}</a>
       <button type="submit" class="btn-primary" aria-label="{% trans 'Salvar' %}">{% trans "Salvar" %}</button>

--- a/eventos/templates/eventos/tarefa_list.html
+++ b/eventos/templates/eventos/tarefa_list.html
@@ -10,7 +10,7 @@
   </header>
   <ul class="space-y-2">
     {% for tarefa in tarefas %}
-      <li class="p-4 bg-white border border-neutral-200 rounded-2xl shadow-sm">
+      <li class="p-4 bg-[var(--bg-secondary)] border border-[var(--border)] rounded-2xl shadow-sm">
         <a href="{% url 'eventos:tarefa_detalhe' tarefa.pk %}" class="font-semibold">{{ tarefa.titulo }}</a>
         <div class="text-sm text-neutral-600">{{ tarefa.responsavel }} - {{ tarefa.status }}</div>
       </li>

--- a/eventos/templates/eventos/update.html
+++ b/eventos/templates/eventos/update.html
@@ -6,48 +6,20 @@
 <section class="max-w-screen-xl mx-auto pt-8 px-6 lg:px-8">
   <h1 class="text-2xl font-bold text-neutral-900 mb-6">{% trans "Editar Evento" %}</h1>
 
-  <form method="post" enctype="multipart/form-data" class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 space-y-6">
+  <form method="post" enctype="multipart/form-data" class="bg-[var(--bg-secondary)] border border-[var(--border)] rounded-2xl shadow-sm p-6 space-y-6">
     {% csrf_token %}
     {% for field in form %}
-      {% if field.name != 'inscricoes' and field.name != 'participantes_maximo' and field.name != 'espera_habilitada' and field.name != 'numero_presentes' %}
-        <div>
-          <label for="{{ field.id_for_label }}" class="block text-sm font-medium text-neutral-700 mb-1">
-            {{ field.label }}
-          </label>
-          {% if field.name == 'avatar' or field.name == 'cover' %}
+      {% if field.name != 'inscricoes' and field.name != 'numero_presentes' %}
+        {% if field.name == 'avatar' or field.name == 'cover' %}
           {% if field.value %}
             <img src="{{ field.value.url }}" alt="{{ field.label }}" class="w-32 h-32 object-cover mb-2">
           {% endif %}
-          {{ field|add_class:'mt-1 block w-full'|attr:'accept:image/*' }}
-          {% else %}
-          {{ field }}
-          {% endif %}
-          {% if field.errors %}
-            <p class="text-sm text-red-600 mt-1">{{ field.errors }}</p>
-          {% endif %}
-        </div>
+          {% include '_forms/field.html' with field=field|attr:'accept:image/*' %}
+        {% else %}
+          {% include '_forms/field.html' with field=field %}
+        {% endif %}
       {% endif %}
     {% endfor %}
-
-    <div>
-      <label for="{{ form.participantes_maximo.id_for_label }}" class="block text-sm font-medium text-neutral-700 mb-1">
-        {{ form.participantes_maximo.label }}
-      </label>
-      {{ form.participantes_maximo }}
-      {% if form.participantes_maximo.errors %}
-        <p class="text-sm text-red-600 mt-1">{{ form.participantes_maximo.errors }}</p>
-      {% endif %}
-    </div>
-
-    <div>
-      <label for="{{ form.espera_habilitada.id_for_label }}" class="block text-sm font-medium text-neutral-700 mb-1">
-        {{ form.espera_habilitada.label }}
-      </label>
-      {{ form.espera_habilitada }}
-      {% if form.espera_habilitada.errors %}
-        <p class="text-sm text-red-600 mt-1">{{ form.espera_habilitada.errors }}</p>
-      {% endif %}
-    </div>
 
     <div class="flex justify-end gap-3 pt-4 border-t border-neutral-100">
       <a href="{% url 'eventos:calendario' %}" class="btn-secondary" aria-label="{% trans 'Cancelar' %}">{% trans "Cancelar" %}</a>
@@ -58,7 +30,7 @@
   <!-- Orçamento -->
   <div class="mt-10">
     <h2 class="text-lg font-semibold text-neutral-900 mb-4">{% trans "Orçamento" %}</h2>
-    <form id="orcamento-form" method="post" action="{% url 'eventos:evento_orcamento' object.pk %}" class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 space-y-6">
+    <form id="orcamento-form" method="post" action="{% url 'eventos:evento_orcamento' object.pk %}" class="bg-[var(--bg-secondary)] border border-[var(--border)] rounded-2xl shadow-sm p-6 space-y-6">
       {% csrf_token %}
       <div>
         <label for="id_orcamento_estimado" class="block text-sm font-medium text-neutral-700 mb-1">{% trans "Orçamento estimado" %}</label>
@@ -81,7 +53,7 @@
     <div class="grid gap-4 sm:grid-cols-2">
       {% for ins in object.inscricoes.all %}
         {% with inscrito=ins.user %}
-        <div class="flex items-center justify-between border border-neutral-200 rounded-xl p-4 bg-white shadow-sm">
+        <div class="flex items-center justify-between border border-[var(--border)] rounded-xl p-4 bg-[var(--bg-secondary)] shadow-sm">
           <div>
             <h3 class="text-sm font-medium text-neutral-800">{{ inscrito.get_full_name|default:inscrito.username }}</h3>
             <p class="text-xs text-neutral-500">{{ inscrito.email }}</p>
@@ -89,7 +61,7 @@
           {% if user.user_type in ['admin', 'coordenador'] %}
           <form method="post" action="{% url 'eventos:evento_remover_inscrito' object.pk inscrito.pk %}">
             {% csrf_token %}
-            <button type="submit" class="text-sm text-red-600 hover:underline" aria-label="{% trans 'Remover' %}">{% trans "Remover" %}</button>
+            <button type="submit" class="btn-secondary text-sm" aria-label="{% trans 'Remover' %}">{% trans "Remover" %}</button>
           </form>
           {% endif %}
         </div>


### PR DESCRIPTION
## Summary
- replace hard-coded event template styles with CSS variables
- render form fields using shared `_forms/field.html`
- standardize buttons to `btn-primary`/`btn-secondary`

## Testing
- `pytest eventos/tests` (fails: ModuleNotFoundError: No module named 'discussao'; coverage 17.79% < 90%)

------
https://chatgpt.com/codex/tasks/task_e_68c0b5d0834483258d8d6da1bc8501e0