### PR TITLE
Refatora templates de tokens para design system

### DIFF
--- a/tokens/templates/tokens/api_tokens.html
+++ b/tokens/templates/tokens/api_tokens.html
@@ -16,26 +16,26 @@
     <div class="card-body">
       {% if tokens %}
       <div class="overflow-x-auto">
-        <table class="min-w-full divide-y divide-neutral-200">
-          <thead class="bg-neutral-50">
+        <table class="min-w-full divide-y divide-[var(--border)]">
+          <thead class="bg-[var(--bg-secondary)]">
             <tr>
-              <th class="px-4 py-2 text-left text-sm font-medium text-neutral-700">{% trans "Cliente" %}</th>
-              <th class="px-4 py-2 text-left text-sm font-medium text-neutral-700">{% trans "Escopo" %}</th>
-              <th class="px-4 py-2 text-left text-sm font-medium text-neutral-700">{% trans "Ações" %}</th>
+              <th class="px-4 py-2 text-left text-sm font-medium text-[var(--text-primary)]">{% trans "Cliente" %}</th>
+              <th class="px-4 py-2 text-left text-sm font-medium text-[var(--text-primary)]">{% trans "Escopo" %}</th>
+              <th class="px-4 py-2 text-left text-sm font-medium text-[var(--text-primary)]">{% trans "Ações" %}</th>
             </tr>
           </thead>
-          <tbody class="divide-y divide-neutral-200">
+          <tbody class="divide-y divide-[var(--border)]">
             {% for token in tokens %}
             <tr>
-              <td class="px-4 py-2 text-sm text-neutral-900">{{ token.client_name }}</td>
-              <td class="px-4 py-2 text-sm text-neutral-900">{{ token.get_scope_display }}</td>
+              <td class="px-4 py-2 text-sm text-[var(--text-primary)]">{{ token.client_name }}</td>
+              <td class="px-4 py-2 text-sm text-[var(--text-primary)]">{{ token.get_scope_display }}</td>
               <td class="px-4 py-2 text-sm">
                 {% if token.revoked_at %}
-                  <span class="text-neutral-400">{% trans "Revogado" %}</span>
+                  <span class="text-[var(--text-secondary)]">{% trans "Revogado" %}</span>
                 {% else %}
                 <form method="post" action="{% url 'tokens:revogar_api_token' token.id %}" hx-confirm="{% trans 'Confirmar revogação?' %}">
                   {% csrf_token %}
-                  <button type="submit" class="text-red-600 hover:underline">{% trans "Revogar" %}</button>
+                  <button type="submit" class="btn btn-secondary">{% trans "Revogar" %}</button>
                 </form>
                 {% endif %}
               </td>
@@ -45,7 +45,7 @@
         </table>
       </div>
       {% else %}
-        <p class="text-sm text-neutral-600">{% trans "Nenhum token de API encontrado." %}</p>
+        <p class="text-sm text-[var(--text-secondary)]">{% trans "Nenhum token de API encontrado." %}</p>
       {% endif %}
     </div>
   </div>
@@ -56,23 +56,11 @@
     <div class="card-body">
       <form method="post" action="{% url 'tokens:gerar_api_token' %}" hx-post="{% url 'tokens:gerar_api_token' %}" hx-target="#resultado" hx-swap="innerHTML" class="space-y-6">
         {% csrf_token %}
-        <div class="space-y-4">
-          {% for field in form %}
-          <div>
-            <label for="{{ field.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ field.label }}</label>
-            {% if field.field.widget.input_type == 'select' %}
-              {{ field|add_class:"form-select" }}
-            {% else %}
-              {{ field|add_class:"form-input" }}
-            {% endif %}
-            {% if field.errors %}
-              <p class="text-red-500 text-xs mt-1">{{ field.errors }}</p>
-            {% endif %}
-          </div>
-          {% endfor %}
-        </div>
-        <div class="flex justify-end gap-3 pt-4 border-t border-neutral-100">
-          <button type="submit" class="text-sm px-4 py-2 rounded-xl bg-primary-600 text-white hover:bg-primary-700">{% trans "Gerar Token" %}</button>
+        {% for field in form %}
+          {% include '_forms/field.html' with field=field %}
+        {% endfor %}
+        <div class="flex justify-end gap-3 pt-4 border-t border-[var(--border)]">
+          <button type="submit" class="btn btn-primary">{% trans "Gerar Token" %}</button>
         </div>
       </form>
       <div id="resultado" class="mt-6 text-center" aria-live="polite">

