### PR TITLE
Use theme error variables in auth templates

### DIFF
--- a/accounts/templates/accounts/password_reset_confirm.html
+++ b/accounts/templates/accounts/password_reset_confirm.html
@@ -5,21 +5,25 @@
 <div class="flex items-center justify-center min-h-screen bg-[var(--bg-primary)]">
     <div class="max-w-md mx-auto p-6 rounded-2xl shadow bg-[var(--bg-secondary)] w-full">
         <h1 class="text-2xl font-bold mb-6 text-center text-[var(--text-primary)]">{% trans "Definir Nova Senha" %}</h1>
+        {% include '_partials/messages.html' %}
         <form method="post" class="space-y-4">
             {% csrf_token %}
+            {% if form.non_field_errors %}
+                <div class="bg-[var(--error-light)] text-[var(--error)] p-2 rounded text-sm" role="alert">{{ form.non_field_errors }}</div>
+            {% endif %}
             <div>
                 <label for="{{ form.new_password1.id_for_label }}" class="block mb-1 font-medium text-[var(--text-secondary)]">{{ form.new_password1.label }}</label>
                 <input type="password"
                        name="{{ form.new_password1.html_name }}"
                        id="{{ form.new_password1.id_for_label }}"
-                       class="w-full p-3 border rounded-md focus:ring-2 focus:ring-primary bg-[var(--bg-secondary)] border-[var(--border)] text-[var(--text-primary)]"
+                       class="form-input w-full p-3 border rounded-md focus:ring-2 focus:ring-primary bg-[var(--bg-secondary)] border-[var(--border)] text-[var(--text-primary)]"
                        placeholder="{% trans 'Nova senha' %}"
                        aria-label="{{ form.new_password1.label }}"
                        aria-describedby="{{ form.new_password1.id_for_label }}_error"
                        {% if form.new_password1.errors %}aria-invalid="true"{% else %}aria-invalid="false"{% endif %}
                        required />
                 {% if form.new_password1.errors %}
-                    <div id="{{ form.new_password1.id_for_label }}_error" class="text-red-600 text-sm" role="alert">{{ form.new_password1.errors }}</div>
+                    <div id="{{ form.new_password1.id_for_label }}_error" class="text-[var(--error)] text-sm" role="alert">{{ form.new_password1.errors }}</div>
                 {% endif %}
             </div>
             <div>
@@ -27,14 +31,14 @@
                 <input type="password"
                        name="{{ form.new_password2.html_name }}"
                        id="{{ form.new_password2.id_for_label }}"
-                       class="w-full p-3 border rounded-md focus:ring-2 focus:ring-primary bg-[var(--bg-secondary)] border-[var(--border)] text-[var(--text-primary)]"
+                       class="form-input w-full p-3 border rounded-md focus:ring-2 focus:ring-primary bg-[var(--bg-secondary)] border-[var(--border)] text-[var(--text-primary)]"
                        placeholder="{% trans 'Confirme a senha' %}"
                        aria-label="{{ form.new_password2.label }}"
                        aria-describedby="{{ form.new_password2.id_for_label }}_error"
                        {% if form.new_password2.errors %}aria-invalid="true"{% else %}aria-invalid="false"{% endif %}
                        required />
                 {% if form.new_password2.errors %}
-                    <div id="{{ form.new_password2.id_for_label }}_error" class="text-red-600 text-sm" role="alert">{{ form.new_password2.errors }}</div>
+                    <div id="{{ form.new_password2.id_for_label }}_error" class="text-[var(--error)] text-sm" role="alert">{{ form.new_password2.errors }}</div>
                 {% endif %}
             </div>
             <button type="submit" class="text-white font-semibold py-2 px-4 rounded-xl w-full bg-[var(--primary)] hover:bg-[var(--primary-hover)]">{% trans "Alterar Senha" %}</button>

--- a/accounts/templates/login/login.html
+++ b/accounts/templates/login/login.html
@@ -14,9 +14,10 @@
       <p class="text-center text-sm mb-6 text-[var(--text-secondary)]">
         {% trans "Entre para acessar sua conta e conectar-se à sua rede" %}
       </p>
+    {% include '_partials/messages.html' %}
 
     {% if form.non_field_errors %}
-      <div class="text-red-600 text-sm mb-4" role="alert">{{ form.non_field_errors }}</div>
+      <div class="bg-[var(--error-light)] text-[var(--error)] p-2 rounded text-sm mb-4" role="alert">{{ form.non_field_errors }}</div>
     {% endif %}
 
     <form method="post" action="{% url 'accounts:login' %}" class="space-y-5">
@@ -36,7 +37,7 @@
                  class="absolute left-3 -top-2 text-xs text-[var(--text-secondary)] transition-all peer-placeholder-shown:top-3 peer-placeholder-shown:text-sm peer-placeholder-shown:text-gray-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary">{% trans "Email" %}</label>
         </div>
         {% if form.email.errors %}
-          <div id="email-error" class="text-red-600 text-xs mt-1" role="alert">{{ form.email.errors }}</div>
+          <div id="email-error" class="text-[var(--error)] text-xs mt-1" role="alert">{{ form.email.errors }}</div>
         {% endif %}
       </div>
       <div>
@@ -53,7 +54,7 @@
                  class="absolute left-3 -top-2 text-xs text-[var(--text-secondary)] transition-all peer-placeholder-shown:top-3 peer-placeholder-shown:text-sm peer-placeholder-shown:text-gray-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary">{% trans "Senha" %}</label>
         </div>
         {% if form.password.errors %}
-          <div id="password-error" class="text-red-600 text-xs mt-1" role="alert">{{ form.password.errors }}</div>
+          <div id="password-error" class="text-[var(--error)] text-xs mt-1" role="alert">{{ form.password.errors }}</div>
         {% endif %}
       </div>
       <div id="totp-field">
@@ -71,7 +72,7 @@
         </div>
         <p class="text-xs mt-1 text-[var(--text-muted)]">{% trans "Deixe em branco se não tiver 2FA" %}</p>
         {% if form.totp.errors %}
-          <div id="totp-error" class="text-red-600 text-xs mt-1" role="alert">{{ form.totp.errors }}</div>
+          <div id="totp-error" class="text-[var(--error)] text-xs mt-1" role="alert">{{ form.totp.errors }}</div>
         {% endif %}
       </div>
       <button type="submit"


### PR DESCRIPTION
## Summary
- use centralized error color variables in login and password reset templates
- include shared message partial and keep form-input styling

## Testing
- `pytest tests/test_accounts_auth.py::test_login_page_exists -q` *(fails: ModuleNotFoundError: No module named 'silk')*

------
https://chatgpt.com/codex/tasks/task_e_68c1c6e996708325ae5935ac3c782fe9