### PR TITLE
Refactor token templates to design system

### DIFF
--- a/tokens/templates/tokens/_resultado.html
+++ b/tokens/templates/tokens/_resultado.html
@@ -1,14 +1,14 @@
 {% load i18n %}
 {% if codigo %}
-  <div class="bg-green-100 text-green-700 p-3 rounded" role="status">
+  <div class="p-3 rounded bg-[var(--success-light)] text-[var(--success)]" role="status">
     {% trans "Código gerado:" %} <code class="font-mono text-lg">{{ codigo }}</code>
   </div>
 {% elif token %}
-  <div class="bg-green-100 text-green-700 p-3 rounded" role="status">
+  <div class="p-3 rounded bg-[var(--success-light)] text-[var(--success)]" role="status">
     {% trans "Token:" %} <code class="font-mono break-all">{{ token }}</code>
   </div>
 {% elif success %}
-  <div class="bg-green-100 text-green-700 p-3 rounded" role="status">{{ success }}</div>
+  <div class="p-3 rounded bg-[var(--success-light)] text-[var(--success)]" role="status">{{ success }}</div>
 {% elif error %}
-  <div class="bg-red-100 text-red-700 p-3 rounded" role="alert">{{ error }}</div>
+  <div class="p-3 rounded bg-[var(--error-light)] text-[var(--error)]" role="alert">{{ error }}</div>
 {% endif %}

--- a/tokens/templates/tokens/api_tokens.html
+++ b/tokens/templates/tokens/api_tokens.html
@@ -7,8 +7,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="container mx-auto p-6">
-<div class="max-w-3xl mx-auto px-4 py-12 card-grid">
+<div class="max-w-3xl mx-auto card-grid">
   <div class="card">
     <div class="card-header">
       <h2 class="text-xl font-semibold">{% trans "Tokens de API" %}</h2>
@@ -58,31 +57,20 @@
         {% csrf_token %}
         <div class="space-y-4">
           {% for field in form %}
-          <div>
-            <label for="{{ field.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ field.label }}</label>
-            {% if field.field.widget.input_type == 'select' %}
-              {{ field|add_class:"form-select" }}
-            {% else %}
-              {{ field|add_class:"form-input" }}
-            {% endif %}
-            {% if field.errors %}
-              <p class="text-red-500 text-xs mt-1">{{ field.errors }}</p>
-            {% endif %}
-          </div>
+            {% include '_forms/field.html' %}
           {% endfor %}
         </div>
         <div class="flex justify-end gap-3 pt-4 border-t border-neutral-100">
-          <button type="submit" class="text-sm px-4 py-2 rounded-xl bg-primary-600 text-white hover:bg-primary-700">{% trans "Gerar Token" %}</button>
+          <button type="submit" class="btn btn-primary">{% trans "Gerar Token" %}</button>
         </div>
       </form>
       <div id="resultado" class="mt-6 text-center" aria-live="polite">
         {% include "tokens/_resultado.html" %}
       </div>
       <div class="mt-6 text-center">
-        <a href="{% url 'configuracoes' %}" class="text-sm text-blue-600 hover:underline">{% trans "Voltar ao painel de segurança" %}</a>
+        <a href="{% url 'configuracoes' %}" class="text-sm text-[var(--primary)] hover:underline">{% trans "Voltar ao painel de segurança" %}</a>
       </div>
     </div>
   </div>
-</div>
 </div>
 {% endblock %}

--- a/tokens/templates/tokens/ativar_2fa.html
+++ b/tokens/templates/tokens/ativar_2fa.html
@@ -8,13 +8,13 @@
 {% endblock %}
 
 {% block content %}
-<div class="container mx-auto p-6">
+<div class="max-w-md mx-auto">
   <div class="card">
     <div class="card-body">
       {% if messages %}
         <div class="mb-4 space-y-2 text-center">
           {% for message in messages %}
-            <p role="alert" class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-green-100 text-green-700{% else %}bg-red-100 text-red-700{% endif %}">
+            <p role="alert" class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-[var(--success-light)] text-[var(--success)]{% else %}bg-[var(--error-light)] text-[var(--error)]{% endif %}">
               {{ message }}
             </p>
           {% endfor %}
@@ -26,25 +26,21 @@
           <img src="data:image/png;base64,{{ qr_code }}" alt="{% trans 'QR Code' %}" class="w-40 h-40" />
           <p class="mt-2 text-sm font-mono">{{ secret }}</p>
         </div>
