### PR TITLE
refactor: remove template container wrappers

### DIFF
--- a/accounts/templates/associados/associado_list.html
+++ b/accounts/templates/associados/associado_list.html
@@ -8,10 +8,9 @@
 {% endblock %}
 
 {% block content %}
-<div class="container mx-auto p-6">
 
 
-<section class="max-w-6xl mx-auto py-8 px-4">
+<section class="max-w-6xl mx-auto py-12 px-4">
   {% include '_components/search_form.html' with q=request.GET.q %}
 
   <!-- Cards de totais -->
@@ -30,5 +29,4 @@
     {% endfor %}
   </div>
 </section>
-</div>
 {% endblock %}

--- a/accounts/templates/login/login.html
+++ b/accounts/templates/login/login.html
@@ -8,8 +8,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="container mx-auto p-6">
-<div class="bg-muted min-h-screen flex items-center justify-center px-4">
+<div class="py-12 bg-muted min-h-screen flex items-center justify-center px-4">
   <div class="card max-w-md w-full mx-auto" role="dialog">
     <div class="card-body">
       <p class="text-center text-sm mb-6 text-[var(--text-secondary)]">
@@ -100,6 +99,5 @@
     </div>
     </div>
   </div>
-</div>
 </div>
 {% endblock %}

--- a/accounts/templates/perfil/disable_2fa.html
+++ b/accounts/templates/perfil/disable_2fa.html
@@ -8,7 +8,6 @@
 
 {% block content %}
 {% include '_partials/sidebar.html' %}
-<div class="container mx-auto p-6">
   <form method="post" class="max-w-md mx-auto card">
     <div class="card-body space-y-6">
       {% csrf_token %}
@@ -17,6 +16,5 @@
       <button type="submit" class="btn btn-primary w-full">{% trans "Desativar" %}</button>
     </div>
   </form>
-</div>
 
 {% endblock %}

--- a/accounts/templates/perfil/enable_2fa.html
+++ b/accounts/templates/perfil/enable_2fa.html
@@ -8,7 +8,6 @@
 
 {% block content %}
 {% include '_partials/sidebar.html' %}
-<div class="container mx-auto p-6">
   <form method="post" class="max-w-md mx-auto card">
     <div class="card-body space-y-6">
       {% csrf_token %}
@@ -18,6 +17,5 @@
       <button type="submit" class="btn btn-primary w-full">{% trans "Ativar" %}</button>
     </div>
   </form>
-</div>
 
 {% endblock %}

--- a/accounts/templates/perfil/perfil.html
+++ b/accounts/templates/perfil/perfil.html
@@ -7,8 +7,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="container mx-auto p-6">
-  <div class="grid grid-cols-1 gap-6">
+  <div class="py-12 grid grid-cols-1 gap-6 px-4">
     <div class="bg-[var(--bg-secondary)] p-6 rounded-lg shadow">
       {% with perfil|default:user as profile %}
       <div class="profile-cover relative h-48 w-full overflow-hidden">
@@ -62,5 +61,4 @@
       {% endwith %}
     </div>
   </div>
-</div>
 {% endblock %}

--- a/core/templates/core/about.html
+++ b/core/templates/core/about.html
@@ -8,7 +8,6 @@
 {% endblock %}
 
 {% block content %}
-<div class="container mx-auto p-6">
 <div class="max-w-3xl mx-auto px-4 py-12 card-grid">
   <div class="card">
     <div class="card-header">
@@ -19,6 +18,5 @@
       <p>{% trans "Nosso objetivo é facilitar a comunicação, gestão de eventos e colaboração entre membros." %}</p>
     </div>
   </div>
-</div>
 </div>
 {% endblock %}

--- a/core/templates/core/home.html
+++ b/core/templates/core/home.html
@@ -8,8 +8,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="container mx-auto p-6">
-<div class="text-center my-8">
+<div class="py-12 text-center my-8 px-4">
   {% if user.is_authenticated %}
   <div class="flex justify-center gap-4">
     <a href="{% url 'dashboard:dashboard' %}" class="bg-primary text-white px-5 py-3 rounded-xl shadow hover:bg-primary/90">{% trans "Ir para Dashboard" %}</a>
@@ -22,7 +21,7 @@
   </div>
   {% endif %}
 </div>
-<section class="py-12 bg-gray-50">
+<section class="py-12 px-4 bg-gray-50">
   <div class="card max-w-7xl mx-auto px-4 text-center">
     <div class="card-header">
       <h2 class="text-2xl font-bold text-neutral-900 mb-8">{% trans "Principais Funcionalidades" %}</h2>
@@ -74,7 +73,7 @@
   </div>
 </section>
 
-<section class="py-12">
+<section class="py-12 px-4">
   <div class="card max-w-7xl mx-auto px-4">
     <div class="card-header">
       <h2 class="text-xl font-semibold mb-4">{% trans "Próximos Eventos" %}</h2>
