### PR TITLE
feat: support nested sidebar navigation

### DIFF
--- a/app/static/css/hubx.css
+++ b/app/static/css/hubx.css
@@ -566,13 +566,28 @@
   /* Sidebar */
   .sidebar-item { @apply flex items-center gap-3 rounded-lg px-3 py-2 text-[var(--text-secondary)] hover:bg-[var(--bg-accent)] transition; }
   .sidebar-item-active { @apply bg-[var(--bg-accent)] text-[var(--text-primary)] font-medium; }
+  .sidebar-menu { @apply flex flex-col gap-1; }
+  .sidebar-entry { @apply relative; }
+  .sidebar-parent { @apply flex items-center gap-2; }
+  .sidebar-toggle {
+    @apply ml-auto inline-flex items-center justify-center rounded-md p-2 text-[var(--text-secondary)] transition hover:bg-[var(--bg-accent)] hover:text-[var(--text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)];
+  }
+  .sidebar-toggle-icon { @apply h-4 w-4 transition-transform; }
+  .sidebar-toggle[aria-expanded='true'] .sidebar-toggle-icon { @apply rotate-180; }
+  .sidebar-submenu { @apply mt-1 ml-3 flex flex-col gap-1 border-l border-[var(--border)] pl-3; }
+  .sidebar-subitem { @apply flex items-center gap-2 rounded-md px-3 py-2 text-sm text-[var(--text-secondary)] hover:bg-[var(--bg-accent)] transition; }
+  .sidebar-subitem svg { @apply h-4 w-4; }
   #sidebar .sidebar-header,
   #sidebar .sidebar-nav { @apply transition-all duration-150 ease-in-out; }
   #sidebar.sidebar-collapsed .sidebar-header,
   #sidebar.sidebar-collapsed .sidebar-nav { @apply px-2; }
   #sidebar.sidebar-collapsed .sidebar-nav { @apply py-3; }
   #sidebar.sidebar-collapsed .sidebar-item { @apply justify-center px-2; }
+  #sidebar.sidebar-collapsed .sidebar-toggle { @apply hidden; }
+  #sidebar.sidebar-collapsed .sidebar-submenu { @apply hidden; }
+  #sidebar.sidebar-collapsed .sidebar-subitem { @apply justify-center px-2; }
   #sidebar.sidebar-collapsed .sidebar-item svg,
+  #sidebar.sidebar-collapsed .sidebar-subitem svg,
   #sidebar.sidebar-collapsed .sidebar-item img { @apply w-6 h-6 flex-shrink-0; }
 
   /* Tabelas */

--- a/core/menu.py
+++ b/core/menu.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import List
 
 from django.urls import reverse
@@ -13,6 +13,7 @@ class MenuItem:
     icon: str
     permissions: List[str] | None = None
     classes: str = "flex items-center gap-x-2 hover:text-primary transition"
+    children: List["MenuItem"] | None = None
 
 
 # Icons as raw HTML so they can be injected into the template safely
@@ -136,23 +137,368 @@ ICON_REGISTER = """
 </svg>
 """
 
+ICON_INFO = """
+<svg aria-hidden=\"true\" xmlns=\"http://www.w3.org/2000/svg\" class=\"w-4 h-4\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\">
+  <circle cx=\"12\" cy=\"12\" r=\"10\" />
+  <path d=\"M12 16v-4\" />
+  <path d=\"M12 8h.01\" />
+</svg>
+"""
 
