### PR TITLE
Adiciona componente hero personalizado para detalhes de núcleo

### DIFF
--- a/nucleos/templates/nucleos/detail.html
+++ b/nucleos/templates/nucleos/detail.html
@@ -4,26 +4,11 @@
 {% block title %}{{ object.nome }}{% endblock %}
 
 {% block hero %}
-  {% include '_components/hero.html' with title=object.nome %}
+  {% include '_components/hero_nucleo.html' with nucleo=object %}
 {% endblock %}
 
 {% block content %}
 <section class="max-w-5xl mx-auto py-8">
-  {% if object.cover %}
-  <img src="{{ object.cover.url }}" class="w-full h-48 object-cover rounded" alt="Capa de {{ object.nome }}" loading="lazy" />
-  {% endif %}
-  <div class="flex items-center gap-4 mt-4">
-    {% if object.avatar %}<img src="{{ object.avatar.url }}" class="w-16 h-16 rounded-full object-cover" alt="{{ object.nome }}" loading="lazy" />{% endif %}
-    <div>
-      <div class="flex items-center gap-2">
-        <h1 class="text-2xl font-bold">{{ object.nome }}</h1>
-        {% if request.user.user_type == 'admin' or request.user.user_type == 'coordenador' %}
-        <a href="{% url 'nucleos:update' object.pk %}" class="btn btn-primary">{% trans 'Editar' %}</a>
-        <a href="{% url 'nucleos:delete' object.pk %}" class="btn btn-danger btn-sm">{% trans 'Excluir' %}</a>
-        {% endif %}
-      </div>
-    </div>
-  </div>
   
   <!-- Cards de totais -->
   <div class="card-grid mt-6 gap-4">

--- a/templates/_components/hero_nucleo.html
+++ b/templates/_components/hero_nucleo.html
@@ -1,0 +1,39 @@
+{% load i18n %}
+<section class="relative isolate overflow-hidden text-white">
+  {% if nucleo.cover %}
+    <div class="absolute inset-0">
+      <img src="{{ nucleo.cover.url }}" alt="" class="h-full w-full object-cover" loading="lazy">
+      <div class="absolute inset-0 bg-black/60"></div>
+    </div>
+  {% else %}
+    <div class="absolute inset-0 bg-gradient-to-r from-[var(--hero-from)] to-[var(--hero-to)]"
+         style="--hero-from: var(--color-primary-500); --hero-to: var(--color-primary-700);"></div>
+  {% endif %}
+  <div class="relative max-w-7xl mx-auto px-4 py-10 flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+    <div class="flex items-center gap-4">
+      <div class="shrink-0">
+        {% if nucleo.avatar %}
+          <img src="{{ nucleo.avatar.url }}" alt="{{ nucleo.nome }}" class="h-20 w-20 rounded-full object-cover ring-4 ring-white/50" loading="lazy">
+        {% else %}
+          <div class="flex h-20 w-20 items-center justify-center rounded-full bg-white/20 text-3xl font-semibold uppercase ring-4 ring-white/30"
+               role="img" aria-label="{{ nucleo.nome }}">
+            {{ nucleo.nome|slice:':1'|upper }}
+          </div>
+        {% endif %}
+      </div>
+      <h1 class="text-3xl font-bold md:text-4xl">{{ nucleo.nome }}</h1>
+    </div>
+    {% if perms.nucleos.change_nucleo or perms.nucleos.delete_nucleo or request.user.user_type == 'admin' or request.user.user_type == 'coordenador' %}
+      <div class="flex flex-wrap gap-3 md:justify-end">
+        {% if perms.nucleos.change_nucleo or request.user.user_type == 'admin' or request.user.user_type == 'coordenador' %}
+          <a href="{% url 'nucleos:update' nucleo.pk %}" class="btn btn-secondary"
+             aria-label="{% trans 'Editar núcleo' %}">{% trans 'Editar' %}</a>
+        {% endif %}
+        {% if perms.nucleos.delete_nucleo or request.user.user_type == 'admin' or request.user.user_type == 'coordenador' %}
+          <a href="{% url 'nucleos:delete' nucleo.pk %}" class="btn btn-danger"
+             aria-label="{% trans 'Excluir núcleo' %}">{% trans 'Excluir' %}</a>
+        {% endif %}
+      </div>
+    {% endif %}
+  </div>
+</section>


### PR DESCRIPTION
## Summary
- adiciona o componente `_components/hero_nucleo.html` com o mesmo layout visual do hero de eventos
- atualiza o template de detalhes do núcleo para usar o novo componente e remove o cabeçalho duplicado do conteúdo

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc2119f2a083258c62bf52de691735