### PR TITLE
Fix Lucide icon for eventos summary

### DIFF
--- a/eventos/templates/eventos/evento_list.html
+++ b/eventos/templates/eventos/evento_list.html
@@ -27,7 +27,7 @@
         </summary>
         {% lucide 'calendar' class='h-5 w-5' as icon_eventos %}
         {% lucide 'activity' class='h-5 w-5' as icon_ativos %}
-        {% lucide 'check-circle-2' class='h-5 w-5' as icon_realizados %}
+        {% lucide 'check-circle' class='h-5 w-5' as icon_realizados %}
         <div class="mt-4 card-grid">
           {% include "_partials/cards/total_card.html" with label=_('Eventos') valor=total_eventos icon_svg=icon_eventos %}
           {% include "_partials/cards/total_card.html" with label=_('Ativos') valor=total_eventos_ativos icon_svg=icon_ativos %}


### PR DESCRIPTION
## Summary
- replace the missing Lucide glyph reference in the eventos list summary with an icon that exists in v1.1.3

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb38d09b288325a7b87e12c0b0631d