-def build_menu(request) -> List[MenuItem]:
-    """Retorna itens de menu filtrados por tipo de usuário."""
-    items = [
+ICON_BRIEFCASE = """
+<svg aria-hidden=\"true\" xmlns=\"http://www.w3.org/2000/svg\" class=\"w-4 h-4\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\">
+  <path d=\"M3 7a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2Z\" />
+  <path d=\"M8 7V5a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2\" />
+  <path d=\"M3 13h18\" />
+</svg>
+"""
+
+ICON_CHAT = """
+<svg aria-hidden=\"true\" xmlns=\"http://www.w3.org/2000/svg\" class=\"w-4 h-4\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\">
+  <path d=\"M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5Z\" />
+</svg>
+"""
+
+ICON_LOCK = """
+<svg aria-hidden=\"true\" xmlns=\"http://www.w3.org/2000/svg\" class=\"w-4 h-4\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\">
+  <rect width=\"18\" height=\"11\" x=\"3\" y=\"11\" rx=\"2\" />
+  <path d=\"M7 11V7a5 5 0 0 1 10 0v4\" />
+</svg>
+"""
+
+ICON_SETTINGS = """
+<svg aria-hidden=\"true\" xmlns=\"http://www.w3.org/2000/svg\" class=\"w-4 h-4\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\">
+  <path d=\"M12 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6Z\" />
+  <path d=\"M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1Z\" />
+</svg>
+"""
+
+ICON_LINK = """
+<svg aria-hidden=\"true\" xmlns=\"http://www.w3.org/2000/svg\" class=\"w-4 h-4\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\">
+  <path d=\"M9 15 7.5 16.5a3.54 3.54 0 0 1-5-5L5 9\" />
+  <path d=\"m15 9 1.5-1.5a3.54 3.54 0 0 1 5 5L19 15\" />
+  <path d=\"m8 12 4 0\" />
+  <path d=\"m12 12 4 0\" />
+</svg>
+"""
+
+ICON_PLUS = """
+<svg aria-hidden=\"true\" xmlns=\"http://www.w3.org/2000/svg\" class=\"w-4 h-4\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\">
+  <path d=\"M12 5v14\" />
+  <path d=\"M5 12h14\" />
+</svg>
+"""
+
+ICON_ARROWS = """
+<svg aria-hidden=\"true\" xmlns=\"http://www.w3.org/2000/svg\" class=\"w-4 h-4\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\">
+  <path d=\"m21 16-4 4-4-4\" />
+  <path d=\"M17 20V4\" />
+  <path d=\"m3 8 4-4 4 4\" />
+  <path d=\"M7 4v16\" />
+</svg>
+"""
+
+ICON_PIGGY_BANK = """
+<svg aria-hidden=\"true\" xmlns=\"http://www.w3.org/2000/svg\" class=\"w-4 h-4\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\">
+  <path d=\"M5 11c-1.1 0-2 .9-2 2v1c0 1.7 1.3 3 3 3h.3a3 3 0 0 0 2.7 2h4a3 3 0 0 0 2.7-2H18c1.7 0 3-1.3 3-3v-3l1-1v-2h-3.3a6.5 6.5 0 0 0-11.7 0H5Z\" />
+  <path d=\"M16 11h.01\" />
+  <path d=\"M2 16v-2a2 2 0 0 1 2-2\" />
+</svg>
+"""
+
+ICON_FILE_TEXT = """
+<svg aria-hidden=\"true\" xmlns=\"http://www.w3.org/2000/svg\" class=\"w-4 h-4\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\">
+  <path d=\"M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8Z\" />
+  <path d=\"M14 2v6h6\" />
+  <path d=\"M16 13H8\" />
+  <path d=\"M16 17H8\" />
+  <path d=\"M10 9H8\" />
+</svg>
+"""
+
+ICON_CHART = """
+<svg aria-hidden=\"true\" xmlns=\"http://www.w3.org/2000/svg\" class=\"w-4 h-4\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\">
+  <path d=\"M3 3v18h18\" />
+  <path d=\"m9 17 2-3 3 2 4-6\" />
+</svg>
+"""
+
+ICON_BUILDING = """
+<svg aria-hidden=\"true\" xmlns=\"http://www.w3.org/2000/svg\" class=\"w-4 h-4\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\">
+  <path d=\"M3 21V7a2 2 0 0 1 2-2h3V3a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2h3a2 2 0 0 1 2 2v14\" />
+  <path d=\"M9 21V9\" />
+  <path d=\"M15 21V9\" />
+  <path d=\"M3 21h18\" />
+</svg>
+"""
+
+ICON_PLUG = """
+<svg aria-hidden=\"true\" xmlns=\"http://www.w3.org/2000/svg\" class=\"w-4 h-4\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\">
+  <path d=\"M10 4V2\" />
+  <path d=\"M14 4V2\" />
+  <path d=\"M7 8h10\" />
+  <path d=\"M7 8a5 5 0 0 0 10 0\" />
+  <path d=\"M12 13v9\" />
+</svg>
+"""
+
+ICON_DOWNLOAD = """
+<svg aria-hidden=\"true\" xmlns=\"http://www.w3.org/2000/svg\" class=\"w-4 h-4\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\">
+  <path d=\"M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4\" />
+  <path d=\"m7 10 5 5 5-5\" />
+  <path d=\"M12 15V3\" />
+</svg>
+"""
+
+ICON_UPLOAD = """
+<svg aria-hidden=\"true\" xmlns=\"http://www.w3.org/2000/svg\" class=\"w-4 h-4\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\">
+  <path d=\"M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4\" />
+  <path d=\"m17 9-5-5-5 5\" />
+  <path d=\"M12 4v12\" />
+</svg>
+"""
+
+ICON_TABLE = """
+<svg aria-hidden=\"true\" xmlns=\"http://www.w3.org/2000/svg\" class=\"w-4 h-4\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\">
+  <path d=\"M3 10h18\" />
+  <path d=\"M10 3v18\" />
+  <rect width=\"18\" height=\"18\" x=\"3\" y=\"3\" rx=\"2\" />
+</svg>
+"""
+
+ICON_FILE_SEARCH = """
+<svg aria-hidden=\"true\" xmlns=\"http://www.w3.org/2000/svg\" class=\"w-4 h-4\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\">
+  <path d=\"M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9.5Z\" />
+  <path d=\"M14 2v6h6\" />
+  <path d=\"M9 11h1\" />
+  <path d=\"M9 15h6\" />
+  <circle cx=\"11.5\" cy=\"17.5\" r=\"2.5\" />
+  <path d=\"m13.3 19.3 1.4 1.4\" />
+</svg>
+"""
+
+ICON_TREND_UP = """
+<svg aria-hidden=\"true\" xmlns=\"http://www.w3.org/2000/svg\" class=\"w-4 h-4\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\">
+  <path d=\"m3 17 6-6 4 4 8-8\" />
+  <path d=\"M14 7h7v7\" />
+</svg>
+"""
+
+ICON_ALERT = """
+<svg aria-hidden=\"true\" xmlns=\"http://www.w3.org/2000/svg\" class=\"w-4 h-4\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\">
+  <path d=\"M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z\" />
+  <path d=\"M12 9v4\" />
+  <path d=\"M12 17h.01\" />
+</svg>
+"""
+
+ICON_CLOCK = """
+<svg aria-hidden=\"true\" xmlns=\"http://www.w3.org/2000/svg\" class=\"w-4 h-4\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\">
+  <circle cx=\"12\" cy=\"12\" r=\"10\" />
+  <path d=\"M12 6v6l3 3\" />
+</svg>
+"""
+
+
+def _get_menu_items() -> List[MenuItem]:
+    perfil_url = reverse("accounts:perfil")
+    configuracoes_url = reverse("configuracoes:configuracoes")
+    nucleos_url = reverse("nucleos:list")
+    eventos_url = reverse("eventos:lista")
+    feed_url = reverse("feed:listar")
+    financeiro_repasses = reverse("financeiro:repasses")
+
+    perfil_children = [
+        MenuItem(
+            id="perfil_info",
+            path=f"{perfil_url}?section=info",
+            label="Informações",
+            icon=ICON_INFO,
+            permissions=["authenticated"],
+        ),
+        MenuItem(
+            id="perfil_portfolio",
+            path=f"{perfil_url}?section=portfolio",
+            label="Portfólio",
+            icon=ICON_BRIEFCASE,
+            permissions=["authenticated"],
+        ),
+        MenuItem(
+            id="perfil_mural",
+            path=f"{perfil_url}?section=mural",
+            label="Mural",
+            icon=ICON_CHAT,
+            permissions=["authenticated"],
+        ),
+        MenuItem(
+            id="perfil_conexoes",
+            path=f"{perfil_url}?section=conexoes",
+            label="Conexões",
+            icon=ICON_LINK,
+            permissions=["authenticated"],
+        ),
+    ]
+
+    configuracoes_children = [
+        MenuItem(
+            id="configuracoes_seguranca",
+            path=f"{configuracoes_url}?tab=seguranca",
+            label="Segurança",
+            icon=ICON_LOCK,
+            permissions=["authenticated"],
+        ),
+        MenuItem(
+            id="configuracoes_preferencias",
+            path=f"{configuracoes_url}?tab=preferencias",
+            label="Preferências",
+            icon=ICON_SETTINGS,
+            permissions=["authenticated"],
+        ),
+    ]
+
+    nucleos_children = [
+        MenuItem(
+            id="nucleos_novo",
+            path=reverse("nucleos:create"),
+            label="Novo Núcleo",
+            icon=ICON_PLUS,
+            permissions=["admin"],
+        )
+    ]
+
+    eventos_children = [
+        MenuItem(
+            id="eventos_novo",
+            path=reverse("eventos:evento_novo"),
+            label="Novo Evento",
+            icon=ICON_PLUS,
+            permissions=["admin"],
+        )
+    ]
+
+    financeiro_children = [
+        MenuItem(
+            id="financeiro_repasses",
+            path=financeiro_repasses,
+            label="Repasses",
+            icon=ICON_ARROWS,
+            permissions=["admin", "financeiro"],
+        ),
+        MenuItem(
+            id="financeiro_importar_pagamentos",
+            path=reverse("financeiro:importar_pagamentos"),
+            label="Importar Pagamentos",
+            icon=ICON_UPLOAD,
+            permissions=["admin", "financeiro"],
+        ),
+        MenuItem(
+            id="financeiro_relatorios",
+            path=reverse("financeiro:relatorios"),
+            label="Relatórios",
+            icon=ICON_CHART,
+            permissions=["admin", "financeiro"],
+        ),
+        MenuItem(
+            id="financeiro_lancamentos",
+            path=reverse("financeiro:lancamentos"),
+            label="Lançamentos",
+            icon=ICON_TABLE,
+            permissions=["admin", "financeiro"],
+        ),
+        MenuItem(
+            id="financeiro_logs",
+            path=reverse("financeiro:logs"),
+            label="Logs",
+            icon=ICON_FILE_SEARCH,
+            permissions=["admin", "financeiro"],
+        ),
+        MenuItem(
+            id="financeiro_forecast",
+            path=reverse("financeiro:forecast"),
+            label="Forecast",
+            icon=ICON_TREND_UP,
+            permissions=["admin", "financeiro"],
+        ),
+        MenuItem(
+            id="financeiro_inadimplencias",
+            path=reverse("financeiro:inadimplencias"),
+            label="Inadimplências",
+            icon=ICON_ALERT,
+            permissions=["admin", "financeiro"],
+        ),
+        MenuItem(
+            id="financeiro_task_logs",
+            path=reverse("financeiro:task_logs"),
+            label="Task Logs",
+            icon=ICON_CLOCK,
+            permissions=["admin", "financeiro"],
+        ),
+        MenuItem(
+            id="financeiro_centros",
+            path=reverse("financeiro:centros"),
+            label="Centros de Custo",
+            icon=ICON_BUILDING,
+            permissions=["admin", "financeiro"],
+        ),
+        MenuItem(
+            id="financeiro_centro_novo",
+            path=reverse("financeiro:centro_form"),
+            label="Novo Centro",
+            icon=ICON_PLUS,
+            permissions=["admin", "financeiro"],
+        ),
+        MenuItem(
+            id="financeiro_integracoes",
+            path=reverse("financeiro:integracoes"),
+            label="Integrações",
+            icon=ICON_PLUG,
+            permissions=["admin", "financeiro"],
+        ),
+        MenuItem(
+            id="financeiro_integracao_nova",
+            path=reverse("financeiro:integracao_form"),
+            label="Nova Integração",
+            icon=ICON_PLUS,
+            permissions=["admin", "financeiro"],
+        ),
+        MenuItem(
+            id="financeiro_importacoes",
+            path=reverse("financeiro:importacoes"),
+            label="Importações",
+            icon=ICON_DOWNLOAD,
+            permissions=["admin", "financeiro"],
+        ),
+        MenuItem(
+            id="financeiro_extrato",
+            path=reverse("financeiro:extrato"),
+            label="Extrato",
+            icon=ICON_FILE_TEXT,
+            permissions=["associado"],
+        ),
+        MenuItem(
+            id="financeiro_aportes",
+            path=reverse("financeiro:aportes_form"),
+            label="Aportes",
+            icon=ICON_PIGGY_BANK,
+            permissions=["associado"],
+        ),
+    ]
+
+    return [
         MenuItem(
             id="perfil",
-            path=reverse("accounts:perfil"),
+            path=perfil_url,
             label="Perfil",
             icon=ICON_USER,
             permissions=["authenticated"],
             classes="flex items-center hover:text-primary transition",
+            children=perfil_children,
         ),
         MenuItem("dashboard", "/", "Dashboard", ICON_DASHBOARD, None),
         MenuItem("associados", reverse("associados_lista"), "Associados", ICON_USERS, ["admin", "coordenador"]),
         MenuItem(
             "nucleos",
-            reverse("nucleos:list"),
+            nucleos_url,
             "Núcleos",
             ICON_USERS,
             [
@@ -163,6 +509,7 @@ def build_menu(request) -> List[MenuItem]:
                 "associado",
                 "convidado",
             ],
+            children=nucleos_children,
         ),
         MenuItem(
             "meus_nucleos",
@@ -179,7 +526,7 @@ def build_menu(request) -> List[MenuItem]:
         ),
         MenuItem(
             "eventos",
-            reverse("eventos:lista"),
+            eventos_url,
             "Eventos",
             ICON_EVENTOS,
             [
@@ -190,10 +537,11 @@ def build_menu(request) -> List[MenuItem]:
                 "associado",
                 "convidado",
             ],
+            children=eventos_children,
         ),
         MenuItem(
             "feed",
-            reverse("feed:listar"),
+            feed_url,
             "Feed",
             ICON_FEED,
             [
@@ -205,17 +553,25 @@ def build_menu(request) -> List[MenuItem]:
                 "convidado",
             ],
         ),
-        MenuItem("financeiro", reverse("financeiro:repasses"), "Financeiro", ICON_FINANCEIRO, ["admin", "financeiro"]),
+        MenuItem(
+            "financeiro",
+            financeiro_repasses,
+            "Financeiro",
+            ICON_FINANCEIRO,
+            ["admin", "financeiro", "associado"],
+            children=financeiro_children,
+        ),
         MenuItem("organizacoes", reverse("organizacoes:list"), "Organizações", ICON_ORGS, ["root"]),
         MenuItem("token_admin", reverse("tokens:listar_api_tokens"), "Token", ICON_TOKEN, ["root", "admin"]),
         MenuItem("token_convite", reverse("tokens:gerar_convite"), "Token", ICON_TOKEN, ["coordenador"]),
         MenuItem(
             "configuracoes",
-            reverse("configuracoes:configuracoes"),
+            configuracoes_url,
             "Configurações",
             ICON_CONFIG,
             ["authenticated"],
             "hover:text-primary transition",
+            configuracoes_children,
         ),
         MenuItem("logout", reverse("accounts:logout"), "Sair", ICON_LOGOUT, ["authenticated"]),
         MenuItem("login", reverse("accounts:login"), "Entrar", ICON_LOGIN, ["anonymous"]),
@@ -229,16 +585,64 @@ def build_menu(request) -> List[MenuItem]:
         ),
     ]
 