@@ -89,7 +88,7 @@
 </section>
 
 {% if user.is_authenticated %}
-<section class="py-12 bg-gray-50">
+<section class="py-12 px-4 bg-gray-50">
   <div class="card max-w-7xl mx-auto px-4">
     <div class="card-header">
       <h2 class="text-xl font-semibold mb-4">{% trans "Posts em destaque" %}</h2>
@@ -105,5 +104,4 @@
 <footer class="py-6 text-center text-sm text-neutral-500">
   &copy; {{ now|date:"Y" }} {% trans "Hubx" %}
 </footer>
-</div>
 {% endblock %}

--- a/core/templates/core/privacy.html
+++ b/core/templates/core/privacy.html
@@ -8,7 +8,6 @@
 {% endblock %}
 
 {% block content %}
-<div class="container mx-auto p-6">
 <div class="max-w-3xl mx-auto px-4 py-12 card-grid">
   <div class="card">
     <div class="card-header">
@@ -18,6 +17,5 @@
       <p>{% trans "Seus dados pessoais são tratados com segurança e apenas para fins da plataforma." %}</p>
     </div>
   </div>
-</div>
 </div>
 {% endblock %}

--- a/core/templates/core/terms.html
+++ b/core/templates/core/terms.html
@@ -8,7 +8,6 @@
 {% endblock %}
 
 {% block content %}
-<div class="container mx-auto p-6">
 <div class="max-w-3xl mx-auto px-4 py-12 card-grid">
   <div class="card">
     <div class="card-header">
@@ -18,6 +17,5 @@
       <p>{% trans "Ao utilizar o HubX, você concorda com nossas políticas de uso e privacidade." %}</p>
     </div>
   </div>
-</div>
 </div>
 {% endblock %}

--- a/dashboard/templates/dashboard/admin.html
+++ b/dashboard/templates/dashboard/admin.html
@@ -8,8 +8,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="container mx-auto p-6">
-<div class="max-w-7xl mx-auto px-4 py-10 card-grid" aria-label="{% trans 'Dashboard' %}">
+<div class="py-12 max-w-7xl mx-auto px-4 py-10 card-grid" aria-label="{% trans 'Dashboard' %}">
   <div class="card col-span-full">
     <div class="card-header">
       <h2 class="text-xl font-semibold text-center">{% trans "Dashboard Administrativo" %}</h2>
@@ -82,6 +81,5 @@
       </section>
     </div>
   </div>
-</div>
 </div>
 {% endblock %}

--- a/dashboard/templates/dashboard/cliente.html
+++ b/dashboard/templates/dashboard/cliente.html
@@ -8,8 +8,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="container mx-auto p-6">
-  <div class="max-w-7xl mx-auto">
+  <div class="py-12 max-w-7xl mx-auto px-4">
     <div class="card">
       <div class="card-body space-y-8">
         {% include '_partials/messages.html' %}
@@ -54,5 +53,4 @@
       </div>
     </div>
   </div>
-</div>
 {% endblock %}

--- a/dashboard/templates/dashboard/config_confirm_delete.html
+++ b/dashboard/templates/dashboard/config_confirm_delete.html
@@ -6,8 +6,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="container mx-auto p-6">
-  <div class="max-w-xl mx-auto">
+  <div class="py-12 max-w-xl mx-auto px-4">
     <div class="card">
       <div class="card-body space-y-4">
         <p>{% trans "Tem certeza que deseja excluir esta configuração?" %}</p>
@@ -18,5 +17,4 @@
       </div>
     </div>
   </div>
-</div>
 {% endblock %}

--- a/dashboard/templates/dashboard/config_form.html
+++ b/dashboard/templates/dashboard/config_form.html
@@ -6,8 +6,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="container mx-auto p-6">
-  <div class="max-w-md mx-auto">
+  <div class="py-12 max-w-md mx-auto px-4">
     <div class="card">
       <div class="card-body">
         <form method="post" class="space-y-4" aria-label="{% trans 'Formulário de configuração do dashboard' %}">
@@ -48,5 +47,4 @@
       </div>
     </div>
   </div>
-</div>
 {% endblock %}

--- a/dashboard/templates/dashboard/config_list.html
+++ b/dashboard/templates/dashboard/config_list.html
@@ -6,8 +6,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="container mx-auto p-6">
-  <div class="max-w-2xl mx-auto">
+  <div class="py-12 max-w-2xl mx-auto px-4">
     <div class="card">
       <div class="card-body">
         {% include '_partials/messages.html' %}
@@ -32,5 +31,4 @@
       </div>
     </div>
   </div>
-</div>
 {% endblock %}

--- a/dashboard/templates/dashboard/coordenador.html
+++ b/dashboard/templates/dashboard/coordenador.html
@@ -9,8 +9,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="container mx-auto p-6">
-  <div class="max-w-7xl mx-auto">
+  <div class="py-12 max-w-7xl mx-auto px-4">
     <div class="card">
       <div class="card-body space-y-8">
         {% include '_partials/messages.html' %}
