### PR TITLE
Preserve search query during event pagination

### DIFF
--- a/eventos/templates/eventos/evento_list.html
+++ b/eventos/templates/eventos/evento_list.html
@@ -18,7 +18,7 @@
 {% block content %}
   <div class="py-12 card px-4">
     <div class="card-header">
-      {% include '_components/search_form.html' with q=request.GET.q %}
+      {% include '_components/search_form.html' with q=q %}
     </div>
     <div class="card-body">
       <div class="card-grid mb-6">
@@ -34,7 +34,7 @@
           <p class="col-span-full text-center text-[var(--text-muted)]">{% trans 'Nenhum evento encontrado.' %}</p>
         {% endfor %}
       </div>
-      {% include '_partials/pagination.html' with page_obj=page_obj querystring="q="|add:q %}
+      {% include '_partials/pagination.html' with page_obj=page_obj querystring=querystring %}
     </div>
   </div>
 {% endblock %}

--- a/eventos/views.py
+++ b/eventos/views.py
@@ -115,6 +115,7 @@ class EventoListView(LoginRequiredMixin, NoSuperadminMixin, ListView):
             params.pop("page")
         except KeyError:
             pass
+        ctx["q"] = self.request.GET.get("q", "").strip()
         ctx["querystring"] = urlencode(params, doseq=True)
         return ctx
 


### PR DESCRIPTION
## Summary
- expose search query in `EventoListView` context and keep querystring via `urlencode`
- update event list template to use context `q` and prebuilt `querystring`

## Testing
- `python -m py_compile eventos/views.py`
- `pytest eventos/tests` *(fails: Unknown pytest mark and collection errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c8256a70588325844d19a8b5fca25b