### PR TITLE
Adjust eventos list grid layout

### DIFF
--- a/eventos/templates/eventos/evento_list.html
+++ b/eventos/templates/eventos/evento_list.html
@@ -26,7 +26,7 @@
         {% include "_partials/cards/total_card.html" with label=_('Ativos') valor=total_eventos_ativos %}
         {% include "_partials/cards/total_card.html" with label=_('Realizados') valor=total_eventos_concluidos %}
       </div>
-      <div class="card-grid" role="list" aria-label="{% trans 'Lista de eventos' %}">
+      <div class="grid gap-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-2" role="list" aria-label="{% trans 'Lista de eventos' %}">
         {% for evento in eventos %}
           {% include '_components/card_evento.html' %}
         {% empty %}


### PR DESCRIPTION
## Summary
- enforce a responsive two-column grid for the eventos list so it no longer inherits the four-column card-grid layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb3234dfc8832593f812684dfb3c20