### PR TITLE
Refactor card grids to new card component

### DIFF
--- a/eventos/templates/eventos/detail.html
+++ b/eventos/templates/eventos/detail.html
@@ -8,8 +8,8 @@
 
 {% block content %}
 <section class="container mx-auto p-6">
-  <div class="grid gap-6 md:grid-cols-2">
-    <div class="card">
+  <div class="card-grid gap-6">
+    <article class="card">
       <div class="card-header">
         <h2 class="text-xl font-semibold">{% trans "Informações" %}</h2>
       </div>
@@ -47,10 +47,10 @@
           <p><strong>{% trans "Valor gasto" %}:</strong> {{ object.valor_gasto }}</p>
         {% endif %}
       </div>
-    </div>
+    </article>
 
     {% if user.is_authenticated and user.user_type != 'admin' %}
-    <div class="card">
+    <article class="card">
       <div class="card-header">
         {% if inscricao and avaliacao_permitida %}
           <h2 class="text-xl font-semibold">{% trans "Avaliação" %}</h2>
@@ -89,31 +89,33 @@
           <a href="{% url 'eventos:inscricao_criar' object.pk %}" class="btn-primary" aria-label="{% trans 'Inscrever-se' %}">{% trans 'Inscrever-se' %}</a>
         {% endif %}
       </div>
-    </div>
+    </article>
     {% endif %}
 
-    <div class="card md:col-span-2">
+    <article class="card md:col-span-2">
       <div class="card-header">
         <h2 class="text-lg font-semibold">{% trans "Inscritos" %}</h2>
       </div>
       <div class="card-body">
         {% if object.inscricoes.all %}
-          <div class="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+          <div class="card-grid gap-4">
             {% for ins in object.inscricoes.all %}
               {% with inscrito=ins.user %}
-              <div class="flex items-center gap-4 p-4 border rounded-xl bg-base-100 shadow-sm">
-                {% if inscrito.avatar %}
-                  <img src="{{ inscrito.avatar.url }}" alt="{{ inscrito.username }}" class="w-12 h-12 rounded-full object-cover">
-                {% else %}
-                  <div class="w-12 h-12 rounded-full bg-base-200 flex items-center justify-center text-sm font-semibold" role="img" aria-label="{{ inscrito.username }}">
-                    {{ inscrito.username|make_list|first|upper }}
+                <article class="card">
+                  <div class="card-body flex items-center gap-4">
+                    {% if inscrito.avatar %}
+                      <img src="{{ inscrito.avatar.url }}" alt="{{ inscrito.username }}" class="w-12 h-12 rounded-full object-cover">
+                    {% else %}
+                      <div class="w-12 h-12 rounded-full bg-base-200 flex items-center justify-center text-sm font-semibold" role="img" aria-label="{{ inscrito.username }}">
+                        {{ inscrito.username|make_list|first|upper }}
+                      </div>
+                    {% endif %}
+                    <div>
+                      <h4 class="text-sm font-medium">{{ inscrito.get_full_name|default:inscrito.username }}</h4>
+                      <p class="text-xs">@{{ inscrito.username }}</p>
+                    </div>
                   </div>
-                {% endif %}
-                <div>
-                  <h4 class="text-sm font-medium">{{ inscrito.get_full_name|default:inscrito.username }}</h4>
-                  <p class="text-xs">@{{ inscrito.username }}</p>
-                </div>
-              </div>
+                </article>
               {% endwith %}
             {% endfor %}
           </div>
@@ -121,7 +123,7 @@
           <p class="text-sm">{% trans "Nenhum inscrito." %}</p>
         {% endif %}
       </div>
-    </div>
+    </article>
   </div>
 
   <div class="flex justify-end mt-6">

--- a/eventos/templates/eventos/tarefa_detail.html
+++ b/eventos/templates/eventos/tarefa_detail.html
@@ -8,8 +8,8 @@
 
 {% block content %}
 <section class="container mx-auto p-6">
-  <div class="grid gap-6 md:grid-cols-2">
-    <div class="card">
+  <div class="card-grid gap-6">
+    <article class="card">
       <div class="card-header">
         <h2 class="text-xl font-semibold">{% trans "Detalhes" %}</h2>
       </div>
@@ -24,9 +24,9 @@
           <p><strong>{% trans "Status" %}:</strong> {{ object.get_status_display }}</p>
         </div>
       </div>
-    </div>
+    </article>
 
-    <div class="card md:col-span-2">
+    <article class="card md:col-span-2">
       <div class="card-header">
         <h2 class="text-lg font-semibold">{% trans "Logs" %}</h2>
       </div>
