### PR TITLE
refactor: align organization detail template with design system

### DIFF
--- a/organizacoes/templates/organizacoes/detail.html
+++ b/organizacoes/templates/organizacoes/detail.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <section class="max-w-4xl mx-auto px-4 py-10 space-y-6">
-  <div class="w-full h-40 bg-neutral-200 rounded-xl overflow-hidden">
+  <div class="w-full h-40 bg-[var(--bg-secondary)] rounded-xl overflow-hidden">
     {% if object.cover %}
       <img src="{{ object.cover.url }}" alt="{{ object.nome }}" class="w-full h-full object-cover">
     {% endif %}
@@ -14,47 +14,47 @@
     {% if object.avatar %}
       <img src="{{ object.avatar.url }}" alt="{{ object.nome }}" class="w-24 h-24 rounded-full object-cover mx-auto mb-4">
     {% else %}
-      <div class="w-24 h-24 bg-neutral-200 rounded-full flex items-center justify-center mx-auto mb-4 text-xl font-semibold text-neutral-600" role="img" aria-label="{{ object.nome }}">
+      <div class="w-24 h-24 bg-[var(--bg-secondary)] rounded-full flex items-center justify-center mx-auto mb-4 text-xl font-semibold text-[var(--text-tertiary)]" role="img" aria-label="{{ object.nome }}">
         {{ object.nome|make_list|first|upper }}
       </div>
     {% endif %}
     <div class="flex items-center justify-center">
-      <h1 class="text-2xl font-bold text-neutral-900">{{ object.nome }}</h1>
+      <h1 class="text-2xl font-bold text-[var(--text-primary)]">{{ object.nome }}</h1>
       {% if object.inativa %}
-        <span class="ml-2 text-xs bg-yellow-200 text-yellow-800 px-2 py-0.5 rounded">{% trans 'Inativa' %}</span>
+        <span class="ml-2 text-xs bg-[var(--warning-light)] text-[var(--warning)] px-2 py-0.5 rounded">{% trans 'Inativa' %}</span>
       {% endif %}
     </div>
   </div>
 
   <section>
-    <dl class="divide-y divide-neutral-200">
-      <div class="py-4 grid grid-cols-3 gap-4">
-        <dt class="font-medium text-neutral-700">{% trans 'CNPJ' %}</dt>
-        <dd class="col-span-2 text-neutral-900">{{ object.cnpj }}</dd>
+    <dl class="divide-y divide-[var(--border)]">
+      <div class="py-4 grid grid-cols-1 gap-4">
+        <dt class="font-medium text-[var(--text-secondary)]">{% trans 'CNPJ' %}</dt>
+        <dd class="text-[var(--text-primary)]">{{ object.cnpj }}</dd>
       </div>
-      <div class="py-4 grid grid-cols-3 gap-4">
-        <dt class="font-medium text-neutral-700">{% trans 'Tipo' %}</dt>
-        <dd class="col-span-2 text-neutral-900">{{ object.get_tipo_display }}</dd>
+      <div class="py-4 grid grid-cols-1 gap-4">
+        <dt class="font-medium text-[var(--text-secondary)]">{% trans 'Tipo' %}</dt>
+        <dd class="text-[var(--text-primary)]">{{ object.get_tipo_display }}</dd>
       </div>
-      <div class="py-4 grid grid-cols-3 gap-4">
-        <dt class="font-medium text-neutral-700">{% trans 'Endereço' %}</dt>
-        <dd class="col-span-2 text-neutral-900">
+      <div class="py-4 grid grid-cols-1 gap-4">
+        <dt class="font-medium text-[var(--text-secondary)]">{% trans 'Endereço' %}</dt>
+        <dd class="text-[var(--text-primary)]">
           {{ object.rua }}<br>
           {{ object.cidade }}{% if object.estado %}/{{ object.estado }}{% endif %}
         </dd>
       </div>
-      <div class="py-4 grid grid-cols-3 gap-4">
-        <dt class="font-medium text-neutral-700">{% trans 'Contato' %}</dt>
-        <dd class="col-span-2 text-neutral-900">
+      <div class="py-4 grid grid-cols-1 gap-4">
+        <dt class="font-medium text-[var(--text-secondary)]">{% trans 'Contato' %}</dt>
+        <dd class="text-[var(--text-primary)]">
           {{ object.contato_nome }}<br>
           {{ object.contato_email }}<br>
           {{ object.contato_telefone }}
         </dd>
       </div>
       {% if object.descricao %}
-      <div class="py-4 grid grid-cols-3 gap-4">
-        <dt class="font-medium text-neutral-700">{% trans 'Descrição' %}</dt>
-        <dd class="col-span-2 text-neutral-900">{{ object.descricao }}</dd>
+      <div class="py-4 grid grid-cols-1 gap-4">
+        <dt class="font-medium text-[var(--text-secondary)]">{% trans 'Descrição' %}</dt>
+        <dd class="text-[var(--text-primary)]">{{ object.descricao }}</dd>
       </div>
       {% endif %}
     </dl>
