### PR TITLE
Add neural hero component for nucleos pages

### DIFF
--- a/nucleos/templates/nucleos/meus_list.html
+++ b/nucleos/templates/nucleos/meus_list.html
@@ -4,7 +4,7 @@
 {% block title %}{% trans "Meus Núcleos" %}{% endblock %}
 
 {% block hero %}
-  {% include '_components/hero.html' with title=_('Meus Núcleos') action_template='nucleos/hero_meus_list_action.html' %}
+  {% include '_components/hero_nucleo.html' with title=_('Meus Núcleos') action_template='nucleos/hero_meus_list_action.html' %}
 {% endblock %}
 
 {% block content %}

--- a/nucleos/templates/nucleos/nucleo_list.html
+++ b/nucleos/templates/nucleos/nucleo_list.html
@@ -4,7 +4,7 @@
 {% block title %}{% trans "Núcleos" %}{% endblock %}
 
 {% block hero %}
-  {% include '_components/hero.html' with title=_('Núcleos') action_template='nucleos/hero_actions_nucleo.html' %}
+  {% include '_components/hero_nucleo.html' with title=_('Núcleos') action_template='nucleos/hero_actions_nucleo.html' %}
 {% endblock %}
 
 {% block content %}

--- a/templates/_components/hero_nucleo.html
+++ b/templates/_components/hero_nucleo.html
@@ -1,0 +1,23 @@
+{% load i18n %}
+<section class="hero-with-neural bg-gradient-to-br from-blue-50 to-blue-100 dark:from-gray-900 dark:to-gray-800 text-white">
+  {% include 'backgrounds/neural_backgrounds.html' with bg_type='nucleos' %}
+  <div class="hero-overlay"></div>
+  <div class="hero-content w-full">
+    <div class="max-w-7xl mx-auto w-full px-4 py-16 text-center md:text-left">
+      {% if breadcrumb_template %}
+        <div class="mb-4">{% include breadcrumb_template %}</div>
+      {% endif %}
+      <div class="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+        <div class="space-y-3 md:max-w-3xl">
+          <h1 class="text-4xl md:text-5xl font-bold text-white">{{ title }}</h1>
+          {% if subtitle %}
+            <p class="text-lg text-white/90">{{ subtitle }}</p>
+          {% endif %}
+        </div>
+        {% if action_template %}
+          <div class="flex justify-center md:justify-end md:self-start">{% include action_template %}</div>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+</section>

--- a/templates/backgrounds/neural_backgrounds.html
+++ b/templates/backgrounds/neural_backgrounds.html
@@ -1,8 +1,9 @@
 <!-- Neural Network Background Templates for Django -->
 <!-- Each background represents a different module with unique neural patterns -->
 
+{% if not bg_type or bg_type == 'nucleos' %}
 <!-- Núcleos Background -->
-<div class="neural-bg-nucleos absolute inset-0 overflow-hidden">
+<div class="neural-bg-base neural-bg-nucleos absolute inset-0 overflow-hidden">
   <svg class="w-full h-full" viewBox="0 0 800 600" xmlns="http://www.w3.org/2000/svg">
     <defs>
       <radialGradient id="nucleos-gradient" cx="50%" cy="50%" r="50%">
@@ -39,9 +40,11 @@
           stroke="#3b82f6" stroke-width="1.5" opacity="0.4" fill="none"/>
   </svg>
 </div>
+{% endif %}
 
+{% if not bg_type or bg_type == 'eventos' %}
 <!-- Eventos Associados Background -->
-<div class="neural-bg-eventos absolute inset-0 overflow-hidden">
+<div class="neural-bg-base neural-bg-eventos absolute inset-0 overflow-hidden">
   <svg class="w-full h-full" viewBox="0 0 800 600" xmlns="http://www.w3.org/2000/svg">
     <defs>
       <linearGradient id="eventos-gradient" x1="0%" y1="0%" x2="100%" y2="0%">
@@ -77,9 +80,11 @@
     </circle>
   </svg>
 </div>
+{% endif %}
 
+{% if not bg_type or bg_type == 'feed' %}
 <!-- Feed Background -->
-<div class="neural-bg-feed absolute inset-0 overflow-hidden">
+<div class="neural-bg-base neural-bg-feed absolute inset-0 overflow-hidden">
   <svg class="w-full h-full" viewBox="0 0 800 600" xmlns="http://www.w3.org/2000/svg">
     <!-- Vertical data streams -->
     <g opacity="0.8">
@@ -112,9 +117,11 @@
     <path d="M150,350 L300,330 L450,370 L600,350" stroke="#1e40af" stroke-width="1" opacity="0.3" fill="none"/>
   </svg>
 </div>
+{% endif %}
 
+{% if not bg_type or bg_type == 'dashboard' %}
 <!-- Dashboard Background -->
-<div class="neural-bg-dashboard absolute inset-0 overflow-hidden">
+<div class="neural-bg-base neural-bg-dashboard absolute inset-0 overflow-hidden">
   <svg class="w-full h-full" viewBox="0 0 800 600" xmlns="http://www.w3.org/2000/svg">
     <!-- Grid pattern -->
     <defs>
@@ -151,9 +158,11 @@
     </g>
   </svg>
 </div>
+{% endif %}
 
+{% if not bg_type or bg_type == 'financeiro' %}
 <!-- Financeiro Background -->
-<div class="neural-bg-financeiro absolute inset-0 overflow-hidden">
+<div class="neural-bg-base neural-bg-financeiro absolute inset-0 overflow-hidden">
   <svg class="w-full h-full" viewBox="0 0 800 600" xmlns="http://www.w3.org/2000/svg">
     <!-- Growth curve -->
     <path d="M50,550 Q200,500 350,400 Q500,300 650,200 Q700,150 750,100" 
@@ -184,9 +193,11 @@
           stroke="#3b82f6" stroke-width="1.5" opacity="0.5" fill="none"/>
   </svg>
 </div>
+{% endif %}
 
+{% if not bg_type or bg_type == 'tokens' %}
 <!-- Tokens Background -->
-<div class="neural-bg-tokens absolute inset-0 overflow-hidden">
+<div class="neural-bg-base neural-bg-tokens absolute inset-0 overflow-hidden">
   <svg class="w-full h-full" viewBox="0 0 800 600" xmlns="http://www.w3.org/2000/svg">
     <!-- Blockchain-like structure -->
     <g opacity="0.8">
@@ -219,9 +230,11 @@
     </g>
   </svg>
 </div>
+{% endif %}
 
+{% if not bg_type or bg_type == 'configuracao' %}
 <!-- Configuração Background -->
-<div class="neural-bg-configuracao absolute inset-0 overflow-hidden">
+<div class="neural-bg-base neural-bg-configuracao absolute inset-0 overflow-hidden">
   <svg class="w-full h-full" viewBox="0 0 800 600" xmlns="http://www.w3.org/2000/svg">
     <!-- Gear system -->
     <g opacity="0.8">
@@ -265,3 +278,4 @@
     <animateTransform attributeName="transform" type="rotate" values="0 400 300;360 400 300" dur="20s" repeatCount="indefinite"/>
   </svg>
 </div>
+{% endif %}


### PR DESCRIPTION
## Summary
- add a dedicated hero_nucleo component that renders the neural background, overlay, and configurable title areas
- teach the neural_backgrounds include to honour the bg_type parameter so only the requested background is shown
- switch the Núcleos list templates to reuse the new hero component

## Testing
- not run (template-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68cc633778e48325b10fa58b96d2ab21