### PR TITLE
refactor: replace fixed colors with CSS variables

### DIFF
--- a/configuracoes/templates/configuracoes/partials/preferencias.html
+++ b/configuracoes/templates/configuracoes/partials/preferencias.html
@@ -81,7 +81,7 @@
     {% with preferencias_form.idioma|add_class:'mt-1'|attr:'tabindex:0' as idioma_field %}
       {% include '_forms/field.html' with field=idioma_field %}
     {% endwith %}
-    <p class="text-xs text-gray-500">{% blocktrans %}Idioma atual: {{ LANGUAGE_CODE }}{% endblocktrans %}</p>
+    <p class="text-xs text-[var(--color-neutral-500)]">{% blocktrans %}Idioma atual: {{ LANGUAGE_CODE }}{% endblocktrans %}</p>
   </div>
   <div>
     {% with preferencias_form.tema|add_class:'mt-1'|attr:'tabindex:0' as tema_field %}

--- a/eventos/templates/eventos/calendario.html
+++ b/eventos/templates/eventos/calendario.html
@@ -33,14 +33,14 @@
               {{ dia.data.day }}
             </span>
             {% if dia.eventos|length > 3 %}
-              <span class="text-xs text-gray-400">+{{ dia.eventos|length|add:"-3" }}</span>
+              <span class="text-xs text-[var(--color-neutral-400)]">+{{ dia.eventos|length|add:"-3" }}</span>
             {% endif %}
           </div>
           <ul class="space-y-1">
             {% for ev in dia.eventos|slice:":3" %}
               <li>
                 <a href="{% url 'eventos:evento_detalhe' ev.id %}"
-                   class="block bg-[var(--success-light)] border border-[var(--success)] text-[var(--success)] rounded px-1.5 py-0.5 text-xs leading-tight hover:bg-emerald-100 transition line-clamp-3"
+                   class="block bg-[var(--success-light)] border border-[var(--success)] text-[var(--success)] rounded px-1.5 py-0.5 text-xs leading-tight hover:bg-[var(--color-success-100)] transition line-clamp-3"
                    hx-get="{% url 'eventos:evento_detalhe' ev.id %}"
                    hx-target="#modal" hx-trigger="click" hx-stop-propagation="click">
                   {{ ev.titulo }}

--- a/nucleos/templates/nucleos/convites_modal.html
+++ b/nucleos/templates/nucleos/convites_modal.html
@@ -26,7 +26,7 @@
       </form>
     </li>
     {% empty %}
-    <li class="text-sm text-gray-500">{% trans 'Nenhum convite pendente.' %}</li>
+    <li class="text-sm text-[var(--color-neutral-500)]">{% trans 'Nenhum convite pendente.' %}</li>
     {% endfor %}
   </ul>
   <script>

--- a/nucleos/templates/nucleos/detail.html
+++ b/nucleos/templates/nucleos/detail.html
@@ -18,7 +18,7 @@
       <div class="flex items-center gap-2">
         <h1 class="text-2xl font-bold">{{ object.nome }}</h1>
         {% if request.user.user_type == 'admin' or request.user.user_type == 'coordenador' %}
-        <a href="{% url 'nucleos:update' object.pk %}" class="px-4 py-2 bg-blue-600 text-white rounded">{% trans 'Editar' %}</a>
+        <a href="{% url 'nucleos:update' object.pk %}" class="px-4 py-2 bg-[var(--color-primary-600)] text-[var(--text-inverse)] rounded">{% trans 'Editar' %}</a>
         <a href="{% url 'nucleos:delete' object.pk %}" class="btn btn-danger btn-sm">{% trans 'Excluir' %}</a>
         {% endif %}
       </div>
@@ -50,7 +50,7 @@
           {% for part in membros_ativos %}
             {% include 'nucleos/partials/membro_card.html' with part=part %}
           {% empty %}
-            <p class="col-span-full text-center text-gray-500">{% trans 'Sem membros.' %}</p>
+            <p class="col-span-full text-center text-[var(--color-neutral-500)]">{% trans 'Sem membros.' %}</p>
           {% endfor %}
         </div>
 
@@ -89,7 +89,7 @@
 
         {% if mostrar_solicitar and request.user.user_type != 'admin' and request.user.user_type != 'coordenador' %}
         <div class="mt-4">
-          <button id="solicitar-btn" type="button" class="px-4 py-2 bg-blue-600 text-white rounded" hx-get="{% url 'nucleos:solicitar_modal' object.pk %}" hx-target="#modal">{% trans 'Solicitar participação' %}</button>
+          <button id="solicitar-btn" type="button" class="px-4 py-2 bg-[var(--color-primary-600)] text-[var(--text-inverse)] rounded" hx-get="{% url 'nucleos:solicitar_modal' object.pk %}" hx-target="#modal">{% trans 'Solicitar participação' %}</button>
         </div>
         {% endif %}
       </div>
@@ -100,7 +100,7 @@
           {% for evento in eventos %}
             {% include '_components/card_evento.html' with evento=evento %}
           {% empty %}
-            <p class="text-sm text-gray-500">{% trans 'Sem eventos.' %}</p>
+            <p class="text-sm text-[var(--color-neutral-500)]">{% trans 'Sem eventos.' %}</p>
           {% endfor %}
         </div>
       </div>
@@ -109,7 +109,7 @@
       <div class="tab-panel hidden" data-tab="feed">
         {% if pode_postar %}
         <div class="mb-4">
-          <button type="button" class="px-4 py-2 bg-green-600 text-white rounded" hx-get="{% url 'nucleos:postar_modal' object.pk %}" hx-target="#modal">{% trans 'Postar no feed' %}</button>
+          <button type="button" class="px-4 py-2 bg-[var(--color-success-600)] text-[var(--text-inverse)] rounded" hx-get="{% url 'nucleos:postar_modal' object.pk %}" hx-target="#modal">{% trans 'Postar no feed' %}</button>
         </div>
         {% endif %}
         {% include 'feed/_grid.html' with posts=nucleo_posts %}


### PR DESCRIPTION
## Summary
- replace hardcoded blue and green backgrounds with CSS variable references
- switch gray text to neutral color variables
- use success color variable for event calendar hover state

## Testing
- `pytest -q` *(fails: No module named 'factory')*


------
https://chatgpt.com/codex/tasks/task_e_68c1f0d752f88325ba6b05162ea41727