### PR TITLE
Refactor empresa form to remove duplicate block and use shared fields

### DIFF
--- a/empresas/templates/empresas/empresa_form.html
+++ b/empresas/templates/empresas/empresa_form.html
@@ -20,76 +20,13 @@
 
     <form method="post" enctype="multipart/form-data" class="card space-y-6">
       {% csrf_token %}
-      <div class="grid md:grid-cols-2 gap-6">
-        <div>
-          <label for="{{ form.nome.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.nome.label }}</label>
-          {{ form.nome|add_class:'w-full p-2 border rounded' }}
-          {{ form.nome.errors }}
-        </div>
-        <div>
-          <label for="{{ form.cnpj.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.cnpj.label }}</label>
-          {{ form.cnpj|add_class:'w-full p-2 border rounded' }}
-          {{ form.cnpj.errors }}
-        </div>
-        <div>
-          <label for="{{ form.validado_em.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.validado_em.label }}</label>
-          {{ form.validado_em|add_class:'w-full p-2 border rounded bg-neutral-100' }}
-          {{ form.validado_em.errors }}
-        </div>
-        <div>
-          <label for="{{ form.fonte_validacao.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.fonte_validacao.label }}</label>
-          {{ form.fonte_validacao|add_class:'w-full p-2 border rounded bg-neutral-100' }}
-          {{ form.fonte_validacao.errors }}
-        </div>
-      </div>
-      <div class="grid md:grid-cols-2 gap-6">
-        <div>
-          <label for="{{ form.tipo.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.tipo.label }}</label>
-          {{ form.tipo|add_class:'w-full p-2 border rounded' }}
-          {{ form.tipo.errors }}
-        </div>
-        <div>
-          <label for="{{ form.tags.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.tags.label }}</label>
-          {{ form.tags|add_class:'w-full p-2 border rounded' }}
-          {{ form.tags.errors }}
-        </div>
-      </div>
-      <div>
-        <label for="{{ form.descricao.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.descricao.label }}</label>
-        {{ form.descricao|add_class:'w-full p-2 border rounded' }}
-        {{ form.descricao.errors }}
-        <p class="text-xs text-neutral-500 mt-1">{% translate 'Descreva brevemente o que sua empresa faz e seus principais objetivos.' %}</p>
-      </div>
-      <div class="grid md:grid-cols-2 gap-6">
-        <div>
-          <label for="{{ form.municipio.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.municipio.label }}</label>
-          {{ form.municipio|add_class:'w-full p-2 border rounded' }}
-          {{ form.municipio.errors }}
-        </div>
-        <div>
-          <label for="{{ form.estado.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.estado.label }}</label>
-          {{ form.estado|add_class:'w-full p-2 border rounded' }}
-          {{ form.estado.errors }}
-        </div>
-      </div>
-      <div>
-        <label for="{{ form.palavras_chave.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.palavras_chave.label }}</label>
-        {{ form.palavras_chave|add_class:'w-full p-2 border rounded' }}
-        {{ form.palavras_chave.errors }}
-        <p class="text-xs text-neutral-500 mt-1">{% translate 'Separe por vírgulas.' %}</p>
-      </div>
-      <div>
-        <label for="{{ form.avatar.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.avatar.label }}</label>
-        {{ form.avatar|add_class:'w-full p-2 border rounded' }}
-        {{ form.avatar.errors }}
-        <p class="text-xs text-neutral-500 mt-1">{% translate 'PNG, JPG até 2MB' %}</p>
-      </div>
-      <div>
-        <label for="{{ form.cover.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.cover.label }}</label>
-        {{ form.cover|add_class:'w-full p-2 border rounded' }}
-        {{ form.cover.errors }}
-        <p class="text-xs text-neutral-500 mt-1">{% translate 'PNG, JPG até 2MB' %}</p>
-      </div>
+      {% for field in form %}
+        {% if field.name == 'validado_em' or field.name == 'fonte_validacao' %}
+          {% include '_forms/field.html' with field=field readonly=True %}
+        {% else %}
+          {% include '_forms/field.html' with field=field %}
+        {% endif %}
+      {% endfor %}
       <div class="flex justify-end gap-3 border-t border-[var(--border)] pt-4">
         <a href="{% url 'empresas:lista' %}" class="btn btn-secondary">{% translate 'Cancelar' %}</a>
         <button type="submit" class="btn btn-primary inline-flex items-center gap-2">
@@ -99,106 +36,6 @@
       </div>
     </form>
   </div>
