### PR TITLE
Padroniza formulários financeiros

### DIFF
--- a/financeiro/templates/financeiro/aportes_form.html
+++ b/financeiro/templates/financeiro/aportes_form.html
@@ -1,35 +1,39 @@
 {% load i18n %}
-<form
-  hx-post="/api/financeiro/aportes/"
-  hx-target="#aportes-messages"
-  hx-on="htmx:afterRequest: if(event.detail.successful){this.reset();var resp=JSON.parse(event.detail.xhr.response);var msg='{{ _('Aporte registrado com sucesso') }}';if(resp.recibo_url){msg+=' <a href=\"'+resp.recibo_url+'\" target=\"_blank\">{{ _('Baixar recibo') }}</a>'; }document.getElementById('aportes-messages').innerHTML=msg;}else{var resp=JSON.parse(event.detail.xhr.response||'{}');var err=resp.valor?resp.valor[0]:'{{ _('Erro ao registrar aporte') }}';document.getElementById('aportes-messages').textContent=err;}"
-  class="p-4 bg-white rounded shadow max-w-md"
-  aria-live="assertive"
->
-  {% csrf_token %}
-  <div class="mb-2">
-    <label for="id_centro" class="block text-sm font-medium">{{ _('Centro de Custo') }}</label>
-    <select id="id_centro" name="centro_custo" class="border p-2 w-full">
-      {% for c in centros %}
-      <option value="{{ c.id }}">{{ c.nome }}</option>
-      {% endfor %}
-    </select>
+<div class="card max-w-md">
+  <div class="card-body">
+    <form
+      hx-post="/api/financeiro/aportes/"
+      hx-target="#aportes-messages"
+      hx-on="htmx:afterRequest: if(event.detail.successful){this.reset();var resp=JSON.parse(event.detail.xhr.response);var msg='{{ _('Aporte registrado com sucesso') }}';if(resp.recibo_url){msg+=' <a href=\\"'+resp.recibo_url+'\\" target=\\"_blank\\">{{ _('Baixar recibo') }}</a>'; }document.getElementById('aportes-messages').innerHTML=msg;}else{var resp=JSON.parse(event.detail.xhr.response||'{}');var err=resp.valor?resp.valor[0]:'{{ _('Erro ao registrar aporte') }}';document.getElementById('aportes-messages').textContent=err;}"
+      class="space-y-2"
+      aria-live="assertive"
+    >
+      {% csrf_token %}
+      <div>
+        <label for="id_centro" class="block text-sm font-medium">{{ _('Centro de Custo') }}</label>
+        <select id="id_centro" name="centro_custo" class="form-select w-full">
+          {% for c in centros %}
+          <option value="{{ c.id }}">{{ c.nome }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div>
+        <label for="id_valor" class="block text-sm font-medium">{{ _('Valor') }}</label>
+        <input id="id_valor" type="number" step="0.01" name="valor" class="form-input w-full" required min="0" />
+      </div>
+      <div>
+        <span class="block text-sm font-medium">{{ _('Tipo') }}</span>
+        {% if request.user.user_type == 'admin' %}
+        <label class="mr-4"><input type="radio" name="tipo" value="aporte_interno" /> {{ _('Interno') }}</label>
+        {% endif %}
+        <label><input type="radio" name="tipo" value="aporte_externo" checked /> {{ _('Externo') }}</label>
+      </div>
+      <div>
+        <label for="id_descricao" class="block text-sm font-medium">{{ _('Descrição') }}</label>
+        <textarea id="id_descricao" name="descricao" class="form-input w-full"></textarea>
+      </div>
+      <button type="submit" class="btn btn-primary">{{ _('Registrar') }}</button>
+      <div id="aportes-messages" class="mt-2 text-sm" aria-live="polite"></div>
+    </form>
   </div>
-  <div class="mb-2">
-    <label for="id_valor" class="block text-sm font-medium">{{ _('Valor') }}</label>
-    <input id="id_valor" type="number" step="0.01" name="valor" class="border p-2 w-full" required min="0" />
-  </div>
-  <div class="mb-2">
-    <span class="block text-sm font-medium">{{ _('Tipo') }}</span>
-    {% if request.user.user_type == 'admin' %}
-    <label class="mr-4"><input type="radio" name="tipo" value="aporte_interno" /> {{ _('Interno') }}</label>
-    {% endif %}
-    <label><input type="radio" name="tipo" value="aporte_externo" checked /> {{ _('Externo') }}</label>
-  </div>
-  <div class="mb-2">
-    <label for="id_descricao" class="block text-sm font-medium">{{ _('Descrição') }}</label>
-    <textarea id="id_descricao" name="descricao" class="border p-2 w-full"></textarea>
-  </div>
-  <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">{{ _('Registrar') }}</button>
-  <div id="aportes-messages" class="mt-2 text-sm" aria-live="polite"></div>
-</form>
+</div>

--- a/financeiro/templates/financeiro/centro_form.html
+++ b/financeiro/templates/financeiro/centro_form.html
@@ -1,95 +1,83 @@
 {% load i18n %}
-<form id="centro-form"
-      {% if centro %}
-        hx-put="/api/financeiro/centros/{{ centro.id }}/"
-      {% else %}
-        hx-post="/api/financeiro/centros/"
-      {% endif %}
-      hx-target="#centros-list"
-      hx-on="htmx:afterRequest: htmx.ajax('GET', '/financeiro/centros/', '#centros-list'); document.getElementById('modal').innerHTML='';"
-      class="p-4 bg-white rounded shadow max-w-md space-y-4" aria-live="assertive">
-  {% csrf_token %}
-  <div>
-    <label for="id_nome" class="block text-sm font-medium">{{ _('Nome') }}</label>
-    <input id="id_nome" name="nome" type="text" class="border p-2 w-full" required {% if centro %}value="{{ centro.nome }}"{% endif %} {% if form and form.nome.errors %}aria-invalid="true"{% endif %} />
-    {% if form and form.nome.errors %}<p class="text-red-600 text-sm" aria-live="polite">{{ form.nome.errors }}</p>{% endif %}
+<div class="card max-w-md">
+  <div class="card-body">
+    <form id="centro-form"
+          {% if centro %}
+            hx-put="/api/financeiro/centros/{{ centro.id }}/"
+          {% else %}
+            hx-post="/api/financeiro/centros/"
+          {% endif %}
+          hx-target="#centros-list"
+          hx-on="htmx:afterRequest: htmx.ajax('GET', '/financeiro/centros/', '#centros-list'); document.getElementById('modal').innerHTML='';"
+          class="space-y-4" aria-live="assertive">
+      {% csrf_token %}
+      {% include '_forms/field.html' with field=form.nome %}
+      {% include '_forms/field.html' with field=form.tipo %}
+      <div>
+        <label for="organizacao-search" class="block text-sm font-medium">{{ _('Organização') }}</label>
+        <input
+          type="text"
+          id="organizacao-search"
+          name="search"
+          class="form-input w-full"
+          form="search-organizacao"
+          hx-get="/api/organizacoes/"
+          hx-trigger="keyup changed delay:500ms"
+          hx-target="#id_organizacao"
+          hx-swap="none"
+          hx-on="htmx:afterRequest: renderOrganizacoes(event)"
+        />
+        <select id="id_organizacao" name="organizacao" class="form-select w-full mt-2">
+          {% if centro and centro.organizacao %}
+          <option value="{{ centro.organizacao.id }}" selected>{{ centro.organizacao.nome }}</option>
+          {% endif %}
+        </select>
+      </div>
+      <div>
+        <label for="nucleo-search" class="block text-sm font-medium">{{ _('Núcleo') }}</label>
+        <input
+          type="text"
+          id="nucleo-search"
+          name="search"
+          class="form-input w-full"
+          form="search-nucleo"
+          hx-get="/api/nucleos/"
+          hx-trigger="keyup changed delay:500ms"
+          hx-target="#id_nucleo"
+          hx-swap="none"
+          hx-on="htmx:afterRequest: renderNucleos(event)"
+        />
+        <select id="id_nucleo" name="nucleo" class="form-select w-full mt-2">
+          {% if centro and centro.nucleo %}
+          <option value="{{ centro.nucleo.id }}" selected>{{ centro.nucleo.nome }}</option>
+          {% endif %}
+        </select>
+      </div>
+      <div>
+        <label for="evento-search" class="block text-sm font-medium">{{ _('Evento') }}</label>
+        <input
+          type="text"
+          id="evento-search"
+          name="search"
+          class="form-input w-full"
+          form="search-evento"
+          hx-get="/api/eventos/"
+          hx-trigger="keyup changed delay:500ms"
+          hx-target="#id_evento"
+          hx-swap="none"
+          hx-on="htmx:afterRequest: renderEventos(event)"
+        />
+        <select id="id_evento" name="evento" class="form-select w-full mt-2">
+          {% if centro and centro.evento %}
+          <option value="{{ centro.evento.id }}" selected>{{ centro.evento.titulo }}</option>
+          {% endif %}
+        </select>
+      </div>
+      {% include '_forms/field.html' with field=form.descricao %}
+      <button type="submit" class="btn btn-primary">{{ _('Salvar') }}</button>
+    </form>
   </div>
-  <div>
-    <label for="id_tipo" class="block text-sm font-medium">{{ _('Tipo') }}</label>
-    <select id="id_tipo" name="tipo" class="border p-2 w-full" required {% if form and form.tipo.errors %}aria-invalid="true"{% endif %}>
-      <option value="organizacao"{% if centro and centro.tipo == 'organizacao' %} selected{% endif %}>{{ _('Organização') }}</option>
-      <option value="nucleo"{% if centro and centro.tipo == 'nucleo' %} selected{% endif %}>{{ _('Núcleo') }}</option>
-      <option value="evento"{% if centro and centro.tipo == 'evento' %} selected{% endif %}>{{ _('Evento') }}</option>
-    </select>
-    {% if form and form.tipo.errors %}<p class="text-red-600 text-sm" aria-live="polite">{{ form.tipo.errors }}</p>{% endif %}
-  </div>
-  <div>
-    <label for="organizacao-search" class="block text-sm font-medium">{{ _('Organização') }}</label>
-    <input
-      type="text"
-      id="organizacao-search"
-      name="search"
-      class="border p-2 w-full"
-      form="search-organizacao"
-      hx-get="/api/organizacoes/"
-      hx-trigger="keyup changed delay:500ms"
-      hx-target="#id_organizacao"
-      hx-swap="none"
-      hx-on="htmx:afterRequest: renderOrganizacoes(event)"
-    />
-    <select id="id_organizacao" name="organizacao" class="border p-2 w-full mt-2">
-      {% if centro and centro.organizacao %}
-      <option value="{{ centro.organizacao.id }}" selected>{{ centro.organizacao.nome }}</option>
-      {% endif %}
-    </select>
-  </div>
-  <div>
-    <label for="nucleo-search" class="block text-sm font-medium">{{ _('Núcleo') }}</label>
-    <input
-      type="text"
-      id="nucleo-search"
-      name="search"
-      class="border p-2 w-full"
-      form="search-nucleo"
-      hx-get="/api/nucleos/"
-      hx-trigger="keyup changed delay:500ms"
-      hx-target="#id_nucleo"
-      hx-swap="none"
-      hx-on="htmx:afterRequest: renderNucleos(event)"
-    />
-    <select id="id_nucleo" name="nucleo" class="border p-2 w-full mt-2">
-      {% if centro and centro.nucleo %}
-      <option value="{{ centro.nucleo.id }}" selected>{{ centro.nucleo.nome }}</option>
-      {% endif %}
-    </select>
-  </div>
-  <div>
-    <label for="evento-search" class="block text-sm font-medium">{{ _('Evento') }}</label>
-    <input
-      type="text"
-      id="evento-search"
-      name="search"
-      class="border p-2 w-full"
-      form="search-evento"
-      hx-get="/api/eventos/"
-      hx-trigger="keyup changed delay:500ms"
-      hx-target="#id_evento"
-      hx-swap="none"
-      hx-on="htmx:afterRequest: renderEventos(event)"
-    />
-    <select id="id_evento" name="evento" class="border p-2 w-full mt-2">
-      {% if centro and centro.evento %}
-      <option value="{{ centro.evento.id }}" selected>{{ centro.evento.titulo }}</option>
-      {% endif %}
-    </select>
-  </div>
-  <div>
-    <label for="id_descricao" class="block text-sm font-medium">{{ _('Descrição') }}</label>
-    <textarea id="id_descricao" name="descricao" class="border p-2 w-full" {% if form and form.descricao.errors %}aria-invalid="true"{% endif %}>{% if centro %}{{ centro.descricao }}{% endif %}</textarea>
-    {% if form and form.descricao.errors %}<p class="text-red-600 text-sm" aria-live="polite">{{ form.descricao.errors }}</p>{% endif %}
-  </div>
-  <button type="submit" class="bg-green-600 text-white px-4 py-2 rounded">{{ _('Salvar') }}</button>
-</form>
+</div>
 
 <script src="{% url 'javascript-catalog' %}"></script>
 <script>

--- a/financeiro/templates/financeiro/hero_centros_action.html
+++ b/financeiro/templates/financeiro/hero_centros_action.html
@@ -1,2 +1,2 @@
 {% load i18n %}
-<button class="bg-blue-600 text-white px-4 py-2 rounded" hx-get="/financeiro/centros/form/" hx-target="#modal" hx-trigger="click">{% trans "Novo Centro" %}</button>
+<button class="btn btn-primary" hx-get="/financeiro/centros/form/" hx-target="#modal" hx-trigger="click">{% trans "Novo Centro" %}</button>

--- a/financeiro/templates/financeiro/hero_integracoes_action.html
+++ b/financeiro/templates/financeiro/hero_integracoes_action.html
@@ -1,2 +1,2 @@
 {% load i18n %}
-<button class="bg-blue-600 text-white px-4 py-2 rounded" hx-get="{% url 'financeiro:integracao_form' %}" hx-target="#modal" hx-trigger="click">{% trans "Nova Configuração" %}</button>
+<button class="btn btn-primary" hx-get="{% url 'financeiro:integracao_form' %}" hx-target="#modal" hx-trigger="click">{% trans "Nova Configuração" %}</button>

--- a/financeiro/templates/financeiro/integracao_form.html
+++ b/financeiro/templates/financeiro/integracao_form.html
@@ -1,66 +1,46 @@
 {% load i18n %}
-<form id="integracao-form"
-      {% if integracao %}
-        hx-put="/api/financeiro/integracoes/{{ integracao.id }}/"
-      {% else %}
-        hx-post="/api/financeiro/integracoes/"
-      {% endif %}
-      hx-target="#integracoes-list"
-      hx-on="htmx:afterRequest: htmx.ajax('GET', '/financeiro/integracoes/', '#integracoes-list'); document.getElementById('modal').innerHTML='';"
-      class="p-4 bg-white rounded shadow max-w-md space-y-4" aria-live="assertive">
-  {% csrf_token %}
-  <div>
-    <label for="id_nome" class="block text-sm font-medium">{{ _('Nome') }}</label>
-    <input id="id_nome" name="nome" type="text" class="border p-2 w-full" required {% if integracao %}value="{{ integracao.nome }}"{% endif %} {% if form and form.nome.errors %}aria-invalid="true"{% endif %} />
-    {% if form and form.nome.errors %}<p class="text-red-600 text-sm" aria-live="polite">{{ form.nome.errors }}</p>{% endif %}
+<div class="card max-w-md">
+  <div class="card-body">
+    <form id="integracao-form"
+          {% if integracao %}
+            hx-put="/api/financeiro/integracoes/{{ integracao.id }}/"
+          {% else %}
+            hx-post="/api/financeiro/integracoes/"
+          {% endif %}
+          hx-target="#integracoes-list"
+          hx-on="htmx:afterRequest: htmx.ajax('GET', '/financeiro/integracoes/', '#integracoes-list'); document.getElementById('modal').innerHTML='';"
+          class="space-y-4" aria-live="assertive">
+      {% csrf_token %}
+      {% include '_forms/field.html' with field=form.nome %}
+      {% include '_forms/field.html' with field=form.tipo %}
+      <div>
+        <label for="integracao-organizacao-search" class="block text-sm font-medium">{{ _('Organização') }}</label>
+        <input
+          type="text"
+          id="integracao-organizacao-search"
+          name="search"
+          class="form-input w-full"
+          form="search-organizacao"
+          hx-get="/api/organizacoes/"
+          hx-trigger="keyup changed delay:500ms"
+          hx-target="#id_organizacao"
+          hx-swap="none"
+          hx-on="htmx:afterRequest: renderOrganizacoes(event)"
+        />
+        <select id="id_organizacao" name="organizacao" class="form-select w-full mt-2" {% if form and form.organizacao.errors %}aria-invalid="true"{% endif %}>
+          {% if integracao and integracao.organizacao %}
+          <option value="{{ integracao.organizacao.id }}" selected>{{ integracao.organizacao.nome }}</option>
+          {% endif %}
+        </select>
+        {% if form and form.organizacao.errors %}<p class="text-red-600 text-sm" aria-live="polite">{{ form.organizacao.errors }}</p>{% endif %}
+      </div>
+      {% include '_forms/field.html' with field=form.base_url %}
+      {% include '_forms/field.html' with field=form.autenticacao %}
+      {% include '_forms/field.html' with field=form.credenciais %}
+      <button type="submit" class="btn btn-primary">{{ _('Salvar') }}</button>
+    </form>
   </div>
-  <div>
-    <label for="id_tipo" class="block text-sm font-medium">{{ _('Tipo') }}</label>
-    <select id="id_tipo" name="tipo" class="border p-2 w-full" required {% if form and form.tipo.errors %}aria-invalid="true"{% endif %}>
-      <option value="erp"{% if integracao and integracao.tipo == 'erp' %} selected{% endif %}>{{ _('ERP') }}</option>
-      <option value="contabilidade"{% if integracao and integracao.tipo == 'contabilidade' %} selected{% endif %}>{{ _('Contabilidade') }}</option>
-      <option value="gateway"{% if integracao and integracao.tipo == 'gateway' %} selected{% endif %}>{{ _('Gateway de Pagamento') }}</option>
-    </select>
-    {% if form and form.tipo.errors %}<p class="text-red-600 text-sm" aria-live="polite">{{ form.tipo.errors }}</p>{% endif %}
-  </div>
-  <div>
-    <label for="integracao-organizacao-search" class="block text-sm font-medium">{{ _('Organização') }}</label>
-    <input
-      type="text"
-      id="integracao-organizacao-search"
-      name="search"
-      class="border p-2 w-full"
-      form="search-organizacao"
-      hx-get="/api/organizacoes/"
-      hx-trigger="keyup changed delay:500ms"
-      hx-target="#id_organizacao"
-      hx-swap="none"
-      hx-on="htmx:afterRequest: renderOrganizacoes(event)"
-    />
-    <select id="id_organizacao" name="organizacao" class="border p-2 w-full mt-2" {% if form and form.organizacao.errors %}aria-invalid="true"{% endif %}>
-      {% if integracao and integracao.organizacao %}
-      <option value="{{ integracao.organizacao.id }}" selected>{{ integracao.organizacao.nome }}</option>
-      {% endif %}
-    </select>
-    {% if form and form.organizacao.errors %}<p class="text-red-600 text-sm" aria-live="polite">{{ form.organizacao.errors }}</p>{% endif %}
-  </div>
-  <div>
-    <label for="id_base_url" class="block text-sm font-medium">{{ _('Base URL') }}</label>
-    <input id="id_base_url" name="base_url" type="url" class="border p-2 w-full" required {% if integracao %}value="{{ integracao.base_url }}"{% endif %} {% if form and form.base_url.errors %}aria-invalid="true"{% endif %} />
-    {% if form and form.base_url.errors %}<p class="text-red-600 text-sm" aria-live="polite">{{ form.base_url.errors }}</p>{% endif %}
-  </div>
-  <div>
-    <label for="id_autenticacao" class="block text-sm font-medium">{{ _('Autenticação') }}</label>
-    <input id="id_autenticacao" name="autenticacao" type="text" class="border p-2 w-full" {% if integracao %}value="{{ integracao.autenticacao }}"{% endif %} {% if form and form.autenticacao.errors %}aria-invalid="true"{% endif %} />
-    {% if form and form.autenticacao.errors %}<p class="text-red-600 text-sm" aria-live="polite">{{ form.autenticacao.errors }}</p>{% endif %}
-  </div>
-  <div>
-    <label for="id_credenciais" class="block text-sm font-medium">{{ _('Credenciais') }}</label>
-    <textarea id="id_credenciais" name="credenciais" class="border p-2 w-full" rows="3" {% if form and form.credenciais.errors %}aria-invalid="true"{% endif %}>{% if integracao %}{{ integracao.credenciais_encrypted }}{% endif %}</textarea>
-    {% if form and form.credenciais.errors %}<p class="text-red-600 text-sm" aria-live="polite">{{ form.credenciais.errors }}</p>{% endif %}
-  </div>
-  <button type="submit" class="bg-green-600 text-white px-4 py-2 rounded">{{ _('Salvar') }}</button>
-</form>
+</div>
 
 <script src="{% url 'javascript-catalog' %}"></script>
 <script>

--- a/financeiro/templates/financeiro/lancamento_ajuste_modal.html
+++ b/financeiro/templates/financeiro/lancamento_ajuste_modal.html
@@ -1,15 +1,19 @@
 {% load i18n %}
-<form hx-post="/api/financeiro/lancamentos/{{ lancamento.id }}/ajustar/"
-      hx-on="htmx:afterRequest: htmx.trigger('#filtros','submit'); this.closest('#modal').innerHTML='';"
-      class="p-4 bg-white rounded shadow max-w-md space-y-4" hx-target="this">
-  {% csrf_token %}
-  <div>
-    <label for="id_valor_corrigido" class="block text-sm font-medium">{{ _('Valor corrigido') }}</label>
-    <input id="id_valor_corrigido" name="valor_corrigido" type="number" step="0.01" class="border p-2 w-full" required />
+<div class="card max-w-md">
+  <div class="card-body">
+    <form hx-post="/api/financeiro/lancamentos/{{ lancamento.id }}/ajustar/"
+          hx-on="htmx:afterRequest: htmx.trigger('#filtros','submit'); this.closest('#modal').innerHTML='';"
+          class="space-y-4" hx-target="this">
+      {% csrf_token %}
+      <div>
+        <label for="id_valor_corrigido" class="block text-sm font-medium">{{ _('Valor corrigido') }}</label>
+        <input id="id_valor_corrigido" name="valor_corrigido" type="number" step="0.01" class="form-input w-full" required />
+      </div>
+      <div>
+        <label for="id_descricao_motivo" class="block text-sm font-medium">{{ _('Descrição do motivo') }}</label>
+        <textarea id="id_descricao_motivo" name="descricao_motivo" class="form-input w-full" required></textarea>
+      </div>
+      <button type="submit" class="btn btn-primary">{{ _('Salvar') }}</button>
+    </form>
   </div>
-  <div>
-    <label for="id_descricao_motivo" class="block text-sm font-medium">{{ _('Descrição do motivo') }}</label>
-    <textarea id="id_descricao_motivo" name="descricao_motivo" class="border p-2 w-full" required></textarea>
-  </div>
-  <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">{{ _('Salvar') }}</button>
-</form>
+</div>


### PR DESCRIPTION
## Summary
- padroniza formulários de integração, centro de custo, aportes e ajuste de lançamento com card e campos `_forms/field.html`
- utiliza `.btn btn-primary` em ações do módulo financeiro

## Testing
- `pytest` (falha: ModuleNotFoundError: No module named 'tokens')

------
https://chatgpt.com/codex/tasks/task_e_68c1c6d5804c83258f34bed819c24976