### PR TITLE
Padroniza avisos e botões de exclusão

### DIFF
--- a/empresas/templates/empresas/confirmar_remocao.html
+++ b/empresas/templates/empresas/confirmar_remocao.html
@@ -3,14 +3,16 @@
 {% block title %}{% trans 'Remover Empresa' %}{% endblock %}
 {% block content %}
 <section class="max-w-md mx-auto py-16">
-  <div class="bg-[var(--error-light)] text-[var(--error)] p-6 rounded-md text-center space-y-4">
-    <h2 class="text-xl font-semibold">{% trans 'Confirmar remoção' %}</h2>
-    <p class="text-sm">{% blocktrans %}Tem certeza que deseja remover <strong>{{ object.nome }}</strong>?{% endblocktrans %}</p>
-    <form method="post" class="flex justify-center gap-3">
-      {% csrf_token %}
-      <a href="{% url 'empresas:lista' %}" class="px-4 py-2 border rounded text-sm">{% trans 'Cancelar' %}</a>
-      <button type="submit" class="px-4 py-2 bg-red-600 text-white rounded text-sm hover:bg-red-700">{% trans 'Remover' %}</button>
-    </form>
+  <div class="card bg-[var(--error-light)] text-[var(--error)]">
+    <div class="card-body text-center space-y-4">
+      <h2 class="text-xl font-semibold">{% trans 'Confirmar remoção' %}</h2>
+      <p class="text-sm">{% blocktrans %}Tem certeza que deseja remover <strong>{{ object.nome }}</strong>?{% endblocktrans %}</p>
+      <form method="post" class="flex justify-center gap-3">
+        {% csrf_token %}
+        <a href="{% url 'empresas:lista' %}" class="btn btn-secondary">{% trans 'Cancelar' %}</a>
+        <button type="submit" class="btn btn-danger">{% trans 'Remover' %}</button>
+      </form>
+    </div>
   </div>
 </section>
 {% endblock %}

--- a/empresas/templates/empresas/contato_confirm_delete.html
+++ b/empresas/templates/empresas/contato_confirm_delete.html
@@ -3,13 +3,15 @@
 {% block title %}{% translate 'Remover Contato' %}{% endblock %}
 {% block content %}
 <section class="max-w-md mx-auto py-10">
-  <div class="bg-[var(--error-light)] text-[var(--error)] p-6 rounded-md text-center space-y-4">
-    <p>{% blocktrans %}Confirma remover contato {{ contato.nome }}?{% endblocktrans %}</p>
-    <form method="post" class="flex justify-center gap-3">
-      {% csrf_token %}
-      <a href="#" onclick="history.back()" class="px-4 py-2 border rounded">{% translate 'Cancelar' %}</a>
-      <button type="submit" class="px-4 py-2 bg-red-600 text-white rounded">{% translate 'Remover' %}</button>
-    </form>
+  <div class="card bg-[var(--error-light)] text-[var(--error)]">
+    <div class="card-body text-center space-y-4">
+      <p>{% blocktrans %}Confirma remover contato {{ contato.nome }}?{% endblocktrans %}</p>
+      <form method="post" class="flex justify-center gap-3">
+        {% csrf_token %}
+        <a href="#" onclick="history.back()" class="btn btn-secondary">{% translate 'Cancelar' %}</a>
+        <button type="submit" class="btn btn-danger">{% translate 'Remover' %}</button>
+      </form>
+    </div>
   </div>
 </section>
 {% endblock %}

--- a/empresas/templates/empresas/tag_confirm_delete.html
+++ b/empresas/templates/empresas/tag_confirm_delete.html
@@ -3,14 +3,16 @@
 {% block title %}{% translate 'Remover Item' %}{% endblock %}
 {% block content %}
 <section class="max-w-md mx-auto py-16">
-  <div class="bg-[var(--error-light)] text-[var(--error)] p-6 rounded-md text-center space-y-4">
-    <h2 class="text-xl font-semibold">{% translate 'Remover Item' %}</h2>
-    <p class="text-sm">{% blocktrans %}Tem certeza que deseja remover <strong>{{ object.nome }}</strong>?{% endblocktrans %}</p>
-    <form method="post" class="flex justify-center gap-3">
-      {% csrf_token %}
-      <a href="{% url 'empresas:tags_list' %}" class="px-4 py-2 border rounded text-sm">{% translate 'Cancelar' %}</a>
-      <button type="submit" class="px-4 py-2 bg-red-600 text-white rounded text-sm hover:bg-red-700">{% translate 'Remover' %}</button>
-    </form>
+  <div class="card bg-[var(--error-light)] text-[var(--error)]">
+    <div class="card-body text-center space-y-4">
+      <h2 class="text-xl font-semibold">{% translate 'Remover Item' %}</h2>
+      <p class="text-sm">{% blocktrans %}Tem certeza que deseja remover <strong>{{ object.nome }}</strong>?{% endblocktrans %}</p>
+      <form method="post" class="flex justify-center gap-3">
+        {% csrf_token %}
+        <a href="{% url 'empresas:tags_list' %}" class="btn btn-secondary">{% translate 'Cancelar' %}</a>
+        <button type="submit" class="btn btn-danger">{% translate 'Remover' %}</button>
+      </form>
+    </div>
   </div>
 </section>
 {% endblock %}

