### PR TITLE
Fix hero block context in briefing form template

### DIFF
--- a/eventos/templates/eventos/briefing_form.html
+++ b/eventos/templates/eventos/briefing_form.html
@@ -3,9 +3,15 @@
 {% block title %}{% if object %}{% trans "Editar Briefing" %}{% else %}{% trans "Novo Briefing" %}{% endif %} | Hubx{% endblock %}
 
 {% block hero %}
-  {% if object %}{% with title=_('Editar Briefing') %}{% else %}{% with title=_('Novo Briefing') %}{% endif %}
-    {% include '_components/hero.html' with title=title %}
-  {% endwith %}
+  {% if object %}
+    {% with title=_('Editar Briefing') %}
+      {% include '_components/hero.html' with title=title %}
+    {% endwith %}
+  {% else %}
+    {% with title=_('Novo Briefing') %}
+      {% include '_components/hero.html' with title=title %}
+    {% endwith %}
+  {% endif %}
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
## Summary
- wrap the hero partial in separate `{% with %}` blocks for each branch so the translated titles are passed correctly

## Testing
- `python manage.py shell <<'PY'
from django.template.loader import render_to_string
from django.test import RequestFactory
from django.contrib.auth.models import AnonymousUser
from django import forms

rf = RequestFactory()
request_new = rf.get('/eventos/briefing/novo/')
request_new.user = AnonymousUser()
request_edit = rf.get('/eventos/briefing/1/editar/')
request_edit.user = AnonymousUser()

class DummyForm(forms.Form):
    name = forms.CharField()

form = DummyForm()

new_html = render_to_string('eventos/briefing_form.html', {'form': form, 'object': None}, request=request_new)
print('new length', len(new_html))

edit_html = render_to_string('eventos/briefing_form.html', {'form': form, 'object': object()}, request=request_edit)
print('edit length', len(edit_html))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68cc0b97ad888325a6a43536c524a1c4