-        <p class="text-sm text-neutral-600 mb-4 text-center">{% trans "Escaneie o QR Code no aplicativo autenticador ou digite o código exibido." %}</p>
+        <p class="text-sm text-[var(--text-secondary)] mb-4 text-center">{% trans "Escaneie o QR Code no aplicativo autenticador ou digite o código exibido." %}</p>
       {% endif %}
 
-      <form method="post" action="{% url 'tokens:ativar_2fa' %}" class="bg-white rounded-2xl shadow p-6 space-y-4">
+      <form method="post" action="{% url 'tokens:ativar_2fa' %}" class="space-y-4">
         {% csrf_token %}
-        <div class="relative">
-          <label for="{{ form.codigo_totp.id_for_label }}" class="label-float">{{ form.codigo_totp.label }}</label>
-          {{ form.codigo_totp|add_class:"peer placeholder-transparent form-input"|attr:"autofocus required pattern=\\d+ inputmode=numeric" }}
-          {% if form.codigo_totp.errors %}
-            <p role="alert" class="text-sm text-red-600 mt-1">{{ form.codigo_totp.errors.0 }}</p>
-          {% endif %}
-        </div>
+        {% for field in form %}
+          {% include '_forms/field.html' %}
+        {% endfor %}
         <div class="text-right">
           <button type="submit" class="btn btn-primary">{% trans "Ativar" %}</button>
         </div>
       </form>
 
       <footer class="mt-6 text-center">
-        <a href="{% url 'configuracoes' %}" class="text-sm text-blue-600 hover:underline">{% trans "Voltar ao perfil de segurança" %}</a>
+        <a href="{% url 'configuracoes' %}" class="text-sm text-[var(--primary)] hover:underline">{% trans "Voltar ao perfil de segurança" %}</a>
       </footer>
     </div>
   </div>

--- a/tokens/templates/tokens/desativar_2fa.html
+++ b/tokens/templates/tokens/desativar_2fa.html
@@ -4,25 +4,29 @@
 {% block title %}{% trans "Desativar 2FA" %} | HubX{% endblock %}
 
 {% block content %}
-<section class="max-w-md mx-auto px-4 py-12">
-  <header class="text-center mb-6">
-    <h1 class="text-2xl font-bold">{% trans "Desativar Autenticação de Dois Fatores" %}</h1>
-    <p class="text-sm text-neutral-600 mt-2">
-      {% trans "Confirme para desativar a autenticação em duas etapas." %}
-    </p>
-  </header>
-  <form method="post" action="" class="bg-white rounded-2xl shadow p-6 space-y-4">
-    {% csrf_token %}
-    <div class="text-right">
-      <button type="submit" class="rounded-xl bg-[var(--error)] px-4 py-2 text-white hover:opacity-90">
-        {% trans "Desativar" %}
-      </button>
+<div class="max-w-md mx-auto">
+  <div class="card">
+    <div class="card-body">
+      <header class="text-center mb-6">
+        <h1 class="text-2xl font-bold">{% trans "Desativar Autenticação de Dois Fatores" %}</h1>
+        <p class="mt-2 text-sm text-[var(--text-secondary)]">
+          {% trans "Confirme para desativar a autenticação em duas etapas." %}
+        </p>
+      </header>
+      <form method="post" action="" class="space-y-4">
+        {% csrf_token %}
+        <div class="text-right">
+          <button type="submit" class="btn btn-primary">
+            {% trans "Desativar" %}
+          </button>
+        </div>
+      </form>
+      <footer class="mt-6 text-center">
+        <a href="{% url 'configuracoes' %}" class="text-sm text-[var(--primary)] hover:underline">
+          {% trans "Voltar ao perfil de segurança" %}
+        </a>
+      </footer>
     </div>
-  </form>
-  <footer class="mt-6 text-center">
-    <a href="{% url 'configuracoes' %}" class="text-sm text-[var(--primary)] hover:underline">
-      {% trans "Voltar ao perfil de segurança" %}
-    </a>
-  </footer>
-</section>
+  </div>
+</div>
 {% endblock %}

--- a/tokens/templates/tokens/gerar_codigo_autenticacao.html
+++ b/tokens/templates/tokens/gerar_codigo_autenticacao.html
@@ -4,45 +4,35 @@
 {% block title %}{% trans "Gerar Código de Autenticação" %} | HubX{% endblock %}
 
 {% block content %}
