### PR TITLE
Adjust API tokens grid layout

### DIFF
--- a/tokens/templates/tokens/api_tokens.html
+++ b/tokens/templates/tokens/api_tokens.html
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="max-w-3xl mx-auto card-grid">
+<div class="mx-auto max-w-5xl card-grid sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-2">
   <div class="card">
     <div class="card-header">
       <h2 class="text-xl font-semibold">{% trans "Tokens de API" %}</h2>


### PR DESCRIPTION
## Summary
- keep the API tokens page grid to two columns on larger screens so the cards use the full width available

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68cc1bc5e8288325b7a2d5d861706069