### PR TITLE
Refatorar templates de notificações para novo padrão UI

### DIFF
--- a/notificacoes/templates/notificacoes/historico_list.html
+++ b/notificacoes/templates/notificacoes/historico_list.html
@@ -6,33 +6,35 @@
   <div class="mb-8">
     <h1 class="text-2xl font-bold text-neutral-900">{% trans 'Histórico de Notificações' %}</h1>
   </div>
-  <form method="get" class="bg-white border border-neutral-200 p-6 rounded-2xl shadow-sm mb-6 flex flex-col sm:flex-row gap-4 sm:items-end">
-    <div>
-      <label for="inicio" class="block text-sm font-medium text-neutral-700 mb-1">{% trans 'De' %}</label>
-      <input type="date" name="inicio" id="inicio" value="{{ request.GET.inicio }}" class="form-input" hx-get="{% url 'notificacoes:historico' %}" hx-target="#historico-container" hx-include="closest form">
+  <form method="get" class="card mb-6">
+    <div class="card-body flex flex-col sm:flex-row gap-4 sm:items-end">
+      <div>
+        <label for="inicio" class="block text-sm font-medium text-neutral-700 mb-1">{% trans 'De' %}</label>
+        <input type="date" name="inicio" id="inicio" value="{{ request.GET.inicio }}" class="form-input" hx-get="{% url 'notificacoes:historico' %}" hx-target="#historico-container" hx-include="closest form">
+      </div>
+      <div>
+        <label for="fim" class="block text-sm font-medium text-neutral-700 mb-1">{% trans 'Até' %}</label>
+        <input type="date" name="fim" id="fim" value="{{ request.GET.fim }}" class="form-input" hx-get="{% url 'notificacoes:historico' %}" hx-target="#historico-container" hx-include="closest form">
+      </div>
+      <div>
+        <label for="canal" class="block text-sm font-medium text-neutral-700 mb-1">{% trans 'Canal' %}</label>
+        <select name="canal" id="canal" class="form-select" hx-get="{% url 'notificacoes:historico' %}" hx-target="#historico-container" hx-include="closest form">
+          <option value="" {% if not request.GET.canal %}selected{% endif %}>{% trans 'Todos' %}</option>
+          <option value="email" {% if request.GET.canal == 'email' %}selected{% endif %}>{% trans 'E-mail' %}</option>
+          <option value="push" {% if request.GET.canal == 'push' %}selected{% endif %}>{% trans 'Push' %}</option>
+          <option value="whatsapp" {% if request.GET.canal == 'whatsapp' %}selected{% endif %}>{% trans 'WhatsApp' %}</option>
+        </select>
+      </div>
+      <div>
+        <label for="frequencia" class="block text-sm font-medium text-neutral-700 mb-1">{% trans 'Frequência' %}</label>
+        <select name="frequencia" id="frequencia" class="form-select" hx-get="{% url 'notificacoes:historico' %}" hx-target="#historico-container" hx-include="closest form">
+          <option value="" {% if not request.GET.frequencia %}selected{% endif %}>{% trans 'Todas' %}</option>
+          <option value="diaria" {% if request.GET.frequencia == 'diaria' %}selected{% endif %}>{% trans 'Diária' %}</option>
+          <option value="semanal" {% if request.GET.frequencia == 'semanal' %}selected{% endif %}>{% trans 'Semanal' %}</option>
+        </select>
+      </div>
+      <noscript><button type="submit" class="btn btn-secondary mt-2 sm:mt-0">{% trans 'Filtrar' %}</button></noscript>
     </div>
