### PR TITLE
refactor: substituir classes dark por variáveis de tema

### DIFF
--- a/accounts/templates/perfil/conexoes.html
+++ b/accounts/templates/perfil/conexoes.html
@@ -6,7 +6,7 @@
 {% block perfil_content %}
 <section id="conexoes" class="space-y-6">
   <div>
-    <h2 class="text-xl font-semibold text-neutral-900 dark:text-neutral-100">{% trans "Minhas Conexões" %}</h2>
+    <h2 class="text-xl font-semibold text-[var(--text-primary)]">{% trans "Minhas Conexões" %}</h2>
     <p class="text-sm text-[var(--text-primary)]">{% trans "Gerencie sua rede de contatos" %}</p>
   </div>
 
@@ -27,7 +27,7 @@
           name="q"
           value="{{ q }}"
           placeholder="{% trans 'Buscar conexões...' %}"
-          class="flex-grow border rounded-lg p-2 text-sm dark:bg-neutral-700 dark:border-neutral-600 dark:text-neutral-100"
+          class="flex-grow border rounded-lg p-2 text-sm bg-[var(--bg-secondary)] border-[var(--border)] text-[var(--text-primary)]"
           aria-label="{% trans 'Buscar conexões' %}" aria-invalid="false"
         />
         <button type="submit" class="btn btn-secondary btn-sm" aria-label="{% trans 'Buscar' %}">
@@ -48,7 +48,7 @@
                 </div>
               {% endif %}
               <div>
-                <p class="font-medium text-neutral-900 dark:text-neutral-100">{{ connection.get_full_name }}</p>
+                <p class="font-medium text-[var(--text-primary)]">{{ connection.get_full_name }}</p>
                 <p class="text-sm text-[var(--text-primary)]">@{{ connection.username }}</p>
               </div>
             </div>
@@ -86,7 +86,7 @@
                 </div>
               {% endif %}
               <div>
-                <p class="font-medium text-neutral-900 dark:text-neutral-100">{{ solicitante.get_full_name }}</p>
+                <p class="font-medium text-[var(--text-primary)]">{{ solicitante.get_full_name }}</p>
                 <p class="text-sm text-[var(--text-primary)]">@{{ solicitante.username }}</p>
               </div>
             </div>

--- a/accounts/templates/perfil/detail.html
+++ b/accounts/templates/perfil/detail.html
@@ -4,13 +4,13 @@
 {% block perfil_content %}
 
 <div class="card-header">
-  <div class="mt-2 border-b border-[var(--border)] dark:border-[var(--border)]">
+  <div class="mt-2 border-b border-[var(--border)]">
     <nav class="-mb-px flex gap-6" aria-label="Tabs">
-      <button type="button" class="tab-btn py-3 text-sm font-medium border-b-2 border-transparent text-neutral-600 dark:text-neutral-400 data-[active=true]:border-primary data-[active=true]:text-primary" data-tab="informacoes">{% trans 'Informações' %}</button>
+      <button type="button" class="tab-btn py-3 text-sm font-medium border-b-2 border-transparent text-[var(--text-secondary)] data-[active=true]:border-primary data-[active=true]:text-primary" data-tab="informacoes">{% trans 'Informações' %}</button>
       {% if user.get_tipo_usuario != 'admin' %}
-        <button type="button" class="tab-btn py-3 text-sm font-medium border-b-2 border-transparent text-neutral-600 dark:text-neutral-400 data-[active=true]:border-primary data-[active=true]:text-primary" data-tab="empresas">{% trans 'Empresas' %}</button>
-        <button type="button" class="tab-btn py-3 text-sm font-medium border-b-2 border-transparent text-neutral-600 dark:text-neutral-400 data-[active=true]:border-primary data-[active=true]:text-primary" data-tab="nucleos">{% trans 'Núcleos' %}</button>
-        <button type="button" class="tab-btn py-3 text-sm font-medium border-b-2 border-transparent text-neutral-600 dark:text-neutral-400 data-[active=true]:border-primary data-[active=true]:text-primary" data-tab="eventos">{% trans 'Eventos' %}</button>
+        <button type="button" class="tab-btn py-3 text-sm font-medium border-b-2 border-transparent text-[var(--text-secondary)] data-[active=true]:border-primary data-[active=true]:text-primary" data-tab="empresas">{% trans 'Empresas' %}</button>
+        <button type="button" class="tab-btn py-3 text-sm font-medium border-b-2 border-transparent text-[var(--text-secondary)] data-[active=true]:border-primary data-[active=true]:text-primary" data-tab="nucleos">{% trans 'Núcleos' %}</button>
+        <button type="button" class="tab-btn py-3 text-sm font-medium border-b-2 border-transparent text-[var(--text-secondary)] data-[active=true]:border-primary data-[active=true]:text-primary" data-tab="eventos">{% trans 'Eventos' %}</button>
       {% endif %}
     </nav>
   </div>
