### PR TITLE
refactor: use CSS variables for dark theme colors

### DIFF
--- a/accounts/templates/account_inactive.html
+++ b/accounts/templates/account_inactive.html
@@ -11,11 +11,11 @@
 
 {% include '_partials/sidebar.html' %}
 <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
-  <div class="bg-white dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 p-8 rounded-lg shadow text-center">
-    <p class="mb-6 text-neutral-600 dark:text-neutral-400" aria-live="polite">{% trans "Sua conta ainda não foi ativada. Verifique seu e-mail para continuar." %}</p>
+  <div class="p-8 rounded-lg shadow text-center bg-[var(--bg-secondary)] border border-[var(--border)]">
+    <p class="mb-6 text-[var(--text-secondary)]" aria-live="polite">{% trans "Sua conta ainda não foi ativada. Verifique seu e-mail para continuar." %}</p>
     <a
       href="{% url 'accounts:login' %}"
-      class="rounded-xl bg-primary-600 px-4 py-2 text-white hover:bg-primary-700 dark:bg-primary-500 dark:hover:bg-primary-600"
+      class="rounded-xl px-4 py-2 text-white bg-[var(--primary)] hover:bg-[var(--primary-hover)]"
 
     >{% trans "Ir para login" %}</a>
   </div>

--- a/accounts/templates/accounts/cancel_delete.html
+++ b/accounts/templates/accounts/cancel_delete.html
@@ -2,13 +2,13 @@
 {% load i18n %}
 {% block title %}{% trans "Cancelar exclusão" %} - HubX{% endblock %}
 {% block content %}
-<section class="max-w-md mx-auto px-4 py-12 bg-white dark:bg-neutral-900">
+<section class="max-w-md mx-auto px-4 py-12 bg-[var(--bg-primary)]">
   {% if status == 'sucesso' %}
-    <div class="bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-300 rounded-xl px-4 py-3 text-center">
+    <div class="rounded-xl px-4 py-3 text-center bg-[var(--success-light)] text-[var(--success)]">
       {% trans "Sua conta foi reativada." %}
     </div>
   {% else %}
-    <div class="bg-red-100 dark:bg-red-900 text-red-700 dark:text-red-300 rounded-xl px-4 py-3 text-center">
+    <div class="rounded-xl px-4 py-3 text-center bg-[var(--error-light)] text-[var(--error)]">
       {% trans "Link inválido ou expirado." %}
     </div>
   {% endif %}

--- a/accounts/templates/accounts/delete_account_confirm.html
+++ b/accounts/templates/accounts/delete_account_confirm.html
@@ -2,21 +2,21 @@
 {% load i18n %}
 {% block title %}{% trans "Excluir Conta" %} - HubX{% endblock %}
 {% block content %}
-<section class="max-w-md mx-auto px-4 py-12 bg-white dark:bg-neutral-900">
-  <h1 class="text-2xl font-bold text-center mb-6 text-neutral-900 dark:text-neutral-100">{% trans "Excluir Conta" %}</h1>
-  <p class="text-red-700 dark:text-red-300 bg-red-100 dark:bg-red-900 rounded-xl px-4 py-2 mb-4 text-sm">
+<section class="max-w-md mx-auto px-4 py-12 bg-[var(--bg-primary)]">
+  <h1 class="text-2xl font-bold text-center mb-6 text-[var(--text-primary)]">{% trans "Excluir Conta" %}</h1>
+  <p class="text-[var(--error)] bg-[var(--error-light)] rounded-xl px-4 py-2 mb-4 text-sm">
     {% trans "A exclusão da conta é permanente e você perderá acesso aos seus dados." %}
   </p>
-  <form method="post" class="bg-white dark:bg-neutral-800 rounded-2xl shadow p-6 space-y-4">
+  <form method="post" class="rounded-2xl shadow p-6 space-y-4 bg-[var(--bg-secondary)]">
     {% csrf_token %}
     <div>
-      <label for="confirm" class="block text-sm font-medium text-neutral-700 dark:text-neutral-300">{% trans "Digite EXCLUIR para confirmar" %}</label>
+      <label for="confirm" class="block text-sm font-medium text-[var(--text-secondary)]">{% trans "Digite EXCLUIR para confirmar" %}</label>
       <input
         type="text"
         name="confirm"
         id="confirm"
         required
-        class="w-full rounded-md border border-neutral-300 dark:border-neutral-600 dark:bg-neutral-700 dark:text-neutral-100 px-3 py-2"
+        class="w-full rounded-md border px-3 py-2 bg-[var(--bg-secondary)] border-[var(--border)] text-[var(--text-primary)]"
         placeholder="EXCLUIR"
         aria-label="{% trans 'Confirmação' %}"
         aria-invalid="false"
@@ -25,7 +25,7 @@
     <div class="text-right">
       <button
         type="submit"
-        class="rounded-xl bg-red-600 hover:bg-red-700 px-4 py-2 text-white"
+        class="rounded-xl px-4 py-2 text-white bg-[var(--error)] hover:bg-[var(--color-error-700)]"
       >
         {% trans "Confirmar exclusão" %}
       </button>

--- a/accounts/templates/accounts/email_confirm.html
+++ b/accounts/templates/accounts/email_confirm.html
@@ -9,13 +9,13 @@
 
 {% include '_partials/sidebar.html' %}
 <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
-  <div class="bg-white dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 p-8 rounded-lg shadow text-center">
+  <div class="p-8 rounded-lg shadow text-center bg-[var(--bg-secondary)] border border-[var(--border)]">
     {% if status == 'sucesso' %}
