### PR TITLE
refactor: standardize tables with responsive wrappers

### DIFF
--- a/eventos/templates/eventos/briefing_list.html
+++ b/eventos/templates/eventos/briefing_list.html
@@ -20,20 +20,20 @@
       </form>
 
       <div class="overflow-x-auto bg-[var(--bg-secondary)] border border-[var(--border)] rounded-2xl shadow-sm">
-        <table class="min-w-full divide-y divide-neutral-200 table-auto text-sm">
-          <thead class="bg-neutral-50">
+        <table class="min-w-full divide-y divide-[var(--border)] table-auto text-sm">
+          <thead class="bg-[var(--bg-secondary)]">
             <tr>
-              <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Evento" %}</th>
-              <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Objetivos" %}</th>
-              <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Público Alvo" %}</th>
-              <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Requisitos Técnicos" %}</th>
-              <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Cronograma Resumido" %}</th>
-              <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Conteúdo Programático" %}</th>
-              <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Observações" %}</th>
-              <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Ações" %}</th>
+              <th class="px-4 py-2 text-left font-semibold text-[var(--text-secondary)]">{% trans "Evento" %}</th>
+              <th class="px-4 py-2 text-left font-semibold text-[var(--text-secondary)]">{% trans "Objetivos" %}</th>
+              <th class="px-4 py-2 text-left font-semibold text-[var(--text-secondary)]">{% trans "Público Alvo" %}</th>
+              <th class="px-4 py-2 text-left font-semibold text-[var(--text-secondary)]">{% trans "Requisitos Técnicos" %}</th>
+              <th class="px-4 py-2 text-left font-semibold text-[var(--text-secondary)]">{% trans "Cronograma Resumido" %}</th>
+              <th class="px-4 py-2 text-left font-semibold text-[var(--text-secondary)]">{% trans "Conteúdo Programático" %}</th>
+              <th class="px-4 py-2 text-left font-semibold text-[var(--text-secondary)]">{% trans "Observações" %}</th>
+              <th class="px-4 py-2 text-left font-semibold text-[var(--text-secondary)]">{% trans "Ações" %}</th>
             </tr>
           </thead>
-          <tbody class="divide-y divide-neutral-200">
+          <tbody class="divide-y divide-[var(--border)]">
             {% for briefing in briefings %}
               <tr>
                 <td class="px-4 py-2">{{ briefing.evento }}</td>
@@ -63,7 +63,7 @@
               </tr>
             {% empty %}
               <tr>
-                <td colspan="8" class="px-4 py-4 text-center text-neutral-500">{% trans "Nenhum briefing encontrado." %}</td>
+                <td colspan="8" class="px-4 py-4 text-center text-[var(--text-secondary)]">{% trans "Nenhum briefing encontrado." %}</td>
               </tr>
             {% endfor %}
           </tbody>

--- a/eventos/templates/eventos/material_list.html
+++ b/eventos/templates/eventos/material_list.html
@@ -20,22 +20,22 @@
       </form>
 
       <div class="overflow-x-auto bg-[var(--bg-secondary)] border border-[var(--border)] rounded-2xl shadow-sm">
-        <table class="min-w-full divide-y divide-neutral-200 table-auto text-sm">
-          <thead class="bg-neutral-50">
+        <table class="min-w-full divide-y divide-[var(--border)] table-auto text-sm">
+          <thead class="bg-[var(--bg-secondary)]">
             <tr>
-              <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Título" %}</th>
-              <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Descrição" %}</th>
-              <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Status" %}</th>
-              <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Arquivo" %}</th>
-              <th class="px-4 py-2 text-left font-semibold text-neutral-700">{% trans "Ações" %}</th>
+              <th class="px-4 py-2 text-left font-semibold text-[var(--text-secondary)]">{% trans "Título" %}</th>
+              <th class="px-4 py-2 text-left font-semibold text-[var(--text-secondary)]">{% trans "Descrição" %}</th>
+              <th class="px-4 py-2 text-left font-semibold text-[var(--text-secondary)]">{% trans "Status" %}</th>
+              <th class="px-4 py-2 text-left font-semibold text-[var(--text-secondary)]">{% trans "Arquivo" %}</th>
+              <th class="px-4 py-2 text-left font-semibold text-[var(--text-secondary)]">{% trans "Ações" %}</th>
             </tr>
           </thead>
