### PR TITLE
refactor: padroniza estilo da tabela

### DIFF
--- a/components/ui/table.tsx
+++ b/components/ui/table.tsx
@@ -6,10 +6,13 @@ const Table = React.forwardRef<
   HTMLTableElement,
   React.HTMLAttributes<HTMLTableElement>
 >(({ className, ...props }, ref) => (
-  <div className="relative w-full overflow-auto">
+  <div className="overflow-x-auto">
     <table
       ref={ref}
-      className={cn("w-full caption-bottom text-sm", className)}
+      className={cn(
+        "min-w-full divide-y divide-[var(--border)] caption-bottom text-sm",
+        className
+      )}
       {...props}
     />
   </div>
@@ -73,7 +76,7 @@ const TableHead = React.forwardRef<
   <th
     ref={ref}
     className={cn(
-      "h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0",
+      "h-12 px-4 text-left align-middle font-medium text-[var(--text-secondary)] [&:has([role=checkbox])]:pr-0",
       className
     )}
     {...props}
@@ -87,7 +90,10 @@ const TableCell = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <td
     ref={ref}
-    className={cn("p-4 align-middle [&:has([role=checkbox])]:pr-0", className)}
+    className={cn(
+      "p-4 align-middle text-[var(--text-primary)] [&:has([role=checkbox])]:pr-0",
+      className
+    )}
     {...props}
   />
 ))


### PR DESCRIPTION
## Summary
- encapsulate Table component with overflow-x wrapper
- apply default table styling and color variables

## Testing
- `npm run lint components/ui/table.tsx` *(fails: Couldn't find any `pages` or `app` directory)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'silk')*


------
https://chatgpt.com/codex/tasks/task_e_68c1f8e2bcfc83259815615d42e08584