@@ -40,5 +39,4 @@
       </div>
     </div>
   </div>
-</div>
 {% endblock %}

--- a/dashboard/templates/dashboard/custom_metric_confirm_delete.html
+++ b/dashboard/templates/dashboard/custom_metric_confirm_delete.html
@@ -6,8 +6,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="container mx-auto p-6">
-  <div class="max-w-md mx-auto">
+  <div class="py-12 max-w-md mx-auto px-4">
     <div class="card">
       <div class="card-body space-y-4">
         <p>{% blocktrans %}Tem certeza que deseja excluir a métrica "{{ object.nome }}"?{% endblocktrans %}</p>
@@ -19,6 +18,5 @@
       </div>
     </div>
   </div>
-</div>
 {% endblock %}
 

--- a/dashboard/templates/dashboard/custom_metric_form.html
+++ b/dashboard/templates/dashboard/custom_metric_form.html
@@ -7,8 +7,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="container mx-auto p-6">
-  <div class="max-w-md mx-auto">
+  <div class="py-12 max-w-md mx-auto px-4">
     <div class="card">
       <div class="card-body">
         <form method="post" class="space-y-4" aria-label="{% trans 'Formulário de métrica personalizada' %}">
@@ -80,6 +79,5 @@
       </div>
     </div>
   </div>
-</div>
 {% endblock %}
 

--- a/dashboard/templates/dashboard/custom_metric_list.html
+++ b/dashboard/templates/dashboard/custom_metric_list.html
@@ -6,8 +6,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="container mx-auto p-6">
-  <div class="max-w-2xl mx-auto">
+  <div class="py-12 max-w-2xl mx-auto px-4">
     <div class="card">
       <div class="card-body">
         {% include '_partials/messages.html' %}
@@ -30,6 +29,5 @@
       </div>
     </div>
   </div>
-</div>
 {% endblock %}
 

--- a/dashboard/templates/dashboard/filter_form.html
+++ b/dashboard/templates/dashboard/filter_form.html
@@ -6,8 +6,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="container mx-auto p-6">
-  <div class="max-w-md mx-auto">
+  <div class="py-12 max-w-md mx-auto px-4">
     <div class="card">
       <div class="card-body">
         <form method="post" class="space-y-4" aria-label="{% trans 'Formulário de filtro rápido' %}">
@@ -48,5 +47,4 @@
       </div>
     </div>
   </div>
-</div>
 {% endblock %}

--- a/dashboard/templates/dashboard/filter_list.html
+++ b/dashboard/templates/dashboard/filter_list.html
@@ -6,8 +6,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="container mx-auto p-6">
-  <div class="max-w-2xl mx-auto">
+  <div class="py-12 max-w-2xl mx-auto px-4">
     <div class="card">
       <div class="card-body">
         {% include '_partials/messages.html' %}
@@ -35,5 +34,4 @@
       </div>
     </div>
   </div>
-</div>
 {% endblock %}

--- a/dashboard/templates/dashboard/layout_confirm_delete.html
+++ b/dashboard/templates/dashboard/layout_confirm_delete.html
@@ -6,8 +6,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="container mx-auto p-6">
-  <div class="max-w-xl mx-auto">
+  <div class="py-12 max-w-xl mx-auto px-4">
     <div class="card">
       <div class="card-body space-y-4">
         <p>{% trans "Tem certeza que deseja excluir este layout?" %}</p>
@@ -18,5 +17,4 @@
       </div>
     </div>
   </div>
-</div>
 {% endblock %}

--- a/dashboard/templates/dashboard/layout_form.html
+++ b/dashboard/templates/dashboard/layout_form.html
@@ -6,8 +6,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="container mx-auto p-6">
-  <div class="max-w-7xl mx-auto">
+  <div class="py-12 max-w-7xl mx-auto px-4">
     <div class="card">
       <div class="card-body space-y-6">
         <form method="post" class="space-y-4">
@@ -50,7 +49,6 @@
       </div>
     </div>
   </div>
-</div>
 {% endblock %}
 
 {% block extra_js %}

--- a/dashboard/templates/dashboard/layout_list.html
+++ b/dashboard/templates/dashboard/layout_list.html
@@ -6,8 +6,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="container mx-auto p-6">
-  <div class="max-w-3xl mx-auto">
+  <div class="py-12 max-w-3xl mx-auto px-4">
     <div class="card">
       <div class="card-body">
         <ul class="space-y-2">
@@ -33,5 +32,4 @@
       </div>
     </div>
   </div>
-</div>
 {% endblock %}

