### PR TITLE
Ajusta layout da lista de associados

### DIFF
--- a/accounts/templates/associados/associado_list.html
+++ b/accounts/templates/associados/associado_list.html
@@ -8,26 +8,27 @@
 {% endblock %}
 
 {% block content %}
-
-
-<section class="max-w-6xl mx-auto py-12 px-4">
-  <div class="card-header space-y-4">
-  {% include '_components/search_form.html' with q=request.GET.q %}
-</div>
-  <!-- Cards de totais -->
-  <div class="mb-6 card-grid gap-4">
-    {% include "_partials/cards/total_card.html" with label=_('Usuários') valor=total_usuarios %}
-    {% include "_partials/cards/total_card.html" with label=_('Associados') valor=total_associados %}
-    {% include "_partials/cards/total_card.html" with label=_('Nucleados') valor=total_nucleados %}
-  </div>
-  <div role="list" class="card-grid sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-2">
-    {% for user in associados %}
-      <div role="listitem">
-        {% include '_components/card_usuario.html' with user=user %}
+  <div class="py-12 card px-4">
+    <div class="card-header space-y-4">
+      {% include '_components/search_form.html' with q=request.GET.q %}
+    </div>
+    <div class="card-body">
+      <!-- Cards de totais -->
+      <div class="mb-6 card-grid gap-4">
+        {% include "_partials/cards/total_card.html" with label=_('Usuários') valor=total_usuarios %}
+        {% include "_partials/cards/total_card.html" with label=_('Associados') valor=total_associados %}
+        {% include "_partials/cards/total_card.html" with label=_('Nucleados') valor=total_nucleados %}
       </div>
-    {% empty %}
-      <p class="text-[var(--text-muted)]">{% trans "Nenhum associado encontrado." %}</p>
-    {% endfor %}
+      <div role="list" aria-label="{% trans 'Lista de associados' %}" class="card-grid sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-2">
+        {% for user in associados %}
+          <div role="listitem">
+            {% include '_components/card_usuario.html' with user=user %}
+          </div>
+        {% empty %}
+          <p class="col-span-full text-center text-[var(--text-muted)]">{% trans "Nenhum associado encontrado." %}</p>
+        {% endfor %}
+      </div>
+      {% include '_partials/pagination.html' with page_obj=page_obj querystring=request.GET.urlencode %}
+    </div>
   </div>
-</section>
 {% endblock %}


### PR DESCRIPTION
## Summary
- atualiza a listagem de associados para usar o mesmo contêiner em card aplicado na listagem de núcleos
- move o formulário de busca para o cabeçalho do card e envolve os conteúdos em uma seção `card-body`
- alinha o estado vazio e adiciona paginação com preservação dos filtros de busca

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc02b36e9083258be627174f377300