--- a/nucleos/templates/nucleos/detail.html
+++ b/nucleos/templates/nucleos/detail.html
@@ -15,7 +15,7 @@
         <h1 class="text-2xl font-bold">{{ object.nome }}</h1>
         {% if request.user.user_type == 'admin' or request.user.user_type == 'coordenador' %}
         <a href="{% url 'nucleos:update' object.pk %}" class="px-4 py-2 bg-blue-600 text-white rounded">{% trans 'Editar' %}</a>
-        <a href="{% url 'nucleos:delete' object.pk %}" class="px-4 py-2 bg-red-600 text-white rounded">{% trans 'Excluir' %}</a>
+        <a href="{% url 'nucleos:delete' object.pk %}" class="btn btn-danger btn-sm">{% trans 'Excluir' %}</a>
         {% endif %}
       </div>
     </div>
@@ -63,7 +63,7 @@
               <td>{{ part.data_solicitacao|date:'d/m/Y' }}</td>
               <td class="space-x-2">
                 <button class="text-sm text-green-600" hx-post="{% url 'nucleos_api:nucleo-aprovar-membro' object.pk part.user.pk %}" hx-target="#pendente-{{ part.id }}" hx-swap="none" hx-on="htmx:afterRequest: this.closest('tr').remove()" hx-confirm="{% trans 'Confirmar aprovação?' %}" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>{% trans 'Aprovar' %}</button>
-                <button class="text-sm text-red-600" hx-post="{% url 'nucleos_api:nucleo-recusar-membro' object.pk part.user.pk %}" hx-target="#pendente-{{ part.id }}" hx-swap="none" hx-on="htmx:afterRequest: this.closest('tr').remove()" hx-confirm="{% trans 'Confirmar recusa?' %}" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>{% trans 'Recusar' %}</button>
+                <button class="btn btn-danger btn-sm" hx-post="{% url 'nucleos_api:nucleo-recusar-membro' object.pk part.user.pk %}" hx-target="#pendente-{{ part.id }}" hx-swap="none" hx-on="htmx:afterRequest: this.closest('tr').remove()" hx-confirm="{% trans 'Confirmar recusa?' %}" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>{% trans 'Recusar' %}</button>
               </td>
             </tr>
           {% endfor %}

--- a/organizacoes/templates/organizacoes/delete.html
+++ b/organizacoes/templates/organizacoes/delete.html
@@ -5,21 +5,19 @@
 
 {% block content %}
 <section class="max-w-md mx-auto px-4 py-16">
-    <div class="card text-center border-red-200">
-    <h1 class="text-xl font-semibold text-red-700 mb-4">{% trans 'Confirmar remoção' %}</h1>
-    <p class="text-sm text-neutral-700">
-      {% blocktrans with nome=object.nome %}Tem certeza que deseja remover <strong>{{ nome }}</strong>?{% endblocktrans %}
-    </p>
+  <div class="card bg-[var(--error-light)] text-[var(--error)] text-center">
+    <div class="card-body">
+      <h1 class="text-xl font-semibold mb-4">{% trans 'Confirmar remoção' %}</h1>
+      <p class="text-sm text-neutral-700">
+        {% blocktrans with nome=object.nome %}Tem certeza que deseja remover <strong>{{ nome }}</strong>?{% endblocktrans %}
+      </p>
 
-    <form method="post" class="mt-6 flex justify-center gap-3">
-      {% csrf_token %}
-      <a href="{% url 'organizacoes:list' %}" class="text-sm px-4 py-2 rounded-xl border border-neutral-300 text-neutral-700 hover:bg-neutral-100">
-        {% trans 'Cancelar' %}
-      </a>
-      <button type="submit" class="text-sm px-4 py-2 rounded-xl bg-red-600 text-white hover:bg-red-700">
-        {% trans 'Remover' %}
-      </button>
-    </form>
+      <form method="post" class="mt-6 flex justify-center gap-3">
+        {% csrf_token %}
+        <a href="{% url 'organizacoes:list' %}" class="btn btn-secondary">{% trans 'Cancelar' %}</a>
+        <button type="submit" class="btn btn-danger">{% trans 'Remover' %}</button>
+      </form>
+    </div>
   </div>
 </section>
 {% endblock %}


### PR DESCRIPTION
## Summary
- usa card com variáveis de erro para avisos de exclusão
- padroniza botões de remover como `.btn-danger` e cancelar como `.btn-secondary`
- ajusta ações de recusa de membros para `.btn-danger`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'freezegun')*

------
https://chatgpt.com/codex/tasks/task_e_68c1c0996b3c832581ea93fb69f3b3b2