### PR TITLE
Fix event update template user type check

### DIFF
--- a/eventos/templates/eventos/update.html
+++ b/eventos/templates/eventos/update.html
@@ -61,7 +61,7 @@
               <h3 class="text-sm font-medium text-[var(--text-primary)]">{{ inscrito.display_name }}</h3>
               <p class="text-xs text-[var(--text-secondary)]">{{ inscrito.email }}</p>
             </div>
-            {% if user.user_type in ['admin', 'coordenador'] %}
+            {% if user.user_type == 'admin' or user.user_type == 'coordenador' %}
             <form method="post" action="{% url 'eventos:evento_remover_inscrito' object.pk inscrito.pk %}">
               {% csrf_token %}
               <button type="submit" class="btn btn-secondary text-sm" aria-label="{% trans 'Remover' %}">{% trans "Remover" %}</button>


### PR DESCRIPTION
## Summary
- replace invalid template list literal with explicit comparisons when checking user roles in the event update template

## Testing
- python manage.py check *(fails: ModuleNotFoundError: No module named 'silk')*


------
https://chatgpt.com/codex/tasks/task_e_68cc0fa1cfa88325bff6dee853f847ea