--- a/dashboard/templates/dashboard/root.html
+++ b/dashboard/templates/dashboard/root.html
@@ -8,8 +8,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="container mx-auto p-6">
-  <div class="max-w-7xl mx-auto">
+  <div class="py-12 max-w-7xl mx-auto px-4">
     <div class="card">
       <div class="card-body space-y-8">
         {% include '_partials/messages.html' %}
@@ -83,5 +82,4 @@
       </div>
     </div>
   </div>
-</div>
 {% endblock %}

--- a/empresas/templates/empresas/empresa_detail.html
+++ b/empresas/templates/empresas/empresa_detail.html
@@ -7,8 +7,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="container mx-auto p-6">
-  <div class="card max-w-4xl mx-auto">
+  <div class="py-12 card max-w-4xl mx-auto px-4">
     <div class="card-body">
       <div class="space-y-1 text-sm text-neutral-800">
     <p><strong>{% trans "CNPJ" %}:</strong> {{ empresa.cnpj|localize }}</p>
@@ -186,5 +185,4 @@
       </div>
     </div>
   </div>
-</div>
 {% endblock %}

--- a/empresas/templates/empresas/empresa_form.html
+++ b/empresas/templates/empresas/empresa_form.html
@@ -15,8 +15,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="container mx-auto p-6">
-  <div class="max-w-3xl mx-auto space-y-6">
+  <div class="py-12 max-w-3xl mx-auto space-y-6 px-4">
     <a href="{% url 'empresas:lista' %}" class="btn btn-secondary">{% translate 'Voltar' %}</a>
 
     <form method="post" enctype="multipart/form-data" class="card space-y-6">
@@ -198,7 +197,6 @@
         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"/></svg>
         {% if form.instance.pk %}{% translate 'Salvar' %}{% else %}{% translate 'Cadastrar Empresa' %}{% endif %}
       </button>
-    </div>
   </form>
 </section>
 {% endblock %}

--- a/empresas/templates/empresas/favoritos.html
+++ b/empresas/templates/empresas/favoritos.html
@@ -8,8 +8,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="container mx-auto p-6">
-  <div class="card">
+  <div class="py-12 card px-4">
     <div class="card-body">
       <ul class="space-y-4" id="lista-favoritos" hx-on:afterRequest="if (this.children.length === 0) { const li=document.createElement('li'); li.className='text-neutral-600'; li.textContent='{{ _('Nenhuma empresa favorita.')|escapejs }}'; this.appendChild(li); }">
         {% for empresa in empresas %}
@@ -29,5 +28,4 @@
       </ul>
     </div>
   </div>
-</div>
 {% endblock %}

--- a/eventos/templates/eventos/avaliacao_form.html
+++ b/eventos/templates/eventos/avaliacao_form.html
@@ -7,8 +7,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="container mx-auto p-6">
-  <div class="card">
+  <div class="py-12 card px-4">
     <div class="card-body">
       <form method="post" class="space-y-4">
         {% csrf_token %}
@@ -30,5 +29,4 @@
       </form>
     </div>
   </div>
-</div>
 {% endblock %}

--- a/eventos/templates/eventos/briefing_form.html
+++ b/eventos/templates/eventos/briefing_form.html
@@ -9,7 +9,6 @@
 {% endblock %}
 
 {% block content %}
-<div class="container mx-auto p-6">
 <section class="max-w-3xl mx-auto px-4 py-12 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
   <div class="card">
     <div class="card-header">
@@ -44,5 +43,4 @@
     </div>
   </div>
 </section>
-</div>
 {% endblock %}

--- a/eventos/templates/eventos/briefing_list.html
+++ b/eventos/templates/eventos/briefing_list.html
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block content %}
-<div id="briefing-container" class="container mx-auto p-6">
+<div id="briefing-container"  class="py-12 px-4">
   <div class="card">
     <div class="card-header flex items-center justify-between">
       <a href="{% url 'eventos:briefing_criar' %}" class="btn-primary">{% trans "Novo Briefing" %}</a>

--- a/eventos/templates/eventos/checkin_form.html
+++ b/eventos/templates/eventos/checkin_form.html
@@ -7,8 +7,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="container mx-auto p-6">
-  <div class="card">
+  <div class="py-12 card px-4">
     <div class="card-body">
       <form method="post" action="{% url 'eventos:inscricao_checkin' inscricao.id %}" id="checkin-form" class="space-y-4">
         {% csrf_token %}
@@ -22,7 +21,6 @@
       </form>
     </div>
   </div>
-</div>
 
 <script src="https://unpkg.com/html5-qrcode" defer></script>
 <script>

--- a/eventos/templates/eventos/detail.html
+++ b/eventos/templates/eventos/detail.html
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block content %}
-<section class="container mx-auto p-6">
+<section class="py-12 px-4">
   <div class="card-grid gap-6">
     <article class="card">
       <div class="card-header">

--- a/eventos/templates/eventos/evento_list.html
+++ b/eventos/templates/eventos/evento_list.html
@@ -10,8 +10,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="container mx-auto p-6">
-  <div class="card">
+  <div class="py-12 card px-4">
     <div class="card-header">
       {% include '_components/search_form.html' with q=request.GET.q %}
     </div>
