### PR TITLE
Refatora cards e links de segurança

### DIFF
--- a/accounts/templates/perfil/partials/conexoes_solicitacoes.html
+++ b/accounts/templates/perfil/partials/conexoes_solicitacoes.html
@@ -1,7 +1,8 @@
 {% load i18n %}
 <div class="space-y-4">
   {% for solicitante in connection_requests %}
-  <div class="request-card flex items-start justify-between p-4 border rounded-xl bg-[var(--bg-secondary)] shadow-sm">
+  <article class="card request-card">
+    <div class="card-body flex items-start justify-between">
     <div class="flex items-center gap-3">
       {% if solicitante.avatar %}
         <img src="{{ solicitante.avatar.url }}" alt="{{ solicitante.username }}" class="w-10 h-10 rounded-full object-cover" />
@@ -33,7 +34,8 @@
         <button class="btn btn-danger btn-sm">{% trans "Recusar" %}</button>
       </form>
     </div>
-  </div>
+    </div>
+  </article>
   {% empty %}
   <div class="text-center text-sm text-[var(--text-secondary)]">
     <p>{% trans "Você não tem solicitações de conexão pendentes." %}</p>

--- a/eventos/templates/eventos/tarefa_list.html
+++ b/eventos/templates/eventos/tarefa_list.html
@@ -10,9 +10,13 @@
   </header>
   <ul class="space-y-2">
     {% for tarefa in tarefas %}
-      <li class="p-4 bg-[var(--bg-secondary)] border border-[var(--border)] rounded-2xl shadow-sm">
-        <a href="{% url 'eventos:tarefa_detalhe' tarefa.pk %}" class="font-semibold">{{ tarefa.titulo }}</a>
-        <div class="text-sm text-neutral-600">{{ tarefa.responsavel }} - {{ tarefa.status }}</div>
+      <li>
+        <article class="card">
+          <div class="card-body">
+            <a href="{% url 'eventos:tarefa_detalhe' tarefa.pk %}" class="font-semibold">{{ tarefa.titulo }}</a>
+            <div class="text-sm text-neutral-600">{{ tarefa.responsavel }} - {{ tarefa.status }}</div>
+          </div>
+        </article>
       </li>
     {% empty %}
       <li>{% trans "Nenhuma tarefa encontrada." %}</li>

--- a/nucleos/templates/nucleos/partials/membro.html
+++ b/nucleos/templates/nucleos/partials/membro.html
@@ -1,54 +1,56 @@
 {% load i18n %}
-<div id="membro-{{ part.id }}" class="p-4 bg-[var(--bg-secondary)] border border-[var(--border)] rounded shadow-sm flex flex-col gap-2">
-  <div class="flex items-center gap-4">
-    {% if part.user.avatar %}
-    <img src="{{ part.user.avatar.url }}" alt="{{ part.user.username }}" class="w-12 h-12 rounded-full object-cover" />
-    {% else %}
-    <div class="w-12 h-12 rounded-full bg-[var(--bg-tertiary)]"></div>
-    {% endif %}
-    <div>
-  <a href="{% url 'accounts:perfil_publico_uuid' part.user.public_id %}" class="font-medium text-[var(--text-primary)]">
-        {{ part.user.get_full_name|default:part.user.username }}
-      </a>
-      {% if part.papel == 'coordenador' %}
-        <span class="text-sm text-[var(--text-secondary)]"> - {% trans 'Coordenador' %}</span>
+<article id="membro-{{ part.id }}" class="card">
+  <div class="card-body flex flex-col gap-2">
+    <div class="flex items-center gap-4">
+      {% if part.user.avatar %}
+      <img src="{{ part.user.avatar.url }}" alt="{{ part.user.username }}" class="w-12 h-12 rounded-full object-cover" />
+      {% else %}
+      <div class="w-12 h-12 rounded-full bg-[var(--bg-tertiary)]"></div>
       {% endif %}
-      {% if part.status_suspensao %}
+      <div>
+        <a href="{% url 'accounts:perfil_publico_uuid' part.user.public_id %}" class="font-medium text-[var(--text-primary)]">
+          {{ part.user.get_full_name|default:part.user.username }}
+        </a>
+        {% if part.papel == 'coordenador' %}
+        <span class="text-sm text-[var(--text-secondary)]"> - {% trans 'Coordenador' %}</span>
+        {% endif %}
+        {% if part.status_suspensao %}
         <span class="text-sm text-red-600">({% trans 'Suspenso' %})</span>
