### PR TITLE
Refatorar listagem de membros com partial paginada

### DIFF
--- a/nucleos/templates/nucleos/detail.html
+++ b/nucleos/templates/nucleos/detail.html
@@ -30,12 +30,15 @@
     <div id="tab-panels" class="mt-6">
       <!-- Painel: Membros -->
       <div class="tab-panel" data-tab="membros">
-        <div class="card-grid gap-4" role="list" aria-label="{% trans 'Lista de membros do núcleo' %}">
-          {% for part in membros_ativos %}
-            {% include 'nucleos/partials/membro_card.html' with part=part %}
-          {% empty %}
-            <p class="col-span-full text-center text-[var(--text-muted)]">{% trans 'Sem membros.' %}</p>
-          {% endfor %}
+        {% url 'nucleos:membros_list' object.pk as membros_list_url %}
+        <div
+          id="membros-list"
+          hx-get="{{ membros_list_url }}?page={{ page_obj.number }}{% if querystring %}&{{ querystring }}{% endif %}"
+          hx-trigger="load"
+          hx-target="#membros-list"
+          hx-swap="innerHTML"
+        >
+          {% include 'nucleos/partials/membros_list.html' %}
         </div>
 
         {% if membros_pendentes %}

--- a/nucleos/templates/nucleos/partials/membros_list.html
+++ b/nucleos/templates/nucleos/partials/membros_list.html
@@ -1,0 +1,12 @@
+{% load i18n %}
+<div class="card-grid gap-4" role="list" aria-label="{% trans 'Lista de membros do núcleo' %}">
+  {% if page_obj.object_list %}
+    {% for part in page_obj.object_list %}
+      {% include 'nucleos/partials/membro_card.html' with part=part %}
+    {% endfor %}
+  {% else %}
+    <p class="col-span-full text-center text-[var(--text-muted)]">{% trans 'Sem membros.' %}</p>
+  {% endif %}
+</div>
+{% url 'nucleos:membros_list' object.pk as membros_list_url %}
+{% include '_partials/pagination.html' with page_obj=page_obj querystring=querystring hx_get=membros_list_url hx_target='#membros-list' hx_push_url='false' %}

--- a/nucleos/urls.py
+++ b/nucleos/urls.py
@@ -9,6 +9,7 @@ urlpatterns = [
     path("meus/", views.NucleoMeusView.as_view(), name="meus"),
     path("novo/", views.NucleoCreateView.as_view(), name="create"),
     path("uuid/<uuid:public_id>/", views.NucleoDetailView.as_view(), name="detail_uuid"),
+    path("<int:pk>/membros/", views.NucleoMembrosPartialView.as_view(), name="membros_list"),
     path("<int:pk>/", views.NucleoDetailView.as_view(), name="detail"),
     path("<int:pk>/editar/", views.NucleoUpdateView.as_view(), name="update"),
     path("<int:pk>/remover/", views.NucleoDeleteView.as_view(), name="delete"),

--- a/tests/nucleos/test_views.py
+++ b/tests/nucleos/test_views.py
@@ -294,6 +294,10 @@ def test_nucleo_detail_view_queries(admin_user, organizacao, django_assert_num_q
         obj = qs.get()
         view.object = obj
         ctx = view.get_context_data()
+        page_obj = ctx["page_obj"]
+        assert page_obj.paginator.count == len(members)
+        for p in page_obj.object_list:
+            _ = p.user
         for p in ctx["membros_ativos"]:
             _ = p.user
         for p in ctx["coordenadores"]:


### PR DESCRIPTION
## Summary
- extrai a grade de membros para um partial reutilizável com paginação
- atualiza a view de detalhes para fornecer um queryset paginado e expõe endpoint HTMX
- ajusta o teste de detalhe para validar o novo `page_obj`

## Testing
- pytest --no-cov tests/nucleos/test_views.py::test_nucleo_detail_view_queries -q

------
https://chatgpt.com/codex/tasks/task_e_68cc352513188325bfc636614df1919f