-      <p class="rounded-xl px-4 py-2 bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-100" role="status" aria-live="polite">
+      <p class="rounded-xl px-4 py-2 bg-[var(--success-light)] text-[var(--success)]" role="status" aria-live="polite">
         {% trans "Seu e-mail foi confirmado com sucesso." %}
       </p>
     {% else %}
-      <p class="rounded-xl px-4 py-2 bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-100" role="alert" aria-live="assertive">
+      <p class="rounded-xl px-4 py-2 bg-[var(--error-light)] text-[var(--error)]" role="alert" aria-live="assertive">
         {% trans "Link inválido ou expirado." %}
       </p>
     {% endif %}

--- a/accounts/templates/accounts/password_reset.html
+++ b/accounts/templates/accounts/password_reset.html
@@ -2,18 +2,18 @@
 {% load i18n %}
 {% block title %}{% trans "Recuperar Senha" %} - HubX{% endblock %}
 {% block content %}
-<div class="flex items-center justify-center min-h-screen bg-white dark:bg-neutral-900">
-    <div class="max-w-md mx-auto p-6 rounded-2xl shadow bg-white dark:bg-neutral-800 w-full">
-        <h1 class="text-2xl font-bold mb-6 text-center text-neutral-900 dark:text-neutral-100">{% trans "Recuperar Senha" %}</h1>
-        <p class="text-center text-neutral-600 dark:text-neutral-400 mb-4">{% trans "Informe o e-mail cadastrado para receber instruções." %}</p>
+<div class="flex items-center justify-center min-h-screen bg-[var(--bg-primary)]">
+    <div class="max-w-md mx-auto p-6 rounded-2xl shadow bg-[var(--bg-secondary)] w-full">
+        <h1 class="text-2xl font-bold mb-6 text-center text-[var(--text-primary)]">{% trans "Recuperar Senha" %}</h1>
+        <p class="text-center mb-4 text-[var(--text-secondary)]">{% trans "Informe o e-mail cadastrado para receber instruções." %}</p>
         <form method="post" class="space-y-4">
             {% csrf_token %}
             <div>
-                <label for="id_email" class="block mb-1 font-medium text-neutral-700 dark:text-neutral-300">{% trans "E-mail" %}</label>
-                <input type="email" name="email" id="id_email" required class="w-full p-3 border rounded-md focus:ring-2 focus:ring-primary dark:bg-neutral-700 dark:border-neutral-600 dark:text-neutral-100" placeholder="{% trans 'Seu e-mail' %}" aria-label="{% trans 'E-mail' %}" aria-invalid="false" aria-describedby="email_help">
-                <small id="email_help" class="text-sm text-neutral-500 dark:text-neutral-400">{% trans "Digite o e-mail utilizado no cadastro" %}</small>
+                <label for="id_email" class="block mb-1 font-medium text-[var(--text-secondary)]">{% trans "E-mail" %}</label>
+                <input type="email" name="email" id="id_email" required class="w-full p-3 border rounded-md focus:ring-2 focus:ring-primary bg-[var(--bg-secondary)] border-[var(--border)] text-[var(--text-primary)]" placeholder="{% trans 'Seu e-mail' %}" aria-label="{% trans 'E-mail' %}" aria-invalid="false" aria-describedby="email_help">
+                <small id="email_help" class="text-sm text-[var(--text-muted)]">{% trans "Digite o e-mail utilizado no cadastro" %}</small>
             </div>
-            <button type="submit" class="bg-primary dark:bg-primary text-white font-semibold py-2 px-4 rounded-xl w-full">{% trans "Enviar" %}</button>
+            <button type="submit" class="text-white font-semibold py-2 px-4 rounded-xl w-full bg-[var(--primary)] hover:bg-[var(--primary-hover)]">{% trans "Enviar" %}</button>
         </form>
     </div>
 </div>

--- a/accounts/templates/accounts/password_reset_confirm.html
+++ b/accounts/templates/accounts/password_reset_confirm.html
@@ -2,17 +2,17 @@
 {% load i18n %}
 {% block title %}{% trans "Definir Nova Senha" %} - HubX{% endblock %}
 {% block content %}
-<div class="flex items-center justify-center min-h-screen bg-white dark:bg-neutral-900">
-    <div class="max-w-md mx-auto p-6 rounded-2xl shadow bg-white dark:bg-neutral-800 w-full">
-        <h1 class="text-2xl font-bold mb-6 text-center text-neutral-900 dark:text-neutral-100">{% trans "Definir Nova Senha" %}</h1>
+<div class="flex items-center justify-center min-h-screen bg-[var(--bg-primary)]">
+    <div class="max-w-md mx-auto p-6 rounded-2xl shadow bg-[var(--bg-secondary)] w-full">
+        <h1 class="text-2xl font-bold mb-6 text-center text-[var(--text-primary)]">{% trans "Definir Nova Senha" %}</h1>
         <form method="post" class="space-y-4">
             {% csrf_token %}
             <div>
-                <label for="{{ form.new_password1.id_for_label }}" class="block mb-1 font-medium text-neutral-700 dark:text-neutral-300">{{ form.new_password1.label }}</label>
+                <label for="{{ form.new_password1.id_for_label }}" class="block mb-1 font-medium text-[var(--text-secondary)]">{{ form.new_password1.label }}</label>
                 <input type="password"
                        name="{{ form.new_password1.html_name }}"
                        id="{{ form.new_password1.id_for_label }}"
