### PR TITLE
Simplify profile hero contact info

### DIFF
--- a/templates/_components/hero_profile.html
+++ b/templates/_components/hero_profile.html
@@ -32,32 +32,15 @@
       </div>
 
       <div class="grid grid-cols-1 sm:grid-cols-2 gap-6 p-6">
-        <div class="space-y-4">
-          <div>
-            <div class="text-[var(--text-tertiary)] text-sm mb-1">E-mail</div>
-            <a href="mailto:{{ profile.email }}" class="text-[var(--text-primary)] hover:underline break-all">
-              {{ profile.email|default:"-" }}
-            </a>
-          </div>
-          <div>
-            <div class="text-[var(--text-tertiary)] text-sm mb-1">Telefone</div>
-            <div class="text-[var(--text-primary)]">{{ profile.phone_number|default:"-" }}</div>
-          </div>
+        <div>
+          <div class="text-[var(--text-tertiary)] text-sm mb-1">E-mail</div>
+          <a href="mailto:{{ profile.email }}" class="text-[var(--text-primary)] hover:underline break-all">
+            {{ profile.email|default:"-" }}
+          </a>
         </div>
-
-        <div class="space-y-4">
-          <div>
-            <div class="text-[var(--text-tertiary)] text-sm mb-1">Endereço</div>
-            <div class="text-[var(--text-primary)]">{{ profile.endereco|default:"-" }}</div>
-          </div>
-          <div>
-            <div class="text-[var(--text-tertiary)] text-sm mb-1">Cidade / Estado</div>
-            <div class="text-[var(--text-primary)]">
-              {% if profile.cidade or profile.estado %}
-                {{ profile.cidade }}{% if profile.estado %} - {{ profile.estado }}{% endif %}
-              {% else %}-{% endif %}
-            </div>
-          </div>
+        <div>
+          <div class="text-[var(--text-tertiary)] text-sm mb-1">Fone</div>
+          <div class="text-[var(--text-primary)]">{{ profile.phone_number|default:"-" }}</div>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- remove address info and show email and phone side by side in hero profile

## Testing
- `pytest` *(fails: Module errors during test collection, 81 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c5d142624483258802a8f6ea1077b6