### PR TITLE
Add collapsible summary with icons to núcleos list

### DIFF
--- a/nucleos/templates/nucleos/nucleo_list.html
+++ b/nucleos/templates/nucleos/nucleo_list.html
@@ -16,11 +16,15 @@
       {% endif %}
     </div>
     <div class="card-body">
-      <div class="card-grid mb-6">
-        {% include "_partials/cards/total_card.html" with label=_('Núcleos') valor=total_nucleos %}
-        {% include "_partials/cards/total_card.html" with label=_('Membros (todos os núcleos)') valor=total_membros_org %}
-
-      </div>
+      <details class="card mb-6" open>
+        <summary class="cursor-pointer text-base font-semibold text-[var(--text-primary)]">
+          {% trans "Resumo" %}
+        </summary>
+        <div class="mt-4 card-grid">
+          {% include "_partials/cards/total_card.html" with label=_('Núcleos') valor=total_nucleos icon='network' %}
+          {% include "_partials/cards/total_card.html" with label=_('Membros (todos os núcleos)') valor=total_membros_org icon='users' %}
+        </div>
+      </details>
       <div role="list" aria-label="{% trans 'Lista de núcleos' %}" class="nucleos-grid">
         {% for nucleo in object_list %}
           {% include '_components/card_nucleo.html' with nucleo=nucleo %}

--- a/templates/_partials/cards/total_card.html
+++ b/templates/_partials/cards/total_card.html
@@ -1,7 +1,13 @@
+{% load lucide_icons %}
 {# Card de total #}
 <article class="card">
   <div class="card-body">
-    <div class="text-sm text-[var(--text-secondary)]">{{ label }}</div>
+    <div class="flex items-center gap-2 text-sm text-[var(--text-secondary)]">
+      {% if icon %}
+        {% lucide icon class="h-4 w-4 text-[var(--text-secondary)]" %}
+      {% endif %}
+      <span>{{ label }}</span>
+    </div>
     <div class="mt-1 text-2xl font-bold text-[var(--text-primary)]">{{ valor }}</div>
   </div>
 </article>


### PR DESCRIPTION
## Summary
- wrap the total metrics on the núcleos list inside a collapsible "Resumo" accordion
- extend the total card partial to support optional Lucide icons and pass icons for Núcleos and Membros totals

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb322cb8148325aeac23f4477d8e7a