### PR TITLE
Adjust nucleo detail summary accordion

### DIFF
--- a/nucleos/templates/nucleos/detail.html
+++ b/nucleos/templates/nucleos/detail.html
@@ -11,11 +11,18 @@
 <section class="max-w-5xl mx-auto py-8">
   
   <!-- Cards de totais -->
-  <div class="card-grid mt-6 gap-4">
-    {% include "_partials/cards/total_card.html" with label=_('Membros') valor=total_membros %}
-    {% include "_partials/cards/total_card.html" with label=_('Eventos ativos') valor=total_eventos_ativos %}
-    {% include "_partials/cards/total_card.html" with label=_('Eventos realizados') valor=total_eventos_concluidos %}
-  </div>
+  <details class="card mt-6" open>
+    <summary class="card-header flex cursor-pointer items-center justify-between gap-2 text-sm font-semibold text-[var(--text-primary)] sm:text-base">
+      {% trans 'Resumo' %}
+    </summary>
+    <div class="card-body">
+      <div class="card-grid gap-4">
+        {% include "_partials/cards/total_card.html" with label=_('Membros') valor=total_membros icon_name='users' %}
+        {% include "_partials/cards/total_card.html" with label=_('Eventos ativos') valor=total_eventos_ativos icon_name='activity' %}
+        {% include "_partials/cards/total_card.html" with label=_('Eventos realizados') valor=total_eventos_concluidos icon_name='check' %}
+      </div>
+    </div>
+  </details>
 
   <!-- Abas -->
   <div class="mt-8">

--- a/templates/_partials/cards/total_card.html
+++ b/templates/_partials/cards/total_card.html
@@ -4,7 +4,11 @@
   <div class="card-body">
     <div class="flex items-center gap-2 text-sm text-[var(--text-secondary)]">
 
-      {% if icon_svg %}
+      {% if icon_name %}
+        <span class="inline-flex items-center justify-center text-[inherit]" aria-hidden="true">
+          {% lucide icon_name class="h-5 w-5" %}
+        </span>
+      {% elif icon_svg %}
         <span class="inline-flex items-center justify-center text-[inherit]" aria-hidden="true">
           {{ icon_svg|safe }}
         </span>


### PR DESCRIPTION
## Summary
- wrap the nucleus detail totals in a card-styled accordion summary section
- pass lucide icon names with each total card include for the new summary
- allow the shared total_card partial to render icons via an `icon_name` parameter

## Testing
- python -m compileall nucleos templates/_partials

------
https://chatgpt.com/codex/tasks/task_e_68cc2fb85a2c83259cb9ac224dbc898d