### PR TITLE
Reintroduce profile nav class variables

### DIFF
--- a/templates/_components/perfil_nav.html
+++ b/templates/_components/perfil_nav.html
@@ -1,5 +1,9 @@
 {% load i18n %}
-{% with default_section=perfil_default_section|default:"portfolio" base_classes="inline-flex items-center gap-2 rounded-full border border-[var(--border)] bg-[var(--surface-secondary)] px-4 py-2 text-sm font-medium text-[var(--text-secondary)] transition-colors hover:bg-[var(--surface-tertiary)] hover:text-[var(--text-primary)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)] focus-visible:ring-offset-2" active_classes="is-active border-transparent bg-[var(--primary)] text-[var(--text-inverse)] shadow-sm" %}
+{% with
+  default_section=perfil_default_section|default:"portfolio"
+  base_classes="inline-flex items-center gap-2 rounded-full border border-[var(--border)] bg-[var(--surface-secondary)] px-4 py-2 text-sm font-medium text-[var(--text-secondary)] transition-colors hover:bg-[var(--surface-tertiary)] hover:text-[var(--text-primary)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)] focus-visible:ring-offset-2"
+  active_classes="is-active border-transparent bg-[var(--primary)] text-[var(--text-inverse)] shadow-sm"
+%}
 <nav class="mb-6" aria-label="{% trans 'Seções do perfil' %}">
   <ul class="flex flex-wrap gap-2">
     <li>


### PR DESCRIPTION
## Summary
- restore the `{% with %}` block in the shared perfil navigation component so the base and active pill classes are defined once
- keep each profile navigation link interpolating the shared class variables for consistent styling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cac634dc2483259696b73182199e45