### PR TITLE
feat: improve hero profile layout

### DIFF
--- a/templates/_components/hero_profile.html
+++ b/templates/_components/hero_profile.html
@@ -2,15 +2,7 @@
   {% if profile.cover %}
     <img src="{{ profile.cover.url }}" alt="" class="absolute inset-0 h-full w-full object-cover opacity-40" loading="lazy">
   {% endif %}
-  <div class="relative mx-auto max-w-7xl px-4 pt-16 pb-28 text-center text-white">
-    <h1 class="text-3xl md:text-4xl font-bold tracking-tight">{{ profile.get_full_name|default:profile.username }}</h1>
-    <p class="text-sm md:text-base text-white/80">@{{ profile.username }}</p>
-    <div class="mt-6 flex flex-wrap items-center justify-center gap-2">
-      <a href="/u/{{ profile.username }}/empresas/" class="btn btn-primary">Empresas</a>
-      <a href="{% url 'feed:usuario' profile.username %}" class="btn btn-secondary">Mural</a>
-      <a href="/u/{{ profile.username }}/conexoes/" class="btn btn-outline">Conexões</a>
-    </div>
-  </div>
+  <div class="relative mx-auto max-w-7xl px-4 pt-16 pb-28 text-center text-white"></div>
   <div class="absolute bottom-0 left-1/2 translate-y-1/2 -translate-x-1/2 z-50">
     <div class="h-32 w-32 md:h-40 md:w-40 rounded-full ring-4 ring-white/90 overflow-hidden shadow-lg bg-[var(--bg-primary)]">
       {% if profile.avatar %}
@@ -28,13 +20,18 @@
   <div class="mx-auto max-w-4xl">
     <div class="profile-card rounded-xl border bg-[var(--bg-primary)]">
       <div class="pt-20 md:pt-8 text-center md:text-left md:pl-44">
-        <h2 class="text-2xl font-semibold text-[var(--text-primary)] md:mb-1 md:mt-2 md:hidden">
+        <h2 class="text-2xl font-semibold text-[var(--text-primary)] md:mb-1 md:mt-2">
           {{ profile.get_full_name|default:profile.username }}
         </h2>
-        <p class="text-sm text-[var(--text-muted)] md:hidden">@{{ profile.username }}</p>
+        <p class="text-sm text-[var(--text-muted)]">@{{ profile.username }}</p>
+        <div class="mt-6 flex flex-wrap items-center justify-center gap-2 md:justify-start">
+          <a href="/u/{{ profile.username }}/empresas/" class="btn btn-primary">Empresas</a>
+          <a href="{% url 'feed:usuario' profile.username %}" class="btn btn-secondary">Mural</a>
+          <a href="/u/{{ profile.username }}/conexoes/" class="btn btn-outline">Conexões</a>
+        </div>
       </div>
 
-      <div class="grid grid-cols-1 md:grid-cols-2 gap-6 p-6">
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 p-6">
         <div class="space-y-4">
           <div>
             <div class="text-[var(--text-tertiary)] text-sm mb-1">E-mail</div>
@@ -66,11 +63,7 @@
 
       <div class="border-t border-[var(--border)] p-4 sm:p-6">
         <div class="flex flex-wrap items-center justify-between gap-3">
-          <div class="profile-actions">
-            <a href="/u/{{ profile.username }}/empresas/" class="btn btn-primary">Empresas</a>
-            <a href="{% url 'feed:usuario' profile.username %}" class="btn btn-secondary">Mural</a>
-            <a href="/u/{{ profile.username }}/conexoes/" class="btn btn-outline">Conexões</a>
-          </div>
+          <a href="/u/{{ profile.username }}/empresas/" class="btn btn-primary">Empresas</a>
           {% if profile.redes_sociais %}
             <div class="flex items-center gap-4 text-xl text-[var(--text-secondary)] mx-auto md:mx-0">
               {% for nome, link in profile.redes_sociais.items %}


### PR DESCRIPTION
## Summary
- remove cover section profile data and relocate content to card
- simplify contact grid and ensure desktop-only two-column layout
- keep social icons in footer beside main button

## Testing
- `pytest tests/accounts/test_login_rate_limit.py::test_login_ratelimit_blocks_authenticate -q` *(fails: Required test coverage of 90% not reached)*
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_68c5ac5828048325ad4a952149a82a23