### PR TITLE
refactor: replace color classes with css variables

### DIFF
--- a/core/menu.py
+++ b/core/menu.py
@@ -202,7 +202,7 @@ def build_menu(request) -> List[MenuItem]:
             "Cadastrar",
             ICON_REGISTER,
             ["anonymous"],
-            classes="flex items-center gap-x-2 bg-primary text-white py-2 px-4 rounded-xl hover:bg-primary/90 transition",
+            classes="gap-x-2 btn btn-primary",
         ),
     ]
 

--- a/core/templates/core/home.html
+++ b/core/templates/core/home.html
@@ -11,61 +11,61 @@
 <div class="py-12 text-center my-8 px-4">
   {% if user.is_authenticated %}
   <div class="flex justify-center gap-4">
-    <a href="{% url 'dashboard:dashboard' %}" class="bg-primary text-white px-5 py-3 rounded-xl shadow hover:bg-primary/90">{% trans "Ir para Dashboard" %}</a>
-    <a href="{% url 'feed:listar' %}" class="bg-secondary border border-primary text-primary px-5 py-3 rounded-xl hover:bg-primary/5">{% trans "Ver Feed" %}</a>
+    <a href="{% url 'dashboard:dashboard' %}" class="btn btn-primary shadow">{% trans "Ir para Dashboard" %}</a>
+    <a href="{% url 'feed:listar' %}" class="btn btn-secondary">{% trans "Ver Feed" %}</a>
   </div>
   {% else %}
   <div class="flex justify-center gap-4">
-    <a href="{% url 'accounts:onboarding' %}" class="bg-primary text-white px-5 py-3 rounded-xl shadow hover:bg-primary/90">{% trans "Criar conta" %}</a>
-    <a href="{% url 'accounts:login' %}" class="bg-secondary border border-primary text-primary px-5 py-3 rounded-xl hover:bg-primary/5">{% trans "Entrar" %}</a>
+    <a href="{% url 'accounts:onboarding' %}" class="btn btn-primary shadow">{% trans "Criar conta" %}</a>
+    <a href="{% url 'accounts:login' %}" class="btn btn-secondary">{% trans "Entrar" %}</a>
   </div>
   {% endif %}
 </div>
-<section class="py-12 px-4 bg-gray-50">
+<section class="py-12 px-4 bg-[var(--bg-secondary)]">
   <div class="card max-w-7xl mx-auto px-4 text-center">
     <div class="card-header">
-      <h2 class="text-2xl font-bold text-neutral-900 mb-8">{% trans "Principais Funcionalidades" %}</h2>
+      <h2 class="text-2xl font-bold text-[var(--text-primary)] mb-8">{% trans "Principais Funcionalidades" %}</h2>
     </div>
     <div class="card-body">
       <div class="card-grid">
         <div class="card text-center flex flex-col items-center">
           <div class="card-body">
-            {% lucide 'rss' class='text-indigo-600 w-8 h-8 mb-4' %}
-            <h3 class="font-semibold text-neutral-900">{% trans "Feed/Mural" %}</h3>
-            <p class="text-sm text-neutral-600 mb-4">{% trans "Compartilhe novidades e acompanhe atualizações." %}</p>
-            <a href="{% url 'feed:listar' %}" class="text-sm font-medium text-indigo-600 hover:underline">{% trans "Acessar" %}</a>
+            {% lucide 'rss' class='text-[var(--link)] w-8 h-8 mb-4' %}
+            <h3 class="font-semibold text-[var(--text-primary)]">{% trans "Feed/Mural" %}</h3>
+            <p class="text-sm text-[var(--text-secondary)] mb-4">{% trans "Compartilhe novidades e acompanhe atualizações." %}</p>
+            <a href="{% url 'feed:listar' %}" class="text-sm font-medium text-[var(--link)] hover:underline">{% trans "Acessar" %}</a>
           </div>
         </div>
         <div class="card text-center flex flex-col items-center">
           <div class="card-body">
-            {% lucide 'calendar-days' class='text-indigo-600 w-8 h-8 mb-4' %}
-            <h3 class="font-semibold text-neutral-900">{% trans "Eventos" %}</h3>
-            <p class="text-sm text-neutral-600 mb-4">{% trans "Organize eventos e gerencie inscrições." %}</p>
-            <a href="{% url 'eventos:calendario' %}" class="text-sm font-medium text-indigo-600 hover:underline">{% trans "Acessar" %}</a>
+            {% lucide 'calendar-days' class='text-[var(--link)] w-8 h-8 mb-4' %}
+            <h3 class="font-semibold text-[var(--text-primary)]">{% trans "Eventos" %}</h3>
+            <p class="text-sm text-[var(--text-secondary)] mb-4">{% trans "Organize eventos e gerencie inscrições." %}</p>
+            <a href="{% url 'eventos:calendario' %}" class="text-sm font-medium text-[var(--link)] hover:underline">{% trans "Acessar" %}</a>
           </div>
         </div>
         <div class="card text-center flex flex-col items-center">
           <div class="card-body">
