### PR TITLE
Add contato field to profile detail template

### DIFF
--- a/accounts/templates/perfil/partials/detail_informacoes.html
+++ b/accounts/templates/perfil/partials/detail_informacoes.html
@@ -43,6 +43,12 @@
     <dt class="text-[var(--text-secondary)]">{% trans "Telefone" %}</dt>
     <dd class="font-medium text-[var(--text-primary)]">{{ user.phone_number }}</dd>
   </div>
+  {% if user.contato %}
+  <div class="flex flex-col gap-1 rounded-lg border border-[var(--border)] px-3 py-2">
+    <dt class="text-[var(--text-secondary)]">{% trans "Contato" %}</dt>
+    <dd class="font-medium text-[var(--text-primary)]">{{ user.contato }}</dd>
+  </div>
+  {% endif %}
   <div class="flex flex-col gap-1 rounded-lg border border-[var(--border)] px-3 py-2">
     <dt class="text-[var(--text-secondary)]">{% trans "E-mail" %}</dt>
     <dd class="font-medium text-[var(--text-primary)]">{{ user.email }}</dd>


### PR DESCRIPTION
## Summary
- display the user's contato field within the profile information list when available

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb26d2ac1483258edffc07212a2097