-    <div>
-      <label for="fim" class="block text-sm font-medium text-neutral-700 mb-1">{% trans 'Até' %}</label>
-      <input type="date" name="fim" id="fim" value="{{ request.GET.fim }}" class="form-input" hx-get="{% url 'notificacoes:historico' %}" hx-target="#historico-container" hx-include="closest form">
-    </div>
-    <div>
-      <label for="canal" class="block text-sm font-medium text-neutral-700 mb-1">{% trans 'Canal' %}</label>
-      <select name="canal" id="canal" class="form-select" hx-get="{% url 'notificacoes:historico' %}" hx-target="#historico-container" hx-include="closest form">
-        <option value="" {% if not request.GET.canal %}selected{% endif %}>{% trans 'Todos' %}</option>
-        <option value="email" {% if request.GET.canal == 'email' %}selected{% endif %}>{% trans 'E-mail' %}</option>
-        <option value="push" {% if request.GET.canal == 'push' %}selected{% endif %}>{% trans 'Push' %}</option>
-        <option value="whatsapp" {% if request.GET.canal == 'whatsapp' %}selected{% endif %}>{% trans 'WhatsApp' %}</option>
-      </select>
-    </div>
-    <div>
-      <label for="frequencia" class="block text-sm font-medium text-neutral-700 mb-1">{% trans 'Frequência' %}</label>
-      <select name="frequencia" id="frequencia" class="form-select" hx-get="{% url 'notificacoes:historico' %}" hx-target="#historico-container" hx-include="closest form">
-        <option value="" {% if not request.GET.frequencia %}selected{% endif %}>{% trans 'Todas' %}</option>
-        <option value="diaria" {% if request.GET.frequencia == 'diaria' %}selected{% endif %}>{% trans 'Diária' %}</option>
-        <option value="semanal" {% if request.GET.frequencia == 'semanal' %}selected{% endif %}>{% trans 'Semanal' %}</option>
-      </select>
-    </div>
-    <noscript><button type="submit" class="mt-2 sm:mt-0 bg-neutral-200 text-neutral-800 px-4 py-2 rounded-xl text-sm hover:bg-neutral-300">{% trans 'Filtrar' %}</button></noscript>
   </form>
   <div id="historico-container" hx-target="this">
     {% include 'notificacoes/historico_table.html' %}

--- a/notificacoes/templates/notificacoes/logs_list.html
+++ b/notificacoes/templates/notificacoes/logs_list.html
@@ -6,35 +6,37 @@
   <div class="mb-8">
     <h1 class="text-2xl font-bold text-neutral-900">{% trans 'Logs de Notificação' %}</h1>
   </div>
-  <form method="get" class="bg-white border border-neutral-200 p-6 rounded-2xl shadow-sm mb-6 flex flex-col sm:flex-row gap-4 sm:items-end">
-    <div>
-      <label for="inicio" class="block text-sm font-medium text-neutral-700 mb-1">{% trans 'De' %}</label>
-      <input type="date" name="inicio" id="inicio" value="{{ request.GET.inicio }}" class="form-input" hx-get="{% url 'notificacoes:logs_list' %}" hx-target="#logs-container" hx-include="closest form">
+  <form method="get" class="card mb-6">
+    <div class="card-body flex flex-col sm:flex-row gap-4 sm:items-end">
+      <div>
+        <label for="inicio" class="block text-sm font-medium text-neutral-700 mb-1">{% trans 'De' %}</label>
+        <input type="date" name="inicio" id="inicio" value="{{ request.GET.inicio }}" class="form-input" hx-get="{% url 'notificacoes:logs_list' %}" hx-target="#logs-container" hx-include="closest form">
+      </div>
+      <div>
+        <label for="fim" class="block text-sm font-medium text-neutral-700 mb-1">{% trans 'Até' %}</label>
+        <input type="date" name="fim" id="fim" value="{{ request.GET.fim }}" class="form-input" hx-get="{% url 'notificacoes:logs_list' %}" hx-target="#logs-container" hx-include="closest form">
+      </div>
+      <div>
+        <label for="canal" class="block text-sm font-medium text-neutral-700 mb-1">{% trans 'Canal' %}</label>
+        <select name="canal" id="canal" class="form-select" hx-get="{% url 'notificacoes:logs_list' %}" hx-target="#logs-container" hx-include="closest form">
+          <option value="" {% if not request.GET.canal %}selected{% endif %}>{% trans 'Todos' %}</option>
+          <option value="email" {% if request.GET.canal == 'email' %}selected{% endif %}>{% trans 'E-mail' %}</option>
+          <option value="push" {% if request.GET.canal == 'push' %}selected{% endif %}>{% trans 'Push' %}</option>
+          <option value="whatsapp" {% if request.GET.canal == 'whatsapp' %}selected{% endif %}>{% trans 'WhatsApp' %}</option>
+        </select>
+      </div>
+      <div>
+        <label for="status" class="block text-sm font-medium text-neutral-700 mb-1">{% trans 'Status' %}</label>
+        <select name="status" id="status" class="form-select" hx-get="{% url 'notificacoes:logs_list' %}" hx-target="#logs-container" hx-include="closest form">
+          <option value="" {% if not request.GET.status %}selected{% endif %}>{% trans 'Todos' %}</option>
+          <option value="pendente" {% if request.GET.status == 'pendente' %}selected{% endif %}>{% trans 'Pendente' %}</option>
+          <option value="enviada" {% if request.GET.status == 'enviada' %}selected{% endif %}>{% trans 'Enviada' %}</option>
+          <option value="falha" {% if request.GET.status == 'falha' %}selected{% endif %}>{% trans 'Falha' %}</option>
+          <option value="lida" {% if request.GET.status == 'lida' %}selected{% endif %}>{% trans 'Lida' %}</option>
+        </select>
+      </div>
+      <noscript><button type="submit" class="btn btn-secondary mt-2 sm:mt-0">{% trans 'Filtrar' %}</button></noscript>
     </div>
