### PR TITLE
Handle duplicate soft-deleted bookmarks before toggling

### DIFF
--- a/feed/api.py
+++ b/feed/api.py
@@ -374,6 +374,14 @@ class PostViewSet(viewsets.ModelViewSet):
         )
         if bookmark:
             if not bookmark.deleted:
+                duplicates = (
+                    Bookmark.all_objects.filter(
+                        user=request.user, post=post, deleted=True
+                    )
+                    .exclude(pk=bookmark.pk)
+                )
+                for duplicated in duplicates:
+                    duplicated.hard_delete()
                 bookmark.delete()
                 return Response({"bookmarked": False}, status=status.HTTP_200_OK)
             bookmark.undelete()

--- a/feed/tests/test_bookmark_api.py
+++ b/feed/tests/test_bookmark_api.py
@@ -75,8 +75,16 @@ class BookmarkAPITest(TestCase):
         self.assertEqual(res.status_code, 200)
         self.assertFalse(res.data["bookmarked"])
         self.assertEqual(Bookmark.objects.filter(user=self.user, post=post).count(), 0)
+        self.assertEqual(
+            Bookmark.all_objects.filter(user=self.user, post=post).count(),
+            1,
+        )
 
         res = self.client.post(url)
         self.assertEqual(res.status_code, 201)
         self.assertTrue(res.data["bookmarked"])
         self.assertEqual(Bookmark.objects.filter(user=self.user, post=post).count(), 1)
+        self.assertEqual(
+            Bookmark.all_objects.filter(user=self.user, post=post).count(),
+            1,
+        )


### PR DESCRIPTION
## Summary
- hard delete any previously soft-deleted bookmark duplicates before soft-deleting the active record when toggling bookmarks
- extend the duplicate bookmark API test to assert that only a single historical bookmark remains after toggling off

## Testing
- PYTEST_ADDOPTS="--cov-fail-under=0" pytest feed/tests/test_bookmark_api.py::BookmarkAPITest::test_duplicate_bookmarks_do_not_error -q


------
https://chatgpt.com/codex/tasks/task_e_68c881a4a7cc8325a0a91c100f277ffc