### PR TITLE
feat: integrate neural hero backgrounds

### DIFF
--- a/nucleos/templates/nucleos/meus_list.html
+++ b/nucleos/templates/nucleos/meus_list.html
@@ -4,7 +4,7 @@
 {% block title %}{% trans "Meus Núcleos" %}{% endblock %}
 
 {% block hero %}
-  {% include '_components/hero.html' with title=_('Meus Núcleos') action_template='nucleos/hero_meus_list_action.html' %}
+  {% include '_components/hero.html' with title=_('Meus Núcleos') action_template='nucleos/hero_meus_list_action.html' neural_background='nucleos' %}
 {% endblock %}
 
 {% block content %}

--- a/nucleos/templates/nucleos/nucleo_list.html
+++ b/nucleos/templates/nucleos/nucleo_list.html
@@ -4,7 +4,7 @@
 {% block title %}{% trans "Núcleos" %}{% endblock %}
 
 {% block hero %}
-  {% include '_components/hero.html' with title=_('Núcleos') action_template='nucleos/hero_actions_nucleo.html' %}
+  {% include '_components/hero.html' with title=_('Núcleos') action_template='nucleos/hero_actions_nucleo.html' neural_background='nucleos' %}
 {% endblock %}
 
 {% block content %}

--- a/static/css/neural_backgrounds.css
+++ b/static/css/neural_backgrounds.css
@@ -5,10 +5,14 @@
   position: absolute;
   top: 0;
   left: 0;
+  right: 0;
+  bottom: 0;
   width: 100%;
   height: 100%;
   overflow: hidden;
   background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%);