@@ -56,7 +56,7 @@
           <p class="text-sm">{% trans "Nenhum log disponível." %}</p>
         {% endif %}
       </div>
-    </div>
+    </article>
   </div>
 
   <div class="flex justify-end mt-6">

--- a/eventos/templates/eventos/update.html
+++ b/eventos/templates/eventos/update.html
@@ -50,21 +50,23 @@
   <!-- Inscritos -->
   <h2 class="text-lg font-semibold text-neutral-900 mt-10 mb-4">{% trans "Inscritos" %}</h2>
   {% if object.inscricoes.all %}
-    <div class="grid gap-4 sm:grid-cols-2">
+    <div class="card-grid gap-4">
       {% for ins in object.inscricoes.all %}
         {% with inscrito=ins.user %}
-        <div class="flex items-center justify-between border border-[var(--border)] rounded-xl p-4 bg-[var(--bg-secondary)] shadow-sm">
-          <div>
-            <h3 class="text-sm font-medium text-neutral-800">{{ inscrito.get_full_name|default:inscrito.username }}</h3>
-            <p class="text-xs text-neutral-500">{{ inscrito.email }}</p>
+        <article class="card">
+          <div class="card-body flex items-center justify-between">
+            <div>
+              <h3 class="text-sm font-medium text-neutral-800">{{ inscrito.get_full_name|default:inscrito.username }}</h3>
+              <p class="text-xs text-neutral-500">{{ inscrito.email }}</p>
+            </div>
+            {% if user.user_type in ['admin', 'coordenador'] %}
+            <form method="post" action="{% url 'eventos:evento_remover_inscrito' object.pk inscrito.pk %}">
+              {% csrf_token %}
+              <button type="submit" class="btn-secondary text-sm" aria-label="{% trans 'Remover' %}">{% trans "Remover" %}</button>
+            </form>
+            {% endif %}
           </div>
-          {% if user.user_type in ['admin', 'coordenador'] %}
-          <form method="post" action="{% url 'eventos:evento_remover_inscrito' object.pk inscrito.pk %}">
-            {% csrf_token %}
-            <button type="submit" class="btn-secondary text-sm" aria-label="{% trans 'Remover' %}">{% trans "Remover" %}</button>
-          </form>
-          {% endif %}
-        </div>
+        </article>
         {% endwith %}
       {% endfor %}
     </div>

--- a/nucleos/templates/nucleos/detail.html
+++ b/nucleos/templates/nucleos/detail.html
@@ -22,7 +22,7 @@
   </div>
   
   <!-- Cards de totais -->
-  <div class="mt-6 grid grid-cols-1 sm:grid-cols-4 gap-4">
+  <div class="card-grid mt-6 gap-4">
     {% include "_partials/cards/total_card.html" with label=_('Membros') valor=total_membros %}
     {% include "_partials/cards/total_card.html" with label=_('Eventos (ativos + concluídos)') valor=total_eventos %}
     {% include "_partials/cards/total_card.html" with label=_('Eventos ativos') valor=total_eventos_ativos %}
@@ -42,7 +42,7 @@
     <div id="tab-panels" class="mt-6">
       <!-- Painel: Membros -->
       <div class="tab-panel" data-tab="membros">
-        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4" role="list" aria-label="{% trans 'Lista de membros do núcleo' %}">
+        <div class="card-grid gap-4" role="list" aria-label="{% trans 'Lista de membros do núcleo' %}">
           {% for part in membros_ativos %}
             {% include 'nucleos/partials/membro_card.html' with part=part %}
           {% empty %}
@@ -92,7 +92,7 @@
 
       <!-- Painel: Eventos -->
       <div class="tab-panel hidden" data-tab="eventos">
-        <div class="mt-2 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        <div class="card-grid mt-2 gap-4">
           {% for evento in eventos %}
             {% include '_components/card_evento.html' with evento=evento %}
           {% empty %}

