### PR TITLE
Handle profile section redirects for non-HTMX requests

### DIFF
--- a/accounts/templates/perfil/perfil.html
+++ b/accounts/templates/perfil/perfil.html
@@ -12,8 +12,8 @@
     <section
       id="perfil-content"
       class="space-y-6"
-      data-perfil-default-url="{% url 'accounts:perfil_portfolio' %}"
-      data-perfil-default-section="portfolio"
+      data-perfil-default-url="{{ perfil_default_url }}"
+      data-perfil-default-section="{{ perfil_default_section }}"
       data-perfil-mode="{% if is_owner %}owner{% else %}public{% endif %}"
       data-perfil-username="{{ profile.username }}"
       data-perfil-public-id="{{ profile.public_id }}"

--- a/accounts/templates/perfil/publico.html
+++ b/accounts/templates/perfil/publico.html
@@ -11,8 +11,8 @@
   <section
     id="perfil-content"
     class="space-y-6"
-    data-perfil-default-url="{% url 'accounts:perfil_portfolio' %}"
-    data-perfil-default-section="portfolio"
+    data-perfil-default-url="{{ perfil_default_url }}"
+    data-perfil-default-section="{{ perfil_default_section }}"
     data-perfil-mode="{% if is_owner %}owner{% else %}public{% endif %}"
     data-perfil-username="{{ perfil.username }}"
     data-perfil-public-id="{{ perfil.public_id }}"


### PR DESCRIPTION
## Summary
- add helpers to detect HTMX/AJAX requests and compute default profile section URLs
- redirect non-HTMX calls to the perfil section endpoints back to the full profile while preserving section parameters
- read the computed defaults in the perfil templates so the correct section partial loads on page render

## Testing
- pytest accounts -q *(fails: ModuleNotFoundError: No module named 'silk')*

------
https://chatgpt.com/codex/tasks/task_e_68c9c45b1c748325b720d016c9ccda00