+  pointer-events: none;
+  z-index: 0;
 }
 
 .dark .neural-bg-base {
@@ -97,21 +101,22 @@
 /* Hero component integration */
 .hero-with-neural {
   position: relative;
-  min-height: 400px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
   overflow: hidden;
+  min-height: 320px;
 }
 
-.hero-content {
+@media (min-width: 768px) {
+  .hero-with-neural {
+    min-height: 400px;
+  }
+}
+
+.hero-with-neural .hero-content {
   position: relative;
   z-index: 10;
-  text-align: center;
-  padding: 2rem;
 }
 
-.hero-overlay {
+.hero-with-neural .hero-overlay {
   position: absolute;
   top: 0;
   left: 0;
@@ -119,9 +124,10 @@
   bottom: 0;
   background: linear-gradient(135deg, rgba(0, 0, 0, 0.3) 0%, rgba(0, 0, 0, 0.1) 100%);
   z-index: 5;
+  pointer-events: none;
 }
 
 /* Dark mode adjustments */
-.dark .hero-overlay {
+.dark .hero-with-neural .hero-overlay {
   background: linear-gradient(135deg, rgba(0, 0, 0, 0.5) 0%, rgba(0, 0, 0, 0.2) 100%);
 }

--- a/templates/_components/hero.html
+++ b/templates/_components/hero.html
@@ -1,6 +1,12 @@
 {% load i18n %}
-<section class="bg-gradient-to-r from-[var(--hero-from)] to-[var(--hero-to)] text-white" style="--hero-from: var(--color-primary-500); --hero-to: var(--color-primary-700);{% if style %} {{ style }}{% endif %}">
-  <div class="max-w-7xl mx-auto px-4 py-10">
+<section class="{% if neural_background %}hero-with-neural {% endif %}bg-gradient-to-r from-[var(--hero-from)] to-[var(--hero-to)] text-white" style="--hero-from: var(--color-primary-500); --hero-to: var(--color-primary-700);{% if style %} {{ style }}{% endif %}">
+  {% if neural_background %}
+    <div class="neural-bg-base" aria-hidden="true">
+      {% include 'backgrounds/neural_backgrounds.html' with bg_type=neural_background only %}
+    </div>
+    <div class="hero-overlay" aria-hidden="true"></div>
+  {% endif %}
+  <div class="{% if neural_background %}hero-content relative z-10 w-full {% endif %}max-w-7xl mx-auto px-4 py-10">
     {% if breadcrumb_template %}
       <div class="mb-4">{% include breadcrumb_template %}</div>
     {% endif %}

--- a/templates/backgrounds/hero_examples.html
+++ b/templates/backgrounds/hero_examples.html
@@ -1,12 +1,15 @@
 <!-- Django Template Examples for Neural Network Hero Backgrounds -->
 
 <!-- Núcleos Hero Example -->
-<div class="hero-with-neural bg-gradient-to-br from-blue-50 to-blue-100 dark:from-gray-900 dark:to-gray-800">
-  {% include 'backgrounds/neural_backgrounds.html' with bg_type='nucleos' %}
-  <div class="hero-overlay"></div>
-  <div class="hero-content">
+<section class="hero-with-neural bg-gradient-to-br from-blue-50 to-blue-100 dark:from-gray-900 dark:to-gray-800 text-white">
+  <div class="neural-bg-base" aria-hidden="true">
+    {% include 'backgrounds/neural_backgrounds.html' with bg_type='nucleos' only %}
+  </div>
+  <div class="hero-overlay" aria-hidden="true"></div>
+  <div class="hero-content relative z-10 max-w-5xl mx-auto px-6 py-16 text-center">
     <h1 class="text-4xl md:text-6xl font-bold text-white mb-4">Núcleos</h1>
     <p class="text-xl text-white/90 max-w-2xl mx-auto">
       Centro de conexões e processamento principal do sistema
     </p>
-  </di
+  </div>
+</section>

--- a/templates/backgrounds/neural_backgrounds.html
+++ b/templates/backgrounds/neural_backgrounds.html
@@ -1,6 +1,7 @@
 <!-- Neural Network Background Templates for Django -->
 <!-- Each background represents a different module with unique neural patterns -->
 
+{% if bg_type == 'nucleos' or not bg_type %}
 <!-- Núcleos Background -->
 <div class="neural-bg-nucleos absolute inset-0 overflow-hidden">
   <svg class="w-full h-full" viewBox="0 0 800 600" xmlns="http://www.w3.org/2000/svg">
@@ -39,7 +40,7 @@
           stroke="#3b82f6" stroke-width="1.5" opacity="0.4" fill="none"/>
   </svg>
 </div>
-
+{% elif bg_type == 'eventos' %}
 <!-- Eventos Associados Background -->
 <div class="neural-bg-eventos absolute inset-0 overflow-hidden">
   <svg class="w-full h-full" viewBox="0 0 800 600" xmlns="http://www.w3.org/2000/svg">
@@ -77,7 +78,7 @@
     </circle>
   </svg>
 </div>
-
+{% elif bg_type == 'feed' %}
 <!-- Feed Background -->
 <div class="neural-bg-feed absolute inset-0 overflow-hidden">
   <svg class="w-full h-full" viewBox="0 0 800 600" xmlns="http://www.w3.org/2000/svg">
@@ -112,7 +113,7 @@
     <path d="M150,350 L300,330 L450,370 L600,350" stroke="#1e40af" stroke-width="1" opacity="0.3" fill="none"/>
   </svg>
 </div>
-
+{% elif bg_type == 'dashboard' %}
 <!-- Dashboard Background -->
 <div class="neural-bg-dashboard absolute inset-0 overflow-hidden">
   <svg class="w-full h-full" viewBox="0 0 800 600" xmlns="http://www.w3.org/2000/svg">
@@ -151,7 +152,7 @@
     </g>
   </svg>
 </div>
-
+{% elif bg_type == 'financeiro' %}
 <!-- Financeiro Background -->
 <div class="neural-bg-financeiro absolute inset-0 overflow-hidden">
   <svg class="w-full h-full" viewBox="0 0 800 600" xmlns="http://www.w3.org/2000/svg">
@@ -184,7 +185,7 @@
           stroke="#3b82f6" stroke-width="1.5" opacity="0.5" fill="none"/>
   </svg>
 </div>
-
+{% elif bg_type == 'tokens' %}
 <!-- Tokens Background -->
 <div class="neural-bg-tokens absolute inset-0 overflow-hidden">
   <svg class="w-full h-full" viewBox="0 0 800 600" xmlns="http://www.w3.org/2000/svg">
@@ -219,7 +220,7 @@
     </g>
   </svg>
 </div>
-
+{% elif bg_type == 'configuracao' %}
 <!-- Configuração Background -->
 <div class="neural-bg-configuracao absolute inset-0 overflow-hidden">
   <svg class="w-full h-full" viewBox="0 0 800 600" xmlns="http://www.w3.org/2000/svg">
@@ -265,3 +266,5 @@
     <animateTransform attributeName="transform" type="rotate" values="0 400 300;360 400 300" dur="20s" repeatCount="indefinite"/>
   </svg>
 </div>
+{% endif %}
+

--- a/templates/base.html
+++ b/templates/base.html
@@ -32,6 +32,7 @@
   <link rel="preconnect" href="https://rsms.me/">
   <link rel="stylesheet" href="https://rsms.me/inter/inter.css">
   <link rel="stylesheet" href="{% static 'tailwind.css' %}">
+  <link rel="stylesheet" href="{% static 'css/neural_backgrounds.css' %}">
   <!-- Font Awesome removed: icons are now inline SVGs -->
   {% block extra_css %}{% endblock %}
   <style>


### PR DESCRIPTION
## Summary
- include the neural backgrounds stylesheet in the base template and extend the neural CSS to support hero overlays
- allow the shared hero component to render neural backgrounds and update the background partial/example accordingly
- enable the neural hero styling on the Núcleos list views

## Testing
- pytest nucleos -q *(fails: ModuleNotFoundError: No module named 'silk')*


------
https://chatgpt.com/codex/tasks/task_e_68cc6345bc9083259d7f6df6019e9cc5