### PR TITLE
Add hero action for Núcleos list

### DIFF
--- a/nucleos/templates/nucleos/hero_actions_nucleo.html
+++ b/nucleos/templates/nucleos/hero_actions_nucleo.html
@@ -1,0 +1,9 @@
+{% load i18n lucide_icons %}
+<div class="flex gap-2">
+  {% if request.user.user_type == 'admin' %}
+  <a href="{% url 'nucleos:create' %}" class="btn btn-primary" aria-label="{% trans 'Criar novo núcleo' %}">
+    {% lucide 'circle-plus' class='w-4 h-4' %}
+    {% trans 'Novo Núcleo' %}
+  </a>
+  {% endif %}
+</div>

--- a/nucleos/templates/nucleos/nucleo_list.html
+++ b/nucleos/templates/nucleos/nucleo_list.html
@@ -4,7 +4,7 @@
 {% block title %}{% trans "Núcleos" %}{% endblock %}
 
 {% block hero %}
-  {% include '_components/hero.html' with title=_('Núcleos') %}
+  {% include '_components/hero.html' with title=_('Núcleos') action_template='nucleos/hero_actions_nucleo.html' %}
 {% endblock %}
 
 {% block content %}
@@ -13,9 +13,6 @@
       {% include '_components/search_form.html' with q=request.GET.q %}
       {% if request.user.user_type != 'admin' %}
       <a href="{% url 'nucleos:meus' %}" class="btn btn-secondary text-sm" aria-label="{% trans 'Ver meus núcleos' %}">{% trans 'Meus Núcleos' %}</a>
-      {% endif %}
-      {% if request.user.user_type == 'admin' %}
-      <a href="{% url 'nucleos:create' %}" class="btn btn-primary" aria-label="{% trans 'Criar novo núcleo' %}">{% trans 'Novo' %}</a>
       {% endif %}
     </div>
     <div class="card-body">


### PR DESCRIPTION
## Summary
- add a hero action template for Núcleos with a Novo Núcleo button for administrators
- connect the new hero action to the Núcleos list page and remove the duplicate in-page button

## Testing
- not run (templates change)


------
https://chatgpt.com/codex/tasks/task_e_68cb0985e3408325843ae17db378183f