@@ -68,7 +68,7 @@
         {% for empresa in empresas %}
           {% include '_components/card_empresa.html' with empresa=empresa %}
         {% empty %}
-          <p class="text-sm text-neutral-500 dark:text-neutral-400">{% trans "Nenhuma empresa encontrada." %}</p>
+          <p class="text-sm text-[var(--text-secondary)]">{% trans "Nenhuma empresa encontrada." %}</p>
         {% endfor %}
       </div>
     </div>
@@ -79,7 +79,7 @@
         {% for nucleo in nucleos %}
           {% include '_components/card_nucleo.html' with nucleo=nucleo %}
         {% empty %}
-          <p class="text-sm text-neutral-500 dark:text-neutral-400">{% trans "Nenhum núcleo encontrado." %}</p>
+          <p class="text-sm text-[var(--text-secondary)]">{% trans "Nenhum núcleo encontrado." %}</p>
         {% endfor %}
       </div>
     </div>
@@ -90,7 +90,7 @@
         {% for ins in inscricoes %}
           {% include '_components/card_evento.html' with evento=ins.evento %}
         {% empty %}
-          <p class="text-sm text-neutral-500 dark:text-neutral-400">{% trans "Nenhum evento encontrado." %}</p>
+          <p class="text-sm text-[var(--text-secondary)]">{% trans "Nenhum evento encontrado." %}</p>
         {% endfor %}
       </div>
     </div>

--- a/accounts/templates/perfil/midia_confirm_delete.html
+++ b/accounts/templates/perfil/midia_confirm_delete.html
@@ -4,8 +4,8 @@
 
 {% block perfil_content %}
 <section class="space-y-4">
-  <h2 class="text-xl font-semibold text-red-600 dark:text-red-300">{% trans "Remover Mídia" %}</h2>
-  <p class="text-gray-600 dark:text-gray-400">{% trans "Tem certeza que deseja remover esta mídia?" %}</p>
+  <h2 class="text-xl font-semibold text-error">{% trans "Remover Mídia" %}</h2>
+  <p class="text-[var(--text-secondary)]">{% trans "Tem certeza que deseja remover esta mídia?" %}</p>
   <form method="post" class="flex justify-end gap-2">
     {% csrf_token %}
     <a href="{% url 'accounts:midias' %}" class="btn-secondary btn-sm inline-flex items-center gap-1">

--- a/accounts/templates/perfil/midia_detail.html
+++ b/accounts/templates/perfil/midia_detail.html
@@ -30,9 +30,9 @@
       </a>
     </p>
   {% endif %}
-  <p class="text-center text-gray-700 dark:text-gray-200">{{ media.descricao }}</p>
+  <p class="text-center text-[var(--text-primary)]">{{ media.descricao }}</p>
   <div class="text-center">
-    <a href="{% url 'accounts:midias' %}" class="inline-flex items-center gap-1 text-sm text-primary dark:text-primary hover:underline">
+    <a href="{% url 'accounts:midias' %}" class="inline-flex items-center gap-1 text-sm text-primary hover:underline">
       {% lucide 'arrow-left' class='w-4 h-4' aria_hidden='true' %}
       {% trans "Voltar para mídias" %}
     </a>

--- a/accounts/templates/perfil/midias.html
+++ b/accounts/templates/perfil/midias.html
@@ -6,7 +6,7 @@
 {% block perfil_content %}
 <section id="midias" class="perfil-section active">
   <div class="section-header mb-6">
-    <h2 class="text-xl font-semibold text-neutral-900 dark:text-neutral-100">{% trans "Mídias" %}</h2>
+    <h2 class="text-xl font-semibold text-[var(--text-primary)]">{% trans "Mídias" %}</h2>
     <p class="text-sm text-[var(--text-primary)]">{% trans "Gerencie suas imagens, vídeos e documentos" %}</p>
 
   </div>