-    <div>
-      <label for="fim" class="block text-sm font-medium text-neutral-700 mb-1">{% trans 'Até' %}</label>
-      <input type="date" name="fim" id="fim" value="{{ request.GET.fim }}" class="form-input" hx-get="{% url 'notificacoes:logs_list' %}" hx-target="#logs-container" hx-include="closest form">
-    </div>
-    <div>
-      <label for="canal" class="block text-sm font-medium text-neutral-700 mb-1">{% trans 'Canal' %}</label>
-      <select name="canal" id="canal" class="form-select" hx-get="{% url 'notificacoes:logs_list' %}" hx-target="#logs-container" hx-include="closest form">
-        <option value="" {% if not request.GET.canal %}selected{% endif %}>{% trans 'Todos' %}</option>
-        <option value="email" {% if request.GET.canal == 'email' %}selected{% endif %}>{% trans 'E-mail' %}</option>
-        <option value="push" {% if request.GET.canal == 'push' %}selected{% endif %}>{% trans 'Push' %}</option>
-        <option value="whatsapp" {% if request.GET.canal == 'whatsapp' %}selected{% endif %}>{% trans 'WhatsApp' %}</option>
-      </select>
-    </div>
-    <div>
-      <label for="status" class="block text-sm font-medium text-neutral-700 mb-1">{% trans 'Status' %}</label>
-      <select name="status" id="status" class="form-select" hx-get="{% url 'notificacoes:logs_list' %}" hx-target="#logs-container" hx-include="closest form">
-        <option value="" {% if not request.GET.status %}selected{% endif %}>{% trans 'Todos' %}</option>
-        <option value="pendente" {% if request.GET.status == 'pendente' %}selected{% endif %}>{% trans 'Pendente' %}</option>
-        <option value="enviada" {% if request.GET.status == 'enviada' %}selected{% endif %}>{% trans 'Enviada' %}</option>
-        <option value="falha" {% if request.GET.status == 'falha' %}selected{% endif %}>{% trans 'Falha' %}</option>
-        <option value="lida" {% if request.GET.status == 'lida' %}selected{% endif %}>{% trans 'Lida' %}</option>
-      </select>
-    </div>
-    <noscript><button type="submit" class="mt-2 sm:mt-0 bg-neutral-200 text-neutral-800 px-4 py-2 rounded-xl text-sm hover:bg-neutral-300">{% trans 'Filtrar' %}</button></noscript>
   </form>
   <div id="logs-container" hx-target="this">
     {% include 'notificacoes/logs_table.html' %}

--- a/notificacoes/templates/notificacoes/metrics.html
+++ b/notificacoes/templates/notificacoes/metrics.html
@@ -7,17 +7,19 @@
   <div class="mb-8">
     <h1 class="text-2xl font-bold text-neutral-900">{% trans 'Métricas de Notificações' %}</h1>
   </div>
