### PR TITLE
Handle selected social icons on hero profile

### DIFF
--- a/core/templatetags/string_filters.py
+++ b/core/templatetags/string_filters.py
@@ -1,4 +1,4 @@
-"""Template filters for string operations."""
+"""Template filters for common string and mapping operations."""
 
 from django import template
 
@@ -7,7 +7,7 @@ register = template.Library()
 
 @register.filter(name="startswith")
 def startswith(text: str, prefix: str) -> bool:
-    """Return True if ``text`` starts with the given ``prefix``.
+    """Return ``True`` if ``text`` starts with the given ``prefix``.
 
     Both arguments are converted to strings to avoid type errors when
     ``None`` or other non-string types are provided.
@@ -15,3 +15,30 @@ def startswith(text: str, prefix: str) -> bool:
     if text is None or prefix is None:
         return False
     return str(text).startswith(str(prefix))
+
+
+@register.filter(name="split")
+def split(value: str | None, delimiter: str = " "):
+    """Split ``value`` by ``delimiter`` and return a list.
+
+    If ``value`` is ``None`` an empty list is returned. The value is
+    converted to ``str`` before splitting to avoid type issues.
+    """
+    if value is None:
+        return []
+    return str(value).split(delimiter)
+
+
+@register.filter(name="get_item")
+def get_item(mapping, key):
+    """Return ``mapping[key]`` for dictionaries or attributes.
+
+    When ``mapping`` is ``None`` or the key does not exist ``None`` is
+    returned. This allows safe lookups in templates without raising
+    exceptions.
+    """
+    if mapping is None:
+        return None
+    if isinstance(mapping, dict):
+        return mapping.get(key)
+    return getattr(mapping, key, None)

--- a/templates/_components/hero_profile.html
+++ b/templates/_components/hero_profile.html
@@ -1,3 +1,4 @@
+{% load string_filters %}
 <section class="relative isolate overflow-visible bg-gradient-to-r from-[var(--hero-from)] to-[var(--hero-to)]">
   {% if profile.cover %}
     <img src="{{ profile.cover.url }}" alt="" class="absolute inset-0 h-full w-full object-cover opacity-40" loading="lazy">
@@ -64,11 +65,17 @@
       {% if profile.redes_sociais %}
         <div class="border-t border-[var(--border)] p-4 sm:p-6">
           <div class="flex items-center justify-center md:justify-start gap-4 text-xl text-[var(--text-secondary)]">
-            {% for nome, link in profile.redes_sociais.items %}
-              <a href="{{ link }}" target="_blank" rel="noopener" class="hover:text-[var(--text-primary)]" aria-label="{{ nome|title }}">
-                <i class="fa-brands fa-{{ nome }}"></i>
-              </a>
-            {% endfor %}
+            {% with redes='whatsapp instagram linkedin x'|split %}
+              {% for nome in redes %}
+                {% with link=profile.redes_sociais|get_item:nome %}
+                  {% if link %}
+                    <a href="{{ link }}" target="_blank" rel="noopener" class="hover:text-[var(--text-primary)]" aria-label="{{ nome|title }}">
+                      <i class="fa-brands {% if nome == 'x' %}fa-x-twitter{% else %}fa-{{ nome }}{% endif %}"></i>
+                    </a>
+                  {% endif %}
+                {% endwith %}
+              {% endfor %}
+            {% endwith %}
           </div>
         </div>
       {% endif %}


### PR DESCRIPTION
## Summary
- add template filters for splitting strings and safely retrieving mapping items
- restrict hero profile social list to WhatsApp, Instagram, LinkedIn and X with icon fallback

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'factory')*

------
https://chatgpt.com/codex/tasks/task_e_68c5d1804d408325b84c52a7d93bdff3