-          <tbody class="divide-y divide-neutral-200">
+          <tbody class="divide-y divide-[var(--border)]">
             {% for material in materiais %}
               {% include "eventos/_material_row.html" with material=material %}
             {% empty %}
               <tr>
-                <td colspan="5" class="px-4 py-4 text-center text-neutral-500">{% trans "Nenhum material disponível." %}</td>
+                <td colspan="5" class="px-4 py-4 text-center text-[var(--text-secondary)]">{% trans "Nenhum material disponível." %}</td>
               </tr>
             {% endfor %}
           </tbody>

--- a/financeiro/templates/financeiro/centros_list.html
+++ b/financeiro/templates/financeiro/centros_list.html
@@ -10,18 +10,19 @@
 {% block content %}
   <div class="py-12 card px-4">
     <div class="card-body">
-      <section id="centros-list" class="overflow-x-auto" aria-live="polite">
+      <section id="centros-list" aria-live="polite">
+        <div class="overflow-x-auto">
         <table class="min-w-full divide-y divide-[var(--border)]">
       <thead class="bg-[var(--bg-secondary)]">
         <tr>
-          <th scope="col" class="px-3 py-2 text-left text-xs font-medium text-[var(--text-primary)]">{% trans "Nome" %}</th>
-          <th scope="col" class="px-3 py-2 text-left text-xs font-medium text-[var(--text-primary)]">{% trans "Tipo" %}</th>
-          <th scope="col" class="px-3 py-2 text-left text-xs font-medium text-[var(--text-primary)]">{% trans "Organização/Núcleo/Evento" %}</th>
-          <th scope="col" class="px-3 py-2 text-left text-xs font-medium text-[var(--text-primary)]">{% trans "Saldo" %}</th>
-          <th scope="col" class="px-3 py-2 text-right text-xs font-medium text-[var(--text-primary)]">{% trans "Ações" %}</th>
+          <th scope="col" class="px-3 py-2 text-left text-xs font-medium text-[var(--text-secondary)]">{% trans "Nome" %}</th>
+          <th scope="col" class="px-3 py-2 text-left text-xs font-medium text-[var(--text-secondary)]">{% trans "Tipo" %}</th>
+          <th scope="col" class="px-3 py-2 text-left text-xs font-medium text-[var(--text-secondary)]">{% trans "Organização/Núcleo/Evento" %}</th>
+          <th scope="col" class="px-3 py-2 text-left text-xs font-medium text-[var(--text-secondary)]">{% trans "Saldo" %}</th>
+          <th scope="col" class="px-3 py-2 text-right text-xs font-medium text-[var(--text-secondary)]">{% trans "Ações" %}</th>
         </tr>
       </thead>
-      <tbody>
+      <tbody class="divide-y divide-[var(--border)]">
         {% for c in centros %}
         <tr class="divide-x divide-[var(--border)]">
           <td class="px-3 py-2">{{ c.nome }}</td>
@@ -37,11 +38,12 @@
           </tr>
         {% empty %}
         <tr>
-          <td colspan="5" class="px-3 py-2 text-center text-sm text-[var(--text-primary)]">{% trans "Nenhum centro encontrado." %}</td>
+          <td colspan="5" class="px-3 py-2 text-center text-sm text-[var(--text-secondary)]">{% trans "Nenhum centro encontrado." %}</td>
         </tr>
         {% endfor %}
       </tbody>
     </table>
+        </div>
         <div class="mt-4 flex justify-between">
           {% if prev %}
             <button class="btn btn-secondary" hx-get="?offset={{ prev }}" hx-target="#centros-list" hx-trigger="click" hx-swap="outerHTML">{% trans "Anterior" %}</button>

--- a/financeiro/templates/financeiro/extrato.html
+++ b/financeiro/templates/financeiro/extrato.html
@@ -38,9 +38,10 @@
     </div>
     <div class="card-body">
       <div id="lista" aria-live="polite">
