### PR TITLE
chore: use design tokens for message colors

### DIFF
--- a/eventos/templates/eventos/_messages.html
+++ b/eventos/templates/eventos/_messages.html
@@ -3,7 +3,7 @@
   {% if messages %}
     <div class="mb-4 space-y-2">
       {% for message in messages %}
-        <p class="rounded-xl px-4 py-2 text-sm {% if 'success' in message.tags %}bg-green-100 text-green-700{% else %}bg-red-100 text-red-700{% endif %}">{{ message }}</p>
+        <p class="rounded-xl px-4 py-2 text-sm {% if 'success' in message.tags %}bg-[var(--success-light)] text-[var(--success)]{% else %}bg-[var(--error-light)] text-[var(--error)]{% endif %}">{{ message }}</p>
       {% endfor %}
     </div>
   {% endif %}

--- a/eventos/templates/eventos/briefing_list.html
+++ b/eventos/templates/eventos/briefing_list.html
@@ -17,7 +17,7 @@
       {% if messages %}
         <div class="mb-4 space-y-2">
           {% for message in messages %}
-            <p class="rounded-xl px-4 py-2 text-sm {% if 'success' in message.tags %}bg-green-100 text-green-700{% else %}bg-red-100 text-red-700{% endif %}">{{ message }}</p>
+            <p class="rounded-xl px-4 py-2 text-sm {% if 'success' in message.tags %}bg-[var(--success-light)] text-[var(--success)]{% else %}bg-[var(--error-light)] text-[var(--error)]{% endif %}">{{ message }}</p>
           {% endfor %}
         </div>
       {% endif %}

--- a/eventos/templates/eventos/inscricao_list.html
+++ b/eventos/templates/eventos/inscricao_list.html
@@ -14,7 +14,7 @@
       {% if messages %}
         <div class="mb-4 space-y-2">
           {% for message in messages %}
-            <p class="rounded-xl px-4 py-2 text-sm {% if 'success' in message.tags %}bg-green-100 text-green-700{% else %}bg-[var(--error-light)] text-[var(--error)]{% endif %}">{{ message }}</p>
+            <p class="rounded-xl px-4 py-2 text-sm {% if 'success' in message.tags %}bg-[var(--success-light)] text-[var(--success)]{% else %}bg-[var(--error-light)] text-[var(--error)]{% endif %}">{{ message }}</p>
           {% endfor %}
         </div>
       {% endif %}

--- a/organizacoes/templates/organizacoes/update.html
+++ b/organizacoes/templates/organizacoes/update.html
@@ -14,7 +14,7 @@
         {% if messages %}
         <div class="mb-4 space-y-2">
           {% for message in messages %}
-            <p class="rounded-xl px-4 py-2 text-sm {% if 'success' in message.tags %}bg-green-100 text-green-700{% else %}bg-red-100 text-red-700{% endif %}">{{ message }}</p>
+            <p class="rounded-xl px-4 py-2 text-sm {% if 'success' in message.tags %}bg-[var(--success-light)] text-[var(--success)]{% else %}bg-[var(--error-light)] text-[var(--error)]{% endif %}">{{ message }}</p>
           {% endfor %}
         </div>
         {% endif %}

--- a/templates/_components/filters_form.html
+++ b/templates/_components/filters_form.html
@@ -4,7 +4,7 @@
 {% if messages %}
 <div id="filter-errors" class="mb-4" aria-live="polite">
   {% for message in messages %}
-    <div class="bg-red-100 text-red-800 p-2 rounded" role="alert">{{ message }}</div>
+    <div class="bg-[var(--error-light)] text-[var(--error)] p-2 rounded" role="alert">{{ message }}</div>
   {% endfor %}
 </div>
 {% else %}


### PR DESCRIPTION
## Summary
- use CSS variable colors for filters form error messages
- switch message templates to success/error tokens

## Testing
- `pytest -m "not slow"` *(fails: ModuleNotFoundError: No module named 'silk'; 81 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c18fe9cd5c8325ae3053ef01046e03