### PR TITLE
feat: add hero block to account settings template

### DIFF
--- a/configuracoes/templates/configuracoes/configuracoes.html
+++ b/configuracoes/templates/configuracoes/configuracoes.html
@@ -2,10 +2,10 @@
 {% load i18n %}
 
 {% block title %}{% trans 'Configurações da Conta' %}{% endblock %}
+{% block hero %}{% include '_components/hero.html' with title=_('Configurações da Conta') %}{% endblock %}
 
 {% block content %}
 <div class="max-w-4xl mx-auto px-4 py-8">
-  <h1 class="text-2xl font-bold mb-4">{% trans 'Configurações' %}</h1>
     <div class="flex flex-wrap gap-4 border-b border-[var(--border)] mb-4 text-sm">
       <nav aria-label="{% trans 'Seções de Configuração' %}" role="tablist" class="flex flex-wrap gap-4">
         <button role="tab" aria-selected="{% if tab == 'seguranca' %}true{% else %}false{% endif %}" aria-controls="content" hx-get="{% url 'configuracoes' %}?tab=seguranca" hx-target="#content" hx-on:click="switchTab(this)" tabindex="0" class="btn {% if tab == 'seguranca' %}btn-secondary{% endif %}">{% trans 'Segurança' %}</button>


### PR DESCRIPTION
## Summary
- add hero block to account settings template
- remove redundant heading from content

## Testing
- `pytest tests/configuracoes/test_views.py::test_view_get_autenticado -q` *(fails: Required test coverage of 90% not reached. Total coverage: 8.46%)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e30ddd248325bf63498a218a44bc