+        <div class="overflow-x-auto">
         <table class="min-w-full divide-y divide-[var(--border)]">
-          <thead>
-            <tr class="bg-[var(--bg-tertiary)]">
+          <thead class="bg-[var(--bg-tertiary)]">
+            <tr>
               <th class="px-3 py-2 text-left text-xs font-medium text-[var(--text-secondary)]">{{ _('Centro de Custo') }}</th>
               <th class="px-3 py-2 text-left text-xs font-medium text-[var(--text-secondary)]">{{ _('Tipo') }}</th>
               <th class="px-3 py-2 text-left text-xs font-medium text-[var(--text-secondary)]">{{ _('Valor') }}</th>
@@ -48,7 +49,7 @@
               <th class="px-3 py-2 text-left text-xs font-medium text-[var(--text-secondary)]">{{ _('Status') }}</th>
             </tr>
           </thead>
-          <tbody>
+          <tbody class="divide-y divide-[var(--border)]">
             {% for l in lancamentos %}
             <tr>
               <td class="px-3 py-2">{{ l.centro_custo }}</td>
@@ -62,6 +63,7 @@
             {% endfor %}
           </tbody>
         </table>
+        </div>
       </div>
       <script src="{% url 'javascript-catalog' %}"></script>
       <script>

--- a/financeiro/templates/financeiro/importacoes_list.html
+++ b/financeiro/templates/financeiro/importacoes_list.html
@@ -11,22 +11,25 @@
   <div class="py-12 card px-4">
     <div class="card-body">
       <div id="importacoes"
+           
            hx-get="/api/financeiro/importacoes/"
            hx-trigger="load"
            hx-target="#importacoes"
            hx-swap="none"
            hx-on="htmx:afterRequest: renderImportacoes(event)">
+        <div class="overflow-x-auto">
         <table class="min-w-full divide-y divide-[var(--border)]">
           <thead class="bg-[var(--bg-secondary)]">
             <tr>
-              <th class="px-3 py-2 text-left text-xs font-medium text-[var(--text-primary)]">{% trans "Arquivo" %}</th>
-              <th class="px-3 py-2 text-left text-xs font-medium text-[var(--text-primary)]">{% trans "Status" %}</th>
-              <th class="px-3 py-2 text-left text-xs font-medium text-[var(--text-primary)]">{% trans "Processados" %}</th>
-              <th class="px-3 py-2 text-left text-xs font-medium text-[var(--text-primary)]">{% trans "Ações" %}</th>
+              <th class="px-3 py-2 text-left text-xs font-medium text-[var(--text-secondary)]">{% trans "Arquivo" %}</th>
+              <th class="px-3 py-2 text-left text-xs font-medium text-[var(--text-secondary)]">{% trans "Status" %}</th>
+              <th class="px-3 py-2 text-left text-xs font-medium text-[var(--text-secondary)]">{% trans "Processados" %}</th>
+              <th class="px-3 py-2 text-left text-xs font-medium text-[var(--text-secondary)]">{% trans "Ações" %}</th>
             </tr>
           </thead>
-          <tbody></tbody>
+          <tbody class="divide-y divide-[var(--border)]"></tbody>
         </table>
+        </div>
         <div id="paginacao" class="mt-4 flex justify-between"></div>
       </div>
       <script>

--- a/financeiro/templates/financeiro/importar_pagamentos.html
+++ b/financeiro/templates/financeiro/importar_pagamentos.html
@@ -24,7 +24,7 @@
                  hx-trigger="change"
                  hx-include="#upload-form"
                  hx-on="htmx:afterRequest: renderPreview(event)" />
-          <p class="text-sm text-gray-500">{% trans "Apenas CSV ou XLSX até 5MB" %}</p>
+          <p class="text-sm text-[var(--text-secondary)]">{% trans "Apenas CSV ou XLSX até 5MB" %}</p>
         </div>
       </form>
       <button id="preview-btn"
