### PR TITLE
Use lucide tag in profile hero contact icons

### DIFF
--- a/templates/_components/hero_profile.html
+++ b/templates/_components/hero_profile.html
@@ -37,11 +37,11 @@
           <a href="https://wa.me/{{ profile.whatsapp|cut:"+" }}"
             class="inline-flex items-center hover:scale-110 transition"
             aria-label="WhatsApp">
-            {% lucide_icon "whatsapp" class="h-8 w-8 text-green-500" %}
+            {% lucide "whatsapp" class="h-8 w-8 text-green-500" %}
           </a>
           {% else %}
           <span class="inline-flex items-center" aria-label="WhatsApp indisponível">
-            {% lucide_icon "whatsapp" class="h-8 w-8 text-gray-400" %}
+            {% lucide "whatsapp" class="h-8 w-8 text-gray-400" %}
           </span>
           {% endif %}
 


### PR DESCRIPTION
## Summary
- replace the deprecated `{% lucide_icon %}` usage with `{% lucide %}` in the profile hero component so the WhatsApp contact buttons render correctly

## Testing
- python manage.py shell -c "from django.template.loader import get_template; get_template('_components/hero_profile.html')" *(fails: ModuleNotFoundError: No module named 'silk')*


------
https://chatgpt.com/codex/tasks/task_e_68c9e4f685808325a3dd2bcfbd900654