### PR TITLE
Move hero profile buttons below contact info

### DIFF
--- a/templates/_components/hero_profile.html
+++ b/templates/_components/hero_profile.html
@@ -26,13 +26,6 @@
         </h2>
         <p class="text-sm text-[var(--text-muted)]">@{{ profile.username }}</p>
       </div>
-      <div class="mt-6 flex flex-col items-center justify-center space-y-2 md:flex-row md:flex-wrap md:justify-start md:space-y-0 md:space-x-2 md:pl-44">
-        <button class="btn btn-primary">Info</button>
-        <button class="btn btn-secondary">Portfólio</button>
-        <button class="btn btn-secondary">Mural</button>
-        <button class="btn btn-outline">Conexões</button>
-      </div>
-
       <div class="grid grid-cols-1 sm:grid-cols-2 gap-6 p-6">
         <div>
           <div class="text-[var(--text-tertiary)] text-sm mb-1">E-mail</div>
@@ -44,6 +37,13 @@
           <div class="text-[var(--text-tertiary)] text-sm mb-1">Fone</div>
           <div class="text-[var(--text-primary)]">{{ profile.phone_number|default:"-" }}</div>
         </div>
+      </div>
+
+      <div class="mt-6 flex flex-col items-center justify-center space-y-2 md:flex-row md:flex-wrap md:justify-start md:space-y-0 md:space-x-2 px-6 pb-6">
+        <button class="btn btn-primary">Info</button>
+        <button class="btn btn-secondary">Portfólio</button>
+        <button class="btn btn-secondary">Mural</button>
+        <button class="btn btn-outline">Conexões</button>
       </div>
 
       {% if profile.redes_sociais %}


### PR DESCRIPTION
## Summary
- reorder hero profile buttons after contact info grid
- preserve responsive flex layout and spacing utilities

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'silk')*


------
https://chatgpt.com/codex/tasks/task_e_68c5d42077fc8325901221cc20d2a07b