### PR TITLE
Handle missing perfil initializers gracefully

### DIFF
--- a/accounts/static/perfil/js/perfil.js
+++ b/accounts/static/perfil/js/perfil.js
@@ -4,32 +4,33 @@ document.addEventListener("DOMContentLoaded", () => {
     // Initialize Matrix Code Rain Effect
     initMatrixRain()
 
-    // Initialize Forms
-    initForms()
-
     // Initialize Tabs
     initTabs()
 
     // Initialize Perfil navigation
     initPerfilNavigation()
 
-    // Initialize Modals
-    initModals()
+    // Initialize optional helpers when available
+    const optionalInitializers = [
+        "initForms",
+        "initModals",
+        "initAvatarUpload",
+        "initPasswordStrength",
+        "initConnectionActions",
+        "initAccountSettings",
+        "initEmpresaFormToggle",
+    ]
 
-    // Initialize Avatar Upload
-    initAvatarUpload()
-
-    // Initialize Password Strength
-    initPasswordStrength()
-
-    // Initialize Connection Actions
-    initConnectionActions()
-
-    // Initialize Account Settings
-    initAccountSettings()
-
-    // Initialize Company Form toggle
-    initEmpresaFormToggle()
+    optionalInitializers.forEach(name => {
+        const initializer = globalThis[name]
+        if (typeof initializer === "function") {
+            try {
+                initializer()
+            } catch (error) {
+                console.error(`Erro ao executar ${name}:`, error)
+            }
+        }
+    })
 })
 
 // REMOVIDO: initNavigation() para navegação controlada pelo Django


### PR DESCRIPTION
## Summary
- guard optional perfil helper initializers so missing globals no longer raise runtime ReferenceError
- preserve the matrix rain, tabs, and perfil navigation boot sequence while logging optional initializer failures

## Testing
- node --input-type=module <<'EOF'
  # jsdom-based navigation smoke test
  ...
  EOF

------
https://chatgpt.com/codex/tasks/task_e_68c9b0d26e608325974c79eeb7496855