### PR TITLE
Refatora templates de perfil para usar layout base

### DIFF
--- a/accounts/templates/perfil/conexoes.html
+++ b/accounts/templates/perfil/conexoes.html
@@ -1,9 +1,13 @@
-{% extends 'perfil/perfil.html' %}
+{% extends 'base.html' %}
 {% load static i18n lucide_icons %}
 
 {% block title %}{% trans "Minhas Conexões" %} | HubX{% endblock %}
 
-{% block perfil_content %}
+{% block hero %}
+  {% include '_components/hero.html' with title=_("Minhas Conexões") %}
+{% endblock %}
+
+{% block content %}
 <section id="conexoes" class="space-y-6">
   <div>
     <h2 class="text-xl font-semibold text-[var(--text-primary)]">{% trans "Minhas Conexões" %}</h2>

--- a/accounts/templates/perfil/detail.html
+++ b/accounts/templates/perfil/detail.html
@@ -1,7 +1,12 @@
-{% extends 'perfil/perfil.html' %}
+{% extends 'base.html' %}
 {% load i18n %}
 {% block title %}{% trans "Meu Perfil" %} | Hubx{% endblock %}
-{% block perfil_content %}
+
+{% block hero %}
+  {% include '_components/hero.html' with title=_("Meu Perfil") %}
+{% endblock %}
+
+{% block content %}
 
 <div class="card-header">
   <div class="mt-2 border-b border-[var(--border)]">

--- a/accounts/templates/perfil/informacoes_pessoais.html
+++ b/accounts/templates/perfil/informacoes_pessoais.html
@@ -1,8 +1,12 @@
-{% extends 'perfil/perfil.html' %}
+{% extends 'base.html' %}
 {% load widget_tweaks i18n %}
 {% block title %}{% trans "Informações Pessoais" %} | HubX{% endblock %}
 
-{% block perfil_content %}
+{% block hero %}
+  {% include '_components/hero.html' with title=_("Informações Pessoais") %}
+{% endblock %}
+
+{% block content %}
 <div class="max-w-3xl mx-auto">
   <h3 class="text-xl font-semibold mb-1">{% trans "Informações Pessoais" %}</h3>
   <p class="text-sm text-[var(--text-secondary)] mb-6">{% trans "Atualize seus dados básicos e de contato" %}</p>

--- a/accounts/templates/perfil/midia_confirm_delete.html
+++ b/accounts/templates/perfil/midia_confirm_delete.html
@@ -1,8 +1,12 @@
-{% extends 'perfil/perfil.html' %}
+{% extends 'base.html' %}
 {% load i18n lucide_icons %}
 {% block title %}{% trans "Remover Mídia" %} | Hubx{% endblock %}
 
-{% block perfil_content %}
+{% block hero %}
+  {% include '_components/hero.html' with title=_("Remover Mídia") %}
+{% endblock %}
+
+{% block content %}
 <section class="space-y-4">
   <h2 class="text-xl font-semibold text-error">{% trans "Remover Mídia" %}</h2>
   <p class="text-[var(--text-secondary)]">{% trans "Tem certeza que deseja remover esta mídia?" %}</p>

--- a/accounts/templates/perfil/midia_detail.html
+++ b/accounts/templates/perfil/midia_detail.html
@@ -1,9 +1,13 @@
-{% extends 'perfil/perfil.html' %}
+{% extends 'base.html' %}
 {% load i18n lucide_icons %}
 
 {% block title %}{% trans "Mídia" %} | Hubx{% endblock %}
 
-{% block perfil_content %}
+{% block hero %}
+  {% include '_components/hero.html' with title=_("Mídia") %}
+{% endblock %}
+
+{% block content %}
 <section class="space-y-4">
   {% if media.media_type == 'image' %}
     <img src="{{ media.file.url }}" alt="{{ media.descricao }}" class="rounded card max-w-full mx-auto" />

