### PR TITLE
Implement dynamic profile section loading

### DIFF
--- a/accounts/static/perfil/js/perfil.js
+++ b/accounts/static/perfil/js/perfil.js
@@ -10,6 +10,9 @@ document.addEventListener("DOMContentLoaded", () => {
     // Initialize Tabs
     initTabs()
 
+    // Initialize Perfil navigation
+    initPerfilNavigation()
+
     // Initialize Modals
     initModals()
 
@@ -79,6 +82,156 @@ export function initTabs() {
             })
         })
     })
+}
+
+function initPerfilNavigation() {
+    const container = document.getElementById('perfil-content')
+    if (!container) return
+
+    const navLinks = Array.from(document.querySelectorAll('[data-perfil-nav]'))
+    const defaultUrl = container.dataset.perfilDefaultUrl || null
+    const defaultSection = container.dataset.perfilDefaultSection || null
+    const loadingText = container.dataset.perfilLoadingText || 'Carregando conteúdo...'
+    const errorText = container.dataset.perfilErrorText || 'Não foi possível carregar esta seção.'
+    const mode = container.dataset.perfilMode || 'owner'
+    const publicId = container.dataset.perfilPublicId || ''
+    const username = container.dataset.perfilUsername || ''
+    let activeLink = null
+    let activeSection = defaultSection
+    let activeUrl = null
+    let controller = null
+
+    const prepareUrl = rawUrl => {
+        if (!rawUrl) return null
+        const url = new URL(rawUrl, window.location.origin)
+        if (mode !== 'owner') {
+            if (publicId && !url.searchParams.has('public_id')) {
+                url.searchParams.set('public_id', publicId)
+            } else if (username && !url.searchParams.has('username')) {
+                url.searchParams.set('username', username)
+            }
+        }
+        return url.toString()
+    }
+
+    const showLoading = () => {
+        container.innerHTML = `<div class="py-6 text-center text-sm text-[var(--text-secondary)]">${loadingText}</div>`
+        container.setAttribute('aria-busy', 'true')
+    }
+
+    const showError = () => {
+        container.innerHTML = `<div class="py-6 text-center text-sm text-red-600">${errorText}</div>`
+    }
+
+    const setActive = link => {
+        activeLink = link || null
+        navLinks.forEach(item => {
+            const isActive = item === link
+            item.classList.toggle('is-active', isActive)
+            if (isActive) {
+                item.setAttribute('aria-current', 'page')
+            } else {
+                item.removeAttribute('aria-current')
+            }
+        })
+    }
+
+    const loadSection = async (url, section) => {
+        if (!url) return
+
+        if (controller) {
+            controller.abort()
+        }
+        controller = new AbortController()
+        activeUrl = url
+        if (section) {
+            activeSection = section
+            container.dataset.perfilActiveSection = section
+        }
+
+        showLoading()
+
+        try {
+            const response = await fetch(url, {
+                headers: {
+                    'X-Requested-With': 'XMLHttpRequest',
+                },
+                credentials: 'same-origin',
+                signal: controller.signal,
+            })
+
+            if (!response.ok) {
+                throw new Error(`Failed to load section: ${section || 'unknown'}`)
+            }
+
+            const html = await response.text()
+            container.innerHTML = html
+        } catch (error) {
+            if (error.name !== 'AbortError') {
+                console.error(error)
+                showError()
+            }
+        } finally {
+            container.setAttribute('aria-busy', 'false')
+            controller = null
+        }
+    }
+
+    const handleLink = (link, options = {}) => {
+        const section = options.section || link?.dataset.perfilSection || defaultSection
+        const rawUrl = options.url || link?.dataset.perfilUrl || defaultUrl
+        const finalUrl = prepareUrl(rawUrl)
+        if (!finalUrl) return
+
+        setActive(link || activeLink)
+        loadSection(finalUrl, section)
+    }
+
+    navLinks.forEach(link => {
+        link.addEventListener('click', event => {
+            event.preventDefault()
+            handleLink(link)
+        })
+    })
+
+    container.addEventListener('submit', event => {
+        const form = event.target
+        if (!(form instanceof HTMLFormElement)) return
+
+        const method = (form.method || 'get').toLowerCase()
+        if (method !== 'get' || form.hasAttribute('data-perfil-native')) {
+            return
+        }
+
+        event.preventDefault()
+        const action = form.getAttribute('action') || activeUrl || defaultUrl
+        if (!action) return
+
+        const url = new URL(action, window.location.origin)
+        const formData = new FormData(form)
+        for (const [key, value] of formData.entries()) {
+            if (typeof value === 'string') {
+                if (value) {
+                    url.searchParams.set(key, value)
+                } else {
+                    url.searchParams.delete(key)
+                }
+            }
+        }
+
+        handleLink(activeLink, { url: url.toString(), section: activeSection })
+    })
+
+    const defaultLink = navLinks.find(link => link.dataset.perfilDefault === 'true') || navLinks[0] || null
+    if (defaultLink) {
+        handleLink(defaultLink, {
+            section: defaultLink.dataset.perfilSection || defaultSection,
+            url: defaultUrl || defaultLink.dataset.perfilUrl,
+        })
+    } else if (defaultUrl) {
+        const finalUrl = prepareUrl(defaultUrl)
+        loadSection(finalUrl, defaultSection)
+    }
 }
 
 // Search functionality