--- a/tokens/templates/tokens/ativar_2fa.html
+++ b/tokens/templates/tokens/ativar_2fa.html
@@ -26,18 +26,14 @@
           <img src="data:image/png;base64,{{ qr_code }}" alt="{% trans 'QR Code' %}" class="w-40 h-40" />
           <p class="mt-2 text-sm font-mono">{{ secret }}</p>
         </div>
-        <p class="text-sm text-neutral-600 mb-4 text-center">{% trans "Escaneie o QR Code no aplicativo autenticador ou digite o código exibido." %}</p>
+        <p class="text-sm text-[var(--text-secondary)] mb-4 text-center">{% trans "Escaneie o QR Code no aplicativo autenticador ou digite o código exibido." %}</p>
       {% endif %}
 
-      <form method="post" action="{% url 'tokens:ativar_2fa' %}" class="bg-white rounded-2xl shadow p-6 space-y-4">
+      <form method="post" action="{% url 'tokens:ativar_2fa' %}" class="space-y-4">
         {% csrf_token %}
-        <div class="relative">
-          <label for="{{ form.codigo_totp.id_for_label }}" class="label-float">{{ form.codigo_totp.label }}</label>
-          {{ form.codigo_totp|add_class:"peer placeholder-transparent form-input"|attr:"autofocus required pattern=\\d+ inputmode=numeric" }}
-          {% if form.codigo_totp.errors %}
-            <p role="alert" class="text-sm text-red-600 mt-1">{{ form.codigo_totp.errors.0 }}</p>
-          {% endif %}
-        </div>
+        {% for field in form %}
+          {% include '_forms/field.html' with field=field %}
+        {% endfor %}
         <div class="text-right">
           <button type="submit" class="btn btn-primary">{% trans "Ativar" %}</button>
         </div>

--- a/tokens/templates/tokens/desativar_2fa.html
+++ b/tokens/templates/tokens/desativar_2fa.html
@@ -5,24 +5,28 @@
 
 {% block content %}
 <section class="max-w-md mx-auto px-4 py-12">
-  <header class="text-center mb-6">
-    <h1 class="text-2xl font-bold">{% trans "Desativar Autenticação de Dois Fatores" %}</h1>
-    <p class="text-sm text-neutral-600 mt-2">
-      {% trans "Confirme para desativar a autenticação em duas etapas." %}
-    </p>
-  </header>
-  <form method="post" action="" class="bg-white rounded-2xl shadow p-6 space-y-4">
-    {% csrf_token %}
-    <div class="text-right">
-      <button type="submit" class="rounded-xl bg-[var(--error)] px-4 py-2 text-white hover:opacity-90">
-        {% trans "Desativar" %}
-      </button>
+  <div class="card">
+    <div class="card-body">
+      <header class="text-center mb-6">
+        <h1 class="text-2xl font-bold">{% trans "Desativar Autenticação de Dois Fatores" %}</h1>
+        <p class="text-sm text-[var(--text-secondary)] mt-2">
+          {% trans "Confirme para desativar a autenticação em duas etapas." %}
+        </p>
+      </header>
+      <form method="post" action="" class="space-y-4">
+        {% csrf_token %}
+        <div class="text-right">
+          <button type="submit" class="btn btn-primary">
+            {% trans "Desativar" %}
+          </button>
+        </div>
+      </form>
+      <footer class="mt-6 text-center">
+        <a href="{% url 'configuracoes' %}" class="text-sm text-[var(--primary)] hover:underline">
+          {% trans "Voltar ao perfil de segurança" %}
+        </a>
+      </footer>
     </div>
-  </form>
-  <footer class="mt-6 text-center">
-    <a href="{% url 'configuracoes' %}" class="text-sm text-[var(--primary)] hover:underline">
-      {% trans "Voltar ao perfil de segurança" %}
-    </a>
-  </footer>
+  </div>
 </section>
 {% endblock %}

