### PR TITLE
Align hero profile avatar to left

### DIFF
--- a/templates/_components/hero_profile.html
+++ b/templates/_components/hero_profile.html
@@ -4,7 +4,7 @@
     <img src="{{ profile.cover.url }}" alt="" class="absolute inset-0 h-full w-full object-cover opacity-40" loading="lazy">
   {% endif %}
   <div class="relative mx-auto max-w-7xl px-4 h-48 md:h-64 text-center text-white"></div>
-  <div class="absolute bottom-0 left-1/2 translate-y-1/2 -translate-x-1/2 z-50">
+  <div class="absolute top-1/2 left-8 -translate-y-1/2 z-50">
     <div class="h-32 w-32 md:h-40 md:w-40 rounded-full ring-4 ring-white/90 overflow-hidden shadow-lg bg-[var(--bg-primary)]">
       {% if profile.avatar %}
         <img src="{{ profile.avatar_url }}" alt="{{ profile.get_full_name|default:profile.username }}" class="h-full w-full object-cover" loading="lazy">
@@ -17,16 +17,16 @@
   </div>
 </section>
 
-<section class="container mt-16 md:mt-20">
+<section class="container mt-6 md:mt-10">
   <div class="mx-auto w-full max-w-4xl">
     <div class="profile-card rounded-xl border bg-[var(--bg-primary)]">
-      <div class="pt-24 md:pt-10 text-center md:text-left md:pl-44">
+      <div class="p-6 text-center md:text-left">
         <h2 class="text-2xl font-semibold text-[var(--text-primary)] md:mb-1 md:mt-2">
           {{ profile.get_full_name|default:profile.username }}
         </h2>
         <p class="text-sm text-[var(--text-muted)]">@{{ profile.username }}</p>
       </div>
-      <div class="mt-6 flex flex-col items-center justify-center space-y-2 md:flex-row md:flex-wrap md:justify-start md:space-y-0 md:space-x-2 md:pl-44">
+      <div class="mt-6 flex flex-col items-center justify-center space-y-2 md:flex-row md:flex-wrap md:justify-start md:space-y-0 md:space-x-2 px-6">
         <button class="btn btn-primary">Info</button>
         <button class="btn btn-secondary">Portfólio</button>
         <button class="btn btn-secondary">Mural</button>


### PR DESCRIPTION
## Summary
- Reposition hero profile avatar to left and center vertically
- Remove extra top padding and margin from profile card and align content

## Testing
- `pytest -q` *(fails: Module Twilio import caused KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68c5d40ad8e8832586802a9da85ae878