+        {% endif %}
+      </div>
+    </div>
+    {% if request.user.user_type == 'admin' or request.user.user_type == 'coordenador' %}
+    <div class="mt-2 space-x-2">
+      <button class="text-sm text-blue-600"
+              hx-post="{% url 'nucleos:membro_promover' object.pk part.pk %}"
+              hx-target="#membro-{{ part.id }}"
+              hx-swap="outerHTML"
+              hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
+        {% if part.papel == 'coordenador' %}{% trans 'Rebaixar' %}{% else %}{% trans 'Promover' %}{% endif %}
+      </button>
+      <button class="text-sm text-red-600"
+              hx-post="{% url 'nucleos:membro_remover' object.pk part.pk %}"
+              hx-target="#membro-{{ part.id }}"
+              hx-swap="outerHTML"
+              hx-confirm="{% trans 'Confirmar remoção?' %}"
+              hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
+        {% trans 'Remover' %}
+      </button>
+      {% if part.status_suspensao %}
+        <form hx-post="{% url 'nucleos_api:nucleo-reativar-membro' object.pk part.user.pk %}"
+              hx-on="htmx:afterRequest: location.reload()"
+              class="inline">{% csrf_token %}
+          <button class="text-sm text-green-600">{% trans 'Reativar' %}</button>
+        </form>
+      {% else %}
+        <form hx-post="{% url 'nucleos_api:nucleo-suspender-membro' object.pk part.user.pk %}"
+              hx-on="htmx:afterRequest: location.reload()"
+              class="inline">{% csrf_token %}
+          <button class="text-sm text-yellow-600">{% trans 'Suspender' %}</button>
+        </form>
       {% endif %}
     </div>
-  </div>
-  {% if request.user.user_type == 'admin' or request.user.user_type == 'coordenador' %}
-  <div class="mt-2 space-x-2">
-    <button class="text-sm text-blue-600"
-            hx-post="{% url 'nucleos:membro_promover' object.pk part.pk %}"
-            hx-target="#membro-{{ part.id }}"
-            hx-swap="outerHTML"
-            hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
-      {% if part.papel == 'coordenador' %}{% trans 'Rebaixar' %}{% else %}{% trans 'Promover' %}{% endif %}
-    </button>
-    <button class="text-sm text-red-600"
-            hx-post="{% url 'nucleos:membro_remover' object.pk part.pk %}"
-            hx-target="#membro-{{ part.id }}"
-            hx-swap="outerHTML"
-            hx-confirm="{% trans 'Confirmar remoção?' %}"
-            hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
-      {% trans 'Remover' %}
-    </button>
-    {% if part.status_suspensao %}
-      <form hx-post="{% url 'nucleos_api:nucleo-reativar-membro' object.pk part.user.pk %}"
-            hx-on="htmx:afterRequest: location.reload()"
-            class="inline">{% csrf_token %}
-        <button class="text-sm text-green-600">{% trans 'Reativar' %}</button>
-      </form>
-    {% else %}
-      <form hx-post="{% url 'nucleos_api:nucleo-suspender-membro' object.pk part.user.pk %}"
-            hx-on="htmx:afterRequest: location.reload()"
-            class="inline">{% csrf_token %}
-        <button class="text-sm text-yellow-600">{% trans 'Suspender' %}</button>
-      </form>
     {% endif %}
   </div>
-  {% endif %}
-</div>
+</article>
 

--- a/tokens/templates/tokens/api_tokens.html
+++ b/tokens/templates/tokens/api_tokens.html
@@ -66,7 +66,7 @@
         {% include "tokens/_resultado.html" %}
       </div>
       <div class="mt-6 text-center">
-        <a href="{% url 'configuracoes' %}" class="text-sm text-[var(--primary)] hover:underline">{% trans "Voltar ao painel de segurança" %}</a>
+        <a href="{% url 'configuracoes' %}" class="text-sm link hover:underline">{% trans "Voltar ao painel de segurança" %}</a>
       </div>
     </div>
   </div>

--- a/tokens/templates/tokens/gerar_codigo_autenticacao.html
+++ b/tokens/templates/tokens/gerar_codigo_autenticacao.html
@@ -29,7 +29,7 @@
         {% include "tokens/_resultado.html" %}
       </div>
       <footer class="mt-6 text-center">
-        <a href="{% url 'configuracoes' %}" class="text-sm text-blue-600 hover:underline">{% trans "Voltar ao painel de segurança" %}</a>
+        <a href="{% url 'configuracoes' %}" class="text-sm link hover:underline">{% trans "Voltar ao painel de segurança" %}</a>
       </footer>
     </div>
   </div>

--- a/tokens/templates/tokens/gerar_token.html
+++ b/tokens/templates/tokens/gerar_token.html
@@ -36,7 +36,7 @@
       </div>
 
       <footer class="mt-6 text-center">
-        <a href="{% url 'configuracoes' %}" class="text-sm text-blue-600 hover:underline">{% trans "Voltar ao painel de segurança" %}</a>
+        <a href="{% url 'configuracoes' %}" class="text-sm link hover:underline">{% trans "Voltar ao painel de segurança" %}</a>
       </footer>
     </div>
   </div>

--- a/tokens/templates/tokens/listar_convites.html
+++ b/tokens/templates/tokens/listar_convites.html
@@ -18,26 +18,36 @@
   </div>
 
   <div class="mb-6 card-grid gap-4">
