### PR TITLE
Load perfil navigation script on profile templates

### DIFF
--- a/accounts/templates/perfil/perfil.html
+++ b/accounts/templates/perfil/perfil.html
@@ -4,6 +4,7 @@
 {% block hero %}
   {% include "_components/hero_profile.html" with is_owner=is_owner profile=profile %}
 {% endblock %}
+
 {% block content %}
 
 <div class="card">
@@ -27,5 +28,10 @@
     </section>
   </div>
 </div>
+{% endblock %}
+
+{% block scripts %}
+  {{ block.super }}
+  <script type="module" src="{% static 'perfil/js/perfil.js' %}"></script>
 {% endblock %}
 

--- a/accounts/templates/perfil/publico.html
+++ b/accounts/templates/perfil/publico.html
@@ -28,3 +28,8 @@
 
 {% endblock %}
 
+{% block scripts %}
+  {{ block.super }}
+  <script type="module" src="{% static 'perfil/js/perfil.js' %}"></script>
+{% endblock %}
+


### PR DESCRIPTION
## Summary
- include the perfil navigation module in the owner profile template
- load the same script for the public profile view so navigation can fetch partials dynamically

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c9a075fe948325902a95ba23397450