-                       class="w-full p-3 border rounded-md focus:ring-2 focus:ring-primary dark:bg-neutral-700 dark:border-neutral-600 dark:text-neutral-100"
+                       class="w-full p-3 border rounded-md focus:ring-2 focus:ring-primary bg-[var(--bg-secondary)] border-[var(--border)] text-[var(--text-primary)]"
                        placeholder="{% trans 'Nova senha' %}"
                        aria-label="{{ form.new_password1.label }}"
                        aria-describedby="{{ form.new_password1.id_for_label }}_error"
@@ -23,11 +23,11 @@
                 {% endif %}
             </div>
             <div>
-                <label for="{{ form.new_password2.id_for_label }}" class="block mb-1 font-medium text-neutral-700 dark:text-neutral-300">{{ form.new_password2.label }}</label>
+                <label for="{{ form.new_password2.id_for_label }}" class="block mb-1 font-medium text-[var(--text-secondary)]">{{ form.new_password2.label }}</label>
                 <input type="password"
                        name="{{ form.new_password2.html_name }}"
                        id="{{ form.new_password2.id_for_label }}"
-                       class="w-full p-3 border rounded-md focus:ring-2 focus:ring-primary dark:bg-neutral-700 dark:border-neutral-600 dark:text-neutral-100"
+                       class="w-full p-3 border rounded-md focus:ring-2 focus:ring-primary bg-[var(--bg-secondary)] border-[var(--border)] text-[var(--text-primary)]"
                        placeholder="{% trans 'Confirme a senha' %}"
                        aria-label="{{ form.new_password2.label }}"
                        aria-describedby="{{ form.new_password2.id_for_label }}_error"
@@ -37,7 +37,7 @@
                     <div id="{{ form.new_password2.id_for_label }}_error" class="text-red-600 text-sm" role="alert">{{ form.new_password2.errors }}</div>
                 {% endif %}
             </div>
-            <button type="submit" class="bg-primary dark:bg-primary text-white font-semibold py-2 px-4 rounded-xl w-full">{% trans "Alterar Senha" %}</button>
+            <button type="submit" class="text-white font-semibold py-2 px-4 rounded-xl w-full bg-[var(--primary)] hover:bg-[var(--primary-hover)]">{% trans "Alterar Senha" %}</button>
         </form>
     </div>
 </div>

--- a/accounts/templates/accounts/resend_confirmation.html
+++ b/accounts/templates/accounts/resend_confirmation.html
@@ -2,14 +2,14 @@
 {% load i18n %}
 {% block title %}{% trans "Reenviar confirmação" %}{% endblock %}
 {% block content %}
-<section class="max-w-md mx-auto px-4 py-12 text-center bg-white dark:bg-neutral-900">
-  <div class="rounded-2xl border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800 p-8 shadow-sm">
-    <h1 class="mb-4 text-2xl font-bold text-neutral-900 dark:text-neutral-100">{% trans "Reenviar confirmação" %}</h1>
+<section class="max-w-md mx-auto px-4 py-12 text-center bg-[var(--bg-primary)]">
+  <div class="rounded-2xl border p-8 shadow-sm bg-[var(--bg-secondary)] border-[var(--border)]">
+    <h1 class="mb-4 text-2xl font-bold text-[var(--text-primary)]">{% trans "Reenviar confirmação" %}</h1>
     <form method="post" class="space-y-4">
       {% csrf_token %}
-      <input type="email" name="email" required class="w-full p-3 border border-gray-300 dark:border-neutral-600 dark:bg-neutral-700 dark:text-neutral-100 rounded-lg" placeholder="{% trans 'Seu e-mail' %}" aria-label="{% trans 'E-mail' %}" aria-invalid="false" aria-describedby="email_info">
-      <small id="email_info" class="text-sm text-neutral-500 dark:text-neutral-400">{% trans "Informe o e-mail cadastrado" %}</small>
-      <button type="submit" class="w-full bg-primary dark:bg-primary text-white py-2 rounded-lg">{% trans "Enviar" %}</button>
+      <input type="email" name="email" required class="w-full p-3 border rounded-lg bg-[var(--bg-secondary)] border-[var(--border)] text-[var(--text-primary)]" placeholder="{% trans 'Seu e-mail' %}" aria-label="{% trans 'E-mail' %}" aria-invalid="false" aria-describedby="email_info">
+      <small id="email_info" class="text-sm text-[var(--text-muted)]">{% trans "Informe o e-mail cadastrado" %}</small>
+      <button type="submit" class="w-full py-2 rounded-lg text-white bg-[var(--primary)] hover:bg-[var(--primary-hover)]">{% trans "Enviar" %}</button>
     </form>
   </div>
 </section>

--- a/accounts/templates/login/login.html
+++ b/accounts/templates/login/login.html
@@ -12,7 +12,7 @@
 <div class="bg-muted min-h-screen flex items-center justify-center px-4">
   <div class="card max-w-md w-full mx-auto" role="dialog">
     <div class="card-body">
-      <p class="text-center text-sm text-gray-600 dark:text-gray-300 mb-6">
+      <p class="text-center text-sm mb-6 text-[var(--text-secondary)]">
         {% trans "Entre para acessar sua conta e conectar-se à sua rede" %}
       </p>
 
@@ -34,7 +34,7 @@
                  aria-describedby="email-error"
                  {% if form.email.errors %}aria-invalid="true"{% else %}aria-invalid="false"{% endif %}>
           <label for="id_email"
