### PR TITLE
Adjust feed reaction button styling

### DIFF
--- a/feed/static/feed/js/share.js
+++ b/feed/static/feed/js/share.js
@@ -20,12 +20,12 @@ export async function handleShare(event) {
     });
 
     if (res.status === 201) {
-      btn.classList.add('text-primary');
+      btn.classList.add('text-[var(--primary)]');
       if (countSpan) {
         countSpan.textContent = String(parseInt(countSpan.textContent || '0') + 1);
       }
     } else if (res.status === 204) {
-      btn.classList.remove('text-primary');
+      btn.classList.remove('text-[var(--primary)]');
       if (countSpan) {
         const newValue = Math.max(parseInt(countSpan.textContent || '0') - 1, 0);
         countSpan.textContent = String(newValue);

--- a/feed/templates/feed/_grid.html
+++ b/feed/templates/feed/_grid.html
@@ -61,18 +61,18 @@
           <div id="like-btn-{{ post.id }}">
             {% include 'feed/_like_button.html' with post=post %}
           </div>
-              <button type="button" data-post-id="{{ post.id }}" class="share-btn btn btn-secondary {% if post.is_shared %}text-[var(--primary)]{% endif %}" aria-label="{% trans 'Compartilhar' %}">
-            {% lucide 'share-2' class='w-4 h-4' %}
-            <span class="share-count">{{ post.share_count }}</span>
-          </button>
-
+          <div class="flex items-center gap-2">
+            <button type="button" data-post-id="{{ post.id }}" class="share-btn btn btn-secondary {% if post.is_shared %}text-[var(--primary)]{% endif %}" aria-label="{% trans 'Compartilhar' %}">
+              {% lucide 'share-2' class='w-4 h-4' %}
+              <span class="share-count">{{ post.share_count }}</span>
+            </button>
             <button type="button" data-post-id="{{ post.id }}" class="bookmark-btn btn btn-secondary {% if post.is_bookmarked %}text-[var(--warning)]{% endif %}" aria-label="{% trans 'Salvar' %}">
-            {% lucide 'bookmark' class='w-4 h-4' %}
-          </button>
-            <button type="button" data-post-id="{{ post.id }}" class="flag-btn btn btn-secondary {% if post.is_flagged %}text-[var(--error)] cursor-not-allowed{% endif %}" aria-label="{% trans 'Denunciar' %}" {% if post.is_flagged %}disabled{% endif %}>
-            {% lucide 'flag' class='w-4 h-4' %}
-
-          </button>
+              {% lucide 'bookmark' class='w-4 h-4' %}
+            </button>
+            <button type="button" data-post-id="{{ post.id }}" class="flag-btn btn btn-secondary {% if post.is_flagged %}text-[var(--error)]{% endif %}" aria-label="{% trans 'Denunciar' %}" {% if post.is_flagged %}disabled{% endif %}>
+              {% lucide 'flag' class='w-4 h-4' %}
+            </button>
+          </div>
         </div>
         <span>{{ post.comments.count }} {% trans 'comentários' %}</span>
       </div>
@@ -93,7 +93,7 @@
         return;
       }
       const data = await res.json();
-      btn.classList.toggle('text-yellow-600', data.bookmarked);
+      btn.classList.toggle('text-[var(--warning)]', data.bookmarked);
     });
   });
   document.querySelectorAll('.flag-btn').forEach(btn => {
@@ -104,7 +104,7 @@
         alert('{% trans "Erro ao denunciar" %}');
         return;
       }
-      btn.classList.add('text-red-600', 'cursor-not-allowed');
+      btn.classList.add('text-[var(--error)]');
       btn.setAttribute('disabled', 'disabled');
     });
   });

--- a/feed/templates/feed/post_detail.html
+++ b/feed/templates/feed/post_detail.html
@@ -73,7 +73,7 @@
       <button type="button" data-post-id="{{ post.id }}" class="bookmark-btn btn btn-secondary {% if post.is_bookmarked %}text-[var(--warning)]{% endif %}" aria-label="{% trans 'Salvar' %}">
         {% lucide 'bookmark' class='w-4 h-4' %}
       </button>
-      <button type="button" data-post-id="{{ post.id }}" class="flag-btn btn btn-secondary {% if post.is_flagged %}text-[var(--error)] cursor-not-allowed{% endif %}" aria-label="{% trans 'Denunciar' %}" {% if post.is_flagged %}disabled{% endif %}>
+      <button type="button" data-post-id="{{ post.id }}" class="flag-btn btn btn-secondary {% if post.is_flagged %}text-[var(--error)]{% endif %}" aria-label="{% trans 'Denunciar' %}" {% if post.is_flagged %}disabled{% endif %}>
         {% lucide 'flag' class='w-4 h-4' %}
       </button>
 
@@ -130,7 +130,7 @@
       const res = await fetch(`/api/feed/posts/${postId}/bookmark/`, {method: 'POST', headers: {'X-CSRFToken': csrfToken}});
       if (!res.ok) return;
       const data = await res.json();
-      btn.classList.toggle('text-yellow-600', data.bookmarked);
+      btn.classList.toggle('text-[var(--warning)]', data.bookmarked);
     });
   });
   document.querySelectorAll('.flag-btn').forEach(btn => {
@@ -138,7 +138,7 @@
       const postId = btn.dataset.postId;
       const res = await fetch(`/api/feed/posts/${postId}/flag/`, {method: 'POST', headers: {'X-CSRFToken': csrfToken}});
       if (res.ok) {
-        btn.classList.add('text-red-600', 'cursor-not-allowed');
+        btn.classList.add('text-[var(--error)]');
         btn.setAttribute('disabled', 'disabled');
       }
     });


### PR DESCRIPTION
## Summary
- group feed reaction controls inside a compact flex container for consistent spacing
- align share, bookmark, and flag buttons on grid and detail views to use only btn btn-secondary with variable-driven color states
- update bookmark, flag, and share scripts to toggle the new semantic color utility classes

## Testing
- npm run lint *(fails: command prompts for interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c8495a4ed08325857c98cddec6c6b5