### PR TITLE
Improve collapsed sidebar spacing

### DIFF
--- a/app/static/css/hubx.css
+++ b/app/static/css/hubx.css
@@ -566,6 +566,14 @@
   /* Sidebar */
   .sidebar-item { @apply flex items-center gap-3 rounded-lg px-3 py-2 text-[var(--text-secondary)] hover:bg-[var(--bg-accent)] transition; }
   .sidebar-item-active { @apply bg-[var(--bg-accent)] text-[var(--text-primary)] font-medium; }
+  #sidebar .sidebar-header,
+  #sidebar .sidebar-nav { @apply transition-all duration-150 ease-in-out; }
+  #sidebar.sidebar-collapsed .sidebar-header,
+  #sidebar.sidebar-collapsed .sidebar-nav { @apply px-2; }
+  #sidebar.sidebar-collapsed .sidebar-nav { @apply py-3; }
+  #sidebar.sidebar-collapsed .sidebar-item { @apply justify-center px-2; }
+  #sidebar.sidebar-collapsed .sidebar-item svg,
+  #sidebar.sidebar-collapsed .sidebar-item img { @apply w-6 h-6 flex-shrink-0; }
 
   /* Tabelas */
   .table           { @apply w-full text-sm; }

--- a/static/tailwind.css
+++ b/static/tailwind.css
@@ -1555,6 +1555,37 @@ a:focus {
   color: var(--text-primary);
 }
 
+#sidebar .sidebar-header,
+#sidebar .sidebar-nav {
+  transition-property: padding;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+#sidebar.sidebar-collapsed .sidebar-header,
+#sidebar.sidebar-collapsed .sidebar-nav {
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+#sidebar.sidebar-collapsed .sidebar-nav {
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+}
+
+#sidebar.sidebar-collapsed .sidebar-item {
+  justify-content: center;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+#sidebar.sidebar-collapsed .sidebar-item svg,
+#sidebar.sidebar-collapsed .sidebar-item img {
+  width: 1.5rem;
+  height: 1.5rem;
+  flex-shrink: 0;
+}
+
 /* Tabelas */
 
 .table {

--- a/templates/_partials/sidebar.html
+++ b/templates/_partials/sidebar.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 <aside id="sidebar" class="fixed inset-y-0 left-0 z-20 w-64 bg-[var(--bg-secondary)] border-r border-[var(--border)] flex flex-col transition-all">
-  <div class="flex items-center justify-between p-4 border-b border-[var(--border)]">
+  <div class="sidebar-header flex items-center justify-between p-4 border-b border-[var(--border)]">
     <a href="/" class="text-2xl font-bold text-[var(--text-primary)]" aria-label="{% trans 'Página inicial' %}" {% if request.path == '/' %}aria-current="page"{% endif %}>
       {% trans 'Hubx' %}
     </a>
@@ -10,7 +10,7 @@
       </svg>
     </button>
   </div>
-  <nav class="flex-1 overflow-y-auto px-4 py-4" role="navigation" aria-label="{% trans 'Menu' %}">
+  <nav class="sidebar-nav flex-1 overflow-y-auto px-4 py-4" role="navigation" aria-label="{% trans 'Menu' %}">
     {% for item in NAV_MENU %}
       <a href="{{ item.path }}" class="sidebar-item{% if request.path == item.path %} sidebar-item-active{% endif %}" {% if request.path == item.path %}aria-current="page"{% endif %}>
         {% if item.id == 'perfil' and user.avatar %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -120,30 +120,28 @@
       const content = document.getElementById('content');
       if (sidebarToggle && sidebar && content) {
         const baseMargin = '{% if hide_nav %}ml-0{% else %}ml-64{% endif %}';
-        const saved = localStorage.getItem('sidebar') || 'expanded';
-        if (saved === 'collapsed') {
-          sidebar.classList.remove('w-64');
-          sidebar.classList.add('w-16');
-          content.classList.remove(baseMargin);
-          content.classList.add('ml-16');
-          sidebarToggle.setAttribute('aria-expanded', 'false');
-          document.querySelectorAll('#sidebar .sidebar-label').forEach(el => {
-            el.classList.add('hidden');
+        const sidebarLabels = Array.from(document.querySelectorAll('#sidebar .sidebar-label'));
+
+        const setSidebarState = (collapsed) => {
+          sidebar.classList.toggle('w-64', !collapsed);
+          sidebar.classList.toggle('w-16', collapsed);
+          sidebar.classList.toggle('sidebar-collapsed', collapsed);
+          content.classList.toggle(baseMargin, !collapsed);
+          content.classList.toggle('ml-16', collapsed);
+          sidebarToggle.setAttribute('aria-expanded', String(!collapsed));
+          sidebarLabels.forEach((el) => {
+            el.classList.toggle('hidden', collapsed);
           });
-        } else {
-          sidebarToggle.setAttribute('aria-expanded', 'true');
-        }
+        };
+
+        const savedCollapsed = localStorage.getItem('sidebar') === 'collapsed';
+        setSidebarState(savedCollapsed);
+
         sidebarToggle.addEventListener('click', () => {
-          const expanded = sidebarToggle.getAttribute('aria-expanded') === 'true';
-          sidebarToggle.setAttribute('aria-expanded', String(!expanded));
-          sidebar.classList.toggle('w-64');
-          sidebar.classList.toggle('w-16');
-          content.classList.toggle(baseMargin);
-          content.classList.toggle('ml-16');
-          document.querySelectorAll('#sidebar .sidebar-label').forEach(el => {
-            el.classList.toggle('hidden');
-          });
-          localStorage.setItem('sidebar', expanded ? 'collapsed' : 'expanded');
+          const currentlyExpanded = sidebarToggle.getAttribute('aria-expanded') === 'true';
+          const nextCollapsed = currentlyExpanded;
+          setSidebarState(nextCollapsed);
+          localStorage.setItem('sidebar', nextCollapsed ? 'collapsed' : 'expanded');
         });
       }
       document.body.classList.remove('preload');


### PR DESCRIPTION
## Summary
- add a dedicated `sidebar-collapsed` state in the base template script so the toggle updates width, aria attributes, and stored preference consistently
- tweak the sidebar markup and styles to reduce padding when collapsed and keep icons centered at a readable size

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc0e619838832593a19be7e879e076