### PR TITLE
refactor: centralize toast messages

### DIFF
--- a/accounts/templates/accounts/password_reset_confirm.html
+++ b/accounts/templates/accounts/password_reset_confirm.html
@@ -5,7 +5,6 @@
 <div class="flex items-center justify-center min-h-screen bg-[var(--bg-primary)]">
     <div class="max-w-md mx-auto p-6 rounded-2xl shadow bg-[var(--bg-secondary)] w-full">
         <h1 class="text-2xl font-bold mb-6 text-center text-[var(--text-primary)]">{% trans "Definir Nova Senha" %}</h1>
-        {% include '_partials/messages.html' %}
         <form method="post" class="space-y-4">
             {% csrf_token %}
             {% if form.non_field_errors %}

--- a/accounts/templates/login/login.html
+++ b/accounts/templates/login/login.html
@@ -14,8 +14,6 @@
       <p class="text-center text-sm mb-6 text-[var(--text-secondary)]">
         {% trans "Entre para acessar sua conta e conectar-se à sua rede" %}
       </p>
-    {% include '_partials/messages.html' %}
-
     {% if form.non_field_errors %}
       <div class="bg-[var(--error-light)] text-[var(--error)] p-2 rounded text-sm mb-4" role="alert">{{ form.non_field_errors }}</div>
     {% endif %}

--- a/accounts/templates/register/cpf.html
+++ b/accounts/templates/register/cpf.html
@@ -28,14 +28,6 @@
       <p class="text-[var(--text-secondary)]">{% trans "Precisamos para validar sua identidade e segurança" %}</p>
     </div>
 
-    {% if messages %}
-    <div class="mb-4 space-y-2">
-      {% for message in messages %}
-        <p class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-[var(--success-light)] text-[var(--success)]{% else %}bg-[var(--error-light)] text-[var(--error)]{% endif %}">{{ message }}</p>
-      {% endfor %}
-    </div>
-    {% endif %}
-
     <form id="cpfForm" method="post" action="{% url 'accounts:cpf' %}" class="space-y-6">
       {% csrf_token %}
       <div>

--- a/accounts/templates/register/email.html
+++ b/accounts/templates/register/email.html
@@ -28,14 +28,6 @@
       <p class="text-[var(--text-secondary)]">{% trans "Usaremos para comunicação e recuperação de conta" %}</p>
     </div>
 
-    {% if messages %}
-    <div class="mb-4 space-y-2">
-      {% for message in messages %}
-        <p class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-[var(--success-light)] text-[var(--success)]{% else %}bg-[var(--error-light)] text-[var(--error)]{% endif %}">{{ message }}</p>
-      {% endfor %}
-    </div>
-    {% endif %}
-
     <form id="emailForm" method="post" action="{% url 'accounts:email' %}" class="space-y-6">
       {% csrf_token %}
       <div>

--- a/accounts/templates/register/foto.html
+++ b/accounts/templates/register/foto.html
@@ -28,14 +28,6 @@
       <p class="text-[var(--text-secondary)]">{% trans "Personalize sua presença na comunidade" %}</p>
     </div>
 
-    {% if messages %}
-    <div class="mb-4 space-y-2">
-      {% for message in messages %}
-        <p class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-[var(--success-light)] text-[var(--success)]{% else %}bg-[var(--error-light)] text-[var(--error)]{% endif %}">{{ message }}</p>
-      {% endfor %}
-    </div>
-    {% endif %}
-
     <form id="fotoForm" method="post" action="{% url 'accounts:foto' %}" enctype="multipart/form-data" class="space-y-6">
       {% csrf_token %}
       <div>

--- a/accounts/templates/register/nome.html
+++ b/accounts/templates/register/nome.html
@@ -28,14 +28,6 @@
       <p class="text-[var(--text-secondary)]">{% trans "Digite seu nome completo" %}</p>
     </div>
 
-    {% if messages %}
-    <div class="mb-4 space-y-2">
-      {% for message in messages %}
-        <p class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-[var(--success-light)] text-[var(--success)]{% else %}bg-[var(--error-light)] text-[var(--error)]{% endif %}">{{ message }}</p>
-      {% endfor %}
-    </div>
-    {% endif %}
-
     <form id="nomeForm" method="post" action="{% url 'accounts:nome' %}" class="space-y-6">
       {% csrf_token %}
       <div>

--- a/accounts/templates/register/onboarding.html
+++ b/accounts/templates/register/onboarding.html
@@ -27,14 +27,6 @@
             </p>
         </div>
 
