### PR TITLE
Format hero profile phone link

### DIFF
--- a/templates/_components/hero_profile.html
+++ b/templates/_components/hero_profile.html
@@ -36,10 +36,17 @@
               <span class="text-sm md:text-base">{{ profile.email|default:"-" }}</span>
             </a>
 
+            {% if profile.phone_number %}
+            <a href="tel:{{ profile.phone_number }}" class="inline-flex items-center gap-2 rounded-lg px-2.5 py-1 bg-black/60 text-white hover:bg-black/70 transition">
+              <i class="fa-solid fa-phone text-white/90"></i>
+              <span class="text-sm md:text-base">{{ profile.phone_number.as_national }}</span>
+            </a>
+            {% else %}
             <span class="inline-flex items-center gap-2 rounded-lg px-2.5 py-1 bg-black/60 text-white">
               <i class="fa-solid fa-phone text-white/90"></i>
-              <span class="text-sm md:text-base">{{ profile.phone_number|default:"-" }}</span>
+              <span class="text-sm md:text-base">-</span>
             </span>
+            {% endif %}
           </div>
           <!-- Linha 3: Botões -->
           {% if is_owner %}


### PR DESCRIPTION
## Summary
- link hero profile phone number using `tel:`
- show national formatted phone with fallback when missing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'discussao'; IndentationError in tests/notificacoes/test_templates_view.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c81283bc008325824564afe8c841b3