### PR TITLE
Refactor messages to shared partial and design system colors

### DIFF
--- a/configuracoes/templates/configuracoes/configuracoes.html
+++ b/configuracoes/templates/configuracoes/configuracoes.html
@@ -6,15 +6,9 @@
 {% block content %}
 <div class="max-w-4xl mx-auto px-4 py-8">
   <h1 class="text-2xl font-bold mb-4">{% trans 'Configurações' %}</h1>
-  {% if messages %}
-    <div class="mb-4 space-y-2" aria-live="polite">
-      {% for message in messages %}
-        <p role="alert" class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-green-600 text-white{% else %}bg-red-600 text-white{% endif %}">{{ message }}</p>
-      {% endfor %}
-    </div>
-  {% endif %}
+  {% include '_partials/messages.html' %}
 
-    <div class="flex flex-wrap gap-4 border-b mb-4 text-sm">
+    <div class="flex flex-wrap gap-4 border-b border-[var(--border)] mb-4 text-sm">
       <nav aria-label="{% trans 'Seções de Configuração' %}" role="tablist" class="flex flex-wrap gap-4">
         <button role="tab" aria-selected="{% if tab == 'seguranca' %}true{% else %}false{% endif %}" aria-controls="content" hx-get="{% url 'configuracoes' %}?tab=seguranca" hx-target="#content" hx-on:click="switchTab(this)" tabindex="0" class="btn {% if tab == 'seguranca' %}btn-secondary{% endif %}">{% trans 'Segurança' %}</button>
         <button role="tab" aria-selected="{% if tab == 'preferencias' %}true{% else %}false{% endif %}" aria-controls="content" hx-get="{% url 'configuracoes' %}?tab=preferencias" hx-target="#content" hx-on:click="switchTab(this)" tabindex="0" class="btn {% if tab == 'preferencias' %}btn-secondary{% endif %}">{% trans 'Preferências' %}</button>

--- a/templates/_partials/messages.html
+++ b/templates/_partials/messages.html
@@ -1,8 +1,8 @@
 {% load i18n %}
 {% if messages %}
-<div id="messages" hx-swap-oob="true" class="mb-4">
+<div id="messages" hx-swap-oob="true" class="mb-4 space-y-2" aria-live="polite">
   {% for message in messages %}
-    <div class="bg-red-100 text-red-800 p-2 rounded" role="alert">{{ message }}</div>
+    <p role="alert" class="rounded-xl px-4 py-2 text-sm {% if 'error' in message.tags %}bg-[var(--error)] text-[var(--error-contrast)]{% elif 'success' in message.tags %}bg-[var(--success)] text-[var(--success-contrast)]{% else %}bg-[var(--primary)] text-[var(--primary-contrast)]{% endif %}">{{ message }}</p>
   {% endfor %}
 </div>
 {% endif %}

--- a/templates/_partials/toasts.html
+++ b/templates/_partials/toasts.html
@@ -1,7 +1,7 @@
 {% if messages %}
 <div id="messages" class="fixed top-4 right-4 space-y-2 z-50">
   {% for message in messages %}
-    <div class="px-4 py-2 rounded shadow text-white {% if 'error' in message.tags %}bg-[var(--error)]{% elif 'success' in message.tags %}bg-[var(--success)]{% else %}bg-[var(--primary)]{% endif %}">
+    <div class="px-4 py-2 rounded shadow {% if 'error' in message.tags %}bg-[var(--error)] text-[var(--error-contrast)]{% elif 'success' in message.tags %}bg-[var(--success)] text-[var(--success-contrast)]{% else %}bg-[var(--primary)] text-[var(--primary-contrast)]{% endif %}">
       {{ message }}
     </div>
   {% endfor %}


### PR DESCRIPTION
## Summary
- use shared messages partial on configuration page
- standardize message and toast components with design system colors
- apply design system border color to configuration tabs

## Testing
- `pytest -m "not slow"` *(fails: ModuleNotFoundError: No module named 'silk'; after installing django-silk and pytest-cov, tests still fail during collection with 81 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c18d0694a48325bfe0254b26b1e0a8