### PR TITLE
refactor: remove sidebar includes from account templates

### DIFF
--- a/accounts/templates/account_inactive.html
+++ b/accounts/templates/account_inactive.html
@@ -8,9 +8,7 @@
 {% endblock %}
 
 {% block content %}
-
-{% include '_partials/sidebar.html' %}
-<div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+<div class="max-w-md mx-auto">
   <div class="p-8 rounded-lg shadow text-center bg-[var(--bg-secondary)] border border-[var(--border)]">
     <p class="mb-6 text-[var(--text-secondary)]" aria-live="polite">{% trans "Sua conta ainda não foi ativada. Verifique seu e-mail para continuar." %}</p>
     <a

--- a/accounts/templates/accounts/email_confirm.html
+++ b/accounts/templates/accounts/email_confirm.html
@@ -6,9 +6,7 @@
 {% endblock %}
 
 {% block content %}
-
-{% include '_partials/sidebar.html' %}
-<div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+<div class="max-w-md mx-auto">
   <div class="p-8 rounded-lg shadow text-center bg-[var(--bg-secondary)] border border-[var(--border)]">
     {% if status == 'sucesso' %}
       <p class="rounded-xl px-4 py-2 bg-[var(--success-light)] text-[var(--success)]" role="status" aria-live="polite">
@@ -21,5 +19,4 @@
     {% endif %}
   </div>
 </div>
-
 {% endblock %}

--- a/accounts/templates/perfil/disable_2fa.html
+++ b/accounts/templates/perfil/disable_2fa.html
@@ -7,7 +7,6 @@
 {% endblock %}
 
 {% block content %}
-{% include '_partials/sidebar.html' %}
   <form method="post" class="max-w-md mx-auto card">
     <div class="card-body space-y-6">
       {% csrf_token %}

--- a/accounts/templates/perfil/enable_2fa.html
+++ b/accounts/templates/perfil/enable_2fa.html
@@ -7,7 +7,6 @@
 {% endblock %}
 
 {% block content %}
-{% include '_partials/sidebar.html' %}
   <form method="post" class="max-w-md mx-auto card">
     <div class="card-body space-y-6">
       {% csrf_token %}


### PR DESCRIPTION
## Summary
- remove sidebar include from email confirmation template
- remove sidebar include from 2FA templates
- remove sidebar include from account inactive template

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'freezegun')*

------
https://chatgpt.com/codex/tasks/task_e_68c1b842c7f88325aeda4cb3e38b304d