### PR TITLE
Adjust bookmark toggle handling for soft-deleted bookmarks

### DIFF
--- a/feed/tests/test_bookmark_api.py
+++ b/feed/tests/test_bookmark_api.py
@@ -24,11 +24,27 @@ class BookmarkAPITest(TestCase):
         self.assertEqual(res.status_code, 201)
         self.assertTrue(res.data["bookmarked"])
         self.assertTrue(Bookmark.objects.filter(user=self.user, post=post).exists())
+        self.assertEqual(Bookmark.all_objects.filter(user=self.user, post=post).count(), 1)
 
         res = self.client.post(url)
         self.assertEqual(res.status_code, 200)
         self.assertFalse(res.data["bookmarked"])
         self.assertFalse(Bookmark.objects.filter(user=self.user, post=post).exists())
+        self.assertEqual(Bookmark.all_objects.filter(user=self.user, post=post).count(), 1)
+        bookmark = Bookmark.all_objects.get(user=self.user, post=post)
+        self.assertTrue(bookmark.deleted)
+
+        res = self.client.post(url)
+        self.assertEqual(res.status_code, 201)
+        self.assertTrue(res.data["bookmarked"])
+        self.assertTrue(Bookmark.objects.filter(user=self.user, post=post).exists())
+        self.assertEqual(Bookmark.all_objects.filter(user=self.user, post=post).count(), 1)
+
+        res = self.client.post(url)
+        self.assertEqual(res.status_code, 200)
+        self.assertFalse(res.data["bookmarked"])
+        self.assertFalse(Bookmark.objects.filter(user=self.user, post=post).exists())
+        self.assertEqual(Bookmark.all_objects.filter(user=self.user, post=post).count(), 1)
 
     def test_list_bookmarks(self):
         post = PostFactory(autor=self.user, organizacao=self.org)


### PR DESCRIPTION
## Summary
- reuse soft-deleted bookmarks when toggling the bookmark action and return 201 when a bookmark is created or restored and 200 when removed
- extend the bookmark API test to cover create/remove cycles and assert the soft-delete state stays consistent

## Testing
- `PYTHONPATH=/tmp python manage.py test feed.tests.test_bookmark_api.BookmarkAPITest.test_toggle_bookmark`


------
https://chatgpt.com/codex/tasks/task_e_68c8742d020c8325b03eed8594d8b353