-    <div class="p-4 rounded-2xl border border-[var(--border)] bg-[var(--bg-secondary)] shadow-sm">
-      <div class="text-sm text-[var(--text-secondary)]">{% trans "Total" %}</div>
-      <div class="mt-1 text-2xl font-bold text-[var(--text-primary)]">{{ totais.total }}</div>
-    </div>
-    <div class="p-4 rounded-2xl border border-[var(--border)] bg-[var(--bg-secondary)] shadow-sm">
-      <div class="text-sm text-[var(--text-secondary)]">{% trans "Não usados" %}</div>
-      <div class="mt-1 text-2xl font-bold text-[var(--text-primary)]">{{ totais.novos }}</div>
-    </div>
-    <div class="p-4 rounded-2xl border border-[var(--border)] bg-[var(--bg-secondary)] shadow-sm">
-      <div class="text-sm text-[var(--text-secondary)]">{% trans "Usados" %}</div>
-      <div class="mt-1 text-2xl font-bold text-[var(--text-primary)]">{{ totais.usados }}</div>
-    </div>
-    <div class="p-4 rounded-2xl border border-[var(--border)] bg-[var(--bg-secondary)] shadow-sm">
-      <div class="text-sm text-[var(--text-secondary)]">{% trans "Expirados" %}</div>
-      <div class="mt-1 text-2xl font-bold text-[var(--text-primary)]">{{ totais.expirados }}</div>
-    </div>
-    <div class="p-4 rounded-2xl border border-[var(--border)] bg-[var(--bg-secondary)] shadow-sm">
-      <div class="text-sm text-[var(--text-secondary)]">{% trans "Revogados" %}</div>
-      <div class="mt-1 text-2xl font-bold text-[var(--text-primary)]">{{ totais.revogados }}</div>
-    </div>
+    <article class="card">
+      <div class="card-body">
+        <div class="text-sm text-[var(--text-secondary)]">{% trans "Total" %}</div>
+        <div class="mt-1 text-2xl font-bold text-[var(--text-primary)]">{{ totais.total }}</div>
+      </div>
+    </article>
+    <article class="card">
+      <div class="card-body">
+        <div class="text-sm text-[var(--text-secondary)]">{% trans "Não usados" %}</div>
+        <div class="mt-1 text-2xl font-bold text-[var(--text-primary)]">{{ totais.novos }}</div>
+      </div>
+    </article>
+    <article class="card">
+      <div class="card-body">
+        <div class="text-sm text-[var(--text-secondary)]">{% trans "Usados" %}</div>
+        <div class="mt-1 text-2xl font-bold text-[var(--text-primary)]">{{ totais.usados }}</div>
+      </div>
+    </article>
+    <article class="card">
+      <div class="card-body">
+        <div class="text-sm text-[var(--text-secondary)]">{% trans "Expirados" %}</div>
+        <div class="mt-1 text-2xl font-bold text-[var(--text-primary)]">{{ totais.expirados }}</div>
+      </div>
+    </article>
+    <article class="card">
+      <div class="card-body">
+        <div class="text-sm text-[var(--text-secondary)]">{% trans "Revogados" %}</div>
+        <div class="mt-1 text-2xl font-bold text-[var(--text-primary)]">{{ totais.revogados }}</div>
+      </div>
+    </article>
   </div>
 
   {% if convites %}
@@ -77,7 +87,7 @@
     <p class="text-sm text-[var(--text-secondary)]">{% trans "Nenhum convite encontrado." %}</p>
   {% endif %}
   <div class="mt-6 text-center">
-    <a href="{% url 'configuracoes' %}" class="text-sm text-blue-600 hover:underline">{% trans "Voltar ao painel de segurança" %}</a>
+    <a href="{% url 'configuracoes' %}" class="text-sm link hover:underline">{% trans "Voltar ao painel de segurança" %}</a>
   </div>
 </section>
 {% endblock %}

--- a/tokens/templates/tokens/validar_codigo_autenticacao.html
+++ b/tokens/templates/tokens/validar_codigo_autenticacao.html
@@ -32,7 +32,7 @@
       </div>
 
       <footer class="mt-6 text-center">
-        <a href="{% url 'configuracoes' %}" class="text-sm text-blue-600 hover:underline">{% trans "Voltar ao painel de segurança" %}</a>
+        <a href="{% url 'configuracoes' %}" class="text-sm link hover:underline">{% trans "Voltar ao painel de segurança" %}</a>
       </footer>
     </div>
   </div>

--- a/tokens/templates/tokens/validar_token.html
+++ b/tokens/templates/tokens/validar_token.html
@@ -31,7 +31,7 @@
       </div>
 
       <footer class="mt-6 text-center">
-        <a href="{% url 'configuracoes' %}" class="text-sm text-blue-600 hover:underline">{% trans "Voltar ao painel de segurança" %}</a>
+        <a href="{% url 'configuracoes' %}" class="text-sm link hover:underline">{% trans "Voltar ao painel de segurança" %}</a>
       </footer>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- padroniza cartões em várias telas substituindo `<div class="p-4 ... shadow-sm">` por `<article class="card"><div class="card-body">` e remove sombras redundantes
- estiliza links "Voltar ao painel de segurança" com a classe `link`

## Testing
- `pytest -m "not slow"` *(fails: 81 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c18cfea5a883259dab8fd89eccf560