-  <form method="get" class="bg-white border border-neutral-200 p-6 rounded-2xl shadow-sm mb-6 flex flex-col sm:flex-row gap-4 sm:items-end">
-    <div>
-      <label for="inicio" class="block text-sm font-medium text-neutral-700 mb-1">{% trans 'Início' %}</label>
-      <input type="date" id="inicio" name="inicio" value="{{ request.GET.inicio }}" class="form-input" />
-    </div>
-    <div>
-      <label for="fim" class="block text-sm font-medium text-neutral-700 mb-1">{% trans 'Fim' %}</label>
-      <input type="date" id="fim" name="fim" value="{{ request.GET.fim }}" class="form-input" />
-    </div>
-    <div>
-      <button type="submit" class="bg-neutral-200 text-neutral-800 px-4 py-2 rounded-xl text-sm hover:bg-neutral-300">{% trans 'Filtrar' %}</button>
+  <form method="get" class="card mb-6">
+    <div class="card-body flex flex-col sm:flex-row gap-4 sm:items-end">
+      <div>
+        <label for="inicio" class="block text-sm font-medium text-neutral-700 mb-1">{% trans 'Início' %}</label>
+        <input type="date" id="inicio" name="inicio" value="{{ request.GET.inicio }}" class="form-input" />
+      </div>
+      <div>
+        <label for="fim" class="block text-sm font-medium text-neutral-700 mb-1">{% trans 'Fim' %}</label>
+        <input type="date" id="fim" name="fim" value="{{ request.GET.fim }}" class="form-input" />
+      </div>
+      <div>
+        <button type="submit" class="btn btn-secondary">{% trans 'Filtrar' %}</button>
+      </div>
     </div>
   </form>
   <div class="space-y-6">

--- a/notificacoes/templates/notificacoes/template_form.html
+++ b/notificacoes/templates/notificacoes/template_form.html
@@ -1,5 +1,4 @@
 {% extends 'base.html' %}
-{% load widget_tweaks %}
 {% load i18n %}
 {% block title %}{% if form.instance.pk %}{% trans 'Editar Template' %}{% else %}{% trans 'Novo Template' %}{% endif %} | HubX{% endblock %}
 {% block content %}
@@ -14,42 +13,22 @@
       {% endfor %}
   </div>
   {% endif %}
-  <form method="post" class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 space-y-6">
-    {% csrf_token %}
-    <div>
-      <label for="{{ form.codigo.id_for_label }}" class="block text-sm font-medium text-neutral-700 mb-1">{% trans 'Código' %}</label>
+  <form method="post" class="card">
+    <div class="card-body space-y-6">
+      {% csrf_token %}
       {% if form.instance.pk %}
-        {{ form.codigo|add_class:'form-input'|attr:'readonly' }}
+        {% include '_forms/field.html' with field=form.codigo|attr:'readonly' %}
       {% else %}
-        {{ form.codigo|add_class:'form-input' }}
+        {% include '_forms/field.html' with field=form.codigo %}
       {% endif %}
-      {% if form.codigo.errors %}<p class="text-sm text-red-600 mt-1">{{ form.codigo.errors.0 }}</p>{% endif %}
-    </div>
-    <div>
-      <label for="{{ form.assunto.id_for_label }}" class="block text-sm font-medium text-neutral-700 mb-1">{% trans 'Assunto' %}</label>
-      {{ form.assunto|add_class:'form-input' }}
-      {% if form.assunto.errors %}<p class="text-sm text-red-600 mt-1">{{ form.assunto.errors.0 }}</p>{% endif %}
-    </div>
-    <div>
-      <label for="{{ form.corpo.id_for_label }}" class="block text-sm font-medium text-neutral-700 mb-1">{% trans 'Corpo' %}</label>
-      {{ form.corpo|add_class:'form-textarea' }}
-      {% if form.corpo.errors %}<p class="text-sm text-red-600 mt-1">{{ form.corpo.errors.0 }}</p>{% endif %}
-    </div>
-    <div>
-      <label for="{{ form.canal.id_for_label }}" class="block text-sm font-medium text-neutral-700 mb-1">{% trans 'Canal' %}</label>
-      {{ form.canal|add_class:'form-select' }}
-      {% if form.canal.errors %}<p class="text-sm text-red-600 mt-1">{{ form.canal.errors.0 }}</p>{% endif %}
-    </div>
-    <div>
-      <label class="flex items-center gap-2">
-        {{ form.ativo|add_class:'form-checkbox' }}
-        <span class="text-sm font-medium text-neutral-700">{% trans 'Ativo' %}</span>
-      </label>
-      {% if form.ativo.errors %}<p class="text-sm text-red-600 mt-1">{{ form.ativo.errors.0 }}</p>{% endif %}
-    </div>
-    <div class="flex justify-end gap-3 pt-4 border-t border-neutral-100">
-      <a href="{% url 'notificacoes:templates_list' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100">{% trans 'Cancelar' %}</a>
-      <button type="submit" class="text-sm px-4 py-2 rounded-xl bg-blue-600 text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500">{% trans 'Salvar' %}</button>
+      {% include '_forms/field.html' with field=form.assunto %}
+      {% include '_forms/field.html' with field=form.corpo %}
+      {% include '_forms/field.html' with field=form.canal %}
+      {% include '_forms/field.html' with field=form.ativo %}
+      <div class="flex justify-end gap-3 pt-4 border-t border-[var(--border)]">
+        <a href="{% url 'notificacoes:templates_list' %}" class="btn btn-outline">{% trans 'Cancelar' %}</a>
+        <button type="submit" class="btn btn-primary">{% trans 'Salvar' %}</button>
+      </div>
     </div>
   </form>
 </div>