-<section class="max-w-md mx-auto px-4 py-12">
-  <header class="text-center mb-6">
-    <h1 class="text-2xl font-bold">{% trans "Gerar Código de Autenticação" %}</h1>
-    <p class="text-sm text-neutral-600 mt-2">{% trans "Gere um código temporário para validar sua identidade." %}</p>
-  </header>
+<div class="max-w-md mx-auto">
+  <div class="card">
+    <div class="card-body">
+      <header class="text-center mb-6">
+        <h1 class="text-2xl font-bold">{% trans "Gerar Código de Autenticação" %}</h1>
+        <p class="mt-2 text-sm text-[var(--text-secondary)]">{% trans "Gere um código temporário para validar sua identidade." %}</p>
+      </header>
 
-  <form method="post" action="{% url 'tokens:gerar_codigo' %}"
-        hx-post="{% url 'tokens:gerar_codigo' %}"
-        hx-target="#resultado" hx-swap="innerHTML"
-        class="bg-white rounded-2xl shadow p-6 space-y-4">
-    {% csrf_token %}
-    {% for field in form %}
-      <div>
-        <label for="{{ field.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ field.label }}</label>
-        {% if field.field.widget.input_type == 'select' %}
-          {{ field|add_class:"form-select"|attr:"required" }}
-        {% else %}
-          {% if forloop.first %}
-            {{ field|add_class:"form-input"|attr:"autofocus required" }}
-          {% else %}
-            {{ field|add_class:"form-input"|attr:"required" }}
-          {% endif %}
-        {% endif %}
-        {% if field.errors %}
-          <p class="text-sm text-red-600 mt-1">{{ field.errors.0 }}</p>
-        {% endif %}
+      <form method="post" action="{% url 'tokens:gerar_codigo' %}"
+            hx-post="{% url 'tokens:gerar_codigo' %}"
+            hx-target="#resultado" hx-swap="innerHTML"
+            class="space-y-4">
+        {% csrf_token %}
+        {% for field in form %}
+          {% include '_forms/field.html' %}
+        {% endfor %}
+        <div class="text-right">
+          <button type="submit" class="btn btn-primary">{% trans "Gerar Código" %}</button>
+        </div>
+      </form>
+
+      <div id="resultado" class="mt-6 text-center" aria-live="polite">
+        {% include "tokens/_resultado.html" %}
       </div>
-    {% endfor %}
-    <div class="text-right">
-      <button type="submit" class="rounded-xl bg-primary px-4 py-2 text-white hover:bg-primary/90">{% trans "Gerar Código" %}</button>
+
+      <footer class="mt-6 text-center">
+        <a href="{% url 'configuracoes' %}" class="text-sm text-[var(--primary)] hover:underline">{% trans "Voltar ao painel de segurança" %}</a>
+      </footer>
     </div>
-  </form>
-
-  <div id="resultado" class="mt-6 text-center" aria-live="polite">
-    {% include "tokens/_resultado.html" %}
   </div>
-
-  <footer class="mt-6 text-center">
-    <a href="{% url 'configuracoes' %}" class="text-sm text-blue-600 hover:underline">{% trans "Voltar ao painel de segurança" %}</a>
-  </footer>
-</section>
+</div>
 {% endblock %}

--- a/tokens/templates/tokens/gerar_token.html
+++ b/tokens/templates/tokens/gerar_token.html
@@ -3,53 +3,43 @@
 {% block title %}{% trans "Gerar Token de Acesso" %} | HubX{% endblock %}
 
 {% block content %}
-<section class="max-w-xl mx-auto px-4 py-10">
-  <header class="mb-6 text-center">
-    <h1 class="text-2xl font-bold text-neutral-900">{% trans "Gerar Token de Acesso" %}</h1>
-    <p class="text-sm text-neutral-600 mt-2">{% trans "Use este token para convidar novos membros ou recuperar o acesso." %}</p>
-  </header>
+<div class="max-w-xl mx-auto">
+  <div class="card">
+    <div class="card-body">
+      <header class="mb-6 text-center">
+        <h1 class="text-2xl font-bold">{% trans "Gerar Token de Acesso" %}</h1>
+        <p class="mt-2 text-sm text-[var(--text-secondary)]">{% trans "Use este token para convidar novos membros ou recuperar o acesso." %}</p>
+      </header>
 
-  <form method="post" action="{% url 'tokens:gerar_convite' %}"
-        hx-post="{% url 'tokens:gerar_convite' %}"
-        hx-target="#resultado" hx-swap="innerHTML"
-        class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 space-y-6">
-    {% csrf_token %}
+      <form method="post" action="{% url 'tokens:gerar_convite' %}"
+            hx-post="{% url 'tokens:gerar_convite' %}"
+            hx-target="#resultado" hx-swap="innerHTML"
+            class="space-y-6">
+        {% csrf_token %}
 
