### PR TITLE
Add corporate data fields to profile details

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -75,6 +75,8 @@ class CustomUserCreationForm(UserCreationForm):
 
     def save(self, commit: bool = True) -> User:
         user = super().save(commit=False)
+        user.cnpj = self.cleaned_data.get("cnpj")
+        user.razao_social = self.cleaned_data.get("razao_social")
         user.is_active = False
         user.email_confirmed = False
         if commit:

--- a/accounts/templates/perfil/partials/detail_informacoes.html
+++ b/accounts/templates/perfil/partials/detail_informacoes.html
@@ -16,10 +16,22 @@
     <dt class="text-[var(--text-secondary)]">{% trans "Telefone" %}</dt>
     <dd class="font-medium text-[var(--text-primary)]">{{ user.phone_number }}</dd>
   </div>
-    <div class="flex flex-col gap-1 rounded-lg border border-[var(--border)] px-3 py-2">
+  <div class="flex flex-col gap-1 rounded-lg border border-[var(--border)] px-3 py-2">
     <dt class="text-[var(--text-secondary)]">{% trans "E-mail" %}</dt>
     <dd class="font-medium text-[var(--text-primary)]">{{ user.email }}</dd>
   </div>
+  {% if user.razao_social %}
+    <div class="flex flex-col gap-1 rounded-lg border border-[var(--border)] px-3 py-2">
+      <dt class="text-[var(--text-secondary)]">{% trans "Razão social" %}</dt>
+      <dd class="font-medium text-[var(--text-primary)]">{{ user.razao_social }}</dd>
+    </div>
+  {% endif %}
+  {% if user.cnpj %}
+    <div class="flex flex-col gap-1 rounded-lg border border-[var(--border)] px-3 py-2">
+      <dt class="text-[var(--text-secondary)]">{% trans "CNPJ" %}</dt>
+      <dd class="font-medium text-[var(--text-primary)]">{{ user.cnpj }}</dd>
+    </div>
+  {% endif %}
 </dl>
 
 {% if bio %}

--- a/tests/accounts/test_user_cnpj_fields.py
+++ b/tests/accounts/test_user_cnpj_fields.py
@@ -1,4 +1,5 @@
 import pytest
+
 from django.contrib.auth import get_user_model
 
 from accounts.forms import CustomUserCreationForm, InformacoesPessoaisForm


### PR DESCRIPTION
## Summary
- add conditional cards for the user's corporate name and CNPJ on the profile information page
- ensure CustomUserCreationForm persists corporate identifiers when saving new accounts

## Testing
- pytest -o addopts='-ra' tests/accounts/test_user_cnpj_fields.py

------
https://chatgpt.com/codex/tasks/task_e_68caa51632cc8325a543181b3c31a090