### PR TITLE
Ajusta comportamento do botão de compartilhar no feed

### DIFF
--- a/feed/static/feed/js/share.js
+++ b/feed/static/feed/js/share.js
@@ -3,11 +3,51 @@ export async function handleShare(event) {
   if (!btn) return;
 
   event.preventDefault();
+  event.stopPropagation();
   const postId = btn.dataset.postId;
   if (!postId) return;
 
   const countSpan = btn.querySelector('.share-count');
   const csrfToken = document.cookie.match(/(?:^|; )csrftoken=([^;]+)/)?.[1] || '';
+
+  const readCount = () => {
+    const fromDataset = Number.parseInt(btn.dataset.shareCount || '', 10);
+    if (!Number.isNaN(fromDataset)) {
+      return fromDataset;
+    }
+    if (!countSpan) {
+      return 0;
+    }
+    const parsed = Number.parseInt((countSpan.textContent || '').trim(), 10);
+    return Number.isNaN(parsed) ? 0 : parsed;
+  };
+
+  const updateCount = (value) => {
+    const safeValue = Math.max(0, Number.isNaN(value) ? 0 : value);
+    btn.dataset.shareCount = String(safeValue);
+    if (countSpan) {
+      countSpan.textContent = String(safeValue);
+    }
+    const label = btn.querySelector('[data-share-label]');
+    if (label) {
+      const formatter =
+        typeof window !== 'undefined' && typeof window.ngettext === 'function'
+          ? window.ngettext
+          : null;
+      const template = formatter
+        ? formatter('%(count)s compartilhamento', '%(count)s compartilhamentos', safeValue)
+        : safeValue === 1
+          ? '%(count)s compartilhamento'
+          : '%(count)s compartilhamentos';
+      const interpolator =
+        typeof window !== 'undefined' && typeof window.interpolate === 'function'
+          ? window.interpolate
+          : null;
+      label.textContent = interpolator
+        ? interpolator(template, { count: safeValue }, true)
+        : template.replace('%(count)s', safeValue);
+    }
+  };
 
   try {
     const res = await fetch(`/api/feed/posts/${postId}/reacoes/`, {
@@ -20,16 +60,13 @@ export async function handleShare(event) {
     });
 
     if (res.status === 201) {
-      btn.classList.add('text-primary');
-      if (countSpan) {
-        countSpan.textContent = String(parseInt(countSpan.textContent || '0') + 1);
-      }
+      btn.classList.add('text-[var(--primary)]');
+      btn.setAttribute('aria-pressed', 'true');
+      updateCount(readCount() + 1);
     } else if (res.status === 204) {
-      btn.classList.remove('text-primary');
-      if (countSpan) {
-        const newValue = Math.max(parseInt(countSpan.textContent || '0') - 1, 0);
-        countSpan.textContent = String(newValue);
-      }
+      btn.classList.remove('text-[var(--primary)]');
+      btn.setAttribute('aria-pressed', 'false');
+      updateCount(readCount() - 1);
     }
   } catch (err) {
     console.error('Erro ao compartilhar', err);

--- a/feed/templates/feed/_grid.html
+++ b/feed/templates/feed/_grid.html
@@ -95,10 +95,17 @@
               <div id="like-btn-{{ post.id }}" class="relative z-20">
                 {% include 'feed/_like_button.html' with post=post %}
               </div>
-              <button type="button" data-post-id="{{ post.id }}" class="share-btn btn btn-secondary {% if post.is_shared %}text-[var(--primary)]{% endif %} relative z-20 inline-flex items-center gap-1 rounded-full px-3 py-1.5 text-xs font-semibold transition" aria-label="{% trans 'Compartilhar' %}">
+              <button
+                type="button"
+                data-post-id="{{ post.id }}"
+                data-share-count="{{ post.share_count|default_if_none:0 }}"
+                class="share-btn btn btn-secondary {% if post.is_shared %}text-[var(--primary)]{% endif %} relative z-20 inline-flex items-center gap-1 rounded-full px-3 py-1.5 text-xs font-semibold transition"
+                aria-label="{% trans 'Compartilhar' %}"
+                aria-pressed="{% if post.is_shared %}true{% else %}false{% endif %}"
+              >
                 {% lucide 'share-2' class='w-4 h-4' %}
-                <span aria-hidden="true" class="share-count min-w-[1.5rem] text-center">{{ post.share_count }}</span>
-                <span class="sr-only">
+                <span aria-hidden="true" class="share-count min-w-[1.5rem] text-center">{{ post.share_count|default_if_none:0 }}</span>
+                <span class="sr-only" data-share-label>
                   {% blocktrans trimmed count share_count=post.share_count %}
                     {{ share_count }} compartilhamento
                   {% plural %}


### PR DESCRIPTION
## Summary
- impede que o clique do botão de compartilhar navegue para o post e mantém o estado visual coerente
- torna a atualização da contagem de compartilhamentos mais robusta e sincroniza o texto acessível

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8640731708325a122a0489dd5122f