### PR TITLE
Remove container wrappers from header and footer

### DIFF
--- a/templates/_partials/footer.html
+++ b/templates/_partials/footer.html
@@ -1,12 +1,10 @@
 {% load i18n %}
-<footer class="bg-[var(--bg-secondary)] border-[var(--border)] mt-10">
-  <div class="container mx-auto px-4 py-6 text-sm text-[var(--text-secondary)] flex flex-col items-center gap-2 md:flex-row md:justify-between">
-    <p>{% blocktrans with year=now|date:"Y" %}© {{ year }} HubX. Todos os direitos reservados.{% endblocktrans %}</p>
-    <nav class="flex gap-4">
-      <a href="{% url 'core:about' %}" class="hover:text-[var(--text-primary)]">{% trans "Sobre" %}</a>
-      <a href="mailto:contato@hubx.space" class="hover:text-[var(--text-primary)]">{% trans "Contato" %}</a>
-      <a href="{% url 'core:privacy' %}" class="hover:text-[var(--text-primary)]">{% trans "Privacidade" %}</a>
-      <a href="{% url 'core:terms' %}" class="hover:text-[var(--text-primary)]">{% trans "Termos" %}</a>
-    </nav>
-  </div>
+<footer class="bg-[var(--bg-secondary)] border-[var(--border)] mt-10 px-4 py-6 text-sm text-[var(--text-secondary)] flex flex-col items-center gap-2 md:flex-row md:justify-between">
+  <p>{% blocktrans with year=now|date:"Y" %}© {{ year }} HubX. Todos os direitos reservados.{% endblocktrans %}</p>
+  <nav class="flex gap-4">
+    <a href="{% url 'core:about' %}" class="hover:text-[var(--text-primary)]">{% trans "Sobre" %}</a>
+    <a href="mailto:contato@hubx.space" class="hover:text-[var(--text-primary)]">{% trans "Contato" %}</a>
+    <a href="{% url 'core:privacy' %}" class="hover:text-[var(--text-primary)]">{% trans "Privacidade" %}</a>
+    <a href="{% url 'core:terms' %}" class="hover:text-[var(--text-primary)]">{% trans "Termos" %}</a>
+  </nav>
 </footer>

--- a/templates/_partials/header.html
+++ b/templates/_partials/header.html
@@ -1,43 +1,41 @@
 {% load i18n %}
