### PR TITLE
Streamline profile portfolio rendering

### DIFF
--- a/accounts/templates/perfil/partials/portfolio.html
+++ b/accounts/templates/perfil/partials/portfolio.html
@@ -17,7 +17,7 @@
     </div>
   </form>
 {% else %}
-  {% if not publico %}
+  {% if is_owner %}
     <a href="{% url 'accounts:portfolio' %}?adicionar=1" class="btn btn-primary">
       {% trans "Portfólio" %}
     </a>
@@ -32,7 +32,7 @@
 <div class="card-grid mt-6">
   {% for media in medias %}
     <article class="card relative p-3">
-      {% if not publico %}
+      {% if is_owner %}
       <div class="absolute top-2 right-2 flex gap-2">
         <a href="{% url 'accounts:portfolio_edit' media.pk %}" class="btn-secondary btn-sm" aria-label="{% trans 'Editar' %}">
           {% lucide 'pencil' class='w-4 h-4' aria_hidden='true' %}

--- a/accounts/templates/perfil/perfil.html
+++ b/accounts/templates/perfil/perfil.html
@@ -13,7 +13,7 @@
 
 <div class="card">
   <div class="card-body">
-    {% include "perfil/partials/portfolio.html" with medias=portfolio_recent publico=False form=portfolio_form show_form=portfolio_show_form q=portfolio_q %}
+    {% include "perfil/partials/portfolio.html" with medias=portfolio_recent is_owner=is_owner form=portfolio_form show_form=portfolio_show_form q=portfolio_q %}
   </div>
 </div>
 {% endblock %}

--- a/accounts/templates/perfil/portfolio.html
+++ b/accounts/templates/perfil/portfolio.html
@@ -9,7 +9,7 @@
 
 {% block content %}
 <section id="portfolio" class="perfil-section active">
-  {% include "perfil/partials/portfolio.html" with medias=medias publico=False form=form show_form=show_form q=q %}
+  {% include "perfil/partials/portfolio.html" with medias=medias is_owner=is_owner form=form show_form=show_form q=q %}
 </section>
 
 <div class="mt-8 text-center">

--- a/accounts/templates/perfil/publico.html
+++ b/accounts/templates/perfil/publico.html
@@ -7,6 +7,6 @@
 {% endblock %}
 
 {% block content %}
-  {% include "perfil/partials/portfolio.html" with medias=portfolio_recent publico=True form=portfolio_form show_form=portfolio_show_form q=portfolio_q %}
+  {% include "perfil/partials/portfolio.html" with medias=portfolio_recent is_owner=is_owner form=portfolio_form show_form=portfolio_show_form q=portfolio_q %}
 {% endblock %}
 

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -197,9 +197,6 @@ def perfil_publico(request, pk=None, public_id=None, username=None):
         "portfolio_q": "",
     }
 
-    if request.headers.get("HX-Request"):
-        return render(request, "perfil/partials/portfolio.html", context)
-
     return render(request, "perfil/publico.html", context)
 
 
@@ -380,16 +377,6 @@ def perfil_conexoes(request):
         "q": q,
         "hero_title": _("Perfil"),
     }
-
-    tab = request.GET.get("tab", "minhas-conexoes")
-    if request.headers.get("HX-Request"):
-        template = (
-            "perfil/partials/conexoes_solicitacoes.html"
-            if tab == "solicitacoes"
-            else "perfil/partials/conexoes_minhas.html"
-        )
-        return render(request, template, context)
-
     return render(request, "perfil/conexoes.html", context)
 
 
@@ -403,8 +390,6 @@ def remover_conexao(request, id):
         messages.success(request, f"Conexão com {other_user.get_full_name()} removida.")
     except User.DoesNotExist:
         messages.error(request, "Usuário não encontrado.")
-    if request.headers.get("HX-Request"):
-        return HttpResponse("")
     return redirect("accounts:conexoes")
 
 
@@ -425,8 +410,6 @@ def aceitar_conexao(request, id):
     request.user.connections.add(other_user)
     request.user.followers.remove(other_user)
     messages.success(request, f"Conexão com {other_user.get_full_name()} aceita.")
-    if request.headers.get("HX-Request"):
-        return HttpResponse("")
     return redirect("accounts:conexoes")
 
 
@@ -446,8 +429,6 @@ def recusar_conexao(request, id):
 
     request.user.followers.remove(other_user)
     messages.success(request, f"Solicitação de conexão de {other_user.get_full_name()} recusada.")
-    if request.headers.get("HX-Request"):
-        return HttpResponse("")
     return redirect("accounts:conexoes")
 
 
@@ -488,6 +469,7 @@ def perfil_portfolio(request):
             "show_form": show_form,
             "q": q,
             "hero_title": _("Perfil"),
+            "is_owner": True,
         },
     )
 


### PR DESCRIPTION
## Summary
- Simplify public profile by removing HTMX partial logic and tab query handling
- Add `is_owner` flag to portfolio views and templates
- Always render full templates for profile connections actions

## Testing
- `pytest tests/accounts/test_perfil_publico.py::test_perfil_publico_respects_privacy -q` *(failed: ModuleNotFoundError: No module named 'django_extensions')*

------
https://chatgpt.com/codex/tasks/task_e_68c4b158e3408325af49c8b70c6d57c8