--- a/tokens/templates/tokens/gerar_codigo_autenticacao.html
+++ b/tokens/templates/tokens/gerar_codigo_autenticacao.html
@@ -5,44 +5,34 @@
 
 {% block content %}
 <section class="max-w-md mx-auto px-4 py-12">
-  <header class="text-center mb-6">
-    <h1 class="text-2xl font-bold">{% trans "Gerar Código de Autenticação" %}</h1>
-    <p class="text-sm text-neutral-600 mt-2">{% trans "Gere um código temporário para validar sua identidade." %}</p>
-  </header>
+  <div class="card">
+    <div class="card-body">
+      <header class="text-center mb-6">
+        <h1 class="text-2xl font-bold">{% trans "Gerar Código de Autenticação" %}</h1>
+        <p class="text-sm text-[var(--text-secondary)] mt-2">{% trans "Gere um código temporário para validar sua identidade." %}</p>
+      </header>
 
-  <form method="post" action="{% url 'tokens:gerar_codigo' %}"
-        hx-post="{% url 'tokens:gerar_codigo' %}"
-        hx-target="#resultado" hx-swap="innerHTML"
-        class="bg-white rounded-2xl shadow p-6 space-y-4">
-    {% csrf_token %}
-    {% for field in form %}
-      <div>
-        <label for="{{ field.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ field.label }}</label>
-        {% if field.field.widget.input_type == 'select' %}
-          {{ field|add_class:"form-select"|attr:"required" }}
-        {% else %}
-          {% if forloop.first %}
-            {{ field|add_class:"form-input"|attr:"autofocus required" }}
-          {% else %}
-            {{ field|add_class:"form-input"|attr:"required" }}
-          {% endif %}
-        {% endif %}
-        {% if field.errors %}
-          <p class="text-sm text-red-600 mt-1">{{ field.errors.0 }}</p>
-        {% endif %}
+      <form method="post" action="{% url 'tokens:gerar_codigo' %}"
+            hx-post="{% url 'tokens:gerar_codigo' %}"
+            hx-target="#resultado" hx-swap="innerHTML"
+            class="space-y-4">
+        {% csrf_token %}
+        {% for field in form %}
+          {% include '_forms/field.html' with field=field %}
+        {% endfor %}
+        <div class="text-right">
+          <button type="submit" class="btn btn-primary">{% trans "Gerar Código" %}</button>
+        </div>
+      </form>
+
+      <div id="resultado" class="mt-6 text-center" aria-live="polite">
+        {% include "tokens/_resultado.html" %}
       </div>
-    {% endfor %}
-    <div class="text-right">
-      <button type="submit" class="rounded-xl bg-primary px-4 py-2 text-white hover:bg-primary/90">{% trans "Gerar Código" %}</button>
+
+      <footer class="mt-6 text-center">
+        <a href="{% url 'configuracoes' %}" class="text-sm text-blue-600 hover:underline">{% trans "Voltar ao painel de segurança" %}</a>
+      </footer>
     </div>
-  </form>
-
-  <div id="resultado" class="mt-6 text-center" aria-live="polite">
-    {% include "tokens/_resultado.html" %}
   </div>
-
-  <footer class="mt-6 text-center">
-    <a href="{% url 'configuracoes' %}" class="text-sm text-blue-600 hover:underline">{% trans "Voltar ao painel de segurança" %}</a>
-  </footer>
 </section>
 {% endblock %}

--- a/tokens/templates/tokens/gerar_token.html
+++ b/tokens/templates/tokens/gerar_token.html
@@ -4,52 +4,40 @@
 
 {% block content %}
 <section class="max-w-xl mx-auto px-4 py-10">
-  <header class="mb-6 text-center">
-    <h1 class="text-2xl font-bold text-neutral-900">{% trans "Gerar Token de Acesso" %}</h1>
-    <p class="text-sm text-neutral-600 mt-2">{% trans "Use este token para convidar novos membros ou recuperar o acesso." %}</p>
-  </header>
+  <div class="card">
+    <div class="card-body space-y-6">
+      <header class="mb-6 text-center">
+        <h1 class="text-2xl font-bold text-[var(--text-primary)]">{% trans "Gerar Token de Acesso" %}</h1>
+        <p class="text-sm text-[var(--text-secondary)] mt-2">{% trans "Use este token para convidar novos membros ou recuperar o acesso." %}</p>
+      </header>
 
