### PR TITLE
refactor import payments form styling

### DIFF
--- a/financeiro/templates/financeiro/importar_pagamentos.html
+++ b/financeiro/templates/financeiro/importar_pagamentos.html
@@ -13,20 +13,22 @@
       <div class="mb-4">
         <a href="{% url 'financeiro:importacoes' %}" class="link link-hover">{% trans "Ver importações" %}</a>
       </div>
-      <form id="upload-form" method="post" enctype="multipart/form-data" class="space-y-4 border p-4 rounded-lg bg-white">
-        {% csrf_token %}
-        <label for="file" class="block text-sm font-medium text-gray-700">{% trans "Arquivo" %}</label>
-        <input id="file" type="file" name="file" accept=".csv,.xlsx" class="block w-full border p-2 rounded" required
-               hx-post="/api/financeiro/importar-pagamentos/"
-               hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
-               hx-target="#preview"
-               hx-trigger="change"
-               hx-include="#upload-form"
-               hx-on="htmx:afterRequest: renderPreview(event)" />
-        <p class="text-sm text-gray-500">{% trans "Apenas CSV ou XLSX até 5MB" %}</p>
+      <form id="upload-form" method="post" enctype="multipart/form-data" class="card">
+        <div class="card-body space-y-4">
+          {% csrf_token %}
+          <label for="file" class="block text-sm font-medium text-gray-700">{% trans "Arquivo" %}</label>
+          <input id="file" type="file" name="file" accept=".csv,.xlsx" class="block w-full form-input" required
+                 hx-post="/api/financeiro/importar-pagamentos/"
+                 hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+                 hx-target="#preview"
+                 hx-trigger="change"
+                 hx-include="#upload-form"
+                 hx-on="htmx:afterRequest: renderPreview(event)" />
+          <p class="text-sm text-gray-500">{% trans "Apenas CSV ou XLSX até 5MB" %}</p>
+        </div>
       </form>
       <button id="preview-btn"
-              class="mt-2 bg-primary text-white px-4 py-2 rounded"
+              class="mt-2 btn btn-primary"
               hx-post="/api/financeiro/importar-pagamentos/"
               hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
               hx-target="#preview"
@@ -50,7 +52,7 @@
                 hx-target="#messages"
                 hx-include="#confirm-form"
                 hx-indicator="#loading"
-                class="bg-primary text-white px-4 py-2 rounded">
+                class="btn btn-primary">
           {% trans "Confirmar Importação" %}
         </button>
         <span id="loading" class="htmx-indicator text-sm">{% trans "Processando..." %}</span>
@@ -68,14 +70,14 @@
             const data = JSON.parse(evt.detail.xhr.response);
             if (data.preview && data.preview.length) {
               const rows = data.preview.map(r => `<tr><td class="px-2 py-1">${r.centro_custo}</td><td class="px-2 py-1">${r.conta_associado || ''}</td><td class="px-2 py-1">${r.tipo}</td><td class="px-2 py-1">${r.valor}</td><td class="px-2 py-1">${r.data_lancamento}</td></tr>`).join('');
-              preview.innerHTML = `<table class="min-w-full divide-y divide-gray-200"><thead><tr><th class="px-2 py-1 text-left text-xs font-medium text-gray-500">{% trans "Centro de Custo" %}</th><th class="px-2 py-1 text-left text-xs font-medium text-gray-500">{% trans "Conta" %}</th><th class="px-2 py-1 text-left text-xs font-medium text-gray-500">{% trans "Tipo" %}</th><th class="px-2 py-1 text-left text-xs font-medium text-gray-500">{% trans "Valor" %}</th><th class="px-2 py-1 text-left text-xs font-medium text-gray-500">{% trans "Data" %}</th></tr></thead><tbody>${rows}</tbody></table>`;
+              preview.innerHTML = `<table class="min-w-full divide-y divide-[var(--border)]"><thead><tr><th class="px-2 py-1 text-left text-xs font-medium text-gray-500">{% trans "Centro de Custo" %}</th><th class="px-2 py-1 text-left text-xs font-medium text-gray-500">{% trans "Conta" %}</th><th class="px-2 py-1 text-left text-xs font-medium text-gray-500">{% trans "Tipo" %}</th><th class="px-2 py-1 text-left text-xs font-medium text-gray-500">{% trans "Valor" %}</th><th class="px-2 py-1 text-left text-xs font-medium text-gray-500">{% trans "Data" %}</th></tr></thead><tbody>${rows}</tbody></table>`;
               document.getElementById('confirm-id').value = data.id;
               document.getElementById('confirm-importacao-id').value = data.importacao_id;
               document.getElementById('confirm-btn').disabled = false;
             }
             if (data.erros && data.erros.length) {
               const ul = document.createElement('ul');
-              ul.className = 'list-disc text-red-600 pl-5';
+              ul.className = 'list-disc text-[var(--error)] pl-5';
               data.erros.forEach((err) => {
                 const li = document.createElement('li');
                 li.textContent = err;
@@ -88,7 +90,7 @@
             }
             if (data.token_erros) {
               const token = data.token_erros;
-              reprocess.innerHTML = `<div class="space-y-2"><a href="/media/importacoes/${token}.errors.csv" download class="link link-hover">{% trans "Baixar arquivo de erros" %}</a><form id="reprocess-form" class="space-y-2" enctype="multipart/form-data">{% csrf_token %}<input type="file" name="file" accept=".csv,.xlsx" class="block w-full border p-2 rounded" required /><button type="submit" class="bg-primary text-white px-4 py-2 rounded" hx-post="/api/financeiro/importar-pagamentos/reprocessar/${token}/" hx-target="#messages" hx-include="#reprocess-form" hx-encoding="multipart/form-data" hx-headers='{"X-CSRFToken": "${csrfToken}"}'>{% trans "Reprocessar" %}</button></form></div>`;
+              reprocess.innerHTML = `<div class="space-y-2"><a href="/media/importacoes/${token}.errors.csv" download class="link link-hover">{% trans "Baixar arquivo de erros" %}</a><form id="reprocess-form" class="space-y-2" enctype="multipart/form-data">{% csrf_token %}<input type="file" name="file" accept=".csv,.xlsx" class="block w-full form-input" required /><button type="submit" class="btn btn-primary" hx-post="/api/financeiro/importar-pagamentos/reprocessar/${token}/" hx-target="#messages" hx-include="#reprocess-form" hx-encoding="multipart/form-data" hx-headers='{"X-CSRFToken": "${csrfToken}"}'>{% trans "Reprocessar" %}</button></form></div>`;
             }
           } catch (e) {
             messages.textContent = '{% trans "Erro ao processar pré-visualização" %}';


### PR DESCRIPTION
## Summary
- wrap upload form in card with card-body
- switch file input to form-input and buttons to btn btn-primary
- use CSS variables for preview borders and error text

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'freezegun')*

------
https://chatgpt.com/codex/tasks/task_e_68c1cb84c1c48325af8fac8917c6d38b