--- a/accounts/templates/perfil/partials/conexoes_dashboard.html
+++ b/accounts/templates/perfil/partials/conexoes_dashboard.html
@@ -1,0 +1,16 @@
+{% load i18n %}
+<div class="space-y-10">
+  <section aria-labelledby="perfil-conexoes-list">
+    <div class="section-header mb-4 flex items-center justify-between">
+      <h2 id="perfil-conexoes-list" class="text-base font-semibold text-[var(--text-primary)]">{% trans "Minhas conexões" %}</h2>
+    </div>
+    {% include 'perfil/partials/conexoes_minhas.html' %}
+  </section>
+
+  <section aria-labelledby="perfil-conexoes-requests">
+    <div class="section-header mb-4 flex items-center justify-between">
+      <h2 id="perfil-conexoes-requests" class="text-base font-semibold text-[var(--text-primary)]">{% trans "Solicitações de conexão" %}</h2>
+    </div>
+    {% include 'perfil/partials/conexoes_solicitacoes.html' %}
+  </section>
+</div>

--- a/accounts/templates/perfil/perfil.html
+++ b/accounts/templates/perfil/perfil.html
@@ -8,7 +8,23 @@
 
 <div class="card">
   <div class="card-body">
-    {% include "perfil/partials/portfolio.html" with medias=portfolio_recent is_owner=is_owner form=portfolio_form show_form=portfolio_show_form q=portfolio_q %}
+    <section
+      id="perfil-content"
+      class="space-y-6"
+      data-perfil-default-url="{% url 'accounts:perfil_portfolio' %}"
+      data-perfil-default-section="portfolio"
+      data-perfil-mode="{% if is_owner %}owner{% else %}public{% endif %}"
+      data-perfil-username="{{ profile.username }}"
+      data-perfil-public-id="{{ profile.public_id }}"
+      data-perfil-loading-text="{% trans 'Carregando conteúdo...' %}"
+      data-perfil-error-text="{% trans 'Não foi possível carregar esta seção.' %}"
+      aria-live="polite"
+      aria-busy="true"
+    >
+      <div class="py-6 text-center text-sm text-[var(--text-secondary)]" data-perfil-placeholder>
+        {% trans "Carregando conteúdo..." %}
+      </div>
+    </section>
   </div>
 </div>
 {% endblock %}

--- a/accounts/templates/perfil/publico.html
+++ b/accounts/templates/perfil/publico.html
@@ -7,6 +7,22 @@
 {% endblock %}
 
 {% block content %}
-  {% include "perfil/partials/portfolio.html" with medias=portfolio_recent is_owner=is_owner form=portfolio_form show_form=portfolio_show_form q=portfolio_q %}
+  <section
+    id="perfil-content"
+    class="space-y-6"
+    data-perfil-default-url="{% url 'accounts:perfil_portfolio' %}"
+    data-perfil-default-section="portfolio"
+    data-perfil-mode="{% if is_owner %}owner{% else %}public{% endif %}"
+    data-perfil-username="{{ perfil.username }}"
+    data-perfil-public-id="{{ perfil.public_id }}"
+    data-perfil-loading-text="{% trans 'Carregando conteúdo...' %}"
+    data-perfil-error-text="{% trans 'Não foi possível carregar esta seção.' %}"
+    aria-live="polite"
+    aria-busy="true"
+  >
+    <div class="py-6 text-center text-sm text-[var(--text-secondary)]" data-perfil-placeholder>
+      {% trans "Carregando conteúdo..." %}
+    </div>
+  </section>
 {% endblock %}
 

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -50,6 +50,42 @@ urlpatterns = [
         views.recusar_conexao,
         name="recusar_conexao",
     ),