-  <form method="post" action="{% url 'tokens:gerar_convite' %}"
-        hx-post="{% url 'tokens:gerar_convite' %}"
-        hx-target="#resultado" hx-swap="innerHTML"
-        class="bg-white border border-neutral-200 rounded-2xl shadow-sm p-6 space-y-6">
-    {% csrf_token %}
+      <form method="post" action="{% url 'tokens:gerar_convite' %}"
+            hx-post="{% url 'tokens:gerar_convite' %}"
+            hx-target="#resultado" hx-swap="innerHTML"
+            class="space-y-6">
+        {% csrf_token %}
 
-    <div class="space-y-4">
-      {% for field in form %}
-        {% if user.user_type != 'root' or field.name != 'nucleos' %}
-          <div>
-            <label for="{{ field.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ field.label }}</label>
-            {% if field.field.widget.input_type == 'select' %}
-              {{ field|add_class:"form-select"|attr:"required" }}
-            {% else %}
-              {% if forloop.first %}
-                {{ field|add_class:"form-input"|attr:"autofocus required" }}
-              {% else %}
-                {{ field|add_class:"form-input"|attr:"required" }}
-              {% endif %}
-            {% endif %}
-            {% if field.errors %}
-              <p class="text-red-500 text-xs mt-1">{{ field.errors }}</p>
-            {% endif %}
-          </div>
-        {% endif %}
-      {% endfor %}
+        {% for field in form %}
+          {% if user.user_type != 'root' or field.name != 'nucleos' %}
+            {% include '_forms/field.html' with field=field %}
+          {% endif %}
+        {% endfor %}
+
+        <div class="flex justify-end gap-3 pt-4 border-t border-[var(--border)]">
+          <button type="submit" class="btn btn-primary">
+            {% trans "Gerar Token" %}
+          </button>
+        </div>
+      </form>
+
+      <div id="resultado" class="mt-6 text-center" aria-live="polite">
+        {% include "tokens/_resultado.html" %}
+      </div>
+
+      <footer class="mt-6 text-center">
+        <a href="{% url 'configuracoes' %}" class="text-sm text-blue-600 hover:underline">{% trans "Voltar ao painel de segurança" %}</a>
+      </footer>
     </div>
-
-    <div class="flex justify-end gap-3 pt-4 border-t border-neutral-100">
-      <button type="submit" class="text-sm px-4 py-2 rounded-xl bg-primary-600 text-white hover:bg-primary-700">
-        {% trans "Gerar Token" %}
-      </button>
-    </div>
-  </form>
-
-  <div id="resultado" class="mt-6 text-center" aria-live="polite">
-    {% include "tokens/_resultado.html" %}
   </div>
-
-  <footer class="mt-6 text-center">
-    <a href="{% url 'configuracoes' %}" class="text-sm text-blue-600 hover:underline">{% trans "Voltar ao painel de segurança" %}</a>
-  </footer>
 </section>
 {% endblock %}

--- a/tokens/templates/tokens/listar_convites.html
+++ b/tokens/templates/tokens/listar_convites.html
@@ -13,59 +13,58 @@
 <section class="max-w-6xl mx-auto mt-8 px-4">
   <div class="flex items-center justify-between gap-4 mb-6">
     <h1 class="text-2xl font-bold">{% trans "Convites Emitidos" %}</h1>
-    <a href="{% url 'tokens:gerar_convite' %}"
-       class="inline-flex items-center gap-2 bg-primary text-white px-4 py-2 rounded">
+    <a href="{% url 'tokens:gerar_convite' %}" class="btn btn-primary">
       {% trans "Gerar Token" %}
     </a>
   </div>
 
   <div class="mb-6 card-grid gap-4">
-    <div class="p-4 rounded-2xl border border-neutral-200 bg-white shadow-sm">
-      <div class="text-sm text-neutral-500">{% trans "Total" %}</div>
-      <div class="mt-1 text-2xl font-bold text-neutral-900">{{ totais.total }}</div>
+    <div class="p-4 rounded-2xl border border-[var(--border)] bg-[var(--bg-secondary)] shadow-sm">
+      <div class="text-sm text-[var(--text-secondary)]">{% trans "Total" %}</div>
+      <div class="mt-1 text-2xl font-bold text-[var(--text-primary)]">{{ totais.total }}</div>
     </div>
