### PR TITLE
Limit nucleos list grid to two columns on desktop

### DIFF
--- a/nucleos/templates/nucleos/nucleo_list.html
+++ b/nucleos/templates/nucleos/nucleo_list.html
@@ -21,7 +21,7 @@
         {% include "_partials/cards/total_card.html" with label=_('Membros (todos os núcleos)') valor=total_membros_org %}
 
       </div>
-      <div role="list" aria-label="{% trans 'Lista de núcleos' %}" class="card-grid">
+      <div role="list" aria-label="{% trans 'Lista de núcleos' %}" class="nucleos-grid">
         {% for nucleo in object_list %}
           {% include '_components/card_nucleo.html' with nucleo=nucleo %}
         {% empty %}

--- a/static/tailwind.css
+++ b/static/tailwind.css
@@ -1363,6 +1363,18 @@ a:focus {
   }
 }
 
+.nucleos-grid {
+  display: grid;
+  grid-template-columns: repeat(1, minmax(0, 1fr));
+  gap: 1.5rem;
+}
+
+@media (min-width: 1024px) {
+  .nucleos-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
 .card {
   border-radius: 0.75rem;
   border-width: 1px;


### PR DESCRIPTION
## Summary
- introduce a dedicated grid class for the Núcleos listing that stays single-column on small screens and caps at two columns on desktop
- switch the Núcleos list template to use the new grid class while keeping existing markup and semantics

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb2fb425ec832599478f6105cf4615