-        {% if messages %}
-        <div class="mb-4 space-y-2">
-            {% for message in messages %}
-            <p class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-[var(--success-light)] text-[var(--success)]{% else %}bg-[var(--error-light)] text-[var(--error)]{% endif %}">{{ message }}</p>
-            {% endfor %}
-        </div>
-        {% endif %}
-
         <div class="grid md:grid-cols-3 gap-6 mb-8">
             <div class="text-center">
                 <div class="w-15 h-15 bg-[var(--success-light)] rounded-full flex items-center justify-center mx-auto mb-3">

--- a/accounts/templates/register/registro_sucesso.html
+++ b/accounts/templates/register/registro_sucesso.html
@@ -10,13 +10,6 @@
 {% block content %}
 <div class="card-grid">
   <div class="card p-8 text-center">
-    {% if messages %}
-    <div class="mb-4 space-y-2">
-      {% for message in messages %}
-        <p class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-[var(--success-light)] text-[var(--success)]{% else %}bg-[var(--error-light)] text-[var(--error)]{% endif %}">{{ message }}</p>
-      {% endfor %}
-    </div>
-    {% endif %}
     <h1 class="mb-4 text-3xl font-bold text-[var(--text-primary)]">{% trans "Bem-vindo ao HubX!" %}</h1>
     <p class="mb-6 text-[var(--text-secondary)]">{% trans "Seu cadastro foi concluído. Verifique seu e-mail para ativar sua conta." %}</p>
     <a href="{% url 'accounts:login' %}" class="btn btn-primary">{% trans "Ir para login" %}</a>

--- a/accounts/templates/register/senha.html
+++ b/accounts/templates/register/senha.html
@@ -28,14 +28,6 @@
       <p class="text-[var(--text-secondary)]">{% trans "Proteja sua conta com uma senha forte" %}</p>
     </div>
 
-    {% if messages %}
-    <div class="mb-4 space-y-2">
-      {% for message in messages %}
-        <p class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-[var(--success-light)] text-[var(--success)]{% else %}bg-[var(--error-light)] text-[var(--error)]{% endif %}">{{ message }}</p>
-      {% endfor %}
-    </div>
-    {% endif %}
-
     <form id="senhaForm" method="post" action="{% url 'accounts:senha' %}" class="space-y-6">
       {% csrf_token %}
       <div>

--- a/accounts/templates/register/termos.html
+++ b/accounts/templates/register/termos.html
@@ -28,8 +28,6 @@
       <p class="text-[var(--text-secondary)]">{% trans "Revise e aceite os termos para finalizar" %}</p>
     </div>
 
-    {% include '_partials/messages.html' %}
-
     <form id="termosForm" method="post" action="{% url 'accounts:termos' %}" class="space-y-6">
       {% csrf_token %}
       <div class="space-y-4 max-h-64 overflow-y-auto p-4 border border-[var(--border)] rounded-lg">

--- a/accounts/templates/register/token.html
+++ b/accounts/templates/register/token.html
@@ -35,14 +35,6 @@
       <p class="text-[var(--text-secondary)]">{% trans "Digite seu token de convite para começar o cadastro" %}</p>
     </div>
 
-    {% if messages %}
-    <div class="mb-4 space-y-2">
-      {% for message in messages %}
-        <p class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-[var(--success-light)] text-[var(--success)]{% else %}bg-[var(--error-light)] text-[var(--error)]{% endif %}">{{ message }}</p>
-      {% endfor %}
-    </div>
-    {% endif %}
-
     <form method="post" action="{% url 'tokens:token' %}" class="space-y-6">
       {% csrf_token %}
       <div>

--- a/accounts/templates/register/usuario.html
+++ b/accounts/templates/register/usuario.html
@@ -28,18 +28,6 @@
       <p class="text-[var(--text-secondary)]">{% trans "Como você será identificado na plataforma" %}</p>
     </div>
 
-    {% if messages %}
-    <div class="mb-4 space-y-2">
-      {% for message in messages %}
-        {% if message.tags == 'success' %}
-        <p class="rounded-xl px-4 py-2 text-sm bg-[var(--success-light)] text-[var(--success)]">{{ message }}</p>
-        {% else %}
-        <p class="rounded-xl px-4 py-2 text-sm bg-[var(--error-light)] text-[var(--error)]">{{ message }}</p>
-        {% endif %}
-      {% endfor %}
-    </div>
-    {% endif %}
-
     <form id="usuarioForm" method="post" action="{% url 'accounts:usuario' %}" class="space-y-6">
       {% csrf_token %}
       <div>