-            {% lucide 'users' class='text-indigo-600 w-8 h-8 mb-4' %}
-            <h3 class="font-semibold text-neutral-900">{% trans "Núcleos" %}</h3>
-            <p class="text-sm text-neutral-600 mb-4">{% trans "Encontre grupos de interesse e colabore." %}</p>
-            <a href="{% url 'nucleos:list' %}" class="text-sm font-medium text-indigo-600 hover:underline">{% trans "Acessar" %}</a>
+            {% lucide 'users' class='text-[var(--link)] w-8 h-8 mb-4' %}
+            <h3 class="font-semibold text-[var(--text-primary)]">{% trans "Núcleos" %}</h3>
+            <p class="text-sm text-[var(--text-secondary)] mb-4">{% trans "Encontre grupos de interesse e colabore." %}</p>
+            <a href="{% url 'nucleos:list' %}" class="text-sm font-medium text-[var(--link)] hover:underline">{% trans "Acessar" %}</a>
           </div>
         </div>
         <div class="card text-center flex flex-col items-center">
           <div class="card-body">
-            {% lucide 'chart-line' class='text-indigo-600 w-8 h-8 mb-4' %}
-            <h3 class="font-semibold text-neutral-900">{% trans "Dashboard/Financeiro" %}</h3>
-            <p class="text-sm text-neutral-600 mb-4">{% trans "Acompanhe métricas e controle financeiro." %}</p>
-            <a href="{% url 'dashboard:dashboard' %}" class="text-sm font-medium text-indigo-600 hover:underline">{% trans "Acessar" %}</a>
+            {% lucide 'chart-line' class='text-[var(--link)] w-8 h-8 mb-4' %}
+            <h3 class="font-semibold text-[var(--text-primary)]">{% trans "Dashboard/Financeiro" %}</h3>
+            <p class="text-sm text-[var(--text-secondary)] mb-4">{% trans "Acompanhe métricas e controle financeiro." %}</p>
+            <a href="{% url 'dashboard:dashboard' %}" class="text-sm font-medium text-[var(--link)] hover:underline">{% trans "Acessar" %}</a>
           </div>
         </div>
         <div class="card text-center flex flex-col items-center">
           <div class="card-body">
-            {% lucide 'bell' class='text-indigo-600 w-8 h-8 mb-4' %}
-            <h3 class="font-semibold text-neutral-900">{% trans "Notificações" %}</h3>
-            <p class="text-sm text-neutral-600 mb-4">{% trans "Centralize alertas e preferências de contato." %}</p>
-            <a href="{% url 'configuracoes' %}?tab=preferencias" class="text-sm font-medium text-indigo-600 hover:underline">{% trans "Acessar" %}</a>
+            {% lucide 'bell' class='text-[var(--link)] w-8 h-8 mb-4' %}
+            <h3 class="font-semibold text-[var(--text-primary)]">{% trans "Notificações" %}</h3>
+            <p class="text-sm text-[var(--text-secondary)] mb-4">{% trans "Centralize alertas e preferências de contato." %}</p>
+            <a href="{% url 'configuracoes' %}?tab=preferencias" class="text-sm font-medium text-[var(--link)] hover:underline">{% trans "Acessar" %}</a>
           </div>
         </div>
       </div>
@@ -81,27 +81,27 @@
     <div class="card-body">
       {% now 'Y-m-d' as today %}
       <div id="eventos-destaque" hx-get="{% url 'eventos:lista_eventos' today %}" hx-trigger="load" hx-swap="innerHTML">
-        <p class="text-center text-sm text-gray-500">{% trans "Carregando eventos..." %}</p>
+        <p class="text-center text-sm text-[var(--text-tertiary)]">{% trans "Carregando eventos..." %}</p>
       </div>
     </div>
   </div>
 </section>
 
 {% if user.is_authenticated %}
-<section class="py-12 px-4 bg-gray-50">
+<section class="py-12 px-4 bg-[var(--bg-secondary)]">
   <div class="card max-w-7xl mx-auto px-4">
     <div class="card-header">
       <h2 class="text-xl font-semibold mb-4">{% trans "Posts em destaque" %}</h2>
     </div>
     <div class="card-body">
       <div id="posts-destaque" hx-get="{% url 'core:posts_highlights' %}" hx-trigger="load" hx-swap="innerHTML">
-        <p class="text-center text-sm text-gray-500">{% trans "Carregando posts..." %}</p>
+        <p class="text-center text-sm text-[var(--text-tertiary)]">{% trans "Carregando posts..." %}</p>
       </div>
     </div>
   </div>
 </section>
 {% endif %}
-<footer class="py-6 text-center text-sm text-neutral-500">
+<footer class="py-6 text-center text-sm text-[var(--text-tertiary)]">
   &copy; {{ now|date:"Y" }} {% trans "Hubx" %}
 </footer>
 {% endblock %}


### PR DESCRIPTION
## Summary
- refactor home page to use CSS variable color tokens
- switch action links to button components
- update onboarding menu link with button styling

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68c18cededb08325a93a36c4e975f866