-                 class="absolute left-3 -top-2 text-xs text-gray-700 dark:text-gray-300 transition-all peer-placeholder-shown:top-3 peer-placeholder-shown:text-sm peer-placeholder-shown:text-gray-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary">{% trans "Email" %}</label>
+                 class="absolute left-3 -top-2 text-xs text-[var(--text-secondary)] transition-all peer-placeholder-shown:top-3 peer-placeholder-shown:text-sm peer-placeholder-shown:text-gray-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary">{% trans "Email" %}</label>
         </div>
         {% if form.email.errors %}
           <div id="email-error" class="text-red-600 text-xs mt-1" role="alert">{{ form.email.errors }}</div>
@@ -51,7 +51,7 @@
                  aria-describedby="password-error"
                  {% if form.password.errors %}aria-invalid="true"{% else %}aria-invalid="false"{% endif %}>
           <label for="id_password"
-                 class="absolute left-3 -top-2 text-xs text-gray-700 dark:text-gray-300 transition-all peer-placeholder-shown:top-3 peer-placeholder-shown:text-sm peer-placeholder-shown:text-gray-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary">{% trans "Senha" %}</label>
+                 class="absolute left-3 -top-2 text-xs text-[var(--text-secondary)] transition-all peer-placeholder-shown:top-3 peer-placeholder-shown:text-sm peer-placeholder-shown:text-gray-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary">{% trans "Senha" %}</label>
         </div>
         {% if form.password.errors %}
           <div id="password-error" class="text-red-600 text-xs mt-1" role="alert">{{ form.password.errors }}</div>
@@ -68,9 +68,9 @@
                  aria-describedby="totp-error"
                  {% if form.totp.errors %}aria-invalid="true"{% else %}aria-invalid="false"{% endif %}>
           <label for="id_totp"
-                 class="absolute left-3 -top-2 text-xs text-gray-700 dark:text-gray-300 transition-all peer-placeholder-shown:top-3 peer-placeholder-shown:text-sm peer-placeholder-shown:text-gray-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary">{% trans "TOTP" %}</label>
+                 class="absolute left-3 -top-2 text-xs text-[var(--text-secondary)] transition-all peer-placeholder-shown:top-3 peer-placeholder-shown:text-sm peer-placeholder-shown:text-gray-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary">{% trans "TOTP" %}</label>
         </div>
-        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">{% trans "Deixe em branco se não tiver 2FA" %}</p>
+        <p class="text-xs mt-1 text-[var(--text-muted)]">{% trans "Deixe em branco se não tiver 2FA" %}</p>
         {% if form.totp.errors %}
           <div id="totp-error" class="text-red-600 text-xs mt-1" role="alert">{{ form.totp.errors }}</div>
         {% endif %}
@@ -82,19 +82,19 @@
     </form>
 
     <div class="text-center mt-6 space-y-2">
-      <a href="{% url 'accounts:password_reset' %}" class="text-sm text-primary hover:underline">
+      <a href="{% url 'accounts:password_reset' %}" class="text-sm text-[var(--primary)] hover:underline">
         {% trans "Esqueceu sua senha?" %}
       </a>
       <div>
-        <a href="{% url 'accounts:resend_confirmation' %}" class="text-sm text-primary hover:underline">
+        <a href="{% url 'accounts:resend_confirmation' %}" class="text-sm text-[var(--primary)] hover:underline">
           {% trans "Reenviar confirmação de e-mail" %}
         </a>
       </div>
     </div>
 
-    <div class="text-center mt-4 text-sm text-gray-600 dark:text-gray-300">
+    <div class="text-center mt-4 text-sm text-[var(--text-secondary)]">
       {% trans "Não tem uma conta?" %}
-      <a href="{% url 'accounts:onboarding' %}" class="text-primary dark:text-primary hover:underline">
+      <a href="{% url 'accounts:onboarding' %}" class="text-[var(--primary)] hover:underline">
         {% trans "Cadastre-se gratuitamente" %}
       </a>
     </div>

--- a/app/static/css/hubx.css
+++ b/app/static/css/hubx.css
@@ -576,5 +576,5 @@
   .table td        { @apply py-2 align-middle; }
 
   /* Forms */
-  .errorlist { @apply mt-1 text-xs text-red-600 dark:text-red-400; }
+  .errorlist { @apply mt-1 text-xs text-[var(--error)]; }
 }

--- a/static/tailwind.css
+++ b/static/tailwind.css
@@ -943,6 +943,112 @@ a:focus {
   padding-bottom: 0;
 }
 