--- a/configuracoes/templates/configuracoes/configuracoes.html
+++ b/configuracoes/templates/configuracoes/configuracoes.html
@@ -6,8 +6,6 @@
 {% block content %}
 <div class="max-w-4xl mx-auto px-4 py-8">
   <h1 class="text-2xl font-bold mb-4">{% trans 'Configurações' %}</h1>
-  {% include '_partials/messages.html' %}
-
     <div class="flex flex-wrap gap-4 border-b border-[var(--border)] mb-4 text-sm">
       <nav aria-label="{% trans 'Seções de Configuração' %}" role="tablist" class="flex flex-wrap gap-4">
         <button role="tab" aria-selected="{% if tab == 'seguranca' %}true{% else %}false{% endif %}" aria-controls="content" hx-get="{% url 'configuracoes' %}?tab=seguranca" hx-target="#content" hx-on:click="switchTab(this)" tabindex="0" class="btn {% if tab == 'seguranca' %}btn-secondary{% endif %}">{% trans 'Segurança' %}</button>

--- a/dashboard/templates/dashboard/admin.html
+++ b/dashboard/templates/dashboard/admin.html
@@ -14,7 +14,6 @@
       <h2 class="text-xl font-semibold text-center">{% trans "Dashboard Administrativo" %}</h2>
     </div>
     <div class="card-body">
-      {% include '_partials/messages.html' %}
       {% include '_components/filters_form.html' %}
 
       <div hx-get="{% url 'dashboard:metrics-partial' %}?{{ request.GET.urlencode }}" hx-trigger="load, every 10s" hx-target="#metrics" hx-swap="innerHTML">

--- a/dashboard/templates/dashboard/cliente.html
+++ b/dashboard/templates/dashboard/cliente.html
@@ -11,7 +11,6 @@
   <div class="py-12 max-w-7xl mx-auto px-4">
     <div class="card">
       <div class="card-body space-y-8">
-        {% include '_partials/messages.html' %}
         {% include '_components/filters_form.html' %}
         <div hx-get="{% url 'dashboard:metrics-partial' %}?{{ request.GET.urlencode }}" hx-trigger="load, every 10s" hx-target="#metrics" hx-swap="innerHTML">
           {% include '_partials/metrics_list.html' %}

--- a/dashboard/templates/dashboard/config_list.html
+++ b/dashboard/templates/dashboard/config_list.html
@@ -9,7 +9,6 @@
   <div class="py-12 max-w-2xl mx-auto px-4">
     <div class="card">
       <div class="card-body">
-        {% include '_partials/messages.html' %}
         <ul class="space-y-2">
           {% for cfg in object_list %}
             <li class="card">

--- a/dashboard/templates/dashboard/coordenador.html
+++ b/dashboard/templates/dashboard/coordenador.html
@@ -12,7 +12,6 @@
   <div class="py-12 max-w-7xl mx-auto px-4">
     <div class="card">
       <div class="card-body space-y-8">
-        {% include '_partials/messages.html' %}
         {% include '_components/filters_form.html' %}
         <div hx-get="{% url 'dashboard:metrics-partial' %}?{{ request.GET.urlencode }}" hx-trigger="load, every 10s" hx-target="#metrics" hx-swap="innerHTML">
           {% include '_partials/metrics_list.html' %}

--- a/dashboard/templates/dashboard/custom_metric_list.html
+++ b/dashboard/templates/dashboard/custom_metric_list.html
@@ -9,7 +9,6 @@
   <div class="py-12 max-w-2xl mx-auto px-4">
     <div class="card">
       <div class="card-body">
-        {% include '_partials/messages.html' %}
         <a href="{% url 'dashboard:custom-metric-create' %}" class="btn btn-primary mb-4" aria-label="{% trans 'Nova métrica' %}">{% trans 'Nova métrica' %}</a>
         <ul class="space-y-2">
           {% for m in object_list %}

--- a/dashboard/templates/dashboard/filter_list.html
+++ b/dashboard/templates/dashboard/filter_list.html
@@ -9,7 +9,6 @@
   <div class="py-12 max-w-2xl mx-auto px-4">
     <div class="card">
       <div class="card-body">
-        {% include '_partials/messages.html' %}
         <ul class="space-y-2">
           {% for f in object_list %}
             <li class="card">

--- a/dashboard/templates/dashboard/root.html
+++ b/dashboard/templates/dashboard/root.html
@@ -11,7 +11,6 @@
   <div class="py-12 max-w-7xl mx-auto px-4">
     <div class="card">
       <div class="card-body space-y-8">
