### PR TITLE
Fix profile info bio context

### DIFF
--- a/accounts/templates/perfil/partials/detail_informacoes.html
+++ b/accounts/templates/perfil/partials/detail_informacoes.html
@@ -22,14 +22,12 @@
   </div>
 </dl>
 
-{% with user.biografia|default:user.bio as bio %}
-  {% if bio %}
-    <div class="mt-6">
-      <h3 class="text-sm font-semibold text-[var(--text-primary)]">{% trans "Bio" %}</h3>
-      <p class="mt-2 text-sm text-[var(--text-primary)] whitespace-pre-line">{{ bio }}</p>
-    </div>
-  {% endif %}
-{% endwith %}
+{% if bio %}
+  <div class="mt-6">
+    <h3 class="text-sm font-semibold text-[var(--text-primary)]">{% trans "Bio" %}</h3>
+    <p class="mt-2 text-sm text-[var(--text-primary)] whitespace-pre-line">{{ bio }}</p>
+  </div>
+{% endif %}
 
 {% with user.redes_sociais as redes %}
   {% if redes %}

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -241,7 +241,13 @@ def perfil_section(request, section):
 
     elif section == "info":
         if is_owner:
-            context["user"] = profile
+            bio = getattr(profile, "biografia", "") or getattr(profile, "bio", "")
+            context.update(
+                {
+                    "user": profile,
+                    "bio": bio,
+                }
+            )
             template = "perfil/partials/detail_informacoes.html"
         else:
             template = "perfil/partials/publico_informacoes.html"

--- a/tests/accounts/test_views_perfil.py
+++ b/tests/accounts/test_views_perfil.py
@@ -1,0 +1,58 @@
+import pytest
+from django.test.utils import override_settings
+from django.urls import reverse
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture(autouse=True)
+def _use_project_urls():
+    with override_settings(ROOT_URLCONF="Hubx.urls"):
+        yield
+
+
+def _login_and_get_info_partial(client, user, params=None):
+    client.force_login(user)
+    url = reverse("accounts:perfil_info_partial")
+    params = params or {}
+    return client.get(url, params)
+
+
+def test_perfil_info_partial_renders_biografia(client, django_user_model):
+    user = django_user_model.objects.create_user(
+        email="owner@example.com",
+        username="owner",
+        password="pass123",
+    )
+    user.biografia = "Minha bio"
+    user.save(update_fields=["biografia"])
+
+    response = _login_and_get_info_partial(client, user)
+
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "Minha bio" in content
+
+
+def test_perfil_info_partial_falls_back_to_legacy_bio(client, django_user_model, monkeypatch):
+    user = django_user_model.objects.create_user(
+        email="legacy@example.com",
+        username="legacy",
+        password="pass123",
+    )
+    user.biografia = ""
+    user.save(update_fields=["biografia"])
+
+    monkeypatch.setattr(
+        django_user_model,
+        "bio",
+        property(lambda self: "Bio antiga" if self.pk == user.pk else ""),
+        raising=False,
+    )
+
+    response = _login_and_get_info_partial(client, user)
+
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "Bio antiga" in content
+


### PR DESCRIPTION
## Summary
- add a safe bio value to the info section context for profile owners
- render the profile bio section using the context variable instead of filters
- cover the owner info partial with tests, including legacy `bio` fallback

## Testing
- PYTEST_ADDOPTS="--no-cov" pytest tests/accounts/test_views_perfil.py

------
https://chatgpt.com/codex/tasks/task_e_68c9c09168708325ba75728a4ddf0cb7