--- a/nucleos/templates/nucleos/partials/membro_card.html
+++ b/nucleos/templates/nucleos/partials/membro_card.html
@@ -1,9 +1,9 @@
 {% load i18n %}
 {# Card de Membro do Núcleo, inspirado nos cards de associados #}
 <a href="{% url 'accounts:perfil_publico_uuid' part.user.public_id %}"
-   class="group block rounded-2xl border border-[var(--border)] bg-[var(--bg-secondary)] shadow-sm hover:shadow-lg hover:scale-[1.01] transition-transform focus:outline-none focus:ring-2 focus:ring-primary/40"
+   class="group block focus:outline-none focus:ring-2 focus:ring-primary/40"
    aria-label="{{ part.user.get_full_name|default:part.user.username }}">
-  <article class="overflow-hidden rounded-2xl" role="article">
+  <article class="card overflow-hidden" role="article">
     <header class="relative">
       {% if part.user.cover %}
         <img src="{{ part.user.cover.url }}" alt="{% trans 'Capa do membro' %}"
@@ -22,7 +22,7 @@
         {% endif %}
       </div>
     </header>
-    <div class="px-4 pt-10 pb-4">
+    <div class="card-body pt-10">
       <h3 class="text-base font-semibold text-neutral-900 group-hover:underline">
         {{ part.user.get_full_name|default:part.user.username }}
       </h3>

--- a/templates/_components/card_nucleo.html
+++ b/templates/_components/card_nucleo.html
@@ -1,8 +1,8 @@
 {% load i18n %}
 {# Card de Núcleo #}
 <a href="{% url 'nucleos:detail_uuid' nucleo.public_id %}"
-   class="group block rounded-2xl border border-[var(--border)] bg-[var(--bg-secondary)] shadow-sm hover:shadow-lg hover:scale-[1.01] transition-transform focus:outline-none focus:ring-2 focus:ring-primary/40">
-  <article class="overflow-hidden rounded-2xl" role="article" aria-label="{{ nucleo.nome }}">
+   class="group block focus:outline-none focus:ring-2 focus:ring-primary/40">
+  <article class="card overflow-hidden" role="article" aria-label="{{ nucleo.nome }}">
     <header class="relative">
       {% if nucleo.cover %}
         <img src="{{ nucleo.cover.url }}" alt="{% trans 'Capa do núcleo' %}"
@@ -21,7 +21,7 @@
         {% endif %}
       </div>
     </header>
-    <div class="px-4 pt-10 pb-4">
+    <div class="card-body pt-10">
       <h3 class="text-base font-semibold text-[var(--text-primary)] group-hover:underline">{{ nucleo.nome }}</h3>
       <dl class="mt-3 grid grid-cols-3 gap-2 text-xs text-[var(--text-secondary)]">
         <div>

--- a/templates/_partials/cards/base_card.html
+++ b/templates/_partials/cards/base_card.html
@@ -1,8 +1,8 @@
 {% load i18n %}
 <a href="{{ url }}"
-  class="group block rounded-2xl border border-[var(--border)] bg-[var(--bg-secondary)] shadow-sm hover:shadow-lg transition-shadow focus:outline-none focus:ring-2 focus:ring-primary/40"
+  class="group block focus:outline-none focus:ring-2 focus:ring-primary/40"
   aria-label="{{ title }}">
-  <article class="overflow-hidden rounded-2xl" role="article">
+  <article class="card overflow-hidden" role="article">
     <header class="relative">
       {% if cover %}
         <img src="{{ cover.url|default:cover }}" alt="{% trans 'Capa' %}" class="h-24 w-full object-cover" />
@@ -19,7 +19,7 @@
         {% endif %}
       </div>
     </header>
-  <div class="px-4 pt-10 pb-4">
+    <div class="card-body pt-10">
       <h3 class="text-base font-semibold text-[var(--text-primary)] group-hover:underline">{{ title }}</h3>
       {% include details %}
     </div>

--- a/templates/_partials/cards/total_card.html
+++ b/templates/_partials/cards/total_card.html
@@ -1,5 +1,7 @@
 {# Card de total #}
-<div class="p-4 rounded-2xl border border-[var(--border)] bg-[var(--bg-secondary)] shadow-sm">
-  <div class="text-sm text-[var(--text-secondary)]">{{ label }}</div>
-  <div class="mt-1 text-2xl font-bold text-[var(--text-primary)]">{{ valor }}</div>
-</div>
+<article class="card">
+  <div class="card-body">
+    <div class="text-sm text-[var(--text-secondary)]">{{ label }}</div>
+    <div class="mt-1 text-2xl font-bold text-[var(--text-primary)]">{{ valor }}</div>
+  </div>
+</article>


### PR DESCRIPTION
## Summary
- Replace grid containers with `<div class="card-grid">`
- Standardize card items as `<article class="card"><div class="card-body">…</div></article>`
- Update event and núcleo templates to use the shared card component

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'factory')*

------
https://chatgpt.com/codex/tasks/task_e_68c1790bc9f4832584fb326513b8ea78