### PR TITLE
Add borders to profile information fields

### DIFF
--- a/accounts/templates/perfil/partials/detail_informacoes.html
+++ b/accounts/templates/perfil/partials/detail_informacoes.html
@@ -1,22 +1,22 @@
 {% load i18n %}
 <dl class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6 text-sm">
-  <div>
+  <div class="flex flex-col gap-1 rounded-lg border border-[var(--border)] px-3 py-2">
     <dt class="text-[var(--text-secondary)]">{% trans "E-mail" %}</dt>
     <dd class="font-medium text-[var(--text-primary)]">{{ user.email }}</dd>
   </div>
-  <div>
+  <div class="flex flex-col gap-1 rounded-lg border border-[var(--border)] px-3 py-2">
     <dt class="text-[var(--text-secondary)]">{% trans "Telefone" %}</dt>
     <dd class="font-medium text-[var(--text-primary)]">{{ user.phone_number }}</dd>
   </div>
-  <div>
+  <div class="flex flex-col gap-1 rounded-lg border border-[var(--border)] px-3 py-2">
     <dt class="text-[var(--text-secondary)]">{% trans "Endereço" %}</dt>
     <dd class="font-medium text-[var(--text-primary)]">{{ user.endereco }}</dd>
   </div>
-  <div>
+  <div class="flex flex-col gap-1 rounded-lg border border-[var(--border)] px-3 py-2">
     <dt class="text-[var(--text-secondary)]">{% trans "Cidade / Estado" %}</dt>
     <dd class="font-medium text-[var(--text-primary)]">{{ user.cidade }} - {{ user.estado }}</dd>
   </div>
-  <div>
+  <div class="flex flex-col gap-1 rounded-lg border border-[var(--border)] px-3 py-2">
     <dt class="text-[var(--text-secondary)]">{% trans "CEP" %}</dt>
     <dd class="font-medium text-[var(--text-primary)]">{{ user.cep }}</dd>
   </div>


### PR DESCRIPTION
## Summary
- apply the same flex and border utilities used by social network links to each profile information item
- ensure the existing typography for definition terms and descriptions remains unchanged

## Testing
- python manage.py runserver 0.0.0.0:8000 *(fails: ModuleNotFoundError: No module named 'silk')*

------
https://chatgpt.com/codex/tasks/task_e_68c9c9d0239c832587913fe6de7f4a11