### PR TITLE
Prioritize display name in hero and templates

### DIFF
--- a/accounts/models.py
+++ b/accounts/models.py
@@ -253,6 +253,46 @@ class User(AbstractUser, TimeStampedModel, SoftDeleteModel):
                 pass
         return "https://via.placeholder.com/160"
 
+    def get_contact_name(self) -> str:
+        """Nome utilizado para contato (first_name/last_name)."""
+
+        parts: list[str] = []
+        for part in (self.first_name, self.last_name):
+            if part:
+                cleaned = part.strip()
+                if cleaned:
+                    parts.append(cleaned)
+        return " ".join(parts)
+
+    @property
+    def contact_name(self) -> str:
+        return self.get_contact_name()
+
+    def get_display_name(self) -> str:
+        """Nome preferencial exibido para o usuário."""
+
+        candidates = (
+            self.nome_fantasia,
+            self.get_contact_name(),
+            self.username,
+            self.email,
+        )
+        for value in candidates:
+            if not value:
+                continue
+            if isinstance(value, str):
+                value = value.strip()
+            if value:
+                return str(value)
+        return ""
+
+    @property
+    def display_name(self) -> str:
+        return self.get_display_name()
+
+    def get_full_name(self) -> str:  # type: ignore[override]
+        return self.get_display_name()
+
     # Relacionamentos sociais
     connections = models.ManyToManyField("self", blank=True)
     followers = models.ManyToManyField(

--- a/accounts/templates/perfil/partials/conexoes_minhas.html
+++ b/accounts/templates/perfil/partials/conexoes_minhas.html
@@ -18,14 +18,14 @@
       <div class="card-body flex items-center justify-between">
       <div class="flex items-center gap-3">
         {% if connection.avatar %}
-          <img src="{{ connection.avatar.url }}" alt="{{ connection.username }}" class="w-10 h-10 rounded-full object-cover" loading="lazy" />
+          <img src="{{ connection.avatar.url }}" alt="{{ connection.display_name|default:connection.username }}" class="w-10 h-10 rounded-full object-cover" loading="lazy" />
         {% else %}
-          <div class="w-10 h-10 rounded-full bg-[var(--bg-tertiary)] flex items-center justify-center text-sm font-semibold text-[var(--text-secondary)]" role="img" aria-label="{{ connection.username }}">
+          <div class="w-10 h-10 rounded-full bg-[var(--bg-tertiary)] flex items-center justify-center text-sm font-semibold text-[var(--text-secondary)]" role="img" aria-label="{{ connection.display_name|default:connection.username }}">
             {{ connection.username|first|upper }}
           </div>
         {% endif %}
         <div>
-          <p class="font-medium">{{ connection.get_full_name }}</p>
+          <p class="font-medium">{{ connection.display_name }}</p>
           <p class="text-sm text-[var(--text-secondary)]">@{{ connection.username }}</p>
         </div>
       </div>

--- a/accounts/templates/perfil/partials/conexoes_solicitacoes.html
+++ b/accounts/templates/perfil/partials/conexoes_solicitacoes.html
@@ -5,14 +5,14 @@
     <div class="card-body flex items-start justify-between">
     <div class="flex items-center gap-3">
       {% if solicitante.avatar %}
-        <img src="{{ solicitante.avatar.url }}" alt="{{ solicitante.username }}" class="w-10 h-10 rounded-full object-cover" loading="lazy" />
+        <img src="{{ solicitante.avatar.url }}" alt="{{ solicitante.display_name|default:solicitante.username }}" class="w-10 h-10 rounded-full object-cover" loading="lazy" />
       {% else %}
-        <div class="w-10 h-10 rounded-full bg-[var(--bg-tertiary)] flex items-center justify-center text-sm font-semibold text-[var(--text-secondary)]" role="img" aria-label="{{ solicitante.username }}">
+        <div class="w-10 h-10 rounded-full bg-[var(--bg-tertiary)] flex items-center justify-center text-sm font-semibold text-[var(--text-secondary)]" role="img" aria-label="{{ solicitante.display_name|default:solicitante.username }}">
           {{ solicitante.username|first|upper }}
         </div>
       {% endif %}
       <div>
-        <p class="font-medium">{{ solicitante.get_full_name }}</p>
+        <p class="font-medium">{{ solicitante.display_name }}</p>
         <p class="text-sm text-[var(--text-secondary)]">@{{ solicitante.username }}</p>
       </div>
     </div>

--- a/accounts/templates/perfil/partials/publico_informacoes.html
+++ b/accounts/templates/perfil/partials/publico_informacoes.html
@@ -1,13 +1,31 @@
 {% load i18n %}
 <dl class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6 text-sm">
-  <div>
-    <dt class="text-[var(--text-secondary)]">{% trans "Nome completo" %}</dt>
-    <dd class="font-medium text-[var(--text-primary)]">{{ profile.get_full_name|default:profile.username }}</dd>
-  </div>
-  <div>
-    <dt class="text-[var(--text-secondary)]">{% trans "Usuário" %}</dt>
-    <dd class="font-medium text-[var(--text-primary)]">@{{ profile.username }}</dd>
-  </div>
+  {% with fantasia=profile.nome_fantasia contact=profile.contact_name %}
+    {% if fantasia %}
+      <div>
+        <dt class="text-[var(--text-secondary)]">{% trans "Nome fantasia" %}</dt>
+        <dd class="font-medium text-[var(--text-primary)]">{{ fantasia }}</dd>
+      </div>
+    {% endif %}
+    {% if contact %}
+      <div>
+        <dt class="text-[var(--text-secondary)]">{% trans "Contato principal" %}</dt>
+        <dd class="font-medium text-[var(--text-primary)]">{{ contact }}</dd>
+      </div>
+    {% endif %}
+    {% if not fantasia and not contact %}
+      <div>
+        <dt class="text-[var(--text-secondary)]">{% trans "Usuário" %}</dt>
+        <dd class="font-medium text-[var(--text-primary)]">@{{ profile.username }}</dd>
+      </div>
+    {% endif %}
+    {% if fantasia or contact %}
+      <div>
+        <dt class="text-[var(--text-secondary)]">{% trans "Usuário" %}</dt>
+        <dd class="font-medium text-[var(--text-primary)]">@{{ profile.username }}</dd>
+      </div>
+    {% endif %}
+  {% endwith %}
   {% if profile.email %}
   <div>
     <dt class="text-[var(--text-secondary)]">{% trans "E-mail" %}</dt>

--- a/accounts/templates/perfil/perfil.html
+++ b/accounts/templates/perfil/perfil.html
@@ -2,7 +2,7 @@
 {% load i18n static %}
 
 {% block hero %}
-  {% include "_components/hero_profile.html" with is_owner=is_owner profile=profile %}
+  {% include "_components/hero_profile.html" with is_owner=is_owner profile=profile hero_title=hero_title hero_subtitle=hero_subtitle %}
 {% endblock %}
 
 {% block content %}

--- a/accounts/templates/perfil/publico.html
+++ b/accounts/templates/perfil/publico.html
@@ -1,9 +1,9 @@
 {% extends 'base.html' %}
 {% load static i18n %}
-{% block title %}{% with perfil as profile %}{{ profile.get_full_name|default:profile.username }} | Hubx{% endwith %}{% endblock %}
+{% block title %}{{ perfil.display_name }} | Hubx{% endblock %}
 
 {% block hero %}
-  {% include '_components/hero_profile.html' with profile=perfil is_owner=is_owner %}
+  {% include '_components/hero_profile.html' with profile=perfil is_owner=is_owner hero_title=hero_title hero_subtitle=hero_subtitle %}
 {% endblock %}
 
 {% block content %}

--- a/accounts/templates/register/nome.html
+++ b/accounts/templates/register/nome.html
@@ -24,14 +24,14 @@
     </div>
 
     <div class="mb-8 text-center">
-      <h1 class="mb-2 text-3xl font-bold text-[var(--text-primary)]">{% trans "Como podemos te chamar?" %}</h1>
-      <p class="text-[var(--text-secondary)]">{% trans "Digite seu nome completo" %}</p>
+      <h1 class="mb-2 text-3xl font-bold text-[var(--text-primary)]">{% trans "Quem será o contato principal?" %}</h1>
+      <p class="text-[var(--text-secondary)]">{% trans "Informe o nome da pessoa responsável pelo contato." %}</p>
     </div>
 
     <form id="nomeForm" method="post" action="{% url 'accounts:nome' %}" class="space-y-6">
       {% csrf_token %}
       <div>
-        {% include "_forms/field.html" with id="nome" name="nome" label=_("Nome Completo") placeholder=_("Nome completo") required=True autofocus=True describedby="nome_validation" %}
+        {% include "_forms/field.html" with id="nome" name="nome" label=_("Contato principal") placeholder=_("Nome do contato principal") required=True autofocus=True describedby="nome_validation" %}
         <div class="text-sm text-[var(--error)]" id="nome_validation"></div>
       </div>
 

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -150,6 +150,13 @@ def _portfolio_for(profile, viewer, limit: int = 6):
     return list(qs.select_related(owner_field).prefetch_related("tags").order_by("-created_at")[:limit])
 
 
+def _profile_hero_names(profile):
+    display_name = profile.display_name
+    contact_name = profile.contact_name
+    subtitle = contact_name if contact_name and contact_name != display_name else ""
+    return display_name, subtitle
+
+
 def _nucleos_for(profile):
     from nucleos.models import Nucleo
 
@@ -226,11 +233,13 @@ def perfil(request):
     inscricoes = _inscricoes_for(user)
 
     portfolio_recent = _portfolio_for(user, request.user, limit=6)
+    hero_title, hero_subtitle = _profile_hero_names(user)
 
     context = {
         "nucleos": nucleos,
         "inscricoes": inscricoes,
-        "hero_title": _("Perfil"),
+        "hero_title": hero_title,
+        "hero_subtitle": hero_subtitle,
         "profile": user,
         "is_owner": True,
         "portfolio_recent": portfolio_recent,
@@ -265,13 +274,14 @@ def perfil_publico(request, pk=None, public_id=None, username=None):
 
 
     portfolio_recent = _portfolio_for(perfil, request.user, limit=6)
+    hero_title, hero_subtitle = _profile_hero_names(perfil)
 
     context = {
         "perfil": perfil,
         "nucleos": nucleos,
         "inscricoes": inscricoes,
-        "hero_title": perfil.get_full_name() or perfil.username,
-        "hero_subtitle": f"@{perfil.username}",
+        "hero_title": hero_title,
+        "hero_subtitle": hero_subtitle,
         "is_owner": request.user == perfil,
         "portfolio_recent": portfolio_recent,
         "portfolio_form": None,

--- a/docs/accounts/registro_multietapas.md
+++ b/docs/accounts/registro_multietapas.md
@@ -7,7 +7,7 @@ usuário e, opcionalmente, o núcleo de destino.
 ## Etapas
 
 1. **Nome de usuário** – identificação única. Validar caracteres permitidos.
-2. **Nome completo** – texto livre obrigatório.
+2. **Contato principal** – nome da pessoa responsável pelo cadastro.
 3. **CPF** – deve ser válido e único (`RegexValidator`).
 4. **E‑mail** – usado para comunicação e confirmação. Deve ser único.
 5. **Senha** – validação de força com `validate_password`.

--- a/eventos/templates/eventos/detail.html
+++ b/eventos/templates/eventos/detail.html
@@ -104,14 +104,14 @@
                 <article class="card">
                   <div class="card-body flex items-center gap-4">
                     {% if inscrito.avatar %}
-                      <img src="{{ inscrito.avatar.url }}" alt="{{ inscrito.username }}" class="w-12 h-12 rounded-full object-cover" loading="lazy">
+                      <img src="{{ inscrito.avatar.url }}" alt="{{ inscrito.display_name|default:inscrito.username }}" class="w-12 h-12 rounded-full object-cover" loading="lazy">
                     {% else %}
-                      <div class="w-12 h-12 rounded-full bg-[var(--bg-tertiary)] flex items-center justify-center text-sm font-semibold" role="img" aria-label="{{ inscrito.username }}">
+                      <div class="w-12 h-12 rounded-full bg-[var(--bg-tertiary)] flex items-center justify-center text-sm font-semibold" role="img" aria-label="{{ inscrito.display_name|default:inscrito.username }}">
                         {{ inscrito.username|make_list|first|upper }}
                       </div>
                     {% endif %}
                     <div>
-                      <h4 class="text-sm font-medium">{{ inscrito.get_full_name|default:inscrito.username }}</h4>
+                      <h4 class="text-sm font-medium">{{ inscrito.display_name }}</h4>
                       <p class="text-xs">@{{ inscrito.username }}</p>
                     </div>
                   </div>

--- a/eventos/templates/eventos/update.html
+++ b/eventos/templates/eventos/update.html
@@ -58,7 +58,7 @@
         <article class="card">
           <div class="card-body flex items-center justify-between">
             <div>
-              <h3 class="text-sm font-medium text-[var(--text-primary)]">{{ inscrito.get_full_name|default:inscrito.username }}</h3>
+              <h3 class="text-sm font-medium text-[var(--text-primary)]">{{ inscrito.display_name }}</h3>
               <p class="text-xs text-[var(--text-secondary)]">{{ inscrito.email }}</p>
             </div>
             {% if user.user_type in ['admin', 'coordenador'] %}

--- a/feed/templates/feed/_comment.html
+++ b/feed/templates/feed/_comment.html
@@ -2,7 +2,7 @@
 {% if request.user.user_type != 'root' %}
 <li class="card" id="comment-{{ comment.id }}">
   <div class="card-body">
-  <p class="text-sm font-medium">{{ comment.user.get_full_name|default:comment.user.username }}</p>
+  <p class="text-sm font-medium">{{ comment.user.display_name }}</p>
   <p class="text-xs text-[var(--text-secondary)]">{{ comment.created_at|date:"SHORT_DATETIME_FORMAT" }}</p>
   <p class="text-sm text-[var(--text-primary)]">{{ comment.texto }}</p>
   <div class="flex gap-2">

--- a/feed/templates/feed/_grid.html
+++ b/feed/templates/feed/_grid.html
@@ -27,15 +27,15 @@
           <div class="flex items-center gap-3">
             <a href="{% url 'accounts:perfil_publico_uuid' post.autor.public_id %}" class="relative z-20 flex-shrink-0">
               {% if post.autor.avatar %}
-                <img src="{{ post.autor.avatar.url }}" alt="{{ post.autor.username }}" class="h-12 w-12 rounded-full border-2 border-[var(--bg-primary)] object-cover shadow-md transition duration-300 group-hover:scale-105" loading="lazy">
+                <img src="{{ post.autor.avatar.url }}" alt="{{ post.autor.display_name|default:post.autor.username }}" class="h-12 w-12 rounded-full border-2 border-[var(--bg-primary)] object-cover shadow-md transition duration-300 group-hover:scale-105" loading="lazy">
               {% else %}
-                <div class="flex h-12 w-12 items-center justify-center rounded-full border border-[var(--border)] bg-[var(--bg-tertiary)] text-lg font-semibold text-[var(--text-secondary)] shadow-inner" role="img" aria-label="{{ post.autor.username }}">
+                <div class="flex h-12 w-12 items-center justify-center rounded-full border border-[var(--border)] bg-[var(--bg-tertiary)] text-lg font-semibold text-[var(--text-secondary)] shadow-inner" role="img" aria-label="{{ post.autor.display_name|default:post.autor.username }}">
                   {{ post.autor.username|first|upper }}
                 </div>
               {% endif %}
             </a>
             <div class="min-w-0">
-              <p class="truncate text-sm font-semibold text-[var(--text-primary)]">{{ post.autor.get_full_name|default:post.autor.username }}</p>
+              <p class="truncate text-sm font-semibold text-[var(--text-primary)]">{{ post.autor.display_name }}</p>
               <time datetime="{{ post.created_at|date:'c' }}" class="mt-0.5 flex items-center gap-1 text-xs text-[var(--text-muted)]">
                 {% lucide 'clock' class='h-3.5 w-3.5' %}
                 {{ post.created_at|date:"SHORT_DATETIME_FORMAT" }}

--- a/feed/templates/feed/_post_list.html
+++ b/feed/templates/feed/_post_list.html
@@ -8,12 +8,12 @@
       <div class="card-body space-y-4">
 
       <div class="flex items-center gap-4">
-        <div class="w-10 h-10 rounded-full bg-[var(--bg-secondary)] flex items-center justify-center text-[var(--text-secondary)] font-bold" role="img" aria-label="{{ post.autor.username }}">
+        <div class="w-10 h-10 rounded-full bg-[var(--bg-secondary)] flex items-center justify-center text-[var(--text-secondary)] font-bold" role="img" aria-label="{{ post.autor.display_name|default:post.autor.username }}">
           {{ post.autor.username|first|upper }}
         </div>
         <div>
           <p class="text-sm font-medium text-[var(--text-primary)]">
-            {{ post.autor.get_full_name|default:post.autor.username }}
+            {{ post.autor.display_name }}
           </p>
           <p class="text-xs text-[var(--text-secondary)]">
             {{ post.created_at|date:"SHORT_DATETIME_FORMAT" }}

--- a/feed/templates/feed/post_detail.html
+++ b/feed/templates/feed/post_detail.html
@@ -19,15 +19,15 @@
     <div class="card-body space-y-4">
     <div class="flex items-center gap-4">
       {% if post.autor.avatar %}
-        <img src="{{ post.autor.avatar.url }}" alt="{{ post.autor.username }}" class="w-10 h-10 rounded-full object-cover" loading="lazy">
+        <img src="{{ post.autor.avatar.url }}" alt="{{ post.autor.display_name|default:post.autor.username }}" class="w-10 h-10 rounded-full object-cover" loading="lazy">
       {% else %}
-        <div class="w-10 h-10 rounded-full bg-[var(--bg-secondary)] flex items-center justify-center text-[var(--text-secondary)] font-bold" role="img" aria-label="{{ post.autor.username }}">
+        <div class="w-10 h-10 rounded-full bg-[var(--bg-secondary)] flex items-center justify-center text-[var(--text-secondary)] font-bold" role="img" aria-label="{{ post.autor.display_name|default:post.autor.username }}">
           {{ post.autor.username|first|upper }}
         </div>
       {% endif %}
       <div>
-        <p class="text-sm font-medium text-[var(--text-primary)]">{{ post.autor.get_full_name|default:post.autor.username }}</p>
-  <p class="text-xs text-[var(--text-muted)]">{{ post.created_at|date:"SHORT_DATETIME_FORMAT" }}</p>
+        <p class="text-sm font-medium text-[var(--text-primary)]">{{ post.autor.display_name }}</p>
+        <p class="text-xs text-[var(--text-muted)]">{{ post.created_at|date:"SHORT_DATETIME_FORMAT" }}</p>
       </div>
     </div>
 

--- a/notificacoes/templates/notificacoes/logs_rows.html
+++ b/notificacoes/templates/notificacoes/logs_rows.html
@@ -2,7 +2,7 @@
 {% for log in logs %}
   <tr>
     <td class="px-4 py-2">{{ log.data_envio|date:"SHORT_DATETIME_FORMAT" }}</td>
-    <td class="px-4 py-2">{{ log.user.get_full_name|default:log.user.username }}</td>
+    <td class="px-4 py-2">{{ log.user.display_name }}</td>
     <td class="px-4 py-2">{{ log.template.codigo }}</td>
     <td class="px-4 py-2">{{ log.get_canal_display }}</td>
     <td class="px-4 py-2">{{ log.get_status_display }}</td>

--- a/nucleos/templates/nucleos/detail.html
+++ b/nucleos/templates/nucleos/detail.html
@@ -63,7 +63,7 @@
           <tbody class="divide-y divide-[var(--border)]">
           {% for part in membros_pendentes %}
             <tr id="pendente-{{ part.id }}">
-              <td>{{ part.user.get_full_name|default:part.user.username }}</td>
+              <td>{{ part.user.display_name }}</td>
               <td>{{ part.data_solicitacao|date:'d/m/Y' }}</td>
               <td class="space-x-2">
                 <button class="btn btn-primary btn-sm" hx-post="{% url 'nucleos_api:nucleo-aprovar-membro' object.pk part.user.pk %}" hx-target="#pendente-{{ part.id }}" hx-swap="none" hx-on="htmx:afterRequest: this.closest('tr').remove()" hx-confirm="{% trans 'Confirmar aprovação?' %}" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>{% trans 'Aprovar' %}</button>
@@ -80,7 +80,7 @@
         <ul class="list-disc pl-5 text-sm text-[var(--text-secondary)]">
           {% for s in suplentes %}
             <li>
-              {{ s.usuario.get_full_name|default:s.usuario.username }} —
+              {{ s.usuario.display_name }} —
               {{ s.periodo_inicio|date:'d/m/Y' }} a {{ s.periodo_fim|date:'d/m/Y' }}
             </li>
           {% endfor %}

--- a/nucleos/templates/nucleos/partials/membro.html
+++ b/nucleos/templates/nucleos/partials/membro.html
@@ -3,13 +3,13 @@
   <div class="card-body flex flex-col gap-2">
     <div class="flex items-center gap-4">
       {% if part.user.avatar %}
-      <img src="{{ part.user.avatar.url }}" alt="{{ part.user.username }}" class="w-12 h-12 rounded-full object-cover" loading="lazy" />
+      <img src="{{ part.user.avatar.url }}" alt="{{ part.user.display_name|default:part.user.username }}" class="w-12 h-12 rounded-full object-cover" loading="lazy" />
       {% else %}
-      <div class="w-12 h-12 rounded-full bg-[var(--bg-tertiary)]"></div>
+      <div class="w-12 h-12 rounded-full bg-[var(--bg-tertiary)]" role="img" aria-label="{{ part.user.display_name|default:part.user.username }}"></div>
       {% endif %}
       <div>
         <a href="{% url 'accounts:perfil_publico_uuid' part.user.public_id %}" class="font-medium text-[var(--text-primary)]">
-          {{ part.user.get_full_name|default:part.user.username }}
+          {{ part.user.display_name }}
         </a>
         {% if part.papel == 'coordenador' %}
         <span class="text-sm text-[var(--text-secondary)]"> - {% trans 'Coordenador' %}</span>

--- a/nucleos/templates/nucleos/partials/membro_card.html
+++ b/nucleos/templates/nucleos/partials/membro_card.html
@@ -2,7 +2,7 @@
 {# Card de Membro do Núcleo, inspirado nos cards de associados #}
 <a href="{% url 'accounts:perfil_publico_uuid' part.user.public_id %}"
    class="group block focus:outline-none focus:ring-2 focus:ring-primary/40"
-   aria-label="{{ part.user.get_full_name|default:part.user.username }}">
+   aria-label="{{ part.user.display_name|default:part.user.username }}">
   <article class="card overflow-hidden" role="article">
     <header class="relative">
       {% if part.user.cover %}
@@ -13,10 +13,10 @@
       {% endif %}
       <div class="absolute -bottom-8 left-4">
         {% if part.user.avatar %}
-          <img src="{{ part.user.avatar.url }}" alt="{{ part.user.username }}"
+          <img src="{{ part.user.avatar.url }}" alt="{{ part.user.display_name|default:part.user.username }}"
                class="h-16 w-16 rounded-full ring-4 ring-[var(--bg-primary)] object-cover" loading="lazy" />
         {% else %}
-          <div class="h-16 w-16 rounded-full ring-4 ring-[var(--bg-primary)] bg-[var(--bg-tertiary)] flex items-center justify-center text-lg font-semibold text-[var(--text-primary)]" role="img" aria-label="{{ part.user.username }}">
+          <div class="h-16 w-16 rounded-full ring-4 ring-[var(--bg-primary)] bg-[var(--bg-tertiary)] flex items-center justify-center text-lg font-semibold text-[var(--text-primary)]" role="img" aria-label="{{ part.user.display_name|default:part.user.username }}">
             {{ part.user.username|first|upper }}
           </div>
         {% endif %}
@@ -24,7 +24,7 @@
     </header>
     <div class="card-body pt-10">
       <h3 class="text-base font-semibold text-[var(--text-primary)] group-hover:underline">
-        {{ part.user.get_full_name|default:part.user.username }}
+        {{ part.user.display_name }}
       </h3>
       <p class="text-sm text-[var(--text-muted)]">@{{ part.user.username }}</p>
       <dl class="mt-3 grid grid-cols-2 gap-2 text-xs text-[var(--text-tertiary)]">

--- a/organizacoes/templates/organizacoes/usuarios_modal.html
+++ b/organizacoes/templates/organizacoes/usuarios_modal.html
@@ -23,7 +23,7 @@
   <ul class="mt-4 space-y-1">
     {% for user in usuarios %}
       <li class="flex justify-between items-center">
-        {{ user.get_full_name|default:user.username }}
+        {{ user.display_name }}
         <button hx-delete="{{ api_url }}{{ user.id }}/" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}' hx-on="htmx:afterRequest: htmx.ajax('GET', '{{ refresh_url }}', '#usuarios-section');" class="btn btn-danger">{% trans 'Remover' %}</button>
       </li>
     {% empty %}

--- a/templates/_components/card_details_empresa.html
+++ b/templates/_components/card_details_empresa.html
@@ -8,7 +8,7 @@
     <dt class="text-[var(--text-muted)]">{% trans 'Proprietário' %}</dt>
     <dd class="font-medium">
       <span class="text-primary">
-        {{ empresa.usuario.get_full_name|default:empresa.usuario.username }}
+        {{ empresa.usuario.display_name }}
       </span>
     </dd>
   </div>

--- a/templates/_components/card_details_nucleo.html
+++ b/templates/_components/card_details_nucleo.html
@@ -8,7 +8,7 @@
     <dt class="text-[var(--text-secondary)]">{% trans 'Coordenador' %}</dt>
     <dd class="font-medium">
       {% with coord=nucleo.coordenadores.first %}
-        {% if coord %}{{ coord.get_full_name|default:coord.username }}{% else %}-{% endif %}
+        {% if coord %}{{ coord.display_name }}{% else %}-{% endif %}
       {% endwith %}
     </dd>
   </div>

--- a/templates/_components/card_usuario.html
+++ b/templates/_components/card_usuario.html
@@ -1,4 +1,4 @@
 {% load i18n %}
 {% url 'accounts:perfil_publico_uuid' user.public_id as profile_url %}
 {% trans 'Ver detalhes do usuário' as sr_label %}
-{% include '_partials/cards/base_card.html' with url=profile_url cover=user.cover avatar=user.avatar title=user.get_full_name|default:user.username details='_components/card_details_usuario.html' sr_label=sr_label %}
+{% include '_partials/cards/base_card.html' with url=profile_url cover=user.cover avatar=user.avatar title=user.display_name details='_components/card_details_usuario.html' sr_label=sr_label %}

--- a/templates/_components/hero_profile.html
+++ b/templates/_components/hero_profile.html
@@ -10,11 +10,11 @@
       <div class="h-full flex flex-col justify-end pb-4 md:pb-6">
         
         <div class="rounded-2xl p-4 md:p-5  ring-1 ring-white/10 shadow-2xl text-white w-full">
-          <!-- Linha 1: Avatar + Nome -->
+          {% with display_name=hero_title|default:profile.display_name subtitle=hero_subtitle %}
           <div class="flex items-center gap-4">
             <div class="h-20 w-20 md:h-24 md:w-24 rounded-full ring-4 ring-white/90 overflow-hidden bg-[var(--bg-primary)] shrink-0">
               {% if profile.avatar %}
-                <img src="{{ profile.avatar_url }}" alt="{{ profile.get_full_name|default:profile.username }}" class="h-full w-full object-cover" loading="lazy">
+                <img src="{{ profile.avatar_url }}" alt="{{ display_name|default:profile.username }}" class="h-full w-full object-cover" loading="lazy">
               {% else %}
                 <div class="h-full w-full grid place-items-center text-2xl font-semibold text-white/80">
                   {{ profile.get_initials|default:profile.username|slice:":2"|upper }}
@@ -22,14 +22,20 @@
               {% endif %}
             </div>
 
-            <h2 class="bg-black/40 text-2xl md:text-3xl font-semibold drop-shadow text-white">
-              {{ profile.get_full_name|default:profile.username }}
-              <div class=" rounded-lg px-2 py-0.5 text-white/90 text-sm">
-              @{{ profile.username }}
+            <div class="min-w-0 space-y-1">
+              <h2 class="bg-black/40 inline-block rounded-lg px-3 py-1 text-2xl md:text-3xl font-semibold drop-shadow text-white">
+                {{ display_name|default:profile.username }}
+              </h2>
+              {% if subtitle %}
+                <p class="text-sm text-white/90">{{ subtitle }}</p>
+              {% endif %}
+              <div class="inline-flex items-center gap-1 rounded-lg bg-white/15 px-2 py-0.5 text-xs font-medium text-white/90">
+                <span aria-hidden="true">@</span>{{ profile.username }}
               </div>
-            </h2>
+            </div>
 
           </div>
+          {% endwith %}
 
           <!-- Linha 2: @usuario e WhatsApp -->
           <div class="mt-3 flex flex-wrap items-center gap-2">

--- a/templates/_partials/cards/evento_card_details.html
+++ b/templates/_partials/cards/evento_card_details.html
@@ -10,7 +10,7 @@
   </div>
   <div>
     <dt class="text-[var(--text-secondary)]">{% trans 'Coordenador' %}</dt>
-    <dd class="font-medium">{{ evento.coordenador.get_full_name|default:evento.coordenador.username }}</dd>
+    <dd class="font-medium">{{ evento.coordenador.display_name }}</dd>
   </div>
   <div>
     <dt class="text-[var(--text-secondary)]">{% trans 'Status' %}</dt>

--- a/templates/_partials/organizacoes/usuarios_list.html
+++ b/templates/_partials/organizacoes/usuarios_list.html
@@ -2,7 +2,7 @@
 <h2 class="text-xl font-semibold text-[var(--text-primary)] mb-2">{% trans 'Membros' %} ({{ usuarios|length }})</h2>
 <ul class="list-disc pl-6 text-[var(--text-secondary)]">
   {% for user in usuarios %}
-    <li>{{ user.get_full_name|default:user.username }}</li>
+    <li>{{ user.display_name }}</li>
   {% empty %}
     <li class="list-none text-[var(--text-muted)]">{% trans 'Nenhum usuário associado.' %}</li>
   {% endfor %}


### PR DESCRIPTION
## Summary
- add User helpers to surface nome_fantasia/contact name and feed hero context with them
- refresh hero/profile templates plus feed, eventos, núcleos and cards to show the preferred display name and updated labels
- adjust onboarding copy and docs to call the contact field out explicitly

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'silk')*

------
https://chatgpt.com/codex/tasks/task_e_68cb09a933f0832594c72666c5138de3