### PR TITLE
refactor: use css vars and form classes

### DIFF
--- a/accounts/templates/perfil/midias.html
+++ b/accounts/templates/perfil/midias.html
@@ -5,33 +5,33 @@
 
 {% block perfil_content %}
 <section id="midias" class="perfil-section active">
-  <div class="section-header mb-6">
-    <h2 class="text-xl font-semibold text-neutral-900 dark:text-neutral-100">{% trans "Mídias" %}</h2>
-    <p class="text-sm text-gray-500 dark:text-gray-400">{% trans "Gerencie suas imagens, vídeos e documentos" %}</p>
+    <div class="section-header mb-6">
+      <h2 class="text-xl font-semibold text-[var(--text-primary)]">{% trans "Mídias" %}</h2>
+      <p class="text-sm text-[var(--text-secondary)]">{% trans "Gerencie suas imagens, vídeos e documentos" %}</p>
   </div>
 
   {% if show_form %}
   <form id="formMidias" class="space-y-6" method="post" action="{% url 'accounts:midias' %}" enctype="multipart/form-data">
     {% csrf_token %}
     <div>
-      <label for="id_file" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{% trans "Enviar arquivo" %}</label>
-      <input type="file" id="id_file" name="file" class="form-input mt-1 block w-full rounded-lg p-2 text-sm dark:bg-neutral-700 dark:border-neutral-600 dark:text-neutral-100" required accept="{{ allowed_exts|join:',' }}" aria-label="{% trans 'Arquivo' %}" aria-invalid="false" aria-describedby="file_help">
+        <label for="id_file" class="block text-sm font-medium text-[var(--text-secondary)]">{% trans "Enviar arquivo" %}</label>
+        <input type="file" id="id_file" name="file" class="form-input mt-1 block w-full rounded-lg p-2 text-sm" required accept="{{ allowed_exts|join:',' }}" aria-label="{% trans 'Arquivo' %}" aria-invalid="false" aria-describedby="file_help">
       {% if form.file.errors %}
         <div class="text-sm text-red-600">{{ form.file.errors }}</div>
       {% endif %}
-      <small id="file_help" class="text-sm text-neutral-500 dark:text-neutral-400">{% trans "Selecione um arquivo" %}</small>
+        <small id="file_help" class="text-sm text-[var(--text-secondary)]">{% trans "Selecione um arquivo" %}</small>
     </div>
     <div>
-      <label for="id_descricao" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{% trans "Descrição" %}</label>
-      <input type="text" id="id_descricao" name="descricao" class="form-input mt-1 block w-full rounded-lg p-2 text-sm dark:bg-neutral-700 dark:border-neutral-600 dark:text-neutral-100" aria-label="{% trans 'Descrição' %}" aria-invalid="false" aria-describedby="descricao_help" placeholder="{% trans 'Descrição' %}">
-      <small id="descricao_help" class="text-sm text-neutral-500 dark:text-neutral-400">{% trans "Breve descrição da mídia" %}</small>
+        <label for="id_descricao" class="block text-sm font-medium text-[var(--text-secondary)]">{% trans "Descrição" %}</label>
+        <input type="text" id="id_descricao" name="descricao" class="form-input mt-1 block w-full rounded-lg p-2 text-sm" aria-label="{% trans 'Descrição' %}" aria-invalid="false" aria-describedby="descricao_help" placeholder="{% trans 'Descrição' %}">
+        <small id="descricao_help" class="text-sm text-[var(--text-secondary)]">{% trans "Breve descrição da mídia" %}</small>
       {% if form.descricao.errors %}
         <div class="text-sm text-red-600">{{ form.descricao.errors }}</div>
       {% endif %}
     </div>
     <div>
-      <label for="id_tags_field" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{% trans "Tags" %}</label>
-      <input type="text" id="id_tags_field" name="tags_field" class="form-input mt-1 block w-full rounded-lg p-2 text-sm dark:bg-neutral-700 dark:border-neutral-600 dark:text-neutral-100" placeholder="{% trans 'paisagem, viagem' %}" aria-label="{% trans 'Tags' %}" aria-invalid="false">
+        <label for="id_tags_field" class="block text-sm font-medium text-[var(--text-secondary)]">{% trans "Tags" %}</label>
+        <input type="text" id="id_tags_field" name="tags_field" class="form-input mt-1 block w-full rounded-lg p-2 text-sm" placeholder="{% trans 'paisagem, viagem' %}" aria-label="{% trans 'Tags' %}" aria-invalid="false">
       {% if form.tags_field.errors %}
         <div class="text-sm text-red-600">{{ form.tags_field.errors }}</div>
       {% endif %}