@@ -16,7 +16,7 @@
     {% csrf_token %}
     <div>
       <label for="id_file" class="block text-sm font-medium text-[var(--text-primary)]">{% trans "Enviar arquivo" %}</label>
-      <input type="file" id="id_file" name="file" class="form-input mt-1 block w-full rounded-lg p-2 text-sm dark:bg-neutral-700 dark:border-neutral-600 dark:text-neutral-100" required accept="{{ allowed_exts|join:',' }}" aria-label="{% trans 'Arquivo' %}" aria-invalid="false" aria-describedby="file_help">
+      <input type="file" id="id_file" name="file" class="form-input mt-1 block w-full rounded-lg p-2 text-sm bg-[var(--bg-secondary)] border border-[var(--border)] text-[var(--text-primary)]" required accept="{{ allowed_exts|join:',' }}" aria-label="{% trans 'Arquivo' %}" aria-invalid="false" aria-describedby="file_help">
 
       {% if form.file.errors %}
         <div class="text-sm text-red-600">{{ form.file.errors }}</div>
@@ -25,8 +25,8 @@
     </div>
     <div>
       <label for="id_descricao" class="block text-sm font-medium text-[var(--text-primary)]">{% trans "Descrição" %}</label>
-      <input type="text" id="id_descricao" name="descricao" class="form-input mt-1 block w-full rounded-lg p-2 text-sm dark:bg-neutral-700 dark:border-neutral-600 dark:text-neutral-100" aria-label="{% trans 'Descrição' %}" aria-invalid="false" aria-describedby="descricao_help" placeholder="{% trans 'Descrição' %}">
-      <small id="descricao_help" class="text-sm text-neutral-500 dark:text-neutral-400">{% trans "Breve descrição da mídia" %}</small>
+      <input type="text" id="id_descricao" name="descricao" class="form-input mt-1 block w-full rounded-lg p-2 text-sm bg-[var(--bg-secondary)] border border-[var(--border)] text-[var(--text-primary)]" aria-label="{% trans 'Descrição' %}" aria-invalid="false" aria-describedby="descricao_help" placeholder="{% trans 'Descrição' %}">
+      <small id="descricao_help" class="text-sm text-[var(--text-secondary)]">{% trans "Breve descrição da mídia" %}</small>
 
       {% if form.descricao.errors %}
         <div class="text-sm text-red-600">{{ form.descricao.errors }}</div>
@@ -34,7 +34,7 @@
     </div>
     <div>
       <label for="id_tags_field" class="block text-sm font-medium text-[var(--text-primary)]">{% trans "Tags" %}</label>
-      <input type="text" id="id_tags_field" name="tags_field" class="form-input mt-1 block w-full rounded-lg p-2 text-sm dark:bg-neutral-700 dark:border-neutral-600 dark:text-neutral-100" placeholder="{% trans 'paisagem, viagem' %}" aria-label="{% trans 'Tags' %}" aria-invalid="false">
+      <input type="text" id="id_tags_field" name="tags_field" class="form-input mt-1 block w-full rounded-lg p-2 text-sm bg-[var(--bg-secondary)] border border-[var(--border)] text-[var(--text-primary)]" placeholder="{% trans 'paisagem, viagem' %}" aria-label="{% trans 'Tags' %}" aria-invalid="false">
       {% if form.tags_field.errors %}
         <div class="text-sm text-red-600">{{ form.tags_field.errors }}</div>
       {% endif %}

--- a/accounts/templates/perfil/perfil.html
+++ b/accounts/templates/perfil/perfil.html
@@ -44,12 +44,12 @@
 
         <nav class="mt-6 border-b flex space-x-4 text-sm font-medium text-[var(--text-secondary)] border-[var(--border)]" role="tablist">
           <a href="{% url 'accounts:informacoes_pessoais' %}"
