### PR TITLE
Fix missing success redirect in briefing views

### DIFF
--- a/eventos/views.py
+++ b/eventos/views.py
@@ -975,6 +975,7 @@ class BriefingEventoCreateView(LoginRequiredMixin, NoSuperadminMixin, CreateView
     model = BriefingEvento
     form_class = BriefingEventoCreateForm
     template_name = "eventos/briefing_form.html"
+    success_url = reverse_lazy("eventos:briefing_list")
 
     def form_valid(self, form):
         evento = form.cleaned_data.get("evento")
@@ -995,6 +996,7 @@ class BriefingEventoUpdateView(LoginRequiredMixin, NoSuperadminMixin, UpdateView
     model = BriefingEvento
     form_class = BriefingEventoForm
     template_name = "eventos/briefing_form.html"
+    success_url = reverse_lazy("eventos:briefing_list")
 
     def get_queryset(self):
         qs = BriefingEvento.objects.all()


### PR DESCRIPTION
## Summary
- add a success redirect to the briefing create view so new briefings return to the listing
- mirror the same success redirect on the update view for consistency

## Testing
- pytest eventos -q *(fails: ModuleNotFoundError: No module named 'silk')*

------
https://chatgpt.com/codex/tasks/task_e_68cc173461d083259ffc911ecb0a4091