--- a/notificacoes/templates/notificacoes/templates_list.html
+++ b/notificacoes/templates/notificacoes/templates_list.html
@@ -16,8 +16,9 @@
   </div>
   {% endif %}
   {% if templates %}
-  <div class="overflow-x-auto bg-white border border-neutral-200 rounded-2xl shadow-sm">
-    <table class="min-w-full divide-y divide-neutral-200 text-sm">
+  <div class="card overflow-x-auto">
+    <div class="card-body p-0">
+    <table class="min-w-full divide-y divide-[var(--border)] text-sm">
       <caption class="sr-only">{% trans 'Lista de templates de notificação' %}</caption>
       <thead class="bg-neutral-50">
         <tr>
@@ -28,7 +29,7 @@
           <th class="px-4 py-2 text-left font-medium text-neutral-700">{% trans 'Ações' %}</th>
         </tr>
       </thead>
-      <tbody class="divide-y divide-neutral-200" id="templates_table">
+      <tbody class="divide-y divide-[var(--border)]" id="templates_table">
         {% for tpl in templates %}
         <tr>
           <td class="px-4 py-2 font-mono">{{ tpl.codigo }}</td>
@@ -41,17 +42,17 @@
               {% if tpl.ativo %}
                 <form method="post" action="{% url 'notificacoes:template_toggle' tpl.codigo %}" class="inline">
                   {% csrf_token %}
-                  <button type="submit" class="text-sm text-neutral-600 hover:underline">{% trans 'Desativar' %}</button>
+                  <button type="submit" class="btn btn-outline btn-sm">{% trans 'Desativar' %}</button>
                 </form>
               {% else %}
                 <form method="post" action="{% url 'notificacoes:template_toggle' tpl.codigo %}" class="inline">
                   {% csrf_token %}
-                  <button type="submit" class="text-sm text-neutral-600 hover:underline">{% trans 'Ativar' %}</button>
+                  <button type="submit" class="btn btn-outline btn-sm">{% trans 'Ativar' %}</button>
                 </form>
               {% endif %}
               <form method="post" action="{% url 'notificacoes:template_delete' tpl.codigo %}" class="inline">
                 {% csrf_token %}
-                <button type="submit" class="text-sm text-red-600 hover:underline">{% trans 'Excluir' %}</button>
+                <button type="submit" class="btn btn-danger btn-sm">{% trans 'Excluir' %}</button>
               </form>
             </div>
           </td>
@@ -59,6 +60,7 @@
         {% endfor %}
       </tbody>
     </table>
+    </div>
   </div>
   {% else %}
     <p class="text-center text-neutral-600">{% trans 'Nenhum template cadastrado.' %}</p>


### PR DESCRIPTION
## Summary
- aplicar estilos `card` e `btn` aos filtros de métricas, histórico e logs
- renderizar formulário de templates com `_forms/field.html`
- atualizar listagem de templates para usar `card` e botões padronizados

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'silk')*

------
https://chatgpt.com/codex/tasks/task_e_68c0bae33bf08325b645684cd624d011