### PR TITLE
Adjust configuracao tabs accessibility and script loading

### DIFF
--- a/configuracoes/templates/configuracoes/configuracao_form.html
+++ b/configuracoes/templates/configuracoes/configuracao_form.html
@@ -9,8 +9,8 @@
   <section class="card bg-[var(--bg-elevated)] border border-[var(--border)] rounded-2xl shadow-sm">
     <header class="card-body border-b border-[var(--border)] p-6">
       <nav aria-label="{% trans 'Seções de Configuração' %}" role="tablist" class="flex flex-wrap gap-4 text-sm">
-        <a href="{% url 'configuracoes:configuracoes' %}?tab=seguranca" role="tab" aria-selected="{% if tab == 'seguranca' %}true{% else %}false{% endif %}" aria-controls="content" hx-get="{% url 'configuracoes:configuracoes' %}?tab=seguranca" hx-target="#content" hx-swap="innerHTML" hx-push-url="true" tabindex="0" data-active-class="btn-secondary" class="btn {% if tab == 'seguranca' %}btn-secondary{% endif %}">{% trans 'Segurança' %}</a>
-        <a href="{% url 'configuracoes:configuracoes' %}?tab=preferencias" role="tab" aria-selected="{% if tab == 'preferencias' %}true{% else %}false{% endif %}" aria-controls="content" hx-get="{% url 'configuracoes:configuracoes' %}?tab=preferencias" hx-target="#content" hx-swap="innerHTML" hx-push-url="true" tabindex="0" data-active-class="btn-secondary" class="btn {% if tab == 'preferencias' %}btn-secondary{% endif %}">{% trans 'Preferências' %}</a>
+        <a href="{% url 'configuracoes:configuracoes' %}?tab=seguranca" role="tab" aria-selected="{% if tab == 'seguranca' %}true{% else %}false{% endif %}" aria-controls="content" hx-get="{% url 'configuracoes:configuracoes' %}?tab=seguranca" hx-target="#content" hx-swap="innerHTML" hx-push-url="true" tabindex="{% if tab == 'seguranca' %}0{% else %}-1{% endif %}" data-active-class="btn-secondary" class="btn {% if tab == 'seguranca' %}btn-secondary{% endif %}">{% trans 'Segurança' %}</a>
+        <a href="{% url 'configuracoes:configuracoes' %}?tab=preferencias" role="tab" aria-selected="{% if tab == 'preferencias' %}true{% else %}false{% endif %}" aria-controls="content" hx-get="{% url 'configuracoes:configuracoes' %}?tab=preferencias" hx-target="#content" hx-swap="innerHTML" hx-push-url="true" tabindex="{% if tab == 'preferencias' %}0{% else %}-1{% endif %}" data-active-class="btn-secondary" class="btn {% if tab == 'preferencias' %}btn-secondary{% endif %}">{% trans 'Preferências' %}</a>
       </nav>
     </header>
     <div class="card-body p-6" id="content" role="tabpanel" hx-get="{% url 'configuracoes:configuracoes' %}?tab={{ tab }}" hx-trigger="load">
@@ -26,5 +26,7 @@
 
 {% block scripts %}
   {{ block.super }}
-  <script src="{% static 'configuracoes/preferencias.js' %}"></script>
+  {% if tab == 'preferencias' %}
+    <script src="{% static 'configuracoes/preferencias.js' %}"></script>
+  {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- ensure only the active configuration tab is focusable via tabindex
- load the preferencias script only when the preferencias tab is active

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c87e5d74a48325b682a2cb92781fc0