@@ -62,21 +62,29 @@
 
     {% if request.user.user_type == 'root' %}
     <div id="org-stats" class="card-grid">
-      <div class="card text-center">
-        <p class="text-xs text-neutral-500">{% trans 'Usuários' %}</p>
-        <p class="text-lg font-semibold text-neutral-900">{{ usuarios|length }}</p>
+      <div class="card">
+        <div class="card-body text-center">
+          <p class="text-xs text-[var(--text-muted)]">{% trans 'Usuários' %}</p>
+          <p class="text-lg font-semibold text-[var(--text-primary)]">{{ usuarios|length }}</p>
+        </div>
       </div>
-      <div class="card text-center">
-        <p class="text-xs text-neutral-500">{% trans 'Núcleos' %}</p>
-        <p class="text-lg font-semibold text-neutral-900">{{ nucleos|length }}</p>
+      <div class="card">
+        <div class="card-body text-center">
+          <p class="text-xs text-[var(--text-muted)]">{% trans 'Núcleos' %}</p>
+          <p class="text-lg font-semibold text-[var(--text-primary)]">{{ nucleos|length }}</p>
+        </div>
       </div>
-      <div class="card text-center">
-        <p class="text-xs text-neutral-500">{% trans 'Eventos' %}</p>
-        <p class="text-lg font-semibold text-neutral-900">{{ eventos|length }}</p>
+      <div class="card">
+        <div class="card-body text-center">
+          <p class="text-xs text-[var(--text-muted)]">{% trans 'Eventos' %}</p>
+          <p class="text-lg font-semibold text-[var(--text-primary)]">{{ eventos|length }}</p>
+        </div>
       </div>
-      <div class="card text-center">
-        <p class="text-xs text-neutral-500">{% trans 'Empresas' %}</p>
-        <p class="text-lg font-semibold text-neutral-900">{{ empresas|length }}</p>
+      <div class="card">
+        <div class="card-body text-center">
+          <p class="text-xs text-[var(--text-muted)]">{% trans 'Empresas' %}</p>
+          <p class="text-lg font-semibold text-[var(--text-primary)]">{{ empresas|length }}</p>
+        </div>
       </div>
     </div>
     {% endif %}
@@ -105,21 +113,21 @@
 
   <div class="flex justify-end gap-3">
     {% if perms.organizacoes.change_organizacao %}
-      <a href="{% url 'organizacoes:update' object.id %}" class="text-sm px-4 py-2 rounded-xl bg-yellow-100 text-yellow-700 hover:bg-yellow-200">{% trans 'Editar' %}</a>
+      <a href="{% url 'organizacoes:update' object.id %}" class="btn-secondary">{% trans 'Editar' %}</a>
     {% endif %}
     {% if request.user.user_type == 'root' %}
       {% if perms.organizacoes.delete_organizacao %}
-        <a href="{% url 'organizacoes:delete' object.id %}" class="text-sm px-4 py-2 rounded-xl bg-red-100 text-red-700 hover:bg-red-200">{% trans 'Excluir' %}</a>
+        <a href="{% url 'organizacoes:delete' object.id %}" class="btn-danger">{% trans 'Excluir' %}</a>
       {% endif %}
       <form method="post" action="{% url 'organizacoes:toggle' object.id %}">
         {% csrf_token %}
-        <button type="submit" class="text-sm px-4 py-2 rounded-xl bg-neutral-100 text-neutral-700 hover:bg-neutral-200">
+        <button type="submit" class="btn-secondary">
           {% if object.inativa %}{% trans 'Reativar' %}{% else %}{% trans 'Inativar' %}{% endif %}
         </button>
       </form>
-      <a href="{% url 'organizacoes:historico' object.id %}" class="text-sm px-4 py-2 rounded-xl bg-neutral-100 text-neutral-700 hover:bg-neutral-200">{% trans 'Histórico' %}</a>
+      <a href="{% url 'organizacoes:historico' object.id %}" class="btn-secondary">{% trans 'Histórico' %}</a>
     {% endif %}
-    <a href="{% url 'organizacoes:list' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100">{% trans 'Voltar' %}</a>
+    <a href="{% url 'organizacoes:list' %}" class="btn-secondary">{% trans 'Voltar' %}</a>
   </div>
   <div id="modal"></div>
 </section>


### PR DESCRIPTION
## Summary
- replace hardcoded neutral colors with design tokens
- restructure organization detail layout and stats cards
- adopt standard button classes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'freezegun')*


------
https://chatgpt.com/codex/tasks/task_e_68c18263c4c483258f6cbd0bd7ef6814