--- a/accounts/templates/perfil/midia_form.html
+++ b/accounts/templates/perfil/midia_form.html
@@ -1,9 +1,17 @@
-{% extends 'perfil/perfil.html' %}
+{% extends 'base.html' %}
 {% load i18n %}
 
 {% block title %}{% if form.instance.pk %}{% trans "Editar Mídia" %}{% else %}{% trans "Nova Mídia" %}{% endif %} | Hubx{% endblock %}
 
-{% block perfil_content %}
+{% block hero %}
+  {% if form.instance.pk %}
+    {% include '_components/hero.html' with title=_("Editar Mídia") %}
+  {% else %}
+    {% include '_components/hero.html' with title=_("Cadastrar Mídia") %}
+  {% endif %}
+{% endblock %}
+
+{% block content %}
 <section class="space-y-6">
   <h2 class="text-xl font-semibold">
     {% if form.instance.pk %}{% trans "Editar Mídia" %}{% else %}{% trans "Cadastrar Mídia" %}{% endif %}

--- a/accounts/templates/perfil/midias.html
+++ b/accounts/templates/perfil/midias.html
@@ -1,9 +1,13 @@
-{% extends 'perfil/perfil.html' %}
+{% extends 'base.html' %}
 {% load static i18n lucide_icons %}
 
 {% block title %}{% trans "Mídias" %} | Hubx{% endblock %}
 
-{% block perfil_content %}
+{% block hero %}
+  {% include '_components/hero.html' with title=_("Mídias") %}
+{% endblock %}
+
+{% block content %}
 <section id="midias" class="perfil-section active">
   <div class="section-header mb-6">
     <h2 class="text-xl font-semibold text-[var(--text-primary)]">{% trans "Mídias" %}</h2>

--- a/accounts/templates/perfil/publico.html
+++ b/accounts/templates/perfil/publico.html
@@ -1,10 +1,14 @@
-{% extends 'perfil/perfil.html' %}
+{% extends 'base.html' %}
 {% load static i18n %}
 {% block title %}{% with perfil as profile %}{{ profile.get_full_name|default:profile.username }} | Hubx{% endwith %}{% endblock %}
-{% block hero_title %}{% with perfil as profile %}{{ profile.get_full_name|default:profile.username }}{% endwith %}{% endblock %}
-{% block hero_subtitle %}{% with perfil as profile %}@{{ profile.username }}{% endwith %}{% endblock %}
 
-{% block perfil_content %}
+{% block hero %}
+  {% with perfil as profile %}
+    {% include '_components/hero.html' with title=profile.get_full_name|default:profile.username subtitle='@'|add:profile.username %}
+  {% endwith %}
+{% endblock %}
+
+{% block content %}
 <div class="card-header">
   <nav class="border-b border-[var(--border)]">
     <ul class="-mb-px flex flex-wrap gap-2" role="tablist" aria-label="{% trans 'Navegação de abas do perfil' %}">

--- a/accounts/templates/perfil/redes_sociais.html
+++ b/accounts/templates/perfil/redes_sociais.html
@@ -1,9 +1,13 @@
-{% extends 'perfil/perfil.html' %}
+{% extends 'base.html' %}
 {% load i18n %}
 
 {% block title %}{% trans "Redes Sociais" %} | HubX{% endblock %}
 
-{% block perfil_content %}
+{% block hero %}
+  {% include '_components/hero.html' with title=_("Redes Sociais") %}
+{% endblock %}
+
+{% block content %}
 <div class="grid grid-cols-1 lg:grid-cols-3 gap-6 max-w-3xl mx-auto">
   <div class="card lg:col-span-3">
     <div class="card-body">


### PR DESCRIPTION
## Summary
- Refatora templates de perfil para estender `base.html`
- Adiciona blocos `hero` e `content` nos templates de perfil

## Testing
- `make test` *(falhou: 81 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c1eca72008832585b47249b1e7cd61