### PR TITLE
Render social media icons in hero profile

### DIFF
--- a/templates/_components/hero_profile.html
+++ b/templates/_components/hero_profile.html
@@ -33,6 +33,24 @@
               @{{ profile.username }}
             </span>
 
+            {% with redes=profile.redes_sociais %}
+              {% if redes %}
+                {% for rede, url in redes.items %}
+                  {% if url %}
+                    <a
+                      href="{{ url }}"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      aria-label="{{ rede|capfirst }}"
+                      class="inline-flex items-center hover:scale-110 transition"
+                    >
+                      {% lucide rede class="h-6 w-6 text-white hover:text-white/90" %}
+                    </a>
+                  {% endif %}
+                {% endfor %}
+              {% endif %}
+            {% endwith %}
+
           {% if profile.whatsapp %}
           <a href="https://wa.me/{{ profile.whatsapp|cut:"+" }}"
             class="inline-flex items-center hover:scale-110 transition"


### PR DESCRIPTION
## Summary
- render dynamic social media icons ahead of the WhatsApp control in the hero profile component
- open social links in new tabs with accessible labels and consistent hover styling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9eec573e083259dc0ab76b03e7e9c