### PR TITLE
Refactor configuracoes template to use card grid layout

### DIFF
--- a/configuracoes/templates/configuracoes/configuracoes.html
+++ b/configuracoes/templates/configuracoes/configuracoes.html
@@ -5,27 +5,29 @@
 {% block hero %}{% include '_components/hero.html' with title=_('Configurações da Conta') %}{% endblock %}
 
 {% block content %}
-<div class="max-w-4xl mx-auto px-4 py-8">
-    <div class="flex flex-wrap gap-4 border-b border-[var(--border)] mb-4 text-sm">
-      <nav aria-label="{% trans 'Seções de Configuração' %}" role="tablist" class="flex flex-wrap gap-4">
-        <button role="tab" aria-selected="{% if tab == 'seguranca' %}true{% else %}false{% endif %}" aria-controls="content" hx-get="{% url 'configuracoes' %}?tab=seguranca" hx-target="#content" hx-on:click="switchTab(this)" tabindex="0" class="btn {% if tab == 'seguranca' %}btn-secondary{% endif %}">{% trans 'Segurança' %}</button>
-        <button role="tab" aria-selected="{% if tab == 'preferencias' %}true{% else %}false{% endif %}" aria-controls="content" hx-get="{% url 'configuracoes' %}?tab=preferencias" hx-target="#content" hx-on:click="switchTab(this)" tabindex="0" class="btn {% if tab == 'preferencias' %}btn-secondary{% endif %}">{% trans 'Preferências' %}</button>
-      </nav>
-    </div>
-    <div id="content" role="tabpanel" class="card" hx-get="{% url 'configuracoes' %}?tab={{ tab }}" hx-trigger="load">
+<div class="max-w-4xl mx-auto card-grid">
+    <div class="card">
       <div class="card-body">
-        {% include 'configuracoes/partials/'|add:tab|add:'.html' %}
+        <div class="flex flex-wrap gap-4 border-b border-[var(--border)] mb-4 text-sm">
+          <nav aria-label="{% trans 'Seções de Configuração' %}" role="tablist" class="flex flex-wrap gap-4">
+            <button role="tab" aria-selected="{% if tab == 'seguranca' %}true{% else %}false{% endif %}" aria-controls="content" hx-get="{% url 'configuracoes' %}?tab=seguranca" hx-target="#content" hx-on:click="switchTab(this)" tabindex="0" class="btn {% if tab == 'seguranca' %}btn-secondary{% endif %}">{% trans 'Segurança' %}</button>
+            <button role="tab" aria-selected="{% if tab == 'preferencias' %}true{% else %}false{% endif %}" aria-controls="content" hx-get="{% url 'configuracoes' %}?tab=preferencias" hx-target="#content" hx-on:click="switchTab(this)" tabindex="0" class="btn {% if tab == 'preferencias' %}btn-secondary{% endif %}">{% trans 'Preferências' %}</button>
+          </nav>
+        </div>
+        <div id="content" role="tabpanel" hx-get="{% url 'configuracoes' %}?tab={{ tab }}" hx-trigger="load">
+          {% include 'configuracoes/partials/'|add:tab|add:'.html' %}
+        </div>
       </div>
     </div>
-    <script>
-      function switchTab(btn) {
-        document.querySelectorAll('[role=tab]').forEach((tab) => {
-          tab.setAttribute('aria-selected', 'false');
-          tab.classList.remove('btn-secondary');
-        });
-        btn.setAttribute('aria-selected', 'true');
-        btn.classList.add('btn-secondary');
-      }
-    </script>
-  </div>
+</div>
+<script>
+  function switchTab(btn) {
+    document.querySelectorAll('[role=tab]').forEach((tab) => {
+      tab.setAttribute('aria-selected', 'false');
+      tab.classList.remove('btn-secondary');
+    });
+    btn.setAttribute('aria-selected', 'true');
+    btn.classList.add('btn-secondary');
+  }
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Use `card-grid` container on account settings page
- Wrap existing content in a single `card` and drop redundant spacing classes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'silk')*

------
https://chatgpt.com/codex/tasks/task_e_68c1e434e10883259efc9dad6a53aa9f