### PR TITLE
Ajusta grid responsiva da lista de núcleos

### DIFF
--- a/nucleos/templates/nucleos/nucleo_list.html
+++ b/nucleos/templates/nucleos/nucleo_list.html
@@ -28,7 +28,7 @@
           {% include "_partials/cards/total_card.html" with label=_('Membros') valor=total_membros_org icon_svg=icon_membros %}
         </div>
       </details>
-      <div role="list" aria-label="{% trans 'Lista de núcleos' %}" class="nucleos-grid">
+      <div role="list" aria-label="{% trans 'Lista de núcleos' %}" class="card-grid sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-2">
         {% for nucleo in object_list %}
           {% include '_components/card_nucleo.html' with nucleo=nucleo %}
         {% empty %}


### PR DESCRIPTION
## Summary
- substitui a grade personalizada da lista de núcleos por `card-grid` e adiciona utilitários responsivos para manter uma coluna no mobile e duas no desktop
- garante que o estado vazio continue ocupando toda a largura da grade

## Testing
- python manage.py runserver 0.0.0.0:8000 *(falha: ModuleNotFoundError: No module named 'silk')*

------
https://chatgpt.com/codex/tasks/task_e_68cb408259008325b4f19d56410fb328