@@ -32,5 +31,4 @@
       {% include '_partials/pagination.html' with page_obj=page_obj querystring="q="|add:q %}
     </div>
   </div>
-</div>
 {% endblock %}

--- a/eventos/templates/eventos/eventos_lista.html
+++ b/eventos/templates/eventos/eventos_lista.html
@@ -9,8 +9,7 @@
 
 {% block content %}
 
-<div class="container mx-auto p-6">
-  <div class="card">
+  <div class="py-12 card px-4">
     <div class="card-header">
       {% include '_components/search_form.html' with q=request.GET.q %}
     </div>
@@ -31,5 +30,4 @@
       {% include '_partials/pagination.html' with page_obj=page_obj querystring=querystring %}
     </div>
   </div>
-</div>
 {% endblock %}

--- a/eventos/templates/eventos/inscricao_list.html
+++ b/eventos/templates/eventos/inscricao_list.html
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block content %}
-<div id="inscricao-container" class="container mx-auto p-6">
+<div id="inscricao-container"  class="py-12 px-4">
   <div class="card">
     <div class="card-body">
       {% if messages %}

--- a/eventos/templates/eventos/material_list.html
+++ b/eventos/templates/eventos/material_list.html
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block content %}
-<div id="material-container" class="container mx-auto p-6">
+<div id="material-container"  class="py-12 px-4">
   <div class="card">
     <div class="card-header flex items-center justify-between">
       <a href="{% url 'eventos:material_criar' %}" class="btn-primary">{% trans "Novo Material" %}</a>

--- a/eventos/templates/eventos/parceria_avaliar.html
+++ b/eventos/templates/eventos/parceria_avaliar.html
@@ -7,8 +7,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="container mx-auto p-6">
-  <div class="card">
+  <div class="py-12 card px-4">
     <div class="card-body">
       <form id="avaliacao-form" method="post" action="{% url 'eventos_api:parceria-avaliar' parceria.pk %}" class="space-y-4">
         {% csrf_token %}
@@ -31,7 +30,6 @@
       <p id="message" class="mt-4 text-sm"></p>
     </div>
   </div>
-</div>
 <script>
 const successMessage = gettext('Avaliação enviada com sucesso.');
 const errorMessage = gettext('Erro ao enviar avaliação.');

--- a/eventos/templates/eventos/parceria_list.html
+++ b/eventos/templates/eventos/parceria_list.html
@@ -8,8 +8,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="container mx-auto p-6">
-  <div class="card">
+  <div class="py-12 card px-4">
     <div class="card-header flex items-center justify-between">
       <a href="{% url 'eventos:parceria_criar' %}" class="btn-primary">{% trans "Nova Parceria" %}</a>
     </div>
@@ -57,5 +56,4 @@
       </div>
     </div>
   </div>
-</div>
 {% endblock %}

--- a/eventos/templates/eventos/tarefa_detail.html
+++ b/eventos/templates/eventos/tarefa_detail.html
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block content %}
-<section class="container mx-auto p-6">
+<section class="py-12 px-4">
   <div class="card-grid gap-6">
     <article class="card">
       <div class="card-header">

--- a/feed/templates/feed/bookmarks.html
+++ b/feed/templates/feed/bookmarks.html
@@ -10,10 +10,8 @@
 {% if request.user.user_type == 'root' %}
   <p class="text-center text-neutral-500">{% trans "Usuário root não tem acesso ao feed." %}</p>
 {% else %}
-<div class="container mx-auto p-6">
 <section class="max-w-6xl mx-auto px-4 py-10">
   {% include "feed/_grid.html" with posts=posts %}
 </section>
-</div>
 {% endif %}
 {% endblock %}

--- a/feed/templates/feed/feed.html
+++ b/feed/templates/feed/feed.html
@@ -11,7 +11,6 @@
 {% if request.user.user_type == 'root' %}
   <p class="text-center text-neutral-500">{% trans "Usuário root não tem acesso ao feed." %}</p>
 {% else %}
-<div class="container mx-auto p-6">
 <section class="max-w-7xl mx-auto px-4 py-10">
 
 
@@ -33,6 +32,5 @@
 
 </section>
 <script src="{% static 'feed/js/feed.js' %}"></script>
-</div>
 {% endif %}
 {% endblock %}

--- a/feed/templates/feed/mural.html
+++ b/feed/templates/feed/mural.html
@@ -10,10 +10,8 @@
 {% if request.user.user_type == 'root' %}
   <p class="text-center text-neutral-500">{% trans "Usuário root não tem acesso ao feed." %}</p>
 {% else %}
-<div class="container mx-auto p-6">
 <section class="max-w-6xl mx-auto px-4 py-10">
     {% include "feed/_grid.html" with posts=posts %}
 </section>