-    <div class="space-y-4">
-      {% for field in form %}
-        {% if user.user_type != 'root' or field.name != 'nucleos' %}
-          <div>
-            <label for="{{ field.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ field.label }}</label>
-            {% if field.field.widget.input_type == 'select' %}
-              {{ field|add_class:"form-select"|attr:"required" }}
-            {% else %}
-              {% if forloop.first %}
-                {{ field|add_class:"form-input"|attr:"autofocus required" }}
-              {% else %}
-                {{ field|add_class:"form-input"|attr:"required" }}
-              {% endif %}
+        <div class="space-y-4">
+          {% for field in form %}
+            {% if user.user_type != 'root' or field.name != 'nucleos' %}
+              {% include '_forms/field.html' %}
             {% endif %}
-            {% if field.errors %}
-              <p class="text-red-500 text-xs mt-1">{{ field.errors }}</p>
-            {% endif %}
-          </div>
-        {% endif %}
-      {% endfor %}
-    </div>
+          {% endfor %}
+        </div>
 
-    <div class="flex justify-end gap-3 pt-4 border-t border-neutral-100">
-      <button type="submit" class="text-sm px-4 py-2 rounded-xl bg-primary-600 text-white hover:bg-primary-700">
-        {% trans "Gerar Token" %}
-      </button>
-    </div>
-  </form>
+        <div class="flex justify-end gap-3 pt-4 border-t border-neutral-100">
+          <button type="submit" class="btn btn-primary">
+            {% trans "Gerar Token" %}
+          </button>
+        </div>
+      </form>
 
-  <div id="resultado" class="mt-6 text-center" aria-live="polite">
-    {% include "tokens/_resultado.html" %}
+      <div id="resultado" class="mt-6 text-center" aria-live="polite">
+        {% include "tokens/_resultado.html" %}
+      </div>
+
+      <footer class="mt-6 text-center">
+        <a href="{% url 'configuracoes' %}" class="text-sm text-[var(--primary)] hover:underline">{% trans "Voltar ao painel de segurança" %}</a>
+      </footer>
+    </div>
   </div>
-
-  <footer class="mt-6 text-center">
-    <a href="{% url 'configuracoes' %}" class="text-sm text-blue-600 hover:underline">{% trans "Voltar ao painel de segurança" %}</a>
-  </footer>
-</section>
+</div>
 {% endblock %}

--- a/tokens/templates/tokens/validar_codigo_autenticacao.html
+++ b/tokens/templates/tokens/validar_codigo_autenticacao.html
@@ -4,35 +4,35 @@
 {% block title %}{% trans "Validar Código de Autenticação" %} | HubX{% endblock %}
 
 {% block content %}
-<section class="max-w-md mx-auto px-4 py-12">
-  <header class="text-center mb-6">
-    <h1 class="text-2xl font-bold">{% trans "Validar Código de Autenticação" %}</h1>
-    <p class="text-sm text-neutral-600 mt-2">{% trans "Informe o código recebido para concluir a validação." %}</p>
-  </header>
+<div class="max-w-md mx-auto">
+  <div class="card">
+    <div class="card-body">
+      <header class="text-center mb-6">
+        <h1 class="text-2xl font-bold">{% trans "Validar Código de Autenticação" %}</h1>
+        <p class="mt-2 text-sm text-[var(--text-secondary)]">{% trans "Informe o código recebido para concluir a validação." %}</p>
+      </header>
 
-  <form method="post" action="{% url 'tokens:validar_codigo' %}"
-        hx-post="{% url 'tokens:validar_codigo' %}"
-        hx-target="#resultado" hx-swap="innerHTML"
-        class="bg-white rounded-2xl shadow p-6 space-y-4">
-    {% csrf_token %}
-    <div>
-      <label for="{{ form.codigo.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.codigo.label }}</label>
-      {{ form.codigo|add_class:"form-input text-center tracking-widest"|attr:"autofocus required pattern=\\d+ inputmode=numeric" }}
-      {% if form.codigo.errors %}
-        <p class="text-sm text-red-600 mt-1">{{ form.codigo.errors.0 }}</p>
-      {% endif %}
-    </div>
-    <div class="text-right">
-      <button type="submit" class="rounded-xl bg-primary px-4 py-2 text-white hover:bg-primary/90">{% trans "Validar Código" %}</button>
-    </div>
-  </form>
+      <form method="post" action="{% url 'tokens:validar_codigo' %}"
+            hx-post="{% url 'tokens:validar_codigo' %}"
+            hx-target="#resultado" hx-swap="innerHTML"
+            class="space-y-4">
+        {% csrf_token %}
+        {% for field in form %}
+          {% include '_forms/field.html' %}
+        {% endfor %}
+        <div class="text-right">
+          <button type="submit" class="btn btn-primary">{% trans "Validar Código" %}</button>
+        </div>
+      </form>
 
