### PR TITLE
Handle empty phone number in profile info template

### DIFF
--- a/accounts/templates/perfil/partials/detail_informacoes.html
+++ b/accounts/templates/perfil/partials/detail_informacoes.html
@@ -40,10 +40,12 @@
   </div>
   {% endif %}
 
+  {% if user.phone_number %}
   <div class="flex flex-col gap-1 rounded-lg border border-[var(--border)] px-3 py-2">
     <dt class="text-[var(--text-secondary)]">{% trans "Telefone" %}</dt>
-    <dd class="font-medium text-[var(--text-primary)]">{{ user.phone_number }}</dd>
+    <dd class="font-medium text-[var(--text-primary)]">{{ user.phone_number.as_national }}</dd>
   </div>
+  {% endif %}
 
   <div class="flex flex-col gap-1 rounded-lg border border-[var(--border)] px-3 py-2">
     <dt class="text-[var(--text-secondary)]">{% trans "E-mail" %}</dt>


### PR DESCRIPTION
## Summary
- display the phone number in the profile details only when it exists
- render the phone number using the national format provided by django-phonenumber-field

## Testing
- not run (template-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cb2c9de7e0832593f4f128532813f5