### PR TITLE
Add configuracoes hero component

### DIFF
--- a/configuracoes/templates/configuracoes/configuracao_form.html
+++ b/configuracoes/templates/configuracoes/configuracao_form.html
@@ -2,7 +2,9 @@
 {% load i18n static %}
 
 {% block title %}{% trans 'Configurações da Conta' %}{% endblock %}
-{% block hero %}{% include '_components/hero.html' with title=_('Configurações da Conta') %}{% endblock %}
+{% block hero %}
+  {% include '_components/hero_configuracoes.html' with title=_('Configurações da Conta') %}
+{% endblock %}
 
 {% block content %}
 <main class="container mx-auto px-4 py-6">

--- a/templates/_components/hero_configuracoes.html
+++ b/templates/_components/hero_configuracoes.html
@@ -1,0 +1,28 @@
+{% load i18n %}
+<section class="hero-with-neural bg-gradient-to-br from-blue-50 via-blue-100 to-indigo-200 dark:from-slate-900 dark:via-slate-900 dark:to-slate-800 text-white">
+  <div class="neural-bg-base" aria-hidden="true">
+    {% include 'backgrounds/neural_backgrounds.html' with bg_type='configuracao' only %}
+  </div>
+  <div class="hero-overlay" aria-hidden="true"></div>
+  <div class="hero-content relative z-10 w-full">
+    <div class="max-w-7xl mx-auto w-full px-4 py-12 text-center md:text-left">
+      {% if breadcrumb_template %}
+        <div class="mb-4">{% include breadcrumb_template %}</div>
+      {% endif %}
+      <div class="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+        <div class="space-y-3 md:max-w-3xl">
+          <h1 class="text-4xl md:text-5xl font-bold text-white">{{ title }}</h1>
+          {% if subtitle %}
+            <p class="text-lg text-white/90">{{ subtitle }}</p>
+          {% endif %}
+        </div>
+        {% if action_template %}
+          <div class="flex justify-center md:justify-end md:self-start">{% include action_template %}</div>
+        {% endif %}
+      </div>
+      {% if helper_text %}
+        <p class="mt-6 text-base text-white/80">{{ helper_text }}</p>
+      {% endif %}
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
## Summary
- add a dedicated hero component for the configurações area using the neural background assets
- update the configurações form page to render the new hero when bg_type is configuracao

## Testing
- pytest tests/configuracoes -k configuracoes *(fails: ModuleNotFoundError: No module named 'silk')*

------
https://chatgpt.com/codex/tasks/task_e_68cd573bd37c832585757a4cf9eb789f