-    user = request.user
+
+def _user_has_permission(user, item: MenuItem) -> bool:
+    perms = item.permissions or []
+    if not perms:
+        return True
+    if "anonymous" in perms and not user.is_authenticated:
+        return True
+    if "authenticated" in perms and user.is_authenticated:
+        return True
+    if user.is_authenticated and user.user_type in perms:
+        return True
+    return False
+
+
+def _filter_items(items: List[MenuItem], user) -> List[MenuItem]:
     filtered: List[MenuItem] = []
     for item in items:
-        perms = item.permissions or []
-        if "anonymous" in perms and not user.is_authenticated:
-            filtered.append(item)
-        elif "authenticated" in perms and user.is_authenticated:
-            filtered.append(item)
-        elif user.is_authenticated and user.user_type in perms:
-            filtered.append(item)
-        elif not perms:
-            filtered.append(item)
+        filtered_children = _filter_items(item.children, user) if item.children else []
+        if _user_has_permission(user, item):
+            filtered_item = replace(item, children=filtered_children or None)
+            filtered.append(filtered_item)
+    return filtered
+
+
+def _mark_active(items: List[MenuItem], current_path: str, current_full_path: str) -> bool:
+    any_active = False
+    for item in items:
+        child_active = False
+        if item.children:
+            child_active = _mark_active(item.children, current_path, current_full_path)
+        is_current = current_path == item.path or current_full_path == item.path
+        item.is_current = is_current
+        item.has_active_child = child_active
+        item.is_active = is_current or child_active
+        item.is_expanded = item.is_active
+        any_active = any_active or item.is_active
+    return any_active
+
+
+def _adjust_item_paths(items: List[MenuItem], user) -> None:
+    for item in items:
+        if item.id == "financeiro" and item.children and getattr(user, "user_type", None) == "associado":
+            for child in item.children:
+                if child.id == "financeiro_extrato":
+                    item.path = child.path
+                    break
+        if item.children:
+            _adjust_item_paths(item.children, user)
+
+
+def build_menu(request) -> List[MenuItem]:
+    """Retorna itens de menu filtrados por tipo de usuário."""
+
+    items = _get_menu_items()
+    user = request.user
+    filtered = _filter_items(items, user)
+    _adjust_item_paths(filtered, user)
+    current_path = request.path
+    current_full_path = request.get_full_path()
+    _mark_active(filtered, current_path, current_full_path)
     return filtered

