### PR TITLE
Use manifest static files storage in production

### DIFF
--- a/Hubx/settings.py
+++ b/Hubx/settings.py
@@ -261,6 +261,9 @@ STATIC_URL = "/static/"
 STATICFILES_DIRS = [BASE_DIR / "static"]
 STATIC_ROOT = BASE_DIR / "staticfiles"
 
+if not DEBUG:
+    STATICFILES_STORAGE = "django.contrib.staticfiles.storage.ManifestStaticFilesStorage"
+
 # Media files
 MEDIA_URL = "/media/"
 MEDIA_ROOT = BASE_DIR / "media"


### PR DESCRIPTION
## Summary
- use Django's ManifestStaticFilesStorage when DEBUG is False

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'factory')*

------
https://chatgpt.com/codex/tasks/task_e_68c202fccf60832589e0e53be0ab1fba