### PR TITLE
Corrige layout da grade de contato no perfil

### DIFF
--- a/templates/_components/hero_profile.html
+++ b/templates/_components/hero_profile.html
@@ -17,7 +17,7 @@
 </section>
 
 <section class="container mt-20 md:mt-24">
-  <div class="mx-auto max-w-4xl">
+  <div class="mx-auto max-w-3xl">
     <div class="profile-card rounded-xl border bg-[var(--bg-primary)]">
       <div class="pt-20 md:pt-8 text-center md:text-left md:pl-44">
         <h2 class="text-2xl font-semibold text-[var(--text-primary)] md:mb-1 md:mt-2">
@@ -31,7 +31,7 @@
         </div>
       </div>
 
-      <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 p-6">
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-6 p-6">
         <div class="space-y-4">
           <div>
             <div class="text-[var(--text-tertiary)] text-sm mb-1">E-mail</div>


### PR DESCRIPTION
## Sumário
- altera grid para duas colunas a partir de 768px
- ajusta largura máxima do card de perfil

## Testes
- `npm run build:css`
- `pytest` *(falhou: 81 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b1c19f9c8325af788951fc234b84