### PR TITLE
feat(feed): add share notification template

### DIFF
--- a/feed/tests/test_notifications.py
+++ b/feed/tests/test_notifications.py
@@ -67,6 +67,14 @@ class FeedNotificationTest(TestCase):
         self.assertEqual(enviar.call_count, 1)
 
     @patch("feed.tasks.enviar_para_usuario")
+    def test_notify_share_once(self, enviar) -> None:
+        from feed.models import Post, Reacao
+
+        post = Post.objects.create(autor=self.other, organizacao=self.other.organizacao, conteudo="ola")
+        Reacao.objects.create(post=post, user=self.user, vote="share")
+        enviar.assert_called_once_with(self.other, "feed_share", {"post_id": str(post.id)})
+
+    @patch("feed.tasks.enviar_para_usuario")
     def test_notify_comment_once(self, enviar) -> None:
         from feed.models import Comment, Post
 

--- a/notificacoes/migrations/0011_feed_share_template.py
+++ b/notificacoes/migrations/0011_feed_share_template.py
@@ -1,0 +1,32 @@
+from django.db import migrations
+
+
+TEMPLATE_CODE = "feed_share"
+
+
+def create_template(apps, schema_editor):
+    NotificationTemplate = apps.get_model("notificacoes", "NotificationTemplate")
+    NotificationTemplate.objects.get_or_create(
+        codigo=TEMPLATE_CODE,
+        defaults={
+            "assunto": "Seu post foi compartilhado",
+            "corpo": "Alguém compartilhou seu post.",
+            "canal": "push",
+        },
+    )
+
+
+def remove_template(apps, schema_editor):
+    NotificationTemplate = apps.get_model("notificacoes", "NotificationTemplate")
+    NotificationTemplate.objects.filter(codigo=TEMPLATE_CODE).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("notificacoes", "0010_feed_interaction_templates"),
+    ]
+
+    operations = [
+        migrations.RunPython(create_template, remove_template),
+    ]


### PR DESCRIPTION
## Summary
- map share interactions to a dedicated `feed_share` notification template when notifying post authors
- seed the new `feed_share` notification template for push delivery
- extend notification tests to cover share reactions and ensure correct template usage

## Testing
- DEBUG=0 pytest feed/tests/test_notifications.py tests/feed/test_notifications.py --no-cov

------
https://chatgpt.com/codex/tasks/task_e_68c878de664c8325a4dea1c0cd7d0b06