@@ -49,10 +49,10 @@
     </a>
   {% endif %}
 
-  <form method="get" class="mt-6">
-    <input type="text" name="q" value="{{ q }}" placeholder="{% trans 'Buscar por descrição ou tags...' %}"
-           class="form-input w-full dark:border-neutral-600 dark:bg-neutral-700 dark:text-neutral-100 rounded-lg px-4 py-2 text-sm" aria-label="{% trans 'Buscar' %}" aria-invalid="false">
-  </form>
+    <form method="get" class="mt-6">
+      <input type="text" name="q" value="{{ q }}" placeholder="{% trans 'Buscar por descrição ou tags...' %}"
+             class="form-input w-full rounded-lg px-4 py-2 text-sm" aria-label="{% trans 'Buscar' %}" aria-invalid="false">
+    </form>
 
     <div class="card-grid mt-6">
       {% for media in medias %}
@@ -73,21 +73,21 @@
         {% elif media.media_type == 'pdf' %}
           <object data="{{ media.file.url }}" type="application/pdf" class="w-full h-40 rounded"></object>
         {% else %}
-          <span class="text-sm text-gray-500">{{ media.file.name }}</span>
+            <span class="text-sm text-[var(--text-secondary)]">{{ media.file.name }}</span>
         {% endif %}
         </a>
         <div class="card-body mt-2">
-          <p class="text-sm font-medium text-gray-700 dark:text-gray-200">{{ media.descricao }}</p>
-          <p class="text-xs text-gray-400 dark:text-gray-500">{{ media.created_at|date:"SHORT_DATETIME_FORMAT" }}</p>
+          <p class="text-sm font-medium text-[var(--text-primary)]">{{ media.descricao }}</p>
+          <p class="text-xs text-[var(--text-secondary)]">{{ media.created_at|date:"SHORT_DATETIME_FORMAT" }}</p>
           <div class="flex flex-wrap gap-1 mt-1">
             {% for tag in media.tags.all %}
-              <span class="bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 text-xs px-2 py-0.5 rounded">{{ tag.nome }}</span>
+                <span class="bg-[var(--bg-tertiary)] text-[var(--text-primary)] text-xs px-2 py-0.5 rounded">{{ tag.nome }}</span>
             {% endfor %}
           </div>
         </div>
       </article>
     {% empty %}
-      <p class="text-sm text-gray-500 dark:text-gray-400">{% trans "Nenhum arquivo enviado." %}</p>
+      <p class="text-sm text-[var(--text-secondary)]">{% trans "Nenhum arquivo enviado." %}</p>
     {% endfor %}
     </div>
   </section>

--- a/components/ui/alert.tsx
+++ b/components/ui/alert.tsx
@@ -10,7 +10,7 @@ const alertVariants = cva(
       variant: {
         default: "bg-background text-foreground",
         destructive:
-          "border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive",
+          "border-destructive/50 text-destructive [&>svg]:text-destructive",
       },
     },
     defaultVariants: {

--- a/organizacoes/templates/organizacoes/create.html
+++ b/organizacoes/templates/organizacoes/create.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load i18n %}
+{% load i18n widget_tweaks %}
 
 {% block title %}{% trans 'Nova Organização' %} | Hubx{% endblock %}
 
@@ -7,14 +7,14 @@
 <section class="max-w-2xl mx-auto px-4 py-10">
 
   <!-- Cabeçalho -->
-  <div class="mb-6 flex items-center gap-4">
-    <a href="{% url 'organizacoes:list' %}" class="inline-flex items-center text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100" aria-label="{% trans 'Voltar' %}">
-      <svg class="mr-2" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+    <div class="mb-6 flex items-center gap-4">
+      <a href="{% url 'organizacoes:list' %}" class="btn btn-secondary" aria-label="{% trans 'Voltar' %}">
+        <svg class="mr-2" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
         <polyline points="15,18 9,12 15,6"/>
       </svg>
       {% trans 'Voltar' %}
     </a>
-    <h1 class="text-2xl font-bold text-neutral-900">{% block form_title %}{% trans 'Cadastrar Organização' %}{% endblock %}</h1>
+      <h1 class="text-2xl font-bold text-[var(--text-primary)]">{% block form_title %}{% trans 'Cadastrar Organização' %}{% endblock %}</h1>
   </div>
 
   <!-- Formulário -->
@@ -23,16 +23,16 @@
 
     <div class="grid md:grid-cols-2 gap-6">
       <div>
