### PR TITLE
Insert NoCacheMiddleware into middleware stack

### DIFF
--- a/Hubx/settings.py
+++ b/Hubx/settings.py
@@ -102,6 +102,7 @@ MIDDLEWARE = [
     "silk.middleware.SilkyMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
+    "core.middleware.NoCacheMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "accounts.middleware.ActiveUserRequiredMiddleware",


### PR DESCRIPTION
## Summary
- disable caching by adding `core.middleware.NoCacheMiddleware` after `CommonMiddleware`

## Testing
- `pytest -m "not slow"` *(fails: ModuleNotFoundError: No module named 'axe_core_python'; ModuleNotFoundError: No module named 'discussao'; IndentationError in test file)*

------
https://chatgpt.com/codex/tasks/task_e_68c1feaf51b483258861c470405dfd6f