-</div>
-{% block content %}
-<section class="max-w-3xl mx-auto px-4 py-10 space-y-6">
-  <header class="flex items-start gap-4">
-    <a href="{% url 'empresas:lista' %}" class="text-sm px-3 py-2 border rounded hover:bg-neutral-100">{% translate 'Voltar' %}</a>
-    <div>
-      <h1 class="text-2xl font-bold text-neutral-900">{% if form.instance.pk %}{% translate 'Editar Empresa' %}{% else %}{% translate 'Nova Empresa' %}{% endif %}</h1>
-      <p class="text-sm text-neutral-600">{% translate 'Cadastre sua empresa na plataforma' %}</p>
-    </div>
-  </header>
-
-  <form method="post" enctype="multipart/form-data" class="bg-white border border-neutral-200 rounded-md shadow-sm p-6 space-y-6">
-    {% csrf_token %}
-
-    {% if form.non_field_errors %}
-    <ul class="errorlist">{% for error in form.non_field_errors %}<li>{{ error }}</li>{% endfor %}</ul>
-    {% endif %}
-    {% for field in form %}
-      {% include '_forms/field.html' with field=field %}
-    {% endfor %}
-
-    <div class="grid md:grid-cols-2 gap-6">
-      <div>
-        <label for="{{ form.nome.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.nome.label }}</label>
-        {{ form.nome|add_class:'w-full p-2 border rounded' }}
-        {{ form.nome.errors }}
-      </div>
-      <div>
-        <label for="{{ form.cnpj.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.cnpj.label }}</label>
-        {{ form.cnpj|add_class:'w-full p-2 border rounded' }}
-        {{ form.cnpj.errors }}
-      </div>
-      <div>
-        <label for="{{ form.validado_em.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.validado_em.label }}</label>
-        {{ form.validado_em|add_class:'w-full p-2 border rounded bg-neutral-100' }}
-        {{ form.validado_em.errors }}
-      </div>
-      <div>
-        <label for="{{ form.fonte_validacao.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.fonte_validacao.label }}</label>
-        {{ form.fonte_validacao|add_class:'w-full p-2 border rounded bg-neutral-100' }}
-        {{ form.fonte_validacao.errors }}
-      </div>
-    </div>
-    <div class="grid md:grid-cols-2 gap-6">
-      <div>
-        <label for="{{ form.tipo.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.tipo.label }}</label>
-        {{ form.tipo|add_class:'w-full p-2 border rounded' }}
-        {{ form.tipo.errors }}
-      </div>
-      <div>
-        <label for="{{ form.tags.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.tags.label }}</label>
-        {{ form.tags|add_class:'w-full p-2 border rounded' }}
-        {{ form.tags.errors }}
-      </div>
-    </div>
-    <div>
-      <label for="{{ form.descricao.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.descricao.label }}</label>
-      {{ form.descricao|add_class:'w-full p-2 border rounded' }}
-      {{ form.descricao.errors }}
-      <p class="text-xs text-neutral-500 mt-1">{% translate 'Descreva brevemente o que sua empresa faz e seus principais objetivos.' %}</p>
-    </div>
-    <div class="grid md:grid-cols-2 gap-6">
-      <div>
-        <label for="{{ form.municipio.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.municipio.label }}</label>
-        {{ form.municipio|add_class:'w-full p-2 border rounded' }}
-        {{ form.municipio.errors }}
-      </div>
-      <div>
-        <label for="{{ form.estado.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.estado.label }}</label>
-        {{ form.estado|add_class:'w-full p-2 border rounded' }}
-        {{ form.estado.errors }}
-      </div>
-    </div>
-    <div>
-      <label for="{{ form.palavras_chave.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.palavras_chave.label }}</label>
-      {{ form.palavras_chave|add_class:'w-full p-2 border rounded' }}
-      {{ form.palavras_chave.errors }}
-      <p class="text-xs text-neutral-500 mt-1">{% translate 'Separe por vírgulas.' %}</p>
-    </div>
-    <div>
-      <label for="{{ form.avatar.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.avatar.label }}</label>
-      {{ form.avatar|add_class:'w-full p-2 border rounded' }}
-      {{ form.avatar.errors }}
-        <p class="text-xs text-neutral-500 mt-1">{% translate 'PNG, JPG até 2MB' %}</p>
-    </div>
-    <div>
-      <label for="{{ form.cover.id_for_label }}" class="block text-sm font-medium text-neutral-700">{{ form.cover.label }}</label>
-      {{ form.cover|add_class:'w-full p-2 border rounded' }}
-      {{ form.cover.errors }}
-        <p class="text-xs text-neutral-500 mt-1">{% translate 'PNG, JPG até 2MB' %}</p>
-    </div>
-
-    <div class="flex justify-end gap-3 border-t pt-4">
-      <a href="{% url 'empresas:lista' %}" class="text-sm px-4 py-2 border rounded">{% translate 'Cancelar' %}</a>
-      <button type="submit" class="text-sm px-4 py-2 bg-primary-600 text-white rounded hover:bg-primary-700 inline-flex items-center gap-2">
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"/></svg>
-        {% if form.instance.pk %}{% translate 'Salvar' %}{% else %}{% translate 'Cadastrar Empresa' %}{% endif %}
-      </button>
-  </form>
-</section>
 {% endblock %}
 
 {% block extra_js %}


### PR DESCRIPTION
## Summary
- render empresa fields via shared `_forms/field.html`
- remove duplicated content block and color classes
- standardize form buttons with `btn` variants

## Testing
- `ruff format empresas/templates/empresas/empresa_form.html` *(fails: Expected an expression)*
- `black empresas/templates/empresas/empresa_form.html` *(fails: Cannot parse: 1:1: {% extends "base.html" %})*
- `pytest` *(fails: 81 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c6b4e4e88325bce5875c1531e510