### PR TITLE
Refatora listagem de favoritos para usar card

### DIFF
--- a/empresas/templates/empresas/favoritos.html
+++ b/empresas/templates/empresas/favoritos.html
@@ -12,15 +12,17 @@
     <div class="card-body">
       <ul class="space-y-4" id="lista-favoritos" hx-on:afterRequest="if (this.children.length === 0) { const li=document.createElement('li'); li.className='text-neutral-600'; li.textContent='{{ _('Nenhuma empresa favorita.')|escapejs }}'; this.appendChild(li); }">
         {% for empresa in empresas %}
-          <li id="empresa-{{ empresa.id }}" class="p-4 bg-white rounded shadow">
-            <h2 class="text-lg font-semibold">{{ empresa.nome }}</h2>
-            <button
-              class="text-sm text-red-600 hover:underline"
-              hx-delete="{% url 'empresas_api:empresa-favoritar' empresa.id %}"
-              hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
-              hx-target="#empresa-{{ empresa.id }}"
-              hx-swap="outerHTML"
-            >{% translate "Remover" %}</button>
+          <li id="empresa-{{ empresa.id }}" class="card">
+            <div class="card-body">
+              {% include '_components/card_empresa.html' with empresa=empresa %}
+              <button
+                class="btn btn-secondary text-[var(--error)]"
+                hx-delete="{% url 'empresas_api:empresa-favoritar' empresa.id %}"
+                hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+                hx-target="#empresa-{{ empresa.id }}"
+                hx-swap="outerHTML"
+              >{% translate "Remover" %}</button>
+            </div>
           </li>
         {% empty %}
           <li class="text-neutral-600">{% translate "Nenhuma empresa favorita." %}</li>


### PR DESCRIPTION
## Summary
- refatora listagem de empresas favoritas para usar componentes de card
- atualiza botão de remoção com estilo `btn btn-secondary`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'freezegun')*

------
https://chatgpt.com/codex/tasks/task_e_68c1d16c169c832581548aed92084063