-        {% include '_partials/messages.html' %}
         {% include '_components/filters_form.html' %}
         <div hx-get="{% url 'dashboard:metrics-partial' %}?{{ request.GET.urlencode }}" hx-trigger="load, every 10s" hx-target="#metrics" hx-swap="innerHTML">
           {% include '_partials/metrics_list.html' %}

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -427,17 +427,17 @@ def metrics_partial(request):
     except PermissionError:
         logger.exception("Acesso negado ao carregar métricas")
         messages.error(request, _("Acesso negado"))
-        html = render_to_string("_partials/messages.html", request=request)
+        html = render_to_string("_partials/toasts.html", request=request)
         return HttpResponse(html, status=403)
     except ValueError as exc:
         logger.exception("Erro de valor ao carregar métricas")
         messages.error(request, str(exc))
-        html = render_to_string("_partials/messages.html", request=request)
+        html = render_to_string("_partials/toasts.html", request=request)
         return HttpResponse(html, status=400)
     except Exception:  # pragma: no cover - logado
         logger.exception("Erro inesperado ao carregar métricas")
         messages.error(request, _("Erro ao carregar métricas."))
-        html = render_to_string("_partials/messages.html", request=request)
+        html = render_to_string("_partials/toasts.html", request=request)
         return HttpResponse(html, status=500)
 
 
@@ -609,7 +609,7 @@ class DashboardExportView(LoginRequiredMixin, View):
         def _response_with_message(msg: str, status: int) -> HttpResponse:
             messages.error(request, msg)
             if request.headers.get("Hx-Request") == "true":
-                html = render_to_string("_partials/messages.html", request=request)
+                html = render_to_string("_partials/toasts.html", request=request)
                 return HttpResponse(html, status=status)
             return HttpResponse(msg, status=status)
 

--- a/empresas/templates/empresas/contato_form.html
+++ b/empresas/templates/empresas/contato_form.html
@@ -3,7 +3,6 @@
 {% block title %}{% translate 'Contato' %}{% endblock %}
 {% block content %}
 <section class="max-w-md mx-auto py-8">
-  {% include '_partials/messages.html' %}
   {% if contato %}
     <div class="space-y-1 bg-white border border-neutral-200 p-6 rounded-md">
       <p class="text-sm font-medium text-neutral-700">{{ contato.nome }}</p>

