### PR TITLE
Refactor nucleus card to reuse base card

### DIFF
--- a/templates/_components/card_details_nucleo.html
+++ b/templates/_components/card_details_nucleo.html
@@ -1,0 +1,19 @@
+{% load i18n %}
+<dl class="mt-3 grid grid-cols-3 gap-2 text-xs text-[var(--text-secondary)]">
+  <div>
+    <dt class="text-[var(--text-secondary)]">{% trans 'Membros' %}</dt>
+    <dd class="font-medium">{{ nucleo.num_membros|default:nucleo.membros.count }}</dd>
+  </div>
+  <div>
+    <dt class="text-[var(--text-secondary)]">{% trans 'Coordenador' %}</dt>
+    <dd class="font-medium">
+      {% with coord=nucleo.coordenadores.first %}
+        {% if coord %}{{ coord.get_full_name|default:coord.username }}{% else %}-{% endif %}
+      {% endwith %}
+    </dd>
+  </div>
+  <div>
+    <dt class="text-[var(--text-secondary)]">{% trans 'Eventos' %}</dt>
+    <dd class="font-medium">{{ nucleo.num_eventos|default:0 }}</dd>
+  </div>
+</dl>

--- a/templates/_components/card_nucleo.html
+++ b/templates/_components/card_nucleo.html
@@ -1,46 +1,4 @@
 {% load i18n %}
-{# Card de Núcleo #}
-<a href="{% url 'nucleos:detail_uuid' nucleo.public_id %}"
-   class="group block focus:outline-none focus:ring-2 focus:ring-primary/40">
-  <article class="card overflow-hidden" role="article" aria-label="{{ nucleo.nome }}">
-    <header class="relative">
-      {% if nucleo.cover %}
-        <img src="{{ nucleo.cover.url }}" alt="{% trans 'Capa do núcleo' %}"
-             class="h-24 w-full object-cover" />
-      {% else %}
-        <div class="h-24 w-full bg-gradient-to-r from-[var(--hero-from)] to-[var(--hero-to)]"{% if style %} style="{{ style }}"{% endif %}></div>
-      {% endif %}
-      <div class="absolute -bottom-8 left-4">
-        {% if nucleo.avatar %}
-          <img src="{{ nucleo.avatar.url }}" alt="{{ nucleo.nome }}"
-               class="h-16 w-16 rounded-full ring-4 ring-[var(--bg-primary)] object-cover" />
-        {% else %}
-          <div class="h-16 w-16 rounded-full ring-4 ring-[var(--bg-primary)] bg-[var(--bg-tertiary)] flex items-center justify-center text-lg font-semibold text-[var(--text-primary)]" role="img" aria-label="{{ nucleo.nome }}">
-            {{ nucleo.nome|first|upper }}
-          </div>
-        {% endif %}
-      </div>
-    </header>
-    <div class="card-body pt-10">
-      <h3 class="text-base font-semibold text-[var(--text-primary)] group-hover:underline">{{ nucleo.nome }}</h3>
-      <dl class="mt-3 grid grid-cols-3 gap-2 text-xs text-[var(--text-secondary)]">
-        <div>
-          <dt class="text-[var(--text-secondary)]">{% trans 'Membros' %}</dt>
-          <dd class="font-medium">{{ nucleo.num_membros|default:nucleo.membros.count }}</dd>
-        </div>
-        <div>
-          <dt class="text-[var(--text-secondary)]">{% trans 'Coordenador' %}</dt>
-          <dd class="font-medium">
-            {% with coord=nucleo.coordenadores.first %}
-              {% if coord %}{{ coord.get_full_name|default:coord.username }}{% else %}-{% endif %}
-            {% endwith %}
-          </dd>
-        </div>
-        <div>
-          <dt class="text-[var(--text-secondary)]">{% trans 'Eventos' %}</dt>
-          <dd class="font-medium">{{ nucleo.num_eventos|default:0 }}</dd>
-        </div>
-      </dl>
-    </div>
-  </article>
-</a>
+{% url 'nucleos:detail_uuid' nucleo.public_id as detail_url %}
+{% trans 'Ver detalhes do núcleo' as sr_label %}
+{% include '_partials/cards/base_card.html' with url=detail_url cover=nucleo.cover avatar=nucleo.avatar title=nucleo.nome details='_components/card_details_nucleo.html' sr_label=sr_label %}


### PR DESCRIPTION
## Summary
- Refactor nucleus card to use shared base card component
- Add card_details_nucleo partial for nucleus statistics
- Ensure company and event cards remain based on base card

## Testing
- `pytest` *(fails: 81 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d929165c8325b8fcc155b50bcc6d