-             class="px-3 py-2 -mb-px border-b-2 {% if request.resolver_match.url_name == 'informacoes_pessoais' %}border-primary text-primary dark:text-primary{% else %}border-transparent hover:text-primary dark:hover:text-primary{% endif %}"
+             class="px-3 py-2 -mb-px border-b-2 {% if request.resolver_match.url_name == 'informacoes_pessoais' %}border-primary text-primary{% else %}border-transparent hover:text-primary{% endif %}"
              role="tab"
              aria-selected="{% if request.resolver_match.url_name == 'informacoes_pessoais' %}true{% else %}false{% endif %}">{% trans "Informações Pessoais" %}</a>
 
           <a href="{% url 'accounts:redes_sociais' %}"
-             class="px-3 py-2 -mb-px border-b-2 {% if request.resolver_match.url_name == 'redes_sociais' %}border-primary text-primary dark:text-primary{% else %}border-transparent hover:text-primary dark:hover:text-primary{% endif %}"
+             class="px-3 py-2 -mb-px border-b-2 {% if request.resolver_match.url_name == 'redes_sociais' %}border-primary text-primary{% else %}border-transparent hover:text-primary{% endif %}"
              role="tab"
              aria-selected="{% if request.resolver_match.url_name == 'redes_sociais' %}true{% else %}false{% endif %}">{% trans "Redes Sociais" %}</a>
         </nav>

--- a/accounts/templates/perfil/publico.html
+++ b/accounts/templates/perfil/publico.html
@@ -6,18 +6,18 @@
 
 {% block perfil_content %}
 <div class="card-header">
-  <nav class="border-b border-gray-200 dark:border-gray-700">
+  <nav class="border-b border-[var(--border)]">
     <ul class="-mb-px flex flex-wrap gap-2" role="tablist" aria-label="{% trans 'Navegação de abas do perfil' %}">
       <li>
         <a href="#tab-informacoes" data-tab-target="tab-informacoes" role="tab" aria-selected="true"
-           class="inline-flex items-center gap-2 rounded-t px-3 py-2 text-sm font-medium border-b-2 border-transparent text-gray-600 dark:text-gray-400 hover:text-primary hover:border-primary data-[active=true]:border-primary data-[active=true]:text-primary">
+           class="inline-flex items-center gap-2 rounded-t px-3 py-2 text-sm font-medium border-b-2 border-transparent text-[var(--text-secondary)] hover:text-primary hover:border-primary data-[active=true]:border-primary data-[active=true]:text-primary">
           {% trans "Informações" %}
         </a>
       </li>
       {% if not profile.is_superuser %}
       <li>
         <a href="#tab-empresas" data-tab-target="tab-empresas" role="tab" aria-selected="false"
-           class="inline-flex items-center gap-2 rounded-t px-3 py-2 text-sm font-medium border-b-2 border-transparent text-gray-600 dark:text-gray-400 hover:text-primary hover:border-primary">
+           class="inline-flex items-center gap-2 rounded-t px-3 py-2 text-sm font-medium border-b-2 border-transparent text-[var(--text-secondary)] hover:text-primary hover:border-primary">
           {% trans "Empresas" %}
         </a>
 
@@ -48,36 +48,36 @@
     <div id="tab-informacoes" role="tabpanel" data-tab-panel class="block">
       <dl class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6 text-sm">
         <div>
-          <dt class="text-gray-500 dark:text-gray-400">{% trans "Nome completo" %}</dt>
+          <dt class="text-[var(--text-secondary)]">{% trans "Nome completo" %}</dt>
           <dd class="font-medium">{{ profile.get_full_name|default:profile.username }}</dd>
         </div>
         <div>
-          <dt class="text-gray-500 dark:text-gray-400">{% trans "Usuário" %}</dt>
+          <dt class="text-[var(--text-secondary)]">{% trans "Usuário" %}</dt>
           <dd class="font-medium">@{{ profile.username }}</dd>
         </div>
         {% if profile.email %}
         <div>
-          <dt class="text-gray-500 dark:text-gray-400">{% trans "E-mail" %}</dt>
+          <dt class="text-[var(--text-secondary)]">{% trans "E-mail" %}</dt>
           <dd class="font-medium">{{ profile.email }}</dd>
         </div>
         {% endif %}
         {% if profile.date_joined %}
         <div>
-          <dt class="text-gray-500 dark:text-gray-400">{% trans "Membro desde" %}</dt>
+          <dt class="text-[var(--text-secondary)]">{% trans "Membro desde" %}</dt>
           <dd class="font-medium">{{ profile.date_joined|date:"d/m/Y H:i" }}</dd>
         </div>
         {% endif %}
         {% if profile.last_login %}
         <div>