--- a/eventos/api.py
+++ b/eventos/api.py
@@ -188,7 +188,7 @@ class MaterialDivulgacaoEventoViewSet(OrganizacaoFilterMixin, viewsets.ModelView
             row_html = render_to_string(
                 "eventos/_material_row.html", {"material": material}, request=request
             )
-            messages_html = render_to_string("_partials/messages.html", request=request)
+            messages_html = render_to_string("_partials/toasts.html", request=request)
             return HttpResponse(row_html + messages_html)
         return Response(self.get_serializer(material).data)
 
@@ -203,7 +203,7 @@ class MaterialDivulgacaoEventoViewSet(OrganizacaoFilterMixin, viewsets.ModelView
                     "eventos/_material_row.html", {"material": material}, request=request
                 )
                 messages_html = render_to_string(
-                    "_partials/messages.html", request=request
+                    "_partials/toasts.html", request=request
                 )
                 return HttpResponse(row_html + messages_html, status=status.HTTP_400_BAD_REQUEST)
             return Response(
@@ -234,7 +234,7 @@ class MaterialDivulgacaoEventoViewSet(OrganizacaoFilterMixin, viewsets.ModelView
             row_html = render_to_string(
                 "eventos/_material_row.html", {"material": material}, request=request
             )
-            messages_html = render_to_string("_partials/messages.html", request=request)
+            messages_html = render_to_string("_partials/toasts.html", request=request)
             return HttpResponse(row_html + messages_html)
         return Response(self.get_serializer(material).data)
 

--- a/eventos/templates/eventos/briefing_list.html
+++ b/eventos/templates/eventos/briefing_list.html
@@ -14,18 +14,6 @@
       <a href="{% url 'eventos:briefing_criar' %}" class="btn-primary">{% trans "Novo Briefing" %}</a>
     </div>
     <div class="card-body">
-<<<<<<< HEAD
-      {% if messages %}
-        <div class="mb-4 space-y-2">
-          {% for message in messages %}
-            <p class="rounded-xl px-4 py-2 text-sm {% if 'success' in message.tags %}bg-[var(--success-light)] text-[var(--success)]{% else %}bg-[var(--error-light)] text-[var(--error)]{% endif %}">{{ message }}</p>
-          {% endfor %}
-        </div>
-      {% endif %}
-=======
-      {% include '_partials/messages.html' %}
->>>>>>> main
-
       <form hx-get="{% url 'eventos:briefing_list' %}" hx-target="#briefing-container" hx-push-url="true" class="mb-6 flex gap-2">
         <input type="text" name="q" value="{{ request.GET.q }}" placeholder="{% trans 'Buscar por evento' %}" class="form-input w-full rounded-md px-3 py-2" />
         <button type="submit" class="btn-primary">{% trans "Filtrar" %}</button>

--- a/eventos/templates/eventos/inscricao_list.html
+++ b/eventos/templates/eventos/inscricao_list.html
@@ -11,14 +11,6 @@
 <div id="inscricao-container"  class="py-12 px-4">
   <div class="card">
     <div class="card-body">
-      {% if messages %}
-        <div class="mb-4 space-y-2">
-          {% for message in messages %}
-            <p class="rounded-xl px-4 py-2 text-sm {% if 'success' in message.tags %}bg-[var(--success-light)] text-[var(--success)]{% else %}bg-[var(--error-light)] text-[var(--error)]{% endif %}">{{ message }}</p>
-          {% endfor %}
-        </div>
-      {% endif %}
-
       {% url 'eventos:inscricao_list' as inscricao_list_url %}
       {% include '_components/search_form.html' with q=request.GET.q hx_get=inscricao_list_url hx_target='#inscricao-container' hx_push_url='true' %}
 

--- a/eventos/templates/eventos/material_list.html
+++ b/eventos/templates/eventos/material_list.html
@@ -14,8 +14,6 @@
       <a href="{% url 'eventos:material_criar' %}" class="btn-primary">{% trans "Novo Material" %}</a>
     </div>
     <div class="card-body">
-      {% include '_partials/messages.html' %}
-
       <form method="get" class="mb-6 flex gap-2">
         <input type="text" name="q" value="{{ request.GET.q }}" placeholder="{% trans 'Buscar por título' %}" class="form-input w-full rounded-md px-3 py-2" />
         <button type="submit" class="btn-primary">{% trans "Filtrar" %}</button>

--- a/notificacoes/templates/notificacoes/template_form.html
+++ b/notificacoes/templates/notificacoes/template_form.html
@@ -4,13 +4,6 @@
 {% block content %}
   <div class="py-12 max-w-xl mx-auto space-y-6 px-4">
     <h1 class="text-2xl font-bold text-[var(--text-primary)]">{% if form.instance.pk %}{% trans 'Editar Template' %}{% else %}{% trans 'Cadastrar Template' %}{% endif %}</h1>
-    {% if messages %}
-    <div class="space-y-2" aria-live="polite">
-      {% for message in messages %}
-        <p role="alert" class="rounded-xl px-4 py-2 text-sm {% if 'success' in message.tags %}bg-[var(--success-light)] text-[var(--success)]{% else %}bg-[var(--error-light)] text-[var(--error)]{% endif %}">{{ message }}</p>
-      {% endfor %}
-    </div>
-    {% endif %}
     <div class="card">
       <div class="card-body space-y-6">
         <form method="post" class="space-y-4">

--- a/notificacoes/templates/notificacoes/templates_list.html
+++ b/notificacoes/templates/notificacoes/templates_list.html
@@ -7,13 +7,6 @@
 
 {% block content %}
   <div class="py-12 max-w-6xl mx-auto space-y-6 px-4">
-    {% if messages %}
-    <div class="space-y-2" aria-live="polite">
-      {% for message in messages %}
-        <p role="alert" class="rounded-xl px-4 py-2 text-sm {% if 'success' in message.tags %}bg-[var(--success-light)] text-[var(--success)]{% else %}bg-[var(--error-light)] text-[var(--error)]{% endif %}">{{ message }}</p>
-      {% endfor %}
-    </div>
-    {% endif %}
     {% if templates %}
     <div class="overflow-x-auto border border-[var(--border)] rounded-2xl shadow-sm">
       <table class="min-w-full divide-y divide-[var(--border)] text-sm">

--- a/organizacoes/templates/organizacoes/update.html
+++ b/organizacoes/templates/organizacoes/update.html
@@ -11,8 +11,6 @@
   <div class="py-12 max-w-2xl mx-auto px-4">
     <div class="card">
       <div class="card-body">
-        {% include '_partials/messages.html' %}
-
         <form method="post" enctype="multipart/form-data" class="space-y-6">
           {% csrf_token %}
           {% for field in form %}

--- a/templates/_components/filters_form.html
+++ b/templates/_components/filters_form.html
@@ -1,7 +1,6 @@
 {% load i18n static %}
 <script src="{% static 'js/vendor/jquery-3.7.1.min.js' %}"></script>
 <script src="{% static 'js/vendor/select2-4.1.0-rc.0.min.js' %}"></script>
-{% include '_partials/messages.html' %}
 <form method="get" class="mb-6 flex flex-wrap gap-4 items-end" aria-label="{% trans 'Filtros do dashboard' %}">
   <div>
     <label for="periodo" class="block text-sm font-medium text-neutral-700">{% trans 'Período' %}</label>

--- a/templates/_partials/messages.html
+++ b/templates/_partials/messages.html
@@ -1,8 +1,0 @@
-{% load i18n %}
-{% if messages %}
-<div id="messages" hx-swap-oob="true" class="mb-4 space-y-2" aria-live="polite">
-  {% for message in messages %}
-    <p role="alert" class="rounded-xl px-4 py-2 text-sm {% if 'error' in message.tags %}bg-[var(--error)] text-[var(--error-contrast)]{% elif 'success' in message.tags %}bg-[var(--success)] text-[var(--success-contrast)]{% else %}bg-[var(--primary)] text-[var(--primary-contrast)]{% endif %}">{{ message }}</p>
-  {% endfor %}
-</div>
-{% endif %}

--- a/templates/_partials/toasts.html
+++ b/templates/_partials/toasts.html
@@ -1,11 +1,11 @@
 {% if messages %}
-<div id="messages" class="fixed top-4 right-4 space-y-2 z-50">
+<ul id="messages" hx-swap-oob="true" class="fixed top-4 right-4 space-y-2 z-50">
   {% for message in messages %}
-    <div class="px-4 py-2 rounded shadow {% if 'error' in message.tags %}bg-[var(--error)] text-[var(--error-contrast)]{% elif 'success' in message.tags %}bg-[var(--success)] text-[var(--success-contrast)]{% else %}bg-[var(--primary)] text-[var(--primary-contrast)]{% endif %}">
+    <li class="px-4 py-2 rounded shadow bg-[var(--bg-secondary)] text-[var(--text-primary)]">
       {{ message }}
-    </div>
+    </li>
   {% endfor %}
-</div>
+</ul>
 <script>
   setTimeout(() => {
     const el = document.getElementById('messages');

--- a/templates/base.html
+++ b/templates/base.html
@@ -49,8 +49,6 @@
   </noscript>
   <a href="#main-content" class="sr-only focus:not-sr-only">{% trans "Pular para o conteúdo principal" %}</a>
 
-  {% include '_partials/toasts.html' %}
-
   {% if not hide_nav %}
     {% include '_partials/sidebar.html' %}
   {% endif %}
@@ -61,6 +59,7 @@
     <main id="main-content" class="container mx-auto p-6 flex-grow">
       {% block content %}{% endblock %}
     </main>
+    {% include '_partials/toasts.html' %}
 
     {% include '_partials/footer.html' %}
   </div>

--- a/tokens/templates/tokens/ativar_2fa.html
+++ b/tokens/templates/tokens/ativar_2fa.html
@@ -12,16 +12,6 @@
 <div class="max-w-md mx-auto">
   <div class="card">
     <div class="card-body">
-      {% if messages %}
-        <div class="mb-4 space-y-2 text-center">
-          {% for message in messages %}
-            <p role="alert" class="rounded-xl px-4 py-2 text-sm {% if message.tags == 'success' %}bg-[var(--success-light)] text-[var(--success)]{% else %}bg-[var(--error-light)] text-[var(--error)]{% endif %}">
-              {{ message }}
-            </p>
-          {% endfor %}
-        </div>
-      {% endif %}
-
       {% if qr_code %}
         <div class="flex flex-col items-center mb-4">
           <img src="data:image/png;base64,{{ qr_code }}" alt="{% trans 'QR Code' %}" class="w-40 h-40" />


### PR DESCRIPTION
## Summary
- replace legacy messages partial with design-system toast list
- include toast partial after `<main>` in base layout
- remove template-level message blocks and update views to render toasts

## Testing
- `pytest` *(fails: ModuleNotFoundError / 81 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d411a96c8325ada0120a06e157fa