### PR TITLE
style: improve form error styling

### DIFF
--- a/app/static/css/hubx.css
+++ b/app/static/css/hubx.css
@@ -576,5 +576,7 @@
   .table td        { @apply py-2 align-middle; }
 
   /* Forms */
-  .errorlist { @apply mt-1 text-xs text-[var(--error)]; }
+  .errorlist { @apply mt-1 p-0 list-none text-xs text-[var(--error)]; }
+  .errorlist li { @apply mt-1; }
+  [aria-invalid="true"] { @apply border-[var(--error)] bg-[var(--error-light)]; }
 }

--- a/templates/_forms/field.html
+++ b/templates/_forms/field.html
@@ -3,7 +3,11 @@
 <div class="space-y-1">
   {% if field|widget_type == 'checkboxinput' %}
   <div class="flex items-center gap-2">
-    {% render_field field class+="form-checkbox" %}
+    {% if field.errors %}
+      {% render_field field|attr:"aria-invalid:true" class+="form-checkbox" %}
+    {% else %}
+      {% render_field field class+="form-checkbox" %}
+    {% endif %}
     <label for="{{ field.id_for_label }}" class="text-sm text-[var(--text-primary)]">
       {{ field.label }}{% if field.field.required %} *{% endif %}
     </label>
@@ -14,22 +18,40 @@
   </label>
   {% if field|widget_type == 'select' %}
     {% if readonly %}
-      {% render_field field class+="form-select w-full" readonly="readonly" %}
+      {% if field.errors %}
+        {% render_field field|attr:"aria-invalid:true" class+="form-select w-full" readonly="readonly" %}
+      {% else %}
+        {% render_field field class+="form-select w-full" readonly="readonly" %}
+      {% endif %}
     {% else %}
-      {% render_field field class+="form-select w-full" %}
+      {% if field.errors %}
+        {% render_field field|attr:"aria-invalid:true" class+="form-select w-full" %}
+      {% else %}
+        {% render_field field class+="form-select w-full" %}
+      {% endif %}
     {% endif %}
   {% else %}
     {% if readonly %}
-      {% render_field field class+="form-input w-full" readonly="readonly" %}
+      {% if field.errors %}
+        {% render_field field|attr:"aria-invalid:true" class+="form-input w-full" readonly="readonly" %}
+      {% else %}
+        {% render_field field class+="form-input w-full" readonly="readonly" %}
+      {% endif %}
     {% else %}
-      {% render_field field class+="form-input w-full" %}
+      {% if field.errors %}
+        {% render_field field|attr:"aria-invalid:true" class+="form-input w-full" %}
+      {% else %}
+        {% render_field field class+="form-input w-full" %}
+      {% endif %}
     {% endif %}
   {% endif %}
   {% endif %}
   {% if field.errors %}
+  <ul class="errorlist">
     {% for error in field.errors %}
-      <p class="text-[var(--error)] text-sm">{{ error }}</p>
+    <li>{{ error }}</li>
     {% endfor %}
+  </ul>
   {% endif %}
   {% if field.help_text %}
   <p class="text-xs text-[var(--text-secondary)]">{{ field.help_text }}</p>


### PR DESCRIPTION
## Summary
- style error lists and invalid inputs
- mark invalid fields with `aria-invalid` and render error lists

## Testing
- `pytest -m "not slow"` *(fails: 81 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d41a05a88325988a56ba84a8cbeb