-</div>
 {% endif %}
 {% endblock %}

--- a/financeiro/templates/financeiro/centros_list.html
+++ b/financeiro/templates/financeiro/centros_list.html
@@ -8,8 +8,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="container mx-auto p-6">
-  <div class="card">
+  <div class="py-12 card px-4">
     <div class="card-body">
       <section id="centros-list" class="overflow-x-auto" aria-live="polite">
         <table class="min-w-full divide-y divide-gray-200">
@@ -55,6 +54,5 @@
       <div id="modal" class="mt-4" aria-live="assertive"></div>
     </div>
   </div>
-</div>
 {% endblock %}
 

--- a/financeiro/templates/financeiro/extrato.html
+++ b/financeiro/templates/financeiro/extrato.html
@@ -8,8 +8,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="container mx-auto p-6">
-  <div class="card">
+  <div class="py-12 card px-4">
     <div class="card-header">
       <form id="filtros" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6"
             hx-get="/api/financeiro/lancamentos/" hx-target="#lista" hx-swap="none"
@@ -94,5 +93,4 @@
       </script>
     </div>
   </div>
-</div>
 {% endblock %}

--- a/financeiro/templates/financeiro/importacoes_list.html
+++ b/financeiro/templates/financeiro/importacoes_list.html
@@ -8,8 +8,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="container mx-auto p-6">
-  <div class="card">
+  <div class="py-12 card px-4">
     <div class="card-body">
       <div id="importacoes"
            hx-get="/api/financeiro/importacoes/"
@@ -79,5 +78,4 @@
       </script>
     </div>
   </div>
-</div>
 {% endblock %}

--- a/financeiro/templates/financeiro/importar_pagamentos.html
+++ b/financeiro/templates/financeiro/importar_pagamentos.html
@@ -8,8 +8,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="container mx-auto p-6">
-  <div class="card">
+  <div class="py-12 card px-4">
     <div class="card-body">
       <div class="mb-4">
         <a href="{% url 'financeiro:importacoes' %}" class="text-blue-600 underline">{% trans "Ver importações" %}</a>
@@ -99,5 +98,4 @@
       </script>
     </div>
   </div>
-</div>
 {% endblock %}

--- a/financeiro/templates/financeiro/integracoes_list.html
+++ b/financeiro/templates/financeiro/integracoes_list.html
@@ -8,8 +8,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="container mx-auto p-6">
-  <div class="card">
+  <div class="py-12 card px-4">
     <div class="card-body">
       <section id="integracoes-list" class="overflow-x-auto" aria-live="polite">
         <table class="min-w-full divide-y divide-gray-200">
@@ -59,5 +58,4 @@
       <div id="modal" class="mt-4" aria-live="assertive"></div>
     </div>
   </div>
-</div>
 {% endblock %}

--- a/financeiro/templates/financeiro/lancamentos_list.html
+++ b/financeiro/templates/financeiro/lancamentos_list.html
@@ -8,8 +8,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="container mx-auto p-6">
-  <div class="card">
+  <div class="py-12 card px-4">
     <div class="card-header">
       <form id="filtros" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6" hx-get="/api/financeiro/lancamentos/" hx-target="#lista" hx-swap="none" hx-trigger="change from:select,change from:input, submit" hx-on="htmx:afterRequest: renderLancamentos(event)">
         <legend class="sr-only">{{ _('Filtros') }}</legend>
@@ -110,5 +109,4 @@
       </script>
     </div>
   </div>
-</div>
 {% endblock %}

--- a/financeiro/templates/financeiro/logs_list.html
+++ b/financeiro/templates/financeiro/logs_list.html
@@ -8,8 +8,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="container mx-auto p-6">
-  <div class="card">
+  <div class="py-12 card px-4">
     <div class="card-header">
       <form id="filtros" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6"
             hx-get="/api/financeiro/logs/"
@@ -89,5 +88,4 @@
       </script>
     </div>
   </div>
-</div>
 {% endblock %}

--- a/financeiro/templates/financeiro/relatorios.html
+++ b/financeiro/templates/financeiro/relatorios.html
@@ -8,8 +8,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="container mx-auto p-6">
-  <div class="card">
+  <div class="py-12 card px-4">
     <div class="card-body space-y-4">
       <form id="relatorio-form" class="space-y-4">
         <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
@@ -94,5 +93,4 @@
       </script>
     </div>
   </div>
-</div>
 {% endblock %}

--- a/financeiro/templates/financeiro/repasses.html
+++ b/financeiro/templates/financeiro/repasses.html
@@ -8,8 +8,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="container mx-auto p-6">
-  <div class="card">
+  <div class="py-12 card px-4">
     <div class="card-header">
       <form id="filtros" class="flex gap-4" hx-get="/api/financeiro/repasses/" hx-target="#lista" hx-swap="none" hx-trigger="change from:select,change from:input, submit" hx-on="htmx:afterRequest: renderRepasses(event)">
         <div>