@@ -70,7 +70,7 @@
             const data = JSON.parse(evt.detail.xhr.response);
             if (data.preview && data.preview.length) {
               const rows = data.preview.map(r => `<tr><td class="px-2 py-1">${r.centro_custo}</td><td class="px-2 py-1">${r.conta_associado || ''}</td><td class="px-2 py-1">${r.tipo}</td><td class="px-2 py-1">${r.valor}</td><td class="px-2 py-1">${r.data_lancamento}</td></tr>`).join('');
-              preview.innerHTML = `<table class="min-w-full divide-y divide-[var(--border)]"><thead><tr><th class="px-2 py-1 text-left text-xs font-medium text-gray-500">{% trans "Centro de Custo" %}</th><th class="px-2 py-1 text-left text-xs font-medium text-gray-500">{% trans "Conta" %}</th><th class="px-2 py-1 text-left text-xs font-medium text-gray-500">{% trans "Tipo" %}</th><th class="px-2 py-1 text-left text-xs font-medium text-gray-500">{% trans "Valor" %}</th><th class="px-2 py-1 text-left text-xs font-medium text-gray-500">{% trans "Data" %}</th></tr></thead><tbody>${rows}</tbody></table>`;
+              preview.innerHTML = `<div class="overflow-x-auto"><table class="min-w-full divide-y divide-[var(--border)]"><thead><tr><th class="px-2 py-1 text-left text-xs font-medium text-[var(--text-secondary)]">{% trans "Centro de Custo" %}</th><th class="px-2 py-1 text-left text-xs font-medium text-[var(--text-secondary)]">{% trans "Conta" %}</th><th class="px-2 py-1 text-left text-xs font-medium text-[var(--text-secondary)]">{% trans "Tipo" %}</th><th class="px-2 py-1 text-left text-xs font-medium text-[var(--text-secondary)]">{% trans "Valor" %}</th><th class="px-2 py-1 text-left text-xs font-medium text-[var(--text-secondary)]">{% trans "Data" %}</th></tr></thead><tbody class="divide-y divide-[var(--border)]">${rows}</tbody></table></div>`;
               document.getElementById('confirm-id').value = data.id;
               document.getElementById('confirm-importacao-id').value = data.importacao_id;
               document.getElementById('confirm-btn').disabled = false;

--- a/financeiro/templates/financeiro/inadimplencias.html
+++ b/financeiro/templates/financeiro/inadimplencias.html
@@ -38,19 +38,21 @@
     </div>
   </form>
   <div id="lista" aria-live="polite">
-    <table class="min-w-full divide-y divide-gray-200">
-      <thead>
-        <tr class="bg-gray-50">
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{% trans "ID" %}</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{% trans "Centro de Custo" %}</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{% trans "Conta" %}</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{% trans "Valor" %}</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{% trans "Data de Vencimento" %}</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500">{% trans "Dias em atraso" %}</th>
+    <div class="overflow-x-auto">
+    <table class="min-w-full divide-y divide-[var(--border)]">
+      <thead class="bg-[var(--bg-secondary)]">
+        <tr>
+          <th class="px-3 py-2 text-left text-xs font-medium text-[var(--text-secondary)]">{% trans "ID" %}</th>
+          <th class="px-3 py-2 text-left text-xs font-medium text-[var(--text-secondary)]">{% trans "Centro de Custo" %}</th>
+          <th class="px-3 py-2 text-left text-xs font-medium text-[var(--text-secondary)]">{% trans "Conta" %}</th>
+          <th class="px-3 py-2 text-left text-xs font-medium text-[var(--text-secondary)]">{% trans "Valor" %}</th>
+          <th class="px-3 py-2 text-left text-xs font-medium text-[var(--text-secondary)]">{% trans "Data de Vencimento" %}</th>
+          <th class="px-3 py-2 text-left text-xs font-medium text-[var(--text-secondary)]">{% trans "Dias em atraso" %}</th>
         </tr>
       </thead>
-      <tbody></tbody>
+      <tbody class="divide-y divide-[var(--border)]"></tbody>
     </table>
+    </div>
   </div>
   <script>
     function renderInadimplencias(evt) {

--- a/financeiro/templates/financeiro/integracoes_list.html
+++ b/financeiro/templates/financeiro/integracoes_list.html
@@ -10,19 +10,20 @@
 {% block content %}
   <div class="py-12 card px-4">
     <div class="card-body">
-      <section id="integracoes-list" class="overflow-x-auto" aria-live="polite">
-        <table class="min-w-full divide-y divide-gray-200">
-      <thead class="bg-gray-50">
+      <section id="integracoes-list" aria-live="polite">
+        <div class="overflow-x-auto">
+        <table class="min-w-full divide-y divide-[var(--border)]">
+      <thead class="bg-[var(--bg-secondary)]">
         <tr>
-          <th scope="col" class="px-3 py-2 text-left text-xs font-medium text-gray-500">{% trans "Nome" %}</th>
-          <th scope="col" class="px-3 py-2 text-left text-xs font-medium text-gray-500">{% trans "Tipo" %}</th>
-          <th scope="col" class="px-3 py-2 text-left text-xs font-medium text-gray-500">{% trans "Base URL" %}</th>
-          <th scope="col" class="px-3 py-2 text-right text-xs font-medium text-gray-500">{% trans "Ações" %}</th>
+          <th scope="col" class="px-3 py-2 text-left text-xs font-medium text-[var(--text-secondary)]">{% trans "Nome" %}</th>
+          <th scope="col" class="px-3 py-2 text-left text-xs font-medium text-[var(--text-secondary)]">{% trans "Tipo" %}</th>
+          <th scope="col" class="px-3 py-2 text-left text-xs font-medium text-[var(--text-secondary)]">{% trans "Base URL" %}</th>
+          <th scope="col" class="px-3 py-2 text-right text-xs font-medium text-[var(--text-secondary)]">{% trans "Ações" %}</th>
         </tr>
       </thead>
-      <tbody>
+      <tbody class="divide-y divide-[var(--border)]">
         {% for i in integracoes %}
-        <tr class="divide-x divide-gray-200">
+        <tr class="divide-x divide-[var(--border)]">
           <td class="px-3 py-2">{{ i.nome }}</td>
           <td class="px-3 py-2">{{ i.get_tipo_display }}</td>
           <td class="px-3 py-2">{{ i.base_url }}</td>
@@ -38,11 +39,12 @@
         </tr>
         {% empty %}
         <tr>
-          <td colspan="4" class="px-3 py-2 text-center text-sm text-gray-500">{% trans "Nenhuma integração encontrada." %}</td>
+          <td colspan="4" class="px-3 py-2 text-center text-sm text-[var(--text-secondary)]">{% trans "Nenhuma integração encontrada." %}</td>
         </tr>
         {% endfor %}
       </tbody>
     </table>
+        </div>
     <div class="mt-4 flex justify-between">
       {% if prev %}
         <button class="px-3 py-1 text-sm bg-gray-200 rounded"

--- a/financeiro/templates/financeiro/lancamentos_list.html
+++ b/financeiro/templates/financeiro/lancamentos_list.html
@@ -14,7 +14,7 @@
         <legend class="sr-only">{{ _('Filtros') }}</legend>
         <article class="card">
           <div class="card-body">
-            <label for="filtro-status" class="block text-sm font-medium text-[var(--text-primary)]">{{ _('Status') }}</label>
+            <label for="filtro-status" class="block text-sm font-medium text-[var(--text-secondary)]">{{ _('Status') }}</label>
             <select name="status" id="filtro-status" class="border p-2 rounded">
               <option value="">{{ _('Todos Status') }}</option>
               <option value="pendente">{{ _('Pendente') }}</option>
@@ -25,7 +25,7 @@
         </article>
         <article class="card">
           <div class="card-body">
-            <label for="filtro-centro" class="block text-sm font-medium text-[var(--text-primary)]">{{ _('Centro de Custo') }}</label>
+            <label for="filtro-centro" class="block text-sm font-medium text-[var(--text-secondary)]">{{ _('Centro de Custo') }}</label>
             <select name="centro" id="filtro-centro" class="border p-2 rounded">
               <option value="">{{ _('Todos Centros') }}</option>
               {% for c in centros %}
@@ -36,7 +36,7 @@
         </article>
         <article class="card">
           <div class="card-body">
-            <label for="filtro-nucleo" class="block text-sm font-medium text-[var(--text-primary)]">{{ _('Núcleo') }}</label>
+            <label for="filtro-nucleo" class="block text-sm font-medium text-[var(--text-secondary)]">{{ _('Núcleo') }}</label>
             <select name="nucleo" id="filtro-nucleo" class="border p-2 rounded">
               <option value="">{{ _('Todos Núcleos') }}</option>
               {% for n in nucleos %}
@@ -47,13 +47,13 @@
         </article>
         <article class="card">
           <div class="card-body">
-            <label for="filtro-periodo-inicial" class="block text-sm font-medium text-[var(--text-primary)]">{{ _('Período inicial') }}</label>
+            <label for="filtro-periodo-inicial" class="block text-sm font-medium text-[var(--text-secondary)]">{{ _('Período inicial') }}</label>
             <input id="filtro-periodo-inicial" type="month" name="periodo_inicial" class="border p-2 rounded" />
           </div>
         </article>
         <article class="card">
           <div class="card-body">
-            <label for="filtro-periodo-final" class="block text-sm font-medium text-[var(--text-primary)]">{{ _('Período final') }}</label>
+            <label for="filtro-periodo-final" class="block text-sm font-medium text-[var(--text-secondary)]">{{ _('Período final') }}</label>
             <input id="filtro-periodo-final" type="month" name="periodo_final" class="border p-2 rounded" />
           </div>
         </article>
@@ -61,22 +61,24 @@
     </div>
     <div class="card-body">
       <div id="lista" aria-live="polite">
+        <div class="overflow-x-auto">
         <table class="min-w-full divide-y divide-[var(--border)]">
           <thead class="bg-[var(--bg-secondary)]">
             <tr>
-              <th class="px-3 py-2 text-left text-xs font-medium text-[var(--text-primary)]">{{ _('ID') }}</th>
-              <th class="px-3 py-2 text-left text-xs font-medium text-[var(--text-primary)]">{{ _('Centro de Custo') }}</th>
-              <th class="px-3 py-2 text-left text-xs font-medium text-[var(--text-primary)]">{{ _('Conta Associada') }}</th>
-              <th class="px-3 py-2 text-left text-xs font-medium text-[var(--text-primary)]">{{ _('Tipo') }}</th>
-              <th class="px-3 py-2 text-left text-xs font-medium text-[var(--text-primary)]">{{ _('Valor') }}</th>
-              <th class="px-3 py-2 text-left text-xs font-medium text-[var(--text-primary)]">{{ _('Data de Lançamento') }}</th>
-              <th class="px-3 py-2 text-left text-xs font-medium text-[var(--text-primary)]">{{ _('Status') }}</th>
-              <th class="px-3 py-2 text-left text-xs font-medium text-[var(--text-primary)]">{{ _('Data de Vencimento') }}</th>
+              <th class="px-3 py-2 text-left text-xs font-medium text-[var(--text-secondary)]">{{ _('ID') }}</th>
+              <th class="px-3 py-2 text-left text-xs font-medium text-[var(--text-secondary)]">{{ _('Centro de Custo') }}</th>
+              <th class="px-3 py-2 text-left text-xs font-medium text-[var(--text-secondary)]">{{ _('Conta Associada') }}</th>
+              <th class="px-3 py-2 text-left text-xs font-medium text-[var(--text-secondary)]">{{ _('Tipo') }}</th>
+              <th class="px-3 py-2 text-left text-xs font-medium text-[var(--text-secondary)]">{{ _('Valor') }}</th>
+              <th class="px-3 py-2 text-left text-xs font-medium text-[var(--text-secondary)]">{{ _('Data de Lançamento') }}</th>
+              <th class="px-3 py-2 text-left text-xs font-medium text-[var(--text-secondary)]">{{ _('Status') }}</th>
+              <th class="px-3 py-2 text-left text-xs font-medium text-[var(--text-secondary)]">{{ _('Data de Vencimento') }}</th>
               <th class="px-3 py-2"></th>
             </tr>
           </thead>
-          <tbody></tbody>
+          <tbody class="divide-y divide-[var(--border)]"></tbody>
         </table>
+        </div>
       </div>
       <script src="{% url 'javascript-catalog' %}"></script>
       <script>

--- a/financeiro/templates/financeiro/logs_list.html
+++ b/financeiro/templates/financeiro/logs_list.html
@@ -47,6 +47,7 @@
     </div>
     <div class="card-body">
       <div id="lista" aria-live="polite">
+        <div class="overflow-x-auto">
         <table class="min-w-full divide-y divide-[var(--border)]">
           <thead>
             <tr class="bg-[var(--bg-tertiary)]">
@@ -56,8 +57,9 @@
               <th class="px-3 py-2 text-left text-xs font-medium text-[var(--text-secondary)]">{{ _('Data') }}</th>
             </tr>
           </thead>
-          <tbody></tbody>
+          <tbody class="divide-y divide-[var(--border)]"></tbody>
         </table>
+        </div>
       </div>
       <script src="{% url 'javascript-catalog' %}"></script>
       <script>

--- a/financeiro/templates/financeiro/relatorios.html
+++ b/financeiro/templates/financeiro/relatorios.html
@@ -85,7 +85,7 @@
             container.innerHTML = `
               <p class=\"mb-2 font-medium\">{% trans "Saldo atual" %}: ${data.saldo_atual}</p>
               <p class=\"mb-2 font-medium\">{% trans "Total inadimplentes" %}: ${data.total_inadimplentes}</p>
-              <table class=\"min-w-full divide-y divide-[var(--border)]\"><thead><tr><th class=\"px-2 py-1 text-left text-xs font-medium text-[var(--text-secondary)]\">{% trans "Mês" %}</th><th class=\"px-2 py-1 text-left text-xs font-medium text-[var(--text-secondary)]\">{% trans "Receitas" %}</th><th class=\"px-2 py-1 text-left text-xs font-medium text-[var(--text-secondary)]\">{% trans "Despesas" %}</th><th class=\"px-2 py-1 text-left text-xs font-medium text-[var(--text-secondary)]\">{% trans "Saldo" %}</th></tr></thead><tbody>${rows}</tbody></table>`;
+              <div class=\"overflow-x-auto\"><table class=\"min-w-full divide-y divide-[var(--border)]\"><thead><tr><th class=\"px-2 py-1 text-left text-xs font-medium text-[var(--text-secondary)]\">{% trans "Mês" %}</th><th class=\"px-2 py-1 text-left text-xs font-medium text-[var(--text-secondary)]\">{% trans "Receitas" %}</th><th class=\"px-2 py-1 text-left text-xs font-medium text-[var(--text-secondary)]\">{% trans "Despesas" %}</th><th class=\"px-2 py-1 text-left text-xs font-medium text-[var(--text-secondary)]\">{% trans "Saldo" %}</th></tr></thead><tbody class="divide-y divide-[var(--border)]">${rows}</tbody></table></div>`;
           } catch (e) {
             container.textContent = gettext('Erro ao gerar relatório');
           }

--- a/financeiro/templates/financeiro/repasses.html
+++ b/financeiro/templates/financeiro/repasses.html
@@ -24,6 +24,7 @@
     </div>
     <div class="card-body">
       <div id="lista" aria-live="polite">
+        <div class="overflow-x-auto">
         <table class="min-w-full divide-y divide-[var(--border)]">
           <thead>
             <tr class="bg-[var(--bg-tertiary)]">
@@ -34,8 +35,9 @@
               <th class="px-3 py-2 text-left text-xs font-medium text-[var(--text-secondary)]">{% trans "Data de Lançamento" %}</th>
             </tr>
           </thead>
-          <tbody></tbody>
+          <tbody class="divide-y divide-[var(--border)]"></tbody>
         </table>
+        </div>
       </div>
       <script src="{% url 'javascript-catalog' %}"></script>
       <script>

--- a/financeiro/templates/financeiro/task_logs.html
+++ b/financeiro/templates/financeiro/task_logs.html
@@ -8,12 +8,12 @@
   <h1 class="text-2xl font-bold text-[var(--text-primary)] mb-6">{{ _('Histórico de Tarefas Financeiras') }}</h1>
   <div class="overflow-x-auto card">
     <table class="min-w-full divide-y divide-[var(--border)] text-sm">
-      <thead class="bg-neutral-50">
+      <thead class="bg-[var(--bg-secondary)]">
         <tr>
-          <th class="px-4 py-2 text-left font-medium text-[var(--text-primary)]">{{ _('Tarefa') }}</th>
-          <th class="px-4 py-2 text-left font-medium text-[var(--text-primary)]">{{ _('Data') }}</th>
-          <th class="px-4 py-2 text-left font-medium text-[var(--text-primary)]">{{ _('Status') }}</th>
-          <th class="px-4 py-2 text-left font-medium text-[var(--text-primary)]">{{ _('Detalhes') }}</th>
+          <th class="px-4 py-2 text-left font-medium text-[var(--text-secondary)]">{{ _('Tarefa') }}</th>
+          <th class="px-4 py-2 text-left font-medium text-[var(--text-secondary)]">{{ _('Data') }}</th>
+          <th class="px-4 py-2 text-left font-medium text-[var(--text-secondary)]">{{ _('Status') }}</th>
+          <th class="px-4 py-2 text-left font-medium text-[var(--text-secondary)]">{{ _('Detalhes') }}</th>
         </tr>
       </thead>
       <tbody class="divide-y divide-[var(--border)]">
@@ -26,7 +26,7 @@
         </tr>
         {% empty %}
         <tr>
-          <td colspan="4" class="px-4 py-2 text-center text-neutral-600">{{ _('Nenhum registro encontrado') }}</td>
+          <td colspan="4" class="px-4 py-2 text-center text-[var(--text-secondary)]">{{ _('Nenhum registro encontrado') }}</td>
         </tr>
         {% endfor %}
       </tbody>

--- a/nucleos/templates/nucleos/detail.html
+++ b/nucleos/templates/nucleos/detail.html
@@ -52,11 +52,11 @@
 
         {% if membros_pendentes %}
         <h3 class="mt-6 font-semibold">{% trans 'Pendentes' %}</h3>
-        <table class="w-full text-left" id="pendentes">
-          <thead>
-            <tr><th>{% trans 'Usuário' %}</th><th>{% trans 'Solicitado em' %}</th><th></th></tr>
+        <div class="overflow-x-auto"><table class="min-w-full divide-y divide-[var(--border)] text-left" id="pendentes">
+          <thead class="bg-[var(--bg-secondary)]">
+            <tr><th class="px-2 py-1 text-left font-medium text-[var(--text-secondary)]">{% trans 'Usuário' %}</th><th class="px-2 py-1 text-left font-medium text-[var(--text-secondary)]">{% trans 'Solicitado em' %}</th><th class="px-2 py-1 text-left font-medium text-[var(--text-secondary)]"></th></tr>
           </thead>
-          <tbody>
+          <tbody class="divide-y divide-[var(--border)]">
           {% for part in membros_pendentes %}
             <tr id="pendente-{{ part.id }}">
               <td>{{ part.user.get_full_name|default:part.user.username }}</td>
@@ -68,7 +68,7 @@
             </tr>
           {% endfor %}
           </tbody>
-        </table>
+        </table></div>
         {% endif %}
 
         {% if suplentes %}

--- a/templates/_components/table_wrapper.html
+++ b/templates/_components/table_wrapper.html
@@ -1,7 +1,7 @@
 <section class="space-y-2">
   {% if title %}<h2 class="text-base font-semibold">{{ title }}</h2>{% endif %}
   <div class="overflow-x-auto">
-    <table class="table">
+    <table class="min-w-full divide-y divide-[var(--border)]">
       {% block thead %}{% endblock %}
       {% block tbody %}{% endblock %}
     </table>


### PR DESCRIPTION
## Summary
- wrap tables in `overflow-x-auto` containers
- update table classes to use `min-w-full divide-y divide-[var(--border)]`
- replace legacy neutral colors with design tokens

## Testing
- `pytest` *(fails: ModuleNotFoundError 'silk'; 81 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d9397f908325ac59e5181290e0d5