+.form-select {
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%236b7280' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e");
+  background-position: right 0.5rem center;
+  background-repeat: no-repeat;
+  background-size: 1.5em 1.5em;
+  padding-right: 2.5rem;
+  -webkit-print-color-adjust: exact;
+          print-color-adjust: exact;
+}
+
+.form-select:where([size]:not([size="1"])) {
+  background-image: initial;
+  background-position: initial;
+  background-repeat: unset;
+  background-size: initial;
+  padding-right: 0.75rem;
+  -webkit-print-color-adjust: unset;
+          print-color-adjust: unset;
+}
+
+.form-checkbox,.form-radio {
+  -webkit-appearance: none;
+     -moz-appearance: none;
+          appearance: none;
+  padding: 0;
+  -webkit-print-color-adjust: exact;
+          print-color-adjust: exact;
+  display: inline-block;
+  vertical-align: middle;
+  background-origin: border-box;
+  -webkit-user-select: none;
+     -moz-user-select: none;
+          user-select: none;
+  flex-shrink: 0;
+  height: 1rem;
+  width: 1rem;
+  color: #2563eb;
+  background-color: #fff;
+  border-color: #6b7280;
+  border-width: 1px;
+  --tw-shadow: 0 0 #0000;
+}
+
+.form-checkbox {
+  border-radius: 0px;
+}
+
+.form-checkbox:focus,.form-radio:focus {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+  --tw-ring-inset: var(--tw-empty,/*!*/ /*!*/);
+  --tw-ring-offset-width: 2px;
+  --tw-ring-offset-color: #fff;
+  --tw-ring-color: #2563eb;
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+}
+
+.form-checkbox:checked,.form-radio:checked {
+  border-color: transparent;
+  background-color: currentColor;
+  background-size: 100% 100%;
+  background-position: center;
+  background-repeat: no-repeat;
+}
+
+.form-checkbox:checked {
+  background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e");
+}
+
+@media (forced-colors: active)  {
+  .form-checkbox:checked {
+    -webkit-appearance: auto;
+       -moz-appearance: auto;
+            appearance: auto;
+  }
+}
+
+.form-checkbox:checked:hover,.form-checkbox:checked:focus,.form-radio:checked:hover,.form-radio:checked:focus {
+  border-color: transparent;
+  background-color: currentColor;
+}
+
+.form-checkbox:indeterminate {
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 16 16'%3e%3cpath stroke='white' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M4 8h8'/%3e%3c/svg%3e");
+  border-color: transparent;
+  background-color: currentColor;
+  background-size: 100% 100%;
+  background-position: center;
+  background-repeat: no-repeat;
+}
+
+@media (forced-colors: active)  {
+  .form-checkbox:indeterminate {
+    -webkit-appearance: auto;
+       -moz-appearance: auto;
+            appearance: auto;
+  }
+}
+
+.form-checkbox:indeterminate:hover,.form-checkbox:indeterminate:focus {
+  border-color: transparent;
+  background-color: currentColor;
+}
+
 .container {
   margin-left: auto;
   margin-right: auto;
@@ -1128,6 +1234,21 @@ a:focus {
 
 /* Modal Component */
 
+.modal {
+  visibility: hidden;
+  position: fixed;
+  inset: 0px;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgb(0 0 0 / 0.5);
+  opacity: 0;
+  transition-property: opacity;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
 .modal.active {
   visibility: visible;
   opacity: 1;
@@ -1247,9 +1368,7 @@ a:focus {
   font-size: 0.875rem;
   line-height: 1.25rem;
   font-weight: 500;
-  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, -webkit-backdrop-filter;
   transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;
-  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter, -webkit-backdrop-filter;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;
 }
@@ -1312,9 +1431,7 @@ a:focus {
   font-size: 0.875rem;
   line-height: 1.25rem;
   font-weight: 500;
-  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, -webkit-backdrop-filter;
   transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;
-  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter, -webkit-backdrop-filter;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;
   border-color: transparent;
@@ -1384,9 +1501,7 @@ a:focus {
   font-size: 0.875rem;
   line-height: 1.25rem;
   font-weight: 500;
-  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, -webkit-backdrop-filter;
   transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;
-  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter, -webkit-backdrop-filter;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;
   border-color: var(--border);
@@ -1410,9 +1525,7 @@ a:focus {
   padding-top: 0.5rem;
   padding-bottom: 0.5rem;
   color: var(--text-secondary);
-  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, -webkit-backdrop-filter;
   transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;
-  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter, -webkit-backdrop-filter;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;
 }
@@ -1461,13 +1574,7 @@ a:focus {
   margin-top: 0.25rem;
   font-size: 0.75rem;
   line-height: 1rem;
-  --tw-text-opacity: 1;
-  color: rgb(220 38 38 / var(--tw-text-opacity, 1));
-}
-
-.errorlist:is(.dark *) {
-  --tw-text-opacity: 1;
-  color: rgb(248 113 113 / var(--tw-text-opacity, 1));
+  color: var(--error);
 }
 
 .sr-only {
@@ -1564,11 +1671,6 @@ a:focus {
   margin-right: auto;
 }
 
-.my-6 {
-  margin-top: 1.5rem;
-  margin-bottom: 1.5rem;
-}
-
 .-mb-px {
   margin-bottom: -1px;
 }
@@ -1609,8 +1711,16 @@ a:focus {
   margin-left: 4rem;
 }
 
+.ml-2 {
+  margin-left: 0.5rem;
+}
+
 .ml-64 {
   margin-left: 16rem;
+}
+
+.mr-1 {
+  margin-right: 0.25rem;
 }
 
 .mt-0 {
@@ -1643,6 +1753,10 @@ a:focus {
 
 .mt-8 {
   margin-top: 2rem;
+}
+
+.mt-auto {
+  margin-top: auto;
 }
 
 .block {
@@ -1729,6 +1843,10 @@ a:focus {
   height: 1.5rem;
 }
 
+.h-64 {
+  height: 16rem;
+}
+
 .h-8 {
   height: 2rem;
 }
@@ -1789,10 +1907,6 @@ a:focus {
   width: 100%;
 }
 
-.min-w-full {
-  min-width: 100%;
-}
-
 .max-w-3xl {
   max-width: 48rem;
 }
@@ -1833,6 +1947,18 @@ a:focus {
   flex-grow: 1;
 }
 
+.cursor-move {
+  cursor: move;
+}
+
+.list-disc {
+  list-style-type: disc;
+}
+
+.list-none {
+  list-style-type: none;
+}
+
 .grid-cols-1 {
   grid-template-columns: repeat(1, minmax(0, 1fr));
 }
@@ -1859,6 +1985,10 @@ a:focus {
 
 .items-start {
   align-items: flex-start;
+}
+
+.items-end {
+  align-items: flex-end;
 }
 
 .items-center {
@@ -1942,17 +2072,6 @@ a:focus {
   --tw-space-y-reverse: 0;
   margin-top: calc(1.5rem * calc(1 - var(--tw-space-y-reverse)));
   margin-bottom: calc(1.5rem * var(--tw-space-y-reverse));
-}
-
-.divide-y > :not([hidden]) ~ :not([hidden]) {
-  --tw-divide-y-reverse: 0;
-  border-top-width: calc(1px * calc(1 - var(--tw-divide-y-reverse)));
-  border-bottom-width: calc(1px * var(--tw-divide-y-reverse));
-}
-
-.divide-neutral-200 > :not([hidden]) ~ :not([hidden]) {
-  --tw-divide-opacity: 1;
-  border-color: rgb(229 229 229 / var(--tw-divide-opacity, 1));
 }
 
 .self-start {
@@ -2081,12 +2200,28 @@ a:focus {
   background-color: var(--error);
 }
 
+.bg-\[var\(--error-light\)\] {
+  background-color: var(--error-light);
+}
+
 .bg-\[var\(--primary\)\] {
   background-color: var(--primary);
 }
 
+.bg-\[var\(--primary-light\)\] {
+  background-color: var(--primary-light);
+}
+
 .bg-\[var\(--success\)\] {
   background-color: var(--success);
+}
+
+.bg-\[var\(--success-light\)\] {
+  background-color: var(--success-light);
+}
+
+.bg-\[var\(--warning-light\)\] {
+  background-color: var(--warning-light);
 }
 
 .bg-gray-100 {
@@ -2107,11 +2242,6 @@ a:focus {
 .bg-neutral-100 {
   --tw-bg-opacity: 1;
   background-color: rgb(245 245 245 / var(--tw-bg-opacity, 1));
-}
-
-.bg-neutral-200 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(229 229 229 / var(--tw-bg-opacity, 1));
 }
 
 .bg-primary {
@@ -2141,17 +2271,14 @@ a:focus {
   background-color: rgb(220 38 38 / var(--tw-bg-opacity, 1));
 }
 
-.bg-success-100 {
-  background-color: var(--color-success-100);
-}
-
-.bg-warning-100 {
-  background-color: var(--color-warning-100);
-}
-
 .bg-white {
   --tw-bg-opacity: 1;
   background-color: rgb(255 255 255 / var(--tw-bg-opacity, 1));
+}
+
+.bg-yellow-200 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(254 240 138 / var(--tw-bg-opacity, 1));
 }
 
 .bg-gradient-to-r {
@@ -2181,6 +2308,10 @@ a:focus {
 .object-cover {
   -o-object-fit: cover;
      object-fit: cover;
+}
+
+.p-10 {
+  padding: 2.5rem;
 }
 
 .p-2 {
@@ -2273,12 +2404,12 @@ a:focus {
   padding-bottom: 2rem;
 }
 
-.pb-4 {
-  padding-bottom: 1rem;
-}
-
 .pl-4 {
   padding-left: 1rem;
+}
+
+.pl-6 {
+  padding-left: 1.5rem;
 }
 
 .pt-10 {
@@ -2291,10 +2422,6 @@ a:focus {
 
 .pt-6 {
   padding-top: 1.5rem;
-}
-
-.text-left {
-  text-align: left;
 }
 
 .text-center {
@@ -2381,6 +2508,14 @@ a:focus {
   color: var(--primary);
 }
 
+.text-\[var\(--success\)\] {
+  color: var(--success);
+}
+
+.text-\[var\(--text-muted\)\] {
+  color: var(--text-muted);
+}
+
 .text-\[var\(--text-primary\)\] {
   color: var(--text-primary);
 }
@@ -2414,19 +2549,9 @@ a:focus {
   color: rgb(55 65 81 / var(--tw-text-opacity, 1));
 }
 
-.text-green-700 {
-  --tw-text-opacity: 1;
-  color: rgb(21 128 61 / var(--tw-text-opacity, 1));
-}
-
 .text-green-800 {
   --tw-text-opacity: 1;
   color: rgb(22 101 52 / var(--tw-text-opacity, 1));
-}
-
-.text-neutral-100 {
-  --tw-text-opacity: 1;
-  color: rgb(245 245 245 / var(--tw-text-opacity, 1));
 }
 
 .text-neutral-500 {
@@ -2471,11 +2596,6 @@ a:focus {
   color: rgb(220 38 38 / var(--tw-text-opacity, 1));
 }
 
-.text-red-700 {
-  --tw-text-opacity: 1;
-  color: rgb(185 28 28 / var(--tw-text-opacity, 1));
-}
-
 .text-red-800 {
   --tw-text-opacity: 1;
   color: rgb(153 27 27 / var(--tw-text-opacity, 1));
@@ -2489,6 +2609,16 @@ a:focus {
 .text-yellow-400 {
   --tw-text-opacity: 1;
   color: rgb(250 204 21 / var(--tw-text-opacity, 1));
+}
+
+.text-yellow-700 {
+  --tw-text-opacity: 1;
+  color: rgb(161 98 7 / var(--tw-text-opacity, 1));
+}
+
+.text-yellow-800 {
+  --tw-text-opacity: 1;
+  color: rgb(133 77 14 / var(--tw-text-opacity, 1));
 }
 
 .placeholder-transparent::-moz-placeholder {
@@ -2531,27 +2661,13 @@ a:focus {
 }
 
 .transition {
-  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, -webkit-backdrop-filter;
   transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;
-  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter, -webkit-backdrop-filter;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;
 }
 
 .transition-all {
   transition-property: all;
-  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-  transition-duration: 150ms;
-}
-
-.transition-shadow {
-  transition-property: box-shadow;
-  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-  transition-duration: 150ms;
-}
-
-.transition-transform {
-  transition-property: transform;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;
 }
@@ -2862,33 +2978,29 @@ a:focus {
   color: rgb(64 64 64 / var(--tw-text-opacity, 1));
 }
 
-.hover\:scale-\[1\.01\]:hover {
-  --tw-scale-x: 1.01;
-  --tw-scale-y: 1.01;
-  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
-}
-
 .hover\:border-primary:hover {
   border-color: var(--primary);
+}
+
+.hover\:bg-\[var\(--bg-accent\)\]:hover {
+  background-color: var(--bg-accent);
 }
 
 .hover\:bg-\[var\(--bg-tertiary\)\]:hover {
   background-color: var(--bg-tertiary);
 }
 
-.hover\:bg-gray-200:hover {
-  --tw-bg-opacity: 1;
-  background-color: rgb(229 231 235 / var(--tw-bg-opacity, 1));
+.hover\:bg-\[var\(--color-error-700\)\]:hover {
+  background-color: var(--color-error-700);
+}
+
+.hover\:bg-\[var\(--primary-hover\)\]:hover {
+  background-color: var(--primary-hover);
 }
 
 .hover\:bg-neutral-100:hover {
   --tw-bg-opacity: 1;
   background-color: rgb(245 245 245 / var(--tw-bg-opacity, 1));
-}
-
-.hover\:bg-neutral-300:hover {
-  --tw-bg-opacity: 1;
-  background-color: rgb(212 212 212 / var(--tw-bg-opacity, 1));
 }
 
 .hover\:bg-primary-700:hover {
@@ -2904,18 +3016,8 @@ a:focus {
   color: var(--primary);
 }
 
-.hover\:text-primary-700:hover {
-  color: var(--color-primary-700);
-}
-
 .hover\:underline:hover {
   text-decoration-line: underline;
-}
-
-.hover\:shadow-lg:hover {
-  --tw-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
-  --tw-shadow-colored: 0 10px 15px -3px var(--tw-shadow-color), 0 4px 6px -4px var(--tw-shadow-color);
-  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
 .hover\:file\:bg-neutral-200::file-selector-button:hover {
@@ -2957,6 +3059,10 @@ a:focus {
   --tw-ring-color: var(--border-focus);
 }
 
+.focus\:ring-\[var\(--primary\)\]:focus {
+  --tw-ring-color: var(--primary);
+}
+
 .focus\:ring-primary:focus {
   --tw-ring-color: var(--primary);
 }
@@ -2967,14 +3073,6 @@ a:focus {
 
 .group:hover .group-hover\:underline {
   text-decoration-line: underline;
-}
-
-.peer:-moz-placeholder ~ .peer-placeholder-shown\:top-2 {
-  top: 0.5rem;
-}
-
-.peer:placeholder-shown ~ .peer-placeholder-shown\:top-2 {
-  top: 0.5rem;
 }
 
 .peer:-moz-placeholder ~ .peer-placeholder-shown\:top-3 {
@@ -3005,16 +3103,6 @@ a:focus {
   color: rgb(156 163 175 / var(--tw-text-opacity, 1));
 }
 
-.peer:-moz-placeholder ~ .peer-placeholder-shown\:text-neutral-400 {
-  --tw-text-opacity: 1;
-  color: rgb(163 163 163 / var(--tw-text-opacity, 1));
-}
-
-.peer:placeholder-shown ~ .peer-placeholder-shown\:text-neutral-400 {
-  --tw-text-opacity: 1;
-  color: rgb(163 163 163 / var(--tw-text-opacity, 1));
-}
-
 .peer:focus ~ .peer-focus\:-top-2 {
   top: -0.5rem;
 }
@@ -3026,10 +3114,6 @@ a:focus {
 
 .peer:focus ~ .peer-focus\:text-primary {
   color: var(--primary);
-}
-
-.peer:focus ~ .peer-focus\:text-primary-600 {
-  color: var(--color-primary-600);
 }
 
 .aria-pressed\:border-primary[aria-pressed="true"] {
@@ -3063,6 +3147,10 @@ a:focus {
   color: var(--primary);
 }
 
+.dark\:border-\[var\(--border\)\]:is(.dark *) {
+  border-color: var(--border);
+}
+
 .dark\:border-gray-700:is(.dark *) {
   --tw-border-opacity: 1;
   border-color: rgb(55 65 81 / var(--tw-border-opacity, 1));
@@ -3073,29 +3161,9 @@ a:focus {
   border-color: rgb(82 82 82 / var(--tw-border-opacity, 1));
 }
 
-.dark\:border-neutral-700:is(.dark *) {
-  --tw-border-opacity: 1;
-  border-color: rgb(64 64 64 / var(--tw-border-opacity, 1));
-}
-
-.dark\:border-slate-600:is(.dark *) {
-  --tw-border-opacity: 1;
-  border-color: rgb(71 85 105 / var(--tw-border-opacity, 1));
-}
-
-.dark\:border-slate-700:is(.dark *) {
-  --tw-border-opacity: 1;
-  border-color: rgb(51 65 85 / var(--tw-border-opacity, 1));
-}
-
 .dark\:bg-gray-700:is(.dark *) {
   --tw-bg-opacity: 1;
   background-color: rgb(55 65 81 / var(--tw-bg-opacity, 1));
-}
-
-.dark\:bg-green-900:is(.dark *) {
-  --tw-bg-opacity: 1;
-  background-color: rgb(20 83 45 / var(--tw-bg-opacity, 1));
 }
 
 .dark\:bg-neutral-700:is(.dark *) {
@@ -3103,58 +3171,9 @@ a:focus {
   background-color: rgb(64 64 64 / var(--tw-bg-opacity, 1));
 }
 
-.dark\:bg-neutral-800:is(.dark *) {
-  --tw-bg-opacity: 1;
-  background-color: rgb(38 38 38 / var(--tw-bg-opacity, 1));
-}
-
-.dark\:bg-neutral-900:is(.dark *) {
-  --tw-bg-opacity: 1;
-  background-color: rgb(23 23 23 / var(--tw-bg-opacity, 1));
-}
-
-.dark\:bg-primary:is(.dark *) {
-  background-color: var(--primary);
-}
-
-.dark\:bg-primary-500:is(.dark *) {
-  background-color: var(--color-primary-500);
-}
-
-.dark\:bg-primary-700:is(.dark *) {
-  background-color: var(--color-primary-700);
-}
-
-.dark\:bg-primary-900:is(.dark *) {
-  background-color: var(--color-primary-900);
-}
-
-.dark\:bg-red-900:is(.dark *) {
-  --tw-bg-opacity: 1;
-  background-color: rgb(127 29 29 / var(--tw-bg-opacity, 1));
-}
-
 .dark\:bg-slate-600:is(.dark *) {
   --tw-bg-opacity: 1;
   background-color: rgb(71 85 105 / var(--tw-bg-opacity, 1));
-}
-
-.dark\:bg-slate-700:is(.dark *) {
-  --tw-bg-opacity: 1;
-  background-color: rgb(51 65 85 / var(--tw-bg-opacity, 1));
-}
-
-.dark\:bg-slate-800:is(.dark *) {
-  --tw-bg-opacity: 1;
-  background-color: rgb(30 41 59 / var(--tw-bg-opacity, 1));
-}
-
-.dark\:bg-success-900:is(.dark *) {
-  background-color: var(--color-success-900);
-}
-
-.dark\:bg-warning-900:is(.dark *) {
-  background-color: var(--color-warning-900);
 }
 
 .dark\:text-gray-200:is(.dark *) {
@@ -3177,24 +3196,9 @@ a:focus {
   color: rgb(107 114 128 / var(--tw-text-opacity, 1));
 }
 
-.dark\:text-green-100:is(.dark *) {
-  --tw-text-opacity: 1;
-  color: rgb(220 252 231 / var(--tw-text-opacity, 1));
-}
-
-.dark\:text-green-300:is(.dark *) {
-  --tw-text-opacity: 1;
-  color: rgb(134 239 172 / var(--tw-text-opacity, 1));
-}
-
 .dark\:text-neutral-100:is(.dark *) {
   --tw-text-opacity: 1;
   color: rgb(245 245 245 / var(--tw-text-opacity, 1));
-}
-
-.dark\:text-neutral-300:is(.dark *) {
-  --tw-text-opacity: 1;
-  color: rgb(212 212 212 / var(--tw-text-opacity, 1));
 }
 
 .dark\:text-neutral-400:is(.dark *) {
@@ -3206,23 +3210,9 @@ a:focus {
   color: var(--primary);
 }
 
-.dark\:text-red-100:is(.dark *) {
-  --tw-text-opacity: 1;
-  color: rgb(254 226 226 / var(--tw-text-opacity, 1));
-}
-
 .dark\:text-red-300:is(.dark *) {
   --tw-text-opacity: 1;
   color: rgb(252 165 165 / var(--tw-text-opacity, 1));
-}
-
-.dark\:hover\:bg-primary-600:hover:is(.dark *) {
-  background-color: var(--color-primary-600);
-}
-
-.dark\:hover\:bg-slate-700:hover:is(.dark *) {
-  --tw-bg-opacity: 1;
-  background-color: rgb(51 65 85 / var(--tw-bg-opacity, 1));
 }
 
 .dark\:hover\:text-primary:hover:is(.dark *) {
@@ -3248,12 +3238,20 @@ a:focus {
     grid-column: span 2 / span 2;
   }
 
+  .md\:col-span-5 {
+    grid-column: span 5 / span 5;
+  }
+
   .md\:grid-cols-2 {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   .md\:grid-cols-3 {
     grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .md\:grid-cols-5 {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
   }
 
   .md\:flex-row {


### PR DESCRIPTION
## Summary
- replace hardcoded dark mode colors in account templates with theme CSS variables
- use theme error color in `.errorlist`

## Testing
- `npm run build:css`
- `pytest` *(fails: ModuleNotFoundError: No module named 'silk')*


------
https://chatgpt.com/codex/tasks/task_e_68c17d15ab548325af097fcda3ea9c31