@@ -66,5 +65,4 @@
       </script>
     </div>
   </div>
-</div>
 {% endblock %}

--- a/notificacoes/templates/notificacoes/historico_list.html
+++ b/notificacoes/templates/notificacoes/historico_list.html
@@ -3,8 +3,7 @@
 {% block title %}{% trans 'Histórico de Notificações' %} | HubX{% endblock %}
 {% block content %}
 
-<div class="container mx-auto p-6">
-  <div class="max-w-6xl mx-auto space-y-6">
+  <div class="py-12 max-w-6xl mx-auto space-y-6 px-4">
     <h1 class="text-2xl font-bold text-[var(--text-primary)]">{% trans 'Histórico de Notificações' %}</h1>
     <div class="card">
       <div class="card-body">
@@ -20,5 +19,4 @@
       {% include 'notificacoes/historico_table.html' %}
     </div>
   </div>
-</div>
 {% endblock %}

--- a/notificacoes/templates/notificacoes/logs_list.html
+++ b/notificacoes/templates/notificacoes/logs_list.html
@@ -2,8 +2,7 @@
 {% load i18n %}
 {% block title %}{% trans 'Logs de Notificação' %} | HubX{% endblock %}
 {% block content %}
-<div class="container mx-auto p-6">
-  <div class="max-w-6xl mx-auto space-y-6">
+  <div class="py-12 max-w-6xl mx-auto space-y-6 px-4">
     <h1 class="text-2xl font-bold text-[var(--text-primary)]">{% trans 'Logs de Notificação' %}</h1>
     <div class="card">
       <div class="card-body">
@@ -19,5 +18,4 @@
       {% include 'notificacoes/logs_table.html' %}
     </div>
   </div>
-</div>
 {% endblock %}

--- a/notificacoes/templates/notificacoes/metrics.html
+++ b/notificacoes/templates/notificacoes/metrics.html
@@ -3,8 +3,7 @@
 
 {% block title %}{% trans 'Métricas de Notificações' %} | HubX{% endblock %}
 {% block content %}
-<div class="container mx-auto p-6">
-  <div class="max-w-6xl mx-auto space-y-6">
+  <div class="py-12 max-w-6xl mx-auto space-y-6 px-4">
     <h1 class="text-2xl font-bold text-[var(--text-primary)]">{% trans 'Métricas de Notificações' %}</h1>
     <div class="card">
       <div class="card-body">
@@ -36,5 +35,4 @@
       <p class="text-[var(--text-secondary)]">{% trans 'Total de templates' %}: {{ templates_total|default:0 }}</p>
     </div>
   </div>
-</div>
 {% endblock %}

--- a/notificacoes/templates/notificacoes/template_confirm_delete.html
+++ b/notificacoes/templates/notificacoes/template_confirm_delete.html
@@ -2,8 +2,7 @@
 {% load i18n %}
 {% block title %}{% trans 'Confirmar exclusão' %} | HubX{% endblock %}
 {% block content %}
-<div class="container mx-auto p-6">
-  <div class="max-w-2xl mx-auto">
+  <div class="py-12 max-w-2xl mx-auto px-4">
     <div class="card">
       <div class="card-body space-y-4">
         <h1 class="text-2xl font-bold text-[var(--text-primary)]">{% trans 'Confirmar exclusão' %}</h1>
@@ -16,5 +15,4 @@
       </div>
     </div>
   </div>
-</div>
 {% endblock %}

--- a/notificacoes/templates/notificacoes/template_form.html
+++ b/notificacoes/templates/notificacoes/template_form.html
@@ -2,8 +2,7 @@
 {% load i18n %}
 {% block title %}{% if form.instance.pk %}{% trans 'Editar Template' %}{% else %}{% trans 'Novo Template' %}{% endif %} | HubX{% endblock %}
 {% block content %}
-<div class="container mx-auto p-6">
-  <div class="max-w-xl mx-auto space-y-6">
+  <div class="py-12 max-w-xl mx-auto space-y-6 px-4">
     <h1 class="text-2xl font-bold text-[var(--text-primary)]">{% if form.instance.pk %}{% trans 'Editar Template' %}{% else %}{% trans 'Cadastrar Template' %}{% endif %}</h1>
     {% if messages %}
     <div class="space-y-2" aria-live="polite">
@@ -27,5 +26,4 @@
       </div>
     </div>
   </div>
-</div>
 {% endblock %}

--- a/notificacoes/templates/notificacoes/templates_list.html
+++ b/notificacoes/templates/notificacoes/templates_list.html
@@ -6,8 +6,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="container mx-auto p-6">
-  <div class="max-w-6xl mx-auto space-y-6">
+  <div class="py-12 max-w-6xl mx-auto space-y-6 px-4">
     {% if messages %}
     <div class="space-y-2" aria-live="polite">
       {% for message in messages %}