-        <label for="{{ form.nome.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.nome.label }}</label>
-        {{ form.nome }}
+        <label for="{{ form.nome.id_for_label }}" class="block text-sm font-medium text-[var(--text-secondary)]">{{ form.nome.label }}</label>
+        {{ form.nome|add_class:'form-input' }}
         {% if form.nome.errors %}
           <p class="text-red-500 text-xs mt-1">{{ form.nome.errors }}</p>
         {% endif %}
       </div>
 
       <div>
-        <label for="{{ form.cnpj.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.cnpj.label }}</label>
-        {{ form.cnpj }}
+        <label for="{{ form.cnpj.id_for_label }}" class="block text-sm font-medium text-[var(--text-secondary)]">{{ form.cnpj.label }}</label>
+        {{ form.cnpj|add_class:'form-input' }}
         {% if form.cnpj.errors %}
           <p class="text-red-500 text-xs mt-1">{{ form.cnpj.errors }}</p>
         {% endif %}
@@ -40,16 +40,16 @@
     </div>
 
     <div>
-      <label for="{{ form.tipo.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.tipo.label }}</label>
-      {{ form.tipo }}
+      <label for="{{ form.tipo.id_for_label }}" class="block text-sm font-medium text-[var(--text-secondary)]">{{ form.tipo.label }}</label>
+      {{ form.tipo|add_class:'form-input' }}
       {% if form.tipo.errors %}
         <p class="text-red-500 text-xs mt-1">{{ form.tipo.errors }}</p>
       {% endif %}
     </div>
 
     <div>
-      <label for="{{ form.descricao.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.descricao.label }}</label>
-      {{ form.descricao }}
+      <label for="{{ form.descricao.id_for_label }}" class="block text-sm font-medium text-[var(--text-secondary)]">{{ form.descricao.label }}</label>
+      {{ form.descricao|add_class:'form-input' }}
       {% if form.descricao.errors %}
         <p class="text-red-500 text-xs mt-1">{{ form.descricao.errors }}</p>
       {% endif %}
@@ -57,22 +57,22 @@
 
     <div class="grid md:grid-cols-3 gap-6">
       <div class="md:col-span-3">
-        <label for="{{ form.rua.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.rua.label }}</label>
-        {{ form.rua }}
+          <label for="{{ form.rua.id_for_label }}" class="block text-sm font-medium text-[var(--text-secondary)]">{{ form.rua.label }}</label>
+          {{ form.rua|add_class:'form-input' }}
         {% if form.rua.errors %}
           <p class="text-red-500 text-xs mt-1">{{ form.rua.errors }}</p>
         {% endif %}
       </div>
       <div class="md:col-span-2">
-        <label for="{{ form.cidade.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.cidade.label }}</label>
-        {{ form.cidade }}
+          <label for="{{ form.cidade.id_for_label }}" class="block text-sm font-medium text-[var(--text-secondary)]">{{ form.cidade.label }}</label>
+          {{ form.cidade|add_class:'form-input' }}
         {% if form.cidade.errors %}
           <p class="text-red-500 text-xs mt-1">{{ form.cidade.errors }}</p>
         {% endif %}
       </div>
       <div>
-        <label for="{{ form.estado.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.estado.label }}</label>
-        {{ form.estado }}
+          <label for="{{ form.estado.id_for_label }}" class="block text-sm font-medium text-[var(--text-secondary)]">{{ form.estado.label }}</label>
+          {{ form.estado|add_class:'form-input' }}
         {% if form.estado.errors %}
           <p class="text-red-500 text-xs mt-1">{{ form.estado.errors }}</p>
         {% endif %}
@@ -81,22 +81,22 @@
 
     <div class="grid md:grid-cols-3 gap-6">
       <div>
-        <label for="{{ form.contato_nome.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.contato_nome.label }}</label>
-        {{ form.contato_nome }}
+          <label for="{{ form.contato_nome.id_for_label }}" class="block text-sm font-medium text-[var(--text-secondary)]">{{ form.contato_nome.label }}</label>
+          {{ form.contato_nome|add_class:'form-input' }}
         {% if form.contato_nome.errors %}
           <p class="text-red-500 text-xs mt-1">{{ form.contato_nome.errors }}</p>
         {% endif %}
       </div>
       <div>
-        <label for="{{ form.contato_email.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.contato_email.label }}</label>
-        {{ form.contato_email }}
+          <label for="{{ form.contato_email.id_for_label }}" class="block text-sm font-medium text-[var(--text-secondary)]">{{ form.contato_email.label }}</label>
+          {{ form.contato_email|add_class:'form-input' }}
         {% if form.contato_email.errors %}
           <p class="text-red-500 text-xs mt-1">{{ form.contato_email.errors }}</p>
         {% endif %}
       </div>
       <div>
