### PR TITLE
Atualiza contato do herói para link do WhatsApp

### DIFF
--- a/templates/_components/hero_profile.html
+++ b/templates/_components/hero_profile.html
@@ -26,25 +26,20 @@
             </h2>
           </div>
 
-          <!-- Linha 2: @usuario, email e fone -->
+          <!-- Linha 2: @usuario e WhatsApp -->
           <div class="mt-3 flex flex-wrap items-center gap-2">
             <span class="inline-block rounded-lg px-2 py-0.5 bg-black/60 text-white/90 text-sm">
               @{{ profile.username }}
             </span>
 
-            <a href="mailto:{{ profile.email }}" class="inline-flex items-center gap-2 rounded-lg px-2.5 py-1 bg-black/60 text-white hover:bg-black/70 transition break-all">
-              <i class="fa-solid fa-envelope text-white/90"></i>
-              <span class="text-sm md:text-base">{{ profile.email|default:"-" }}</span>
-            </a>
-
-            {% if profile.phone_number %}
-            <a href="tel:{{ profile.phone_number }}" class="inline-flex items-center gap-2 rounded-lg px-2.5 py-1 bg-black/60 text-white hover:bg-black/70 transition">
-              <i class="fa-solid fa-phone text-white/90"></i>
-              <span class="text-sm md:text-base">{{ profile.phone_number.as_national }}</span>
+            {% if profile.whatsapp %}
+            <a href="https://wa.me/{{ profile.whatsapp|cut:"+" }}" class="inline-flex items-center gap-2 rounded-lg px-2.5 py-1 bg-black/60 text-white hover:bg-black/70 transition">
+              <i class="fa-brands fa-whatsapp text-white/90"></i>
+              <span class="text-sm md:text-base">{{ profile.whatsapp }}</span>
             </a>
             {% else %}
             <span class="inline-flex items-center gap-2 rounded-lg px-2.5 py-1 bg-black/60 text-white">
-              <i class="fa-solid fa-phone text-white/90"></i>
+              <i class="fa-brands fa-whatsapp text-white/90"></i>
               <span class="text-sm md:text-base">-</span>
             </span>
             {% endif %}


### PR DESCRIPTION
## Summary
- substitui o contato do herói para exibir um link do WhatsApp quando disponível
- mantém fallback com ícone e hífen quando o número não está cadastrado

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c9d0cde7c48325b54823fdbf7a5148