@@ -67,5 +66,4 @@
       <p class="text-center text-[var(--text-secondary)]">{% trans 'Nenhum template cadastrado.' %}</p>
     {% endif %}
   </div>
-</div>
 {% endblock %}

--- a/nucleos/templates/nucleos/meus_list.html
+++ b/nucleos/templates/nucleos/meus_list.html
@@ -8,8 +8,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="container mx-auto p-6">
-<section class="max-w-5xl mx-auto py-8">
+<section class="max-w-5xl mx-auto py-12 px-4">
   <form method="get" class="mb-4 flex gap-2">
     <input type="text" name="q" value="{{ form.q.value }}" placeholder="{% trans 'Buscar...' %}" class="border border-[var(--border)] bg-[var(--bg-secondary)] rounded px-2 py-1 flex-1" />
     <button class="btn btn-primary" aria-label="{% trans 'Buscar núcleos' %}">{% trans 'Buscar' %}</button>
@@ -43,5 +42,4 @@
   </div>
   {% include '_partials/pagination.html' with page_obj=page_obj querystring=querystring %}
 </section>
-</div>
 {% endblock %}

--- a/nucleos/templates/nucleos/nucleo_list.html
+++ b/nucleos/templates/nucleos/nucleo_list.html
@@ -8,8 +8,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="container mx-auto p-6">
-  <div class="card">
+  <div class="py-12 card px-4">
     <div class="card-header space-y-4">
       {% include '_components/search_form.html' with q=request.GET.q %}
       {% if request.user.user_type != 'admin' %}
@@ -37,5 +36,4 @@
       {% include '_partials/pagination.html' with page_obj=page_obj querystring=querystring %}
     </div>
   </div>
-</div>
 {% endblock %}

--- a/organizacoes/templates/organizacoes/list.html
+++ b/organizacoes/templates/organizacoes/list.html
@@ -8,9 +8,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="container mx-auto p-6">
-<section class="max-w-6xl mx-auto px-4 py-10" id="org-list">
+<section class="py-12 max-w-6xl mx-auto px-4 py-10" id="org-list">
     {% include '_partials/organizacoes/list_section.html' %}
 </section>
-</div>
 {% endblock %}

--- a/organizacoes/templates/organizacoes/update.html
+++ b/organizacoes/templates/organizacoes/update.html
@@ -8,8 +8,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="container mx-auto p-6">
-  <div class="max-w-2xl mx-auto">
+  <div class="py-12 max-w-2xl mx-auto px-4">
     <div class="card">
       <div class="card-body">
         {% if messages %}
@@ -46,6 +45,5 @@
       <a href="{% url 'organizacoes:list' %}" class="text-sm text-primary hover:underline">{% trans "Voltar à lista" %}</a>
     </div>
   </div>
-</div>
 {% endblock %}
 

--- a/tokens/templates/tokens/api_tokens.html
+++ b/tokens/templates/tokens/api_tokens.html
@@ -7,7 +7,6 @@
 {% endblock %}
 
 {% block content %}
-<div class="container mx-auto p-6">
 <div class="max-w-3xl mx-auto px-4 py-12 card-grid">
   <div class="card">
     <div class="card-header">
@@ -83,6 +82,5 @@
       </div>
     </div>
   </div>
-</div>
 </div>
 {% endblock %}

--- a/tokens/templates/tokens/ativar_2fa.html
+++ b/tokens/templates/tokens/ativar_2fa.html
@@ -8,8 +8,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="container mx-auto p-6">
-  <div class="card">
+  <div class="py-12 card px-4">
     <div class="card-body">
       {% if messages %}
         <div class="mb-4 space-y-2 text-center">
@@ -48,5 +47,4 @@
       </footer>
     </div>
   </div>
-</div>
 {% endblock %}

--- a/tokens/templates/tokens/listar_convites.html
+++ b/tokens/templates/tokens/listar_convites.html
@@ -8,9 +8,8 @@
 
 {% block content %}
 
-<div class="container mx-auto p-6">
 
-<section class="max-w-6xl mx-auto mt-8 px-4">
+<section class="py-12 max-w-6xl mx-auto mt-8 px-4">
   <div class="flex items-center justify-between gap-4 mb-6">
     <h1 class="text-2xl font-bold">{% trans "Convites Emitidos" %}</h1>
     <a href="{% url 'tokens:gerar_convite' %}"
@@ -80,5 +79,4 @@
     <a href="{% url 'configuracoes' %}" class="text-sm text-blue-600 hover:underline">{% trans "Voltar ao painel de segurança" %}</a>
   </div>
 </section>
-</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- remove nested `container mx-auto p-6` wrappers and rely on base layout
- apply `py-12 px-4` spacing to top-level sections and cards

## Testing
- `pytest` *(fails: 81 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c1827a4b6c83259d8abf678ff0ab55