### PR TITLE
Atualiza cards de totais em associados

### DIFF
--- a/accounts/templates/associados/associado_list.html
+++ b/accounts/templates/associados/associado_list.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load i18n %}
+{% load i18n lucide_icons %}
 
 {% block title %}{% trans 'Associados' %}{% endblock %}
 
@@ -8,18 +8,25 @@
 {% endblock %}
 
 {% block content %}
-
-
 <section class="max-w-6xl mx-auto py-12 px-4">
   <div class="card-header space-y-4">
-  {% include '_components/search_form.html' with q=request.GET.q %}
-</div>
-  <!-- Cards de totais -->
-  <div class="mb-6 card-grid gap-4">
-    {% include "_partials/cards/total_card.html" with label=_('Usuários') valor=total_usuarios %}
-    {% include "_partials/cards/total_card.html" with label=_('Associados') valor=total_associados %}
-    {% include "_partials/cards/total_card.html" with label=_('Nucleados') valor=total_nucleados %}
+    {% include '_components/search_form.html' with q=request.GET.q %}
   </div>
+  <!-- Cards de totais -->
+  <details class="card mb-6" open>
+    <summary class="cursor-pointer text-base font-semibold text-[var(--text-primary)]">
+      {% trans "Resumo" %}
+    </summary>
+    {% lucide 'users' class='h-5 w-5' as icon_usuarios %}
+    {% lucide 'badge-check' class='h-5 w-5' as icon_associados %}
+    {% lucide 'network' class='h-5 w-5' as icon_nucleados %}
+
+    <div class="mt-4 card-grid">
+      {% include "_partials/cards/total_card.html" with label=_('Usuários') valor=total_usuarios icon_svg=icon_usuarios %}
+      {% include "_partials/cards/total_card.html" with label=_('Associados') valor=total_associados icon_svg=icon_associados %}
+      {% include "_partials/cards/total_card.html" with label=_('Nucleados') valor=total_nucleados icon_svg=icon_nucleados %}
+    </div>
+  </details>
   <div role="list" class="card-grid sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-2">
     {% for user in associados %}
       <div role="listitem">


### PR DESCRIPTION
## Summary
- carrega a biblioteca de ícones Lucide no template de associados
- encapsula os cards de totais em um acordeão de resumo alinhado ao padrão existente
- adiciona ícones específicos aos cards de totais e os encaminha como SVG para o include

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc02a6c9a48325b60955586b833c4a