### PR TITLE
Ajusta sincronização de classes ativas no menu de perfil

### DIFF
--- a/accounts/static/perfil/js/perfil.js
+++ b/accounts/static/perfil/js/perfil.js
@@ -126,13 +126,24 @@ function initPerfilNavigation() {
 
     const setActive = link => {
         activeLink = link || null
-        const activeTextClass = 'text-[var(--text-inverse)]'
-        const inactiveTextClass = 'text-[var(--text-secondary)]'
+        const activeClasses = [
+            'is-active',
+            'border-transparent',
+            'bg-[var(--primary)]',
+            'text-[var(--text-inverse)]',
+            'shadow-sm',
+        ]
+        const inactiveClasses = ['text-[var(--text-secondary)]']
+
         navLinks.forEach(item => {
             const isActive = item === link
-            item.classList.toggle('is-active', isActive)
-            item.classList.toggle(activeTextClass, isActive)
-            item.classList.toggle(inactiveTextClass, !isActive)
+            activeClasses.forEach(className => {
+                item.classList.toggle(className, isActive)
+            })
+            inactiveClasses.forEach(className => {
+                item.classList.toggle(className, !isActive)
+            })
+
             if (isActive) {
                 item.setAttribute('aria-current', 'page')
             } else {


### PR DESCRIPTION
## Summary
- sincroniza as classes adicionadas/removidas em `setActive` com o conjunto definido no componente de navegação de perfil
- garante que a aba ativa mantenha fundo primário e as demais retornem ao estilo neutro

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cadd7fb0508325b7e2e6395443d748