-    <div class="p-4 rounded-2xl border border-neutral-200 bg-white shadow-sm">
-      <div class="text-sm text-neutral-500">{% trans "Não usados" %}</div>
-      <div class="mt-1 text-2xl font-bold text-neutral-900">{{ totais.novos }}</div>
+    <div class="p-4 rounded-2xl border border-[var(--border)] bg-[var(--bg-secondary)] shadow-sm">
+      <div class="text-sm text-[var(--text-secondary)]">{% trans "Não usados" %}</div>
+      <div class="mt-1 text-2xl font-bold text-[var(--text-primary)]">{{ totais.novos }}</div>
     </div>
-    <div class="p-4 rounded-2xl border border-neutral-200 bg-white shadow-sm">
-      <div class="text-sm text-neutral-500">{% trans "Usados" %}</div>
-      <div class="mt-1 text-2xl font-bold text-neutral-900">{{ totais.usados }}</div>
+    <div class="p-4 rounded-2xl border border-[var(--border)] bg-[var(--bg-secondary)] shadow-sm">
+      <div class="text-sm text-[var(--text-secondary)]">{% trans "Usados" %}</div>
+      <div class="mt-1 text-2xl font-bold text-[var(--text-primary)]">{{ totais.usados }}</div>
     </div>
-    <div class="p-4 rounded-2xl border border-neutral-200 bg-white shadow-sm">
-      <div class="text-sm text-neutral-500">{% trans "Expirados" %}</div>
-      <div class="mt-1 text-2xl font-bold text-neutral-900">{{ totais.expirados }}</div>
+    <div class="p-4 rounded-2xl border border-[var(--border)] bg-[var(--bg-secondary)] shadow-sm">
+      <div class="text-sm text-[var(--text-secondary)]">{% trans "Expirados" %}</div>
+      <div class="mt-1 text-2xl font-bold text-[var(--text-primary)]">{{ totais.expirados }}</div>
     </div>
-    <div class="p-4 rounded-2xl border border-neutral-200 bg-white shadow-sm">
-      <div class="text-sm text-neutral-500">{% trans "Revogados" %}</div>
-      <div class="mt-1 text-2xl font-bold text-neutral-900">{{ totais.revogados }}</div>
+    <div class="p-4 rounded-2xl border border-[var(--border)] bg-[var(--bg-secondary)] shadow-sm">
+      <div class="text-sm text-[var(--text-secondary)]">{% trans "Revogados" %}</div>
+      <div class="mt-1 text-2xl font-bold text-[var(--text-primary)]">{{ totais.revogados }}</div>
     </div>
   </div>
 
   {% if convites %}
-  <div class="overflow-x-auto rounded-2xl border border-neutral-200 bg-white shadow-sm">
-    <table class="min-w-full divide-y divide-neutral-200">
-      <thead class="bg-neutral-50">
+  <div class="overflow-x-auto">
+    <table class="min-w-full divide-y divide-[var(--border)]">
+      <thead class="bg-[var(--bg-secondary)]">
         <tr>
-          <th class="px-4 py-2 text-left text-sm font-medium text-neutral-700">{% trans "Tipo" %}</th>
-          <th class="px-4 py-2 text-left text-sm font-medium text-neutral-700">{% trans "Estado" %}</th>
-          <th class="px-4 py-2 text-left text-sm font-medium text-neutral-700">{% trans "Ações" %}</th>
+          <th class="px-4 py-2 text-left text-sm font-medium text-[var(--text-primary)]">{% trans "Tipo" %}</th>
+          <th class="px-4 py-2 text-left text-sm font-medium text-[var(--text-primary)]">{% trans "Estado" %}</th>
+          <th class="px-4 py-2 text-left text-sm font-medium text-[var(--text-primary)]">{% trans "Ações" %}</th>
         </tr>
       </thead>
-      <tbody class="divide-y divide-neutral-200">
+      <tbody class="divide-y divide-[var(--border)]">
         {% for token in convites %}
         <tr>
