### PR TITLE
Add neural background to núcleo hero

### DIFF
--- a/static/css/neural_backgrounds.css
+++ b/static/css/neural_backgrounds.css
@@ -51,6 +51,32 @@
               radial-gradient(circle at 50% 50%, rgba(30, 64, 175, 0.05) 0%, transparent 50%);
 }
 
+.neural-bg-collection {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+
+.neural-bg-collection > div {
+  display: none;
+}
+
+.neural-bg-collection[data-bg="nucleos"] .neural-bg-nucleos {
+  display: block;
+}
+
+.neural-bg-collection[data-bg="eventos"] .neural-bg-eventos,
+.neural-bg-collection[data-bg="feed"] .neural-bg-feed,
+.neural-bg-collection[data-bg="dashboard"] .neural-bg-dashboard,
+.neural-bg-collection[data-bg="financeiro"] .neural-bg-financeiro,
+.neural-bg-collection[data-bg="tokens"] .neural-bg-tokens,
+.neural-bg-collection[data-bg="configuracao"] .neural-bg-configuracao {
+  display: block;
+}
+
 /* Animation classes */
 .neural-pulse {
   animation: neural-pulse 2s ease-in-out infinite;

--- a/templates/_components/hero_nucleo.html
+++ b/templates/_components/hero_nucleo.html
@@ -6,10 +6,15 @@
       <div class="absolute inset-0 bg-black/60"></div>
     </div>
   {% else %}
-    <div class="absolute inset-0 bg-gradient-to-r from-[var(--hero-from)] to-[var(--hero-to)]"
-         style="--hero-from: var(--color-primary-500); --hero-to: var(--color-primary-700);"></div>
+    {% with background_type='nucleos' %}
+      <div class="neural-bg-base pointer-events-none" aria-hidden="true"></div>
+      <div class="neural-bg-collection absolute inset-0 pointer-events-none" data-bg="{{ background_type }}" aria-hidden="true">
+        {% include 'backgrounds/neural_backgrounds.html' with bg_type=background_type %}
+      </div>
+      <div class="hero-overlay" aria-hidden="true"></div>
+    {% endwith %}
   {% endif %}
-  <div class="relative max-w-7xl mx-auto px-4 py-10 flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+  <div class="relative z-10 max-w-7xl mx-auto px-4 py-10 flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
     <div class="flex items-center gap-4">
       <div class="shrink-0">
         {% if nucleo.avatar %}


### PR DESCRIPTION
## Summary
- integrate the nucleos neural background into the núcleo hero component when no cover image is present
- ensure hero content remains above decorative layers and mark backgrounds as decorative
- add utility styles to neural backgrounds CSS so only the requested neural scene is rendered via a data attribute

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc588a4dac83259a4b82f8af3b7d87