-        <label for="{{ form.contato_telefone.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.contato_telefone.label }}</label>
-        {{ form.contato_telefone }}
+          <label for="{{ form.contato_telefone.id_for_label }}" class="block text-sm font-medium text-[var(--text-secondary)]">{{ form.contato_telefone.label }}</label>
+          {{ form.contato_telefone|add_class:'form-input' }}
         {% if form.contato_telefone.errors %}
           <p class="text-red-500 text-xs mt-1">{{ form.contato_telefone.errors }}</p>
         {% endif %}
@@ -104,53 +104,53 @@
     </div>
 
     <div>
-      <label for="{{ form.slug.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.slug.label }}</label>
-      {{ form.slug }}
+        <label for="{{ form.slug.id_for_label }}" class="block text-sm font-medium text-[var(--text-secondary)]">{{ form.slug.label }}</label>
+        {{ form.slug|add_class:'form-input' }}
       {% if form.slug.errors %}
         <p class="text-red-500 text-xs mt-1">{{ form.slug.errors }}</p>
       {% endif %}
     </div>
 
     <div>
-      <label for="{{ form.rate_limit_multiplier.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.rate_limit_multiplier.label }}</label>
-      {{ form.rate_limit_multiplier }}
+        <label for="{{ form.rate_limit_multiplier.id_for_label }}" class="block text-sm font-medium text-[var(--text-secondary)]">{{ form.rate_limit_multiplier.label }}</label>
+        {{ form.rate_limit_multiplier|add_class:'form-input' }}
       {% if form.rate_limit_multiplier.errors %}
         <p class="text-red-500 text-xs mt-1">{{ form.rate_limit_multiplier.errors }}</p>
       {% endif %}
     </div>
 
     <div>
-      <label for="{{ form.indice_reajuste.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.indice_reajuste.label }}</label>
-      {{ form.indice_reajuste }}
+        <label for="{{ form.indice_reajuste.id_for_label }}" class="block text-sm font-medium text-[var(--text-secondary)]">{{ form.indice_reajuste.label }}</label>
+        {{ form.indice_reajuste|add_class:'form-input' }}
       {% if form.indice_reajuste.errors %}
         <p class="text-red-500 text-xs mt-1">{{ form.indice_reajuste.errors }}</p>
       {% endif %}
     </div>
 
     <div>
-      <label for="{{ form.avatar.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.avatar.label }}</label>
-      {{ form.avatar }}
+        <label for="{{ form.avatar.id_for_label }}" class="block text-sm font-medium text-[var(--text-secondary)]">{{ form.avatar.label }}</label>
+        {{ form.avatar|add_class:'form-input' }}
       {% if form.avatar.errors %}
         <p class="text-red-500 text-xs mt-1">{{ form.avatar.errors }}</p>
       {% endif %}
     </div>
 
     <div>
-      <label for="{{ form.cover.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.cover.label }}</label>
-      {{ form.cover }}
+        <label for="{{ form.cover.id_for_label }}" class="block text-sm font-medium text-[var(--text-secondary)]">{{ form.cover.label }}</label>
+        {{ form.cover|add_class:'form-input' }}
       {% if form.cover.errors %}
         <p class="text-red-500 text-xs mt-1">{{ form.cover.errors }}</p>
       {% endif %}
     </div>
 
-    <div class="flex justify-end gap-3 pt-4 border-t border-neutral-100">
-      <a href="{% url 'organizacoes:list' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100">
-        {% trans 'Cancelar' %}
-      </a>
-      <button type="submit" class="text-sm px-4 py-2 rounded-xl bg-primary-600 text-white hover:bg-primary-700">
-        {% trans 'Salvar' %}
-      </button>
-    </div>
+      <div class="flex justify-end gap-3 pt-4 border-t border-neutral-100">
+        <a href="{% url 'organizacoes:list' %}" class="btn btn-secondary">
+          {% trans 'Cancelar' %}
+        </a>
+        <button type="submit" class="btn">
+          {% trans 'Salvar' %}
+        </button>
+      </div>
   </form>
 </section>
 {% endblock %}


### PR DESCRIPTION
## Summary
- replace hardcoded colors in organization creation and media templates with CSS variables and standardized form classes
- remove dark mode utility classes relying on CSS variables
- drop redundant dark border in alert component variant

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'silk')*

------
https://chatgpt.com/codex/tasks/task_e_68c1bc85346483258af32ac86d3b620b