-          <td class="px-4 py-2 text-sm text-neutral-900">{{ token.get_tipo_destino_display }}</td>
-          <td class="px-4 py-2 text-sm text-neutral-900">{{ token.get_estado_display }}</td>
+          <td class="px-4 py-2 text-sm text-[var(--text-primary)]">{{ token.get_tipo_destino_display }}</td>
+          <td class="px-4 py-2 text-sm text-[var(--text-primary)]">{{ token.get_estado_display }}</td>
           <td class="px-4 py-2 text-sm">
             {% if token.estado != 'revogado' %}
             <form method="post" action="{% url 'tokens:revogar_convite' token.id %}"
                   hx-confirm="{% trans 'Confirmar revogação?' %}">
               {% csrf_token %}
-              <button type="submit" class="text-red-600 hover:underline">{% trans "Revogar" %}</button>
+              <button type="submit" class="btn btn-secondary">{% trans "Revogar" %}</button>
             </form>
             {% else %}
-            <span class="text-neutral-400">{% trans "Revogado" %}</span>
+            <span class="text-[var(--text-secondary)]">{% trans "Revogado" %}</span>
             {% endif %}
           </td>
         </tr>
@@ -74,7 +73,7 @@
     </table>
   </div>
   {% else %}
-    <p class="text-sm text-neutral-600">{% trans "Nenhum convite encontrado." %}</p>
+    <p class="text-sm text-[var(--text-secondary)]">{% trans "Nenhum convite encontrado." %}</p>
   {% endif %}
   <div class="mt-6 text-center">
     <a href="{% url 'configuracoes' %}" class="text-sm text-blue-600 hover:underline">{% trans "Voltar ao painel de segurança" %}</a>

--- a/tokens/templates/tokens/validar_codigo_autenticacao.html
+++ b/tokens/templates/tokens/validar_codigo_autenticacao.html
@@ -5,34 +5,34 @@
 
 {% block content %}
 <section class="max-w-md mx-auto px-4 py-12">
-  <header class="text-center mb-6">
-    <h1 class="text-2xl font-bold">{% trans "Validar Código de Autenticação" %}</h1>
-    <p class="text-sm text-neutral-600 mt-2">{% trans "Informe o código recebido para concluir a validação." %}</p>
-  </header>
+  <div class="card">
+    <div class="card-body">
+      <header class="text-center mb-6">
+        <h1 class="text-2xl font-bold">{% trans "Validar Código de Autenticação" %}</h1>
+        <p class="text-sm text-[var(--text-secondary)] mt-2">{% trans "Informe o código recebido para concluir a validação." %}</p>
+      </header>
 
-  <form method="post" action="{% url 'tokens:validar_codigo' %}"
-        hx-post="{% url 'tokens:validar_codigo' %}"
-        hx-target="#resultado" hx-swap="innerHTML"
-        class="bg-white rounded-2xl shadow p-6 space-y-4">
-    {% csrf_token %}
-    <div>
-      <label for="{{ form.codigo.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.codigo.label }}</label>
-      {{ form.codigo|add_class:"form-input text-center tracking-widest"|attr:"autofocus required pattern=\\d+ inputmode=numeric" }}
-      {% if form.codigo.errors %}
-        <p class="text-sm text-red-600 mt-1">{{ form.codigo.errors.0 }}</p>
-      {% endif %}
-    </div>
-    <div class="text-right">
-      <button type="submit" class="rounded-xl bg-primary px-4 py-2 text-white hover:bg-primary/90">{% trans "Validar Código" %}</button>
-    </div>
-  </form>
+      <form method="post" action="{% url 'tokens:validar_codigo' %}"
+            hx-post="{% url 'tokens:validar_codigo' %}"
+            hx-target="#resultado" hx-swap="innerHTML"
+            class="space-y-4">
+        {% csrf_token %}
+        {% for field in form %}
+          {% include '_forms/field.html' with field=field %}
+        {% endfor %}
+        <div class="text-right">
+          <button type="submit" class="btn btn-primary">{% trans "Validar Código" %}</button>
+        </div>
+      </form>
 
