### PR TITLE
Use Tailwind form styles for feed search input

### DIFF
--- a/feed/templates/feed/feed.html
+++ b/feed/templates/feed/feed.html
@@ -22,7 +22,7 @@
            hx-trigger="keyup changed delay:500ms"
            hx-target="#feed-grid"
            hx-include="#feed-search-form"
-           class="flex-1 rounded border-gray-300 focus:outline-none focus:ring-2 focus:ring-indigo-500 px-3 py-2">
+           class="form-input flex-1">
     <button type="submit" class="btn btn-primary">{% trans 'Buscar' %}</button>
   </form>
 


### PR DESCRIPTION
## Summary
- restyle feed search with `form-input` class and rely on Tailwind form plugin

## Testing
- `pytest --override-ini addopts="" feed/tests/test_search.py`

------
https://chatgpt.com/codex/tasks/task_e_68c18ff0d1f88325ac803422303cb8f2