-<header class="bg-[var(--bg-secondary)] border-[var(--border)]">
-  <div class="container mx-auto p-4 flex items-center gap-4 justify-between">
-    <a href="/" class="text-xl font-bold text-[var(--text-primary)]" aria-label="{% trans 'Página inicial' %}">HubX</a>
-    <form action="#" method="get" role="search" class="flex-1 max-w-md">
-      <label for="header-search"><span class="sr-only">{% trans 'Buscar' %}</span></label>
-      <input id="header-search" name="q" type="search" placeholder="{% trans 'Buscar' %}" class="w-full border border-[var(--border)] bg-[var(--bg-primary)] rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[var(--border-focus)]" />
-    </form>
-    <div class="flex items-center gap-4">
-      <div class="flex items-center gap-2" role="group" aria-label="{% trans 'Tema' %}">
-        <button type="button" class="btn btn-secondary btn-sm aria-pressed:bg-[var(--primary)] aria-pressed:text-white aria-pressed:border-[var(--primary)]" data-theme-option="claro" aria-pressed="false">
-          {% trans "Claro" %}
-        </button>
-        <button type="button" class="btn btn-secondary btn-sm aria-pressed:bg-[var(--primary)] aria-pressed:text-white aria-pressed:border-[var(--primary)]" data-theme-option="escuro" aria-pressed="false">
-          {% trans "Escuro" %}
-        </button>
-        <button type="button" class="btn btn-secondary btn-sm aria-pressed:bg-[var(--primary)] aria-pressed:text-white aria-pressed:border-[var(--primary)]" data-theme-option="automatico" aria-pressed="false">
-          {% trans "Automático" %}
-        </button>
-      </div>
-      <a href="#" class="relative" aria-label="{% trans 'Notificações' %}">
-        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <path d="M10 21a1 1 0 0 0 2 0" />
-          <path d="M18 8a6 6 0 1 0-12 0c0 7-3 9-3 9h18s-3-2-3-9" />
-        </svg>
-        <span class="sr-only">{% trans "Notificações" %}</span>
-      </a>
-      {% if request.user.is_authenticated %}
-      <a href="{% url 'accounts:perfil' %}" class="block w-8 h-8 rounded-full overflow-hidden" aria-label="{% trans 'Perfil' %}">
-        {% if request.user.avatar %}
-        <img src="{{ request.user.avatar.url }}" alt="{{ request.user.username }}" class="w-full h-full object-cover" />
-        {% else %}
-        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2" />
-          <circle cx="12" cy="7" r="4" />
-        </svg>
-        {% endif %}
-        <span class="sr-only">{% trans "Perfil" %}</span>
-      </a>
-      {% endif %}
+<header class="bg-[var(--bg-secondary)] border-[var(--border)] px-4 py-4 flex items-center gap-4 justify-between">
+  <a href="/" class="text-xl font-bold text-[var(--text-primary)]" aria-label="{% trans 'Página inicial' %}">HubX</a>
+  <form action="#" method="get" role="search" class="flex-1 max-w-md">
+    <label for="header-search"><span class="sr-only">{% trans 'Buscar' %}</span></label>
+    <input id="header-search" name="q" type="search" placeholder="{% trans 'Buscar' %}" class="w-full border border-[var(--border)] bg-[var(--bg-primary)] rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[var(--border-focus)]" />
+  </form>
+  <div class="flex items-center gap-4">
+    <div class="flex items-center gap-2" role="group" aria-label="{% trans 'Tema' %}">
+      <button type="button" class="btn btn-secondary btn-sm aria-pressed:bg-[var(--primary)] aria-pressed:text-white aria-pressed:border-[var(--primary)]" data-theme-option="claro" aria-pressed="false">
+        {% trans "Claro" %}
+      </button>
+      <button type="button" class="btn btn-secondary btn-sm aria-pressed:bg-[var(--primary)] aria-pressed:text-white aria-pressed:border-[var(--primary)]" data-theme-option="escuro" aria-pressed="false">
+        {% trans "Escuro" %}
+      </button>
+      <button type="button" class="btn btn-secondary btn-sm aria-pressed:bg-[var(--primary)] aria-pressed:text-white aria-pressed:border-[var(--primary)]" data-theme-option="automatico" aria-pressed="false">
+        {% trans "Automático" %}
+      </button>
     </div>
+    <a href="#" class="relative" aria-label="{% trans 'Notificações' %}">
+      <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M10 21a1 1 0 0 0 2 0" />
+        <path d="M18 8a6 6 0 1 0-12 0c0 7-3 9-3 9h18s-3-2-3-9" />
+      </svg>
+      <span class="sr-only">{% trans "Notificações" %}</span>
+    </a>
+    {% if request.user.is_authenticated %}
+    <a href="{% url 'accounts:perfil' %}" class="block w-8 h-8 rounded-full overflow-hidden" aria-label="{% trans 'Perfil' %}">
+      {% if request.user.avatar %}
+      <img src="{{ request.user.avatar.url }}" alt="{{ request.user.username }}" class="w-full h-full object-cover" />
+      {% else %}
+      <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2" />
+        <circle cx="12" cy="7" r="4" />
+      </svg>
+      {% endif %}
+      <span class="sr-only">{% trans "Perfil" %}</span>
+    </a>
+    {% endif %}
   </div>
 </header>


### PR DESCRIPTION
## Summary
- drop redundant container divs from header and footer partials
- apply padding and layout classes directly to header and footer elements

## Testing
- `pytest` *(fails: 81 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d931d7a483258c9342116b8e8c72