+    path(
+        "perfil/partials/portfolio/",
+        views.perfil_section,
+        {"section": "portfolio"},
+        name="perfil_portfolio",
+    ),
+    path(
+        "perfil/partials/mural/",
+        views.perfil_section,
+        {"section": "mural"},
+        name="perfil_mural",
+    ),
+    path(
+        "perfil/partials/info/",
+        views.perfil_section,
+        {"section": "info"},
+        name="perfil_info_partial",
+    ),
+    path(
+        "perfil/partials/nucleos/",
+        views.perfil_section,
+        {"section": "nucleos"},
+        name="perfil_nucleos",
+    ),
+    path(
+        "perfil/partials/eventos/",
+        views.perfil_section,
+        {"section": "eventos"},
+        name="perfil_eventos",
+    ),
+    path(
+        "perfil/partials/conexoes/",
+        views.perfil_section,
+        {"section": "conexoes"},
+        name="perfil_conexoes_partial",
+    ),
     # Portfólio
     path("perfil/portfolio/", views.perfil_portfolio, name="portfolio"),
     path("perfil/portfolio/<int:pk>/", views.perfil_portfolio_detail, name="portfolio_detail"),

--- a/templates/_components/hero_profile.html
+++ b/templates/_components/hero_profile.html
@@ -1,3 +1,4 @@
+{% load i18n %}
 <section class="relative isolate overflow-hidden">
   <div class="relative h-[260px] md:h-[320px] lg:h-[360px] bg-gradient-to-r from-[var(--hero-from)] to-[var(--hero-to)]">
     {% if profile.cover %}
@@ -49,14 +50,69 @@
             {% endif %}
           </div>
           <!-- Linha 3: Botões -->
-          {% if is_owner %}
-          <div class="mt-3 flex flex-wrap items-center gap-2">
-            <a href="{% url 'accounts:info' %}" class="btn-hero">Info</a>
-            <a href="{% url 'accounts:portfolio' %}" class="btn-hero">Portfólio</a>
-            <a href="{% url 'feed:meu_mural' %}" class="btn-hero">Mural</a>
-            <a href="{% url 'accounts:conexoes' %}" class="btn-hero">Conexões</a>
-          </div>
-          {% endif %}
+          <nav class="mt-4 flex flex-wrap items-center gap-2" aria-label="{% trans 'Seções do perfil' %}">
+            <a
+              href="{% url 'accounts:perfil_portfolio' %}"
+              class="btn-hero"
+              data-perfil-nav
+              data-perfil-section="portfolio"
+              data-perfil-url="{% url 'accounts:perfil_portfolio' %}"
+              data-perfil-default="true"
+              aria-controls="perfil-content"
+            >
+              {% trans "Portfólio" %}
+            </a>
+            <a
+              href="{% url 'accounts:perfil_mural' %}"
+              class="btn-hero"
+              data-perfil-nav
+              data-perfil-section="mural"
+              data-perfil-url="{% url 'accounts:perfil_mural' %}"
+              aria-controls="perfil-content"
+            >
+              {% trans "Mural" %}
+            </a>
+            <a
+              href="{% url 'accounts:perfil_info_partial' %}"
+              class="btn-hero"
+              data-perfil-nav
+              data-perfil-section="info"
+              data-perfil-url="{% url 'accounts:perfil_info_partial' %}"
+              aria-controls="perfil-content"
+            >
+              {% trans "Informações" %}
+            </a>
+            <a
+              href="{% url 'accounts:perfil_nucleos' %}"
+              class="btn-hero"
+              data-perfil-nav
+              data-perfil-section="nucleos"
+              data-perfil-url="{% url 'accounts:perfil_nucleos' %}"
+              aria-controls="perfil-content"
+            >
+              {% trans "Núcleos" %}
+            </a>
+            <a
+              href="{% url 'accounts:perfil_eventos' %}"
+              class="btn-hero"
+              data-perfil-nav
+              data-perfil-section="eventos"
+              data-perfil-url="{% url 'accounts:perfil_eventos' %}"
+              aria-controls="perfil-content"
+            >
+              {% trans "Eventos" %}
+            </a>
+            <a
+              href="{% url 'accounts:perfil_conexoes_partial' %}"
+              class="btn-hero"
+              data-perfil-nav
+              data-perfil-section="conexoes"
+              data-perfil-url="{% url 'accounts:perfil_conexoes_partial' %}"
+              aria-controls="perfil-content"
+            >
+              {% trans "Conexões" %}
+            </a>
+          </nav>
         </div>
 
       </div>


### PR DESCRIPTION
## Summary
- wrap private and public profile pages with a dynamic `#perfil-content` container and load the initial section via the new partial endpoint
- add `perfil_section` view, routing, and a connections dashboard partial to serve portfolio, mural, info, núcleos, eventos, and conexões snippets
- wire hero profile navigation and the profile JavaScript to fetch partials for each section lazily

## Testing
- pytest tests/accounts/test_perfil_publico.py *(fails: coverage threshold 90% not reached; total coverage ~8%)*

------
https://chatgpt.com/codex/tasks/task_e_68c987c2b6c88325a010f519af0caf2b