-          <dt class="text-gray-500 dark:text-gray-400">{% trans "Último acesso" %}</dt>
+          <dt class="text-[var(--text-secondary)]">{% trans "Último acesso" %}</dt>
           <dd class="font-medium">{{ profile.last_login|date:"d/m/Y H:i" }}</dd>
         </div>
         {% endif %}
       </dl>
       {% if profile.biografia %}
         <div class="mt-4">
-          <h3 class="text-sm font-semibold mb-1 text-neutral-900 dark:text-neutral-100">{% trans "Biografia" %}</h3>
-          <p class="text-gray-700 dark:text-gray-300 whitespace-pre-line">{{ profile.biografia }}</p>
+          <h3 class="text-sm font-semibold mb-1 text-[var(--text-primary)]">{% trans "Biografia" %}</h3>
+          <p class="text-[var(--text-primary)] whitespace-pre-line">{{ profile.biografia }}</p>
         </div>
       {% endif %}
     </div>
@@ -94,7 +94,7 @@
       </div>
       {% else %}
       <div class="grid grid-cols-1">
-        <p class="col-span-full text-center text-neutral-500 dark:text-neutral-400 py-10">{% translate 'Nenhuma empresa encontrada.' %}</p>
+        <p class="col-span-full text-center text-[var(--text-secondary)] py-10">{% translate 'Nenhuma empresa encontrada.' %}</p>
       </div>
       {% endif %}
     </div>
@@ -104,7 +104,7 @@
         {% for nucleo in nucleos %}
           {% include '_components/card_nucleo.html' with nucleo=nucleo %}
         {% empty %}
-          <p class="col-span-full text-center text-neutral-500 dark:text-neutral-400">{% trans "Nenhum núcleo encontrado." %}</p>
+          <p class="col-span-full text-center text-[var(--text-secondary)]">{% trans "Nenhum núcleo encontrado." %}</p>
         {% endfor %}
       </div>
     </div>
@@ -114,7 +114,7 @@
         {% for ins in inscricoes %}
           {% include '_components/card_evento.html' with evento=ins.evento %}
         {% empty %}
-          <p class="col-span-full text-center text-neutral-500 dark:text-neutral-400">{% trans "Nenhum evento encontrado." %}</p>
+          <p class="col-span-full text-center text-[var(--text-secondary)]">{% trans "Nenhum evento encontrado." %}</p>
         {% endfor %}
       </div>
     </div>

--- a/accounts/templates/perfil/redes_sociais.html
+++ b/accounts/templates/perfil/redes_sociais.html
@@ -7,8 +7,8 @@
 <div class="grid grid-cols-1 lg:grid-cols-3 gap-6 max-w-3xl mx-auto">
   <div class="card lg:col-span-3">
     <div class="card-body">
-      <h3 class="text-xl font-semibold mb-1 text-neutral-900 dark:text-neutral-100">{% trans "Redes Sociais" %}</h3>
-      <p class="text-sm text-neutral-500 dark:text-neutral-400 mb-6">{% trans "Conecte suas redes sociais com seu perfil" %}</p>
+      <h3 class="text-xl font-semibold mb-1 text-[var(--text-primary)]">{% trans "Redes Sociais" %}</h3>
+      <p class="text-sm text-[var(--text-secondary)] mb-6">{% trans "Conecte suas redes sociais com seu perfil" %}</p>
 
       <form method="post" action="{% url 'accounts:redes_sociais' %}" class="space-y-6">
         {% csrf_token %}
@@ -31,7 +31,7 @@
 </div>
 
 <div class="mt-6 text-center">
-  <a href="{% url 'accounts:perfil' %}" class="text-sm text-primary dark:text-primary hover:underline">← {% trans "Voltar" %}</a>
+  <a href="{% url 'accounts:perfil' %}" class="text-sm text-primary hover:underline">← {% trans "Voltar" %}</a>
 </div>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- remove dark: utilities from perfil templates in favor of CSS variables
- switch form fields to bg/text/border variables for automatic theming
- clean up profile navigation links to use shared theme colors

## Testing
- `npm run build:css`
- `pytest` *(fails: ModuleNotFoundError: 'silk', 81 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d44e5c4c83258d278f79fa20785e