### PR TITLE
Ensure evento detail cards stack vertically

### DIFF
--- a/eventos/templates/eventos/detail.html
+++ b/eventos/templates/eventos/detail.html
@@ -8,7 +8,7 @@
 
 {% block content %}
 <section class="py-12 px-4">
-  <div class="card-grid gap-6">
+  <div class="flex flex-col gap-6">
     <article class="card">
       <div class="card-header">
         <h2 class="text-xl font-semibold">{% trans "Informações" %}</h2>
@@ -92,13 +92,13 @@
     </article>
     {% endif %}
 
-    <article class="card md:col-span-2">
+    <article class="card">
       <div class="card-header">
         <h2 class="text-lg font-semibold">{% trans "Inscritos" %}</h2>
       </div>
       <div class="card-body">
         {% if object.inscricoes.all %}
-          <div class="card-grid gap-4">
+          <div class="flex flex-col gap-4">
             {% for ins in object.inscricoes.all %}
               {% with inscrito=ins.user %}
                 <article class="card">


### PR DESCRIPTION
## Summary
- replace the evento detail grid wrapper with a vertical flex stack so cards stay in one column
- remove grid-specific classes from the inscritos section and stack attendee cards vertically

## Testing
- pytest --override-ini addopts="" tests/eventos/test_views.py::test_evento_detail_view_htmx

------
https://chatgpt.com/codex/tasks/task_e_68cc05a154dc8325be6b83574dba7ed1