-  <div id="resultado" class="mt-6 text-center" aria-live="polite">
-    {% include "tokens/_resultado.html" %}
+      <div id="resultado" class="mt-6 text-center" aria-live="polite">
+        {% include "tokens/_resultado.html" %}
+      </div>
+
+      <footer class="mt-6 text-center">
+        <a href="{% url 'configuracoes' %}" class="text-sm text-blue-600 hover:underline">{% trans "Voltar ao painel de segurança" %}</a>
+      </footer>
+    </div>
   </div>
-
-  <footer class="mt-6 text-center">
-    <a href="{% url 'configuracoes' %}" class="text-sm text-blue-600 hover:underline">{% trans "Voltar ao painel de segurança" %}</a>
-  </footer>
 </section>
 {% endblock %}

--- a/tokens/templates/tokens/validar_token.html
+++ b/tokens/templates/tokens/validar_token.html
@@ -5,34 +5,34 @@
 
 {% block content %}
 <section class="max-w-md mx-auto px-4 py-12">
-  <header class="text-center mb-6">
-    <h1 class="text-2xl font-bold">{% trans "Validar Token de Convite" %}</h1>
-    <p class="text-sm text-neutral-600 mt-2">{% trans "Informe o token recebido para concluir o convite." %}</p>
-  </header>
+  <div class="card">
+    <div class="card-body">
+      <header class="text-center mb-6">
+        <h1 class="text-2xl font-bold">{% trans "Validar Token de Convite" %}</h1>
+        <p class="text-sm text-[var(--text-secondary)] mt-2">{% trans "Informe o token recebido para concluir o convite." %}</p>
+      </header>
 
-  <form method="post" action="{% url 'tokens:validar_token' %}"
-        hx-post="{% url 'tokens:validar_token' %}"
-        hx-target="#resultado" hx-swap="innerHTML"
-        class="bg-white rounded-2xl shadow p-6 space-y-4">
-    {% csrf_token %}
-    <div>
-      <label for="{{ form.codigo.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.codigo.label }}</label>
-      {{ form.codigo|add_class:"form-input"|attr:"autofocus required" }}
-      {% if form.codigo.errors %}
-        <p class="text-sm text-red-600 mt-1">{{ form.codigo.errors.0 }}</p>
-      {% endif %}
-    </div>
-    <div class="text-right">
-      <button type="submit" class="rounded-xl bg-primary px-4 py-2 text-white hover:bg-primary/90">{% trans "Validar Token" %}</button>
-    </div>
-  </form>
+      <form method="post" action="{% url 'tokens:validar_token' %}"
+            hx-post="{% url 'tokens:validar_token' %}"
+            hx-target="#resultado" hx-swap="innerHTML"
+            class="space-y-4">
+        {% csrf_token %}
+        {% for field in form %}
+          {% include '_forms/field.html' with field=field %}
+        {% endfor %}
+        <div class="text-right">
+          <button type="submit" class="btn btn-primary">{% trans "Validar Token" %}</button>
+        </div>
+      </form>
 
-  <div id="resultado" class="mt-6 text-center" aria-live="polite">
-    {% include "tokens/_resultado.html" %}
+      <div id="resultado" class="mt-6 text-center" aria-live="polite">
+        {% include "tokens/_resultado.html" %}
+      </div>
+
+      <footer class="mt-6 text-center">
+        <a href="{% url 'configuracoes' %}" class="text-sm text-blue-600 hover:underline">{% trans "Voltar ao painel de segurança" %}</a>
+      </footer>
+    </div>
   </div>
-
-  <footer class="mt-6 text-center">
-    <a href="{% url 'configuracoes' %}" class="text-sm text-blue-600 hover:underline">{% trans "Voltar ao painel de segurança" %}</a>
-  </footer>
 </section>
 {% endblock %}


### PR DESCRIPTION
## Summary
- atualiza templates de tokens para usar variáveis de cor e componentes card
- renderiza campos de formulários via include padrão e classes de botão unificadas
- simplifica tabelas e grids seguindo design system

## Testing
- `pytest tests/tokens -q` *(falhou: Required test coverage of 90% not reached. Total coverage: 10.08%)*

------
https://chatgpt.com/codex/tasks/task_e_68c182289ef8832585cbd047ac2d20c5