### PR TITLE
Refatora layout das preferências de notificações

### DIFF
--- a/configuracoes/templates/configuracoes/_partials/preferencias.html
+++ b/configuracoes/templates/configuracoes/_partials/preferencias.html
@@ -21,8 +21,8 @@
   <input type="hidden" name="updated_preferences" id="updated_preferences" value="{{ updated_preferences|yesno:'true,false' }}">
   <fieldset class="space-y-4">
     <legend class="sr-only">{% trans 'Notificações' %}</legend>
-    <section class="card bg-[var(--bg-elevated)] border border-[var(--border)] rounded-2xl shadow-sm">
-      <div class="card-body p-6 grid grid-cols-1 md:grid-cols-2 gap-6">
+    <div class="space-y-6">
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
         {% with email_checked=preferencias_form.receber_notificacoes_email.value|yesno:"true,false" %}
           {% with email_attr='aria-checked:'|add:email_checked %}
           {% with preferencias_form.receber_notificacoes_email|attr:'role:switch'|attr:'tabindex:0'|attr:'aria-label:Receber notificações por e-mail'|attr:email_attr as email_field %}
@@ -34,15 +34,23 @@
         {% include '_forms/field.html' with field=freq_email_field %}
         {% endwith %}
       </div>
-      <footer class="card-footer border-t border-[var(--border)] p-4 flex items-center gap-3">
-        <button type="button" class="btn btn-secondary" hx-post="{% url 'configuracoes_api:configuracoes-testar' %}" hx-vals='{"canal": "email"}' hx-include="[name=csrfmiddlewaretoken],#escopo_tipo,#escopo_id" hx-swap="none" hx-on:afterRequest="document.getElementById('msg-email').innerText = event.detail.xhr.responseJSON.detail" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
+      <div class="flex items-center gap-3">
+        <button
+          type="button"
+          class="btn btn-secondary"
+          hx-post="{% url 'configuracoes_api:configuracoes-testar' %}"
+          hx-vals='{"canal": "email"}'
+          hx-include="[name=csrfmiddlewaretoken],#escopo_tipo,#escopo_id"
+          hx-swap="none"
+          hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+        >
           {% trans 'Testar e-mail' %}
         </button>
         <span id="msg-email" class="text-xs text-[var(--text-tertiary)]" aria-live="polite"></span>
-      </footer>
-    </section>
-    <section class="card bg-[var(--bg-elevated)] border border-[var(--border)] rounded-2xl shadow-sm">
-      <div class="card-body p-6 grid grid-cols-1 md:grid-cols-2 gap-6">
+      </div>
+    </div>
+    <div class="space-y-6">
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
         {% with whats_checked=preferencias_form.receber_notificacoes_whatsapp.value|yesno:"true,false" %}
           {% with whats_attr='aria-checked:'|add:whats_checked %}
           {% with preferencias_form.receber_notificacoes_whatsapp|attr:'role:switch'|attr:'tabindex:0'|attr:'aria-label:Receber notificações por WhatsApp'|attr:whats_attr as whats_field %}
@@ -54,15 +62,23 @@
         {% include '_forms/field.html' with field=freq_whats_field %}
         {% endwith %}
       </div>
-      <footer class="card-footer border-t border-[var(--border)] p-4 flex items-center gap-3">
-        <button type="button" class="btn btn-secondary" hx-post="{% url 'configuracoes_api:configuracoes-testar' %}" hx-vals='{"canal": "whatsapp"}' hx-include="[name=csrfmiddlewaretoken],#escopo_tipo,#escopo_id" hx-swap="none" hx-on:afterRequest="document.getElementById('msg-whatsapp').innerText = event.detail.xhr.responseJSON.detail" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
+      <div class="flex items-center gap-3">
+        <button
+          type="button"
+          class="btn btn-secondary"
+          hx-post="{% url 'configuracoes_api:configuracoes-testar' %}"
+          hx-vals='{"canal": "whatsapp"}'
+          hx-include="[name=csrfmiddlewaretoken],#escopo_tipo,#escopo_id"
+          hx-swap="none"
+          hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+        >
           {% trans 'Testar WhatsApp' %}
         </button>
         <span id="msg-whatsapp" class="text-xs text-[var(--text-tertiary)]" aria-live="polite"></span>
-      </footer>
-    </section>
-    <section class="card bg-[var(--bg-elevated)] border border-[var(--border)] rounded-2xl shadow-sm">
-      <div class="card-body p-6 grid grid-cols-1 md:grid-cols-2 gap-6">
+      </div>
+    </div>
+    <div class="space-y-6">
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
         {% with push_checked=preferencias_form.receber_notificacoes_push.value|yesno:"true,false" %}
           {% with push_attr='aria-checked:'|add:push_checked %}
           {% with preferencias_form.receber_notificacoes_push|attr:'role:switch'|attr:'tabindex:0'|attr:'aria-label:Receber notificações push'|attr:push_attr as push_field %}
@@ -74,13 +90,21 @@
         {% include '_forms/field.html' with field=freq_push_field %}
         {% endwith %}
       </div>
-      <footer class="card-footer border-t border-[var(--border)] p-4 flex items-center gap-3">
-        <button type="button" class="btn btn-secondary" hx-post="{% url 'configuracoes_api:configuracoes-testar' %}" hx-vals='{"canal": "push"}' hx-include="[name=csrfmiddlewaretoken],#escopo_tipo,#escopo_id" hx-swap="none" hx-on:afterRequest="document.getElementById('msg-push').innerText = event.detail.xhr.responseJSON.detail" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
+      <div class="flex items-center gap-3">
+        <button
+          type="button"
+          class="btn btn-secondary"
+          hx-post="{% url 'configuracoes_api:configuracoes-testar' %}"
+          hx-vals='{"canal": "push"}'
+          hx-include="[name=csrfmiddlewaretoken],#escopo_tipo,#escopo_id"
+          hx-swap="none"
+          hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+        >
           {% trans 'Testar push' %}
         </button>
         <span id="msg-push" class="text-xs text-[var(--text-tertiary)]" aria-live="polite"></span>
-      </footer>
-    </section>
+      </div>
+    </div>
     <div id="campo-hora-diaria" class="hidden">
         {% with preferencias_form.hora_notificacao_diaria|attr:'type:time' as hora_diaria_field %}
         {% include '_forms/field.html' with field=hora_diaria_field %}
@@ -97,8 +121,8 @@
       {% endwith %}
     </div>
   </fieldset>
-  <section class="card bg-[var(--bg-elevated)] border border-[var(--border)] rounded-2xl shadow-sm">
-    <div class="card-body p-6 grid grid-cols-1 md:grid-cols-2 gap-6">
+  <div class="space-y-6">
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
       <div>
         {% with preferencias_form.idioma|attr:'tabindex:0' as idioma_field %}
         {% include '_forms/field.html' with field=idioma_field %}
@@ -111,7 +135,7 @@
         {% endwith %}
       </div>
     </div>
-  </section>
+  </div>
   <div class="text-right pt-2">
     <button type="submit" aria-label="{% trans 'Salvar Alterações' %}" class="btn btn-primary">{% trans 'Salvar Alterações' %}</button>
   </div>


### PR DESCRIPTION
## Sumário
- substitui os cartões de preferências por blocos simples com espaçamento vertical
- mantém os campos de alternância e frequência juntos e adiciona rodapés planos com botão de teste por canal
- remove os manipuladores `hx-on:afterRequest` dos botões de teste

## Testes
- não executado (não solicitado)

------
https://chatgpt.com/codex/tasks/task_e_68c87e3463ec83258904d7c87f85b0a5