### PR TITLE
Atualiza header para exibir nome da organização vigente

### DIFF
--- a/templates/_partials/header.html
+++ b/templates/_partials/header.html
@@ -1,6 +1,12 @@
 {% load i18n %}
 <header class="bg-[var(--bg-secondary)] border-[var(--border)] px-4 py-4 flex items-center gap-4 justify-between">
-  <a href="/" class="text-xl font-bold text-[var(--text-primary)]" aria-label="{% trans 'Página inicial' %}">Hubx.Space</a>
+  <a href="/" class="text-xl font-bold text-[var(--text-primary)]" aria-label="{% trans 'Página inicial' %}">
+    {% if request.user.is_authenticated and request.user.organizacao %}
+      {{ request.user.organizacao.nome }}
+    {% else %}
+      {% trans 'Hubx.Space' %}
+    {% endif %}
+  </a>
   <form action="#" method="get" role="search" class="flex-1 max-w-md">
     <label for="header-search"><span class="sr-only">{% trans 'Buscar' %}</span></label>
     <input id="header-search" name="q" type="search" placeholder="{% trans 'Buscar' %}" class="w-full border border-[var(--border)] bg-[var(--bg-primary)] rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[var(--border-focus)]" />


### PR DESCRIPTION
## Summary
- exibe o nome da organização vinculada ao usuário autenticado no cabeçalho
- mantém Hubx.Space como texto padrão quando não houver organização disponível

## Testing
- not run (template change)


------
https://chatgpt.com/codex/tasks/task_e_68cc1c4b95c08325a61eb9623ac210de