--- a/static/tailwind.css
+++ b/static/tailwind.css
@@ -1375,9 +1375,7 @@ a:focus {
   font-size: 0.875rem;
   line-height: 1.25rem;
   font-weight: 500;
-  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, -webkit-backdrop-filter;
   transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;
-  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter, -webkit-backdrop-filter;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;
 }
@@ -1440,9 +1438,7 @@ a:focus {
   font-size: 0.875rem;
   line-height: 1.25rem;
   font-weight: 500;
-  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, -webkit-backdrop-filter;
   transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;
-  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter, -webkit-backdrop-filter;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;
   border-color: transparent;
@@ -1512,9 +1508,7 @@ a:focus {
   font-size: 0.875rem;
   line-height: 1.25rem;
   font-weight: 500;
-  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, -webkit-backdrop-filter;
   transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;
-  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter, -webkit-backdrop-filter;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;
   border-color: var(--border);
@@ -1538,9 +1532,7 @@ a:focus {
   padding-top: 0.5rem;
   padding-bottom: 0.5rem;
   color: var(--text-secondary);
-  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, -webkit-backdrop-filter;
   transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;
-  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter, -webkit-backdrop-filter;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;
 }
@@ -1553,6 +1545,99 @@ a:focus {
   background-color: var(--bg-accent);
   font-weight: 500;
   color: var(--text-primary);
+}
+
+.sidebar-menu {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.sidebar-entry {
+  position: relative;
+}
+
+.sidebar-parent {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.sidebar-toggle {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: calc(var(--radius) - 2px);
+  padding: 0.5rem;
+  color: var(--text-secondary);
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.sidebar-toggle:hover {
+  background-color: var(--bg-accent);
+  color: var(--text-primary);
+}
+
+.sidebar-toggle:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+  --tw-ring-color: var(--primary);
+}
+
+.sidebar-toggle-icon {
+  height: 1rem;
+  width: 1rem;
+  transition-property: transform;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.sidebar-toggle[aria-expanded='true'] .sidebar-toggle-icon {
+  --tw-rotate: 180deg;
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+
+.sidebar-submenu {
+  margin-top: 0.25rem;
+  margin-left: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  border-left-width: 1px;
+  border-color: var(--border);
+  padding-left: 0.75rem;
+}
+
+.sidebar-subitem {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  border-radius: calc(var(--radius) - 2px);
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  color: var(--text-secondary);
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.sidebar-subitem:hover {
+  background-color: var(--bg-accent);
+}
+
+.sidebar-subitem svg {
+  height: 1rem;
+  width: 1rem;
 }
 
 #sidebar .sidebar-header,
@@ -1581,7 +1666,22 @@ a:focus {
   padding-right: 0.5rem;
 }
 
+#sidebar.sidebar-collapsed .sidebar-toggle {
+  display: none;
+}
+
+#sidebar.sidebar-collapsed .sidebar-submenu {
+  display: none;
+}
+
+#sidebar.sidebar-collapsed .sidebar-subitem {
+  justify-content: center;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
 #sidebar.sidebar-collapsed .sidebar-item svg,
+  #sidebar.sidebar-collapsed .sidebar-subitem svg,
   #sidebar.sidebar-collapsed .sidebar-item img {
   height: 1.5rem;
   width: 1.5rem;
@@ -1707,6 +1807,10 @@ a:focus {
 
 .isolate {
   isolation: isolate;
+}
+
+.z-10 {
+  z-index: 10;
 }
 
 .z-20 {
@@ -1938,6 +2042,10 @@ a:focus {
   width: 2rem;
 }
 
+.w-auto {
+  width: auto;
+}
+
 .w-full {
   width: 100%;
 }
@@ -1950,8 +2058,16 @@ a:focus {
   min-width: 100%;
 }
 
+.max-w-2xl {
+  max-width: 42rem;
+}
+
 .max-w-3xl {
   max-width: 48rem;
+}
+
+.max-w-5xl {
+  max-width: 64rem;
 }
 
 .max-w-6xl {
@@ -1980,6 +2096,10 @@ a:focus {
 
 .flex-grow {
   flex-grow: 1;
+}
+
+.transform {
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
 }
 
 .cursor-move {
@@ -2097,6 +2217,12 @@ a:focus {
   --tw-space-y-reverse: 0;
   margin-top: calc(0.5rem * calc(1 - var(--tw-space-y-reverse)));
   margin-bottom: calc(0.5rem * var(--tw-space-y-reverse));
+}
+
+.space-y-3 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(0.75rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(0.75rem * var(--tw-space-y-reverse));
 }
 
 .space-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -2260,6 +2386,10 @@ a:focus {
   background-color: rgb(255 255 255 / 0.2);
 }
 
+.bg-gradient-to-br {
+  background-image: linear-gradient(to bottom right, var(--tw-gradient-stops));
+}
+
 .bg-gradient-to-r {
   background-image: linear-gradient(to right, var(--tw-gradient-stops));
 }
@@ -2270,8 +2400,18 @@ a:focus {
   --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
 }
 
+.from-blue-50 {
+  --tw-gradient-from: #eff6ff var(--tw-gradient-from-position);
+  --tw-gradient-to: rgb(239 246 255 / 0) var(--tw-gradient-to-position);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
+}
+
 .to-\[var\(--hero-to\)\] {
   --tw-gradient-to: var(--hero-to) var(--tw-gradient-to-position);
+}
+
+.to-blue-100 {
+  --tw-gradient-to: #dbeafe var(--tw-gradient-to-position);
 }
 
 .object-cover {
@@ -2316,6 +2456,11 @@ a:focus {
 .px-4 {
   padding-left: 1rem;
   padding-right: 1rem;
+}
+
+.px-6 {
+  padding-left: 1.5rem;
+  padding-right: 1.5rem;
 }
 
 .py-0\.5 {
@@ -2537,6 +2682,12 @@ a:focus {
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
+.ring {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(3px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
 .ring-1 {
   --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
   --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);
@@ -2579,9 +2730,7 @@ a:focus {
 }
 
 .transition {
-  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, -webkit-backdrop-filter;
   transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;
-  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter, -webkit-backdrop-filter;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;
 }
@@ -2984,7 +3133,21 @@ a:focus {
   color: var(--text-inverse);
 }
 
+.dark\:from-gray-900:is(.dark *) {
+  --tw-gradient-from: #111827 var(--tw-gradient-from-position);
+  --tw-gradient-to: rgb(17 24 39 / 0) var(--tw-gradient-to-position);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
+}
+
+.dark\:to-gray-800:is(.dark *) {
+  --tw-gradient-to: #1f2937 var(--tw-gradient-to-position);
+}
+
 @media (min-width: 640px) {
+  .sm\:grid-cols-1 {
+    grid-template-columns: repeat(1, minmax(0, 1fr));
+  }
+
   .sm\:grid-cols-2 {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
@@ -3009,6 +3172,10 @@ a:focus {
 
   .md\:w-24 {
     width: 6rem;
+  }
+
+  .md\:max-w-3xl {
+    max-width: 48rem;
   }
 
   .md\:grid-cols-2 {
@@ -3039,12 +3206,20 @@ a:focus {
     justify-content: space-between;
   }
 
+  .md\:self-start {
+    align-self: flex-start;
+  }
+
   .md\:p-5 {
     padding: 1.25rem;
   }
 
   .md\:pb-6 {
     padding-bottom: 1.5rem;
+  }
+
+  .md\:text-left {
+    text-align: left;
   }
 
   .md\:text-3xl {
@@ -3055,6 +3230,16 @@ a:focus {
   .md\:text-4xl {
     font-size: 2.25rem;
     line-height: 2.5rem;
+  }
+
+  .md\:text-5xl {
+    font-size: 3rem;
+    line-height: 1;
+  }
+
+  .md\:text-6xl {
+    font-size: 3.75rem;
+    line-height: 1;
   }
 }
 

--- a/templates/_partials/sidebar.html
+++ b/templates/_partials/sidebar.html
@@ -12,17 +12,50 @@
     </button>
   </div>
   <nav class="sidebar-nav flex-1 overflow-y-auto px-4 py-4" role="navigation" aria-label="{% trans 'Menu' %}">
-    {% for item in NAV_MENU %}
-      <a href="{{ item.path }}" class="sidebar-item{% if request.path == item.path %} sidebar-item-active{% endif %}" {% if request.path == item.path %}aria-current="page"{% endif %}>
-        {% if item.id == 'perfil' and user.avatar %}
-          <img src="{{ user.avatar.url }}" alt="{{ user.username }}" class="w-6 h-6 rounded-full object-cover" loading="lazy" />
-        {% else %}
-          {{ item.icon|safe }}
-        {% endif %}
-        <span class="sidebar-label">{{ item.label }}</span>
-      </a>
-      {% if item.id == 'perfil' %}<span id="notif-count" class="hidden"></span>{% endif %}
-    {% endfor %}
+    <ul class="sidebar-menu flex flex-col gap-1">
+      {% for item in NAV_MENU %}
+        <li class="sidebar-entry">
+          {% if item.children %}
+            <div class="sidebar-parent">
+              <a href="{{ item.path }}" class="sidebar-item{% if item.is_active %} sidebar-item-active{% endif %}{% if item.classes %} {{ item.classes }}{% endif %}" {% if item.is_current %}aria-current="page"{% endif %}>
+                {% if item.id == 'perfil' and user.avatar %}
+                  <img src="{{ user.avatar.url }}" alt="{{ user.username }}" class="w-6 h-6 rounded-full object-cover" loading="lazy" />
+                {% else %}
+                  {{ item.icon|safe }}
+                {% endif %}
+                <span class="sidebar-label">{{ item.label }}</span>
+              </a>
+              <button type="button" class="sidebar-toggle" aria-expanded="{{ item.is_active|yesno:'true,false' }}" aria-controls="submenu-{{ item.id }}" data-sidebar-submenu-toggle>
+                <span class="sr-only">{% blocktrans with label=item.label %}Alternar {{ label }}{% endblocktrans %}</span>
+                <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="sidebar-toggle-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="m6 9 6 6 6-6" />
+                </svg>
+              </button>
+            </div>
+            <ul id="submenu-{{ item.id }}" class="sidebar-submenu{% if not item.is_active %} hidden{% endif %}" data-sidebar-submenu>
+              {% for child in item.children %}
+                <li>
+                  <a href="{{ child.path }}" class="sidebar-subitem{% if child.is_active %} sidebar-item-active{% endif %}" {% if child.is_current %}aria-current="page"{% endif %}>
+                    {{ child.icon|safe }}
+                    <span class="sidebar-label">{{ child.label }}</span>
+                  </a>
+                </li>
+              {% endfor %}
+            </ul>
+          {% else %}
+            <a href="{{ item.path }}" class="sidebar-item{% if item.is_active %} sidebar-item-active{% endif %}{% if item.classes %} {{ item.classes }}{% endif %}" {% if item.is_current %}aria-current="page"{% endif %}>
+              {% if item.id == 'perfil' and user.avatar %}
+                <img src="{{ user.avatar.url }}" alt="{{ user.username }}" class="w-6 h-6 rounded-full object-cover" loading="lazy" />
+              {% else %}
+                {{ item.icon|safe }}
+              {% endif %}
+              <span class="sidebar-label">{{ item.label }}</span>
+            </a>
+          {% endif %}
+          {% if item.id == 'perfil' %}<span id="notif-count" class="hidden"></span>{% endif %}
+        </li>
+      {% endfor %}
+    </ul>
   </nav>
 </aside>
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -122,6 +122,48 @@
       if (sidebarToggle && sidebar && content) {
         const baseMargin = '{% if hide_nav %}ml-0{% else %}ml-64{% endif %}';
         const sidebarLabels = Array.from(document.querySelectorAll('#sidebar .sidebar-label'));
+        const submenuToggles = Array.from(document.querySelectorAll('#sidebar [data-sidebar-submenu-toggle]'));
+
+        const getSubmenu = (toggle) => {
+          const controls = toggle.getAttribute('aria-controls');
+          return controls ? document.getElementById(controls) : null;
+        };
+
+        submenuToggles.forEach((toggle) => {
+          const expanded = toggle.getAttribute('aria-expanded') === 'true';
+          toggle.dataset.sidebarExpanded = expanded ? 'true' : 'false';
+          const submenu = getSubmenu(toggle);
+          if (submenu && !expanded) {
+            submenu.classList.add('hidden');
+          }
+          toggle.addEventListener('click', (event) => {
+            event.preventDefault();
+            const nextExpanded = toggle.dataset.sidebarExpanded !== 'true';
+            toggle.dataset.sidebarExpanded = nextExpanded ? 'true' : 'false';
+            const submenuEl = getSubmenu(toggle);
+            if (!sidebar.classList.contains('sidebar-collapsed') && submenuEl) {
+              toggle.setAttribute('aria-expanded', String(nextExpanded));
+              submenuEl.classList.toggle('hidden', !nextExpanded);
+            }
+          });
+        });
+
+        const syncSubmenus = (collapsed) => {
+          submenuToggles.forEach((toggle) => {
+            const submenu = getSubmenu(toggle);
+            if (!submenu) {
+              return;
+            }
+            const storedExpanded = toggle.dataset.sidebarExpanded === 'true';
+            if (collapsed) {
+              submenu.classList.add('hidden');
+              toggle.setAttribute('aria-expanded', 'false');
+            } else {
+              toggle.setAttribute('aria-expanded', String(storedExpanded));
+              submenu.classList.toggle('hidden', !storedExpanded);
+            }
+          });
+        };
 
         const setSidebarState = (collapsed) => {
           sidebar.classList.toggle('w-64', !collapsed);
@@ -133,6 +175,7 @@
           sidebarLabels.forEach((el) => {
             el.classList.toggle('hidden', collapsed);
           });
+          syncSubmenus(collapsed);
         };
 
         const savedCollapsed = localStorage.getItem('sidebar') === 'collapsed';

--- a/tests/core/test_menu.py
+++ b/tests/core/test_menu.py
@@ -1,0 +1,62 @@
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import RequestFactory
+
+from accounts.models import UserType
+from core.menu import MenuItem, build_menu
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    ("user_type", "expected_children"),
+    [
+        (UserType.FINANCEIRO, ["child_fin"]),
+        (UserType.ADMIN, ["child_admin"]),
+    ],
+)
+def test_build_menu_filters_nested_items(monkeypatch, user_type, expected_children):
+    def _fake_menu():
+        return [
+            MenuItem(
+                id="parent",
+                path="/parent/",
+                label="Parent",
+                icon="icon",
+                permissions=[UserType.ADMIN.value, UserType.FINANCEIRO.value],
+                children=[
+                    MenuItem(
+                        id="child_fin",
+                        path="/child-fin/",
+                        label="Financeiro",
+                        icon="icon",
+                        permissions=[UserType.FINANCEIRO.value],
+                    ),
+                    MenuItem(
+                        id="child_admin",
+                        path="/child-admin/",
+                        label="Admin",
+                        icon="icon",
+                        permissions=[UserType.ADMIN.value],
+                    ),
+                ],
+            )
+        ]
+
+    monkeypatch.setattr("core.menu._get_menu_items", _fake_menu)
+
+    user_model = get_user_model()
+    user = user_model.objects.create_user(
+        email=f"{user_type.value}@example.com",
+        username=f"{user_type.value}",
+        password="test-pass",
+        user_type=user_type,
+    )
+
+    request = RequestFactory().get("/parent/")
+    request.user = user
+
+    menu = build_menu(request)
+
+    assert len(menu) == 1
+    child_ids = [child.id for child in menu[0].children or []]
+    assert child_ids == expected_children


### PR DESCRIPTION
## Summary
- extend the menu model with child items, dedicated icons, and active state helpers so we can compose role-aware submenus
- render sidebar sections with accessible toggles, nested lists, and matching Tailwind utilities for both expanded and collapsed modes
- add regression coverage ensuring build_menu filters nested items per user role

## Testing
- pytest (fails: missing optional test dependencies such as axe_core_python and discussao)
- pytest --no-cov tests/core/test_menu.py tests/test_nav_sidebar.py

------
https://chatgpt.com/codex/tasks/task_e_68cd51752ef483258a415ae888f395de