### PR TITLE
Refactor account forms to shared field partial

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -234,7 +234,9 @@ class TwoFactorForm(forms.Form):
 class EmailLoginForm(forms.Form):
     email = forms.EmailField(label="Email")
     password = forms.CharField(widget=forms.PasswordInput, label="Senha")
-    totp = forms.CharField(label="TOTP", required=False)
+    totp = forms.CharField(
+        label="TOTP", required=False, help_text=_("Deixe em branco se não tiver 2FA")
+    )
 
     def __init__(self, request=None, *args, **kwargs):
         self.request = request

--- a/accounts/templates/accounts/password_reset_confirm.html
+++ b/accounts/templates/accounts/password_reset_confirm.html
@@ -10,36 +10,9 @@
             {% if form.non_field_errors %}
                 <div class="bg-[var(--error-light)] text-[var(--error)] p-2 rounded text-sm" role="alert">{{ form.non_field_errors }}</div>
             {% endif %}
-            <div>
-                <label for="{{ form.new_password1.id_for_label }}" class="block mb-1 font-medium text-[var(--text-secondary)]">{{ form.new_password1.label }}</label>
-                <input type="password"
-                       name="{{ form.new_password1.html_name }}"
-                       id="{{ form.new_password1.id_for_label }}"
-                       class="form-input w-full p-3 border rounded-md focus:ring-2 focus:ring-primary bg-[var(--bg-secondary)] border-[var(--border)] text-[var(--text-primary)]"
-                       placeholder="{% trans 'Nova senha' %}"
-                       aria-label="{{ form.new_password1.label }}"
-                       aria-describedby="{{ form.new_password1.id_for_label }}_error"
-                       {% if form.new_password1.errors %}aria-invalid="true"{% else %}aria-invalid="false"{% endif %}
-                       required />
-                {% if form.new_password1.errors %}
-                    <div id="{{ form.new_password1.id_for_label }}_error" class="text-[var(--error)] text-sm" role="alert">{{ form.new_password1.errors }}</div>
-                {% endif %}
-            </div>
-            <div>
-                <label for="{{ form.new_password2.id_for_label }}" class="block mb-1 font-medium text-[var(--text-secondary)]">{{ form.new_password2.label }}</label>
-                <input type="password"
-                       name="{{ form.new_password2.html_name }}"
-                       id="{{ form.new_password2.id_for_label }}"
-                       class="form-input w-full p-3 border rounded-md focus:ring-2 focus:ring-primary bg-[var(--bg-secondary)] border-[var(--border)] text-[var(--text-primary)]"
-                       placeholder="{% trans 'Confirme a senha' %}"
-                       aria-label="{{ form.new_password2.label }}"
-                       aria-describedby="{{ form.new_password2.id_for_label }}_error"
-                       {% if form.new_password2.errors %}aria-invalid="true"{% else %}aria-invalid="false"{% endif %}
-                       required />
-                {% if form.new_password2.errors %}
-                    <div id="{{ form.new_password2.id_for_label }}_error" class="text-[var(--error)] text-sm" role="alert">{{ form.new_password2.errors }}</div>
-                {% endif %}
-            </div>
+            {% for field in form %}
+                {% include '_forms/field.html' with field=field %}
+            {% endfor %}
             <button type="submit" class="text-white font-semibold py-2 px-4 rounded-xl w-full bg-[var(--primary)] hover:bg-[var(--primary-hover)]">{% trans "Alterar Senha" %}</button>
         </form>
     </div>

--- a/accounts/templates/login/login.html
+++ b/accounts/templates/login/login.html
@@ -20,59 +20,9 @@
 
     <form method="post" action="{% url 'accounts:login' %}" class="space-y-5">
       {% csrf_token %}
-      <div>
-        <div class="relative">
-          <input type="email" id="id_email" name="email"
-                 value="{{ form.email.value|default_if_none:'' }}"
-                 autocomplete="email"
-                 class="peer form-input w-full p-3 rounded-lg text-sm card-sm focus:ring-2 focus:ring-primary focus:border-transparent"
-                 placeholder="{% trans 'Email' %}"
-                 required
-                 aria-label="{% trans 'Email' %}"
-                 aria-describedby="email-error"
-                 {% if form.email.errors %}aria-invalid="true"{% else %}aria-invalid="false"{% endif %}>
-          <label for="id_email"
-                 class="absolute left-3 -top-2 text-xs text-[var(--text-secondary)] transition-all peer-placeholder-shown:top-3 peer-placeholder-shown:text-sm peer-placeholder-shown:text-gray-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary">{% trans "Email" %}</label>
-        </div>
-        {% if form.email.errors %}
-          <div id="email-error" class="text-[var(--error)] text-xs mt-1" role="alert">{{ form.email.errors }}</div>
-        {% endif %}
-      </div>
-      <div>
-        <div class="relative">
-          <input type="password" id="id_password" name="password"
-                 autocomplete="current-password"
-                 class="peer form-input w-full p-3 rounded-lg text-sm card-sm focus:ring-2 focus:ring-primary focus:border-transparent"
-                 placeholder="{% trans 'Senha' %}"
-                 required
-                 aria-label="{% trans 'Senha' %}"
-                 aria-describedby="password-error"
-                 {% if form.password.errors %}aria-invalid="true"{% else %}aria-invalid="false"{% endif %}>
-          <label for="id_password"
-                 class="absolute left-3 -top-2 text-xs text-[var(--text-secondary)] transition-all peer-placeholder-shown:top-3 peer-placeholder-shown:text-sm peer-placeholder-shown:text-gray-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary">{% trans "Senha" %}</label>
-        </div>
-        {% if form.password.errors %}
-          <div id="password-error" class="text-[var(--error)] text-xs mt-1" role="alert">{{ form.password.errors }}</div>
-        {% endif %}
-      </div>
-      <div id="totp-field">
-        <div class="relative">
-          <input type="text" id="id_totp" name="totp"
-                 value="{{ form.totp.value|default_if_none:'' }}"
-                 autocomplete="one-time-code"
-                 class="peer form-input w-full p-3 rounded-lg text-sm card-sm focus:ring-2 focus:ring-primary focus:border-transparent"
-                 placeholder="{% trans 'TOTP' %}"
-                 aria-label="{% trans 'TOTP' %}"
-                 aria-describedby="totp-error"
-                 {% if form.totp.errors %}aria-invalid="true"{% else %}aria-invalid="false"{% endif %}>
-          <label for="id_totp"
-                 class="absolute left-3 -top-2 text-xs text-[var(--text-secondary)] transition-all peer-placeholder-shown:top-3 peer-placeholder-shown:text-sm peer-placeholder-shown:text-gray-400 peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary">{% trans "TOTP" %}</label>
-        </div>
-        <p class="text-xs mt-1 text-[var(--text-muted)]">{% trans "Deixe em branco se não tiver 2FA" %}</p>
-        {% if form.totp.errors %}
-          <div id="totp-error" class="text-[var(--error)] text-xs mt-1" role="alert">{{ form.totp.errors }}</div>
-        {% endif %}
-      </div>
+      {% for field in form %}
+        {% include '_forms/field.html' with field=field %}
+      {% endfor %}
       <button type="submit"
               class="w-full bg-primary text-white py-3 px-4 rounded-xl font-semibold text-sm card hover:bg-primary/90 transition">
         {% trans "Entrar" %}


### PR DESCRIPTION
## Summary
- use unified field partial in login and password reset confirm templates
- add help text to TOTP field for 2FA hint

## Testing
- `pytest tests/accounts -q` *(fails: Missing coverage 90% and numerous errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f8dae6908325a9a44c418db4383e