-  <div id="resultado" class="mt-6 text-center" aria-live="polite">
-    {% include "tokens/_resultado.html" %}
+      <div id="resultado" class="mt-6 text-center" aria-live="polite">
+        {% include "tokens/_resultado.html" %}
+      </div>
+
+      <footer class="mt-6 text-center">
+        <a href="{% url 'configuracoes' %}" class="text-sm text-[var(--primary)] hover:underline">{% trans "Voltar ao painel de segurança" %}</a>
+      </footer>
+    </div>
   </div>
-
-  <footer class="mt-6 text-center">
-    <a href="{% url 'configuracoes' %}" class="text-sm text-blue-600 hover:underline">{% trans "Voltar ao painel de segurança" %}</a>
-  </footer>
-</section>
+</div>
 {% endblock %}

--- a/tokens/templates/tokens/validar_token.html
+++ b/tokens/templates/tokens/validar_token.html
@@ -4,35 +4,35 @@
 {% block title %}{% trans "Validar Token de Convite" %} | HubX{% endblock %}
 
 {% block content %}
-<section class="max-w-md mx-auto px-4 py-12">
-  <header class="text-center mb-6">
-    <h1 class="text-2xl font-bold">{% trans "Validar Token de Convite" %}</h1>
-    <p class="text-sm text-neutral-600 mt-2">{% trans "Informe o token recebido para concluir o convite." %}</p>
-  </header>
+<div class="max-w-md mx-auto">
+  <div class="card">
+    <div class="card-body">
+      <header class="text-center mb-6">
+        <h1 class="text-2xl font-bold">{% trans "Validar Token de Convite" %}</h1>
+        <p class="mt-2 text-sm text-[var(--text-secondary)]">{% trans "Informe o token recebido para concluir o convite." %}</p>
+      </header>
 
-  <form method="post" action="{% url 'tokens:validar_token' %}"
-        hx-post="{% url 'tokens:validar_token' %}"
-        hx-target="#resultado" hx-swap="innerHTML"
-        class="bg-white rounded-2xl shadow p-6 space-y-4">
-    {% csrf_token %}
-    <div>
-      <label for="{{ form.codigo.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.codigo.label }}</label>
-      {{ form.codigo|add_class:"form-input"|attr:"autofocus required" }}
-      {% if form.codigo.errors %}
-        <p class="text-sm text-red-600 mt-1">{{ form.codigo.errors.0 }}</p>
-      {% endif %}
-    </div>
-    <div class="text-right">
-      <button type="submit" class="rounded-xl bg-primary px-4 py-2 text-white hover:bg-primary/90">{% trans "Validar Token" %}</button>
-    </div>
-  </form>
+      <form method="post" action="{% url 'tokens:validar_token' %}"
+            hx-post="{% url 'tokens:validar_token' %}"
+            hx-target="#resultado" hx-swap="innerHTML"
+            class="space-y-4">
+        {% csrf_token %}
+        {% for field in form %}
+          {% include '_forms/field.html' %}
+        {% endfor %}
+        <div class="text-right">
+          <button type="submit" class="btn btn-primary">{% trans "Validar Token" %}</button>
+        </div>
+      </form>
 
-  <div id="resultado" class="mt-6 text-center" aria-live="polite">
-    {% include "tokens/_resultado.html" %}
+      <div id="resultado" class="mt-6 text-center" aria-live="polite">
+        {% include "tokens/_resultado.html" %}
+      </div>
+
+      <footer class="mt-6 text-center">
+        <a href="{% url 'configuracoes' %}" class="text-sm text-[var(--primary)] hover:underline">{% trans "Voltar ao painel de segurança" %}</a>
+      </footer>
+    </div>
   </div>
-
-  <footer class="mt-6 text-center">
-    <a href="{% url 'configuracoes' %}" class="text-sm text-blue-600 hover:underline">{% trans "Voltar ao painel de segurança" %}</a>
-  </footer>
-</section>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- wrap token templates in design system cards and remove extra container wrappers
- use shared `_forms/field.html` and standard button classes
- style alerts with design system variables

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'silk')*

------
https://chatgpt.com/codex/tasks/task_e_68c18230e5f483259dd7089c5cb65f60