### PR TITLE
feat: add neural hero component for financeiro pages

### DIFF
--- a/financeiro/templates/financeiro/centros_list.html
+++ b/financeiro/templates/financeiro/centros_list.html
@@ -4,7 +4,7 @@
 {% block title %}{% trans "Centros de Custo" %}{% endblock %}
 
 {% block hero %}
-  {% include '_components/hero.html' with title=_('Centros de Custo') action_template='financeiro/hero_centros_action.html' %}
+  {% include '_components/hero_financeiro.html' with title=_('Centros de Custo') action_template='financeiro/hero_centros_action.html' %}
 {% endblock %}
 
 {% block content %}

--- a/financeiro/templates/financeiro/extrato.html
+++ b/financeiro/templates/financeiro/extrato.html
@@ -4,7 +4,7 @@
 {% block title %}{{ _('Extrato') }}{% endblock %}
 
 {% block hero %}
-  {% include '_components/hero.html' with title=_('Extrato') %}
+  {% include '_components/hero_financeiro.html' with title=_('Extrato') %}
 {% endblock %}
 
 {% block content %}

--- a/financeiro/templates/financeiro/importacoes_list.html
+++ b/financeiro/templates/financeiro/importacoes_list.html
@@ -4,7 +4,7 @@
 {% block title %}{% trans "Importações de Pagamentos" %}{% endblock %}
 
 {% block hero %}
-  {% include '_components/hero.html' with title=_('Importações de Pagamentos') %}
+  {% include '_components/hero_financeiro.html' with title=_('Importações de Pagamentos') %}
 {% endblock %}
 
 {% block content %}

--- a/financeiro/templates/financeiro/importar_pagamentos.html
+++ b/financeiro/templates/financeiro/importar_pagamentos.html
@@ -4,7 +4,7 @@
 {% block title %}{% trans "Importar Pagamentos" %}{% endblock %}
 
 {% block hero %}
-  {% include '_components/hero.html' with title=_('Importar Pagamentos') %}
+  {% include '_components/hero_financeiro.html' with title=_('Importar Pagamentos') %}
 {% endblock %}
 
 {% block content %}

--- a/financeiro/templates/financeiro/integracoes_list.html
+++ b/financeiro/templates/financeiro/integracoes_list.html
@@ -4,7 +4,7 @@
 {% block title %}{% trans "Integrações" %}{% endblock %}
 
 {% block hero %}
-  {% include '_components/hero.html' with title=_('Integrações') action_template='financeiro/hero_integracoes_action.html' %}
+  {% include '_components/hero_financeiro.html' with title=_('Integrações') action_template='financeiro/hero_integracoes_action.html' %}
 {% endblock %}
 
 {% block content %}

--- a/financeiro/templates/financeiro/lancamentos_list.html
+++ b/financeiro/templates/financeiro/lancamentos_list.html
@@ -4,7 +4,7 @@
 {% block title %}{{ _('Lançamentos Financeiros') }}{% endblock %}
 
 {% block hero %}
-  {% include '_components/hero.html' with title=_('Lançamentos') %}
+  {% include '_components/hero_financeiro.html' with title=_('Lançamentos') %}
 {% endblock %}
 
 {% block content %}

--- a/financeiro/templates/financeiro/logs_list.html
+++ b/financeiro/templates/financeiro/logs_list.html
@@ -4,7 +4,7 @@
 {% block title %}{{ _('Logs Financeiros') }}{% endblock %}
 
 {% block hero %}
-  {% include '_components/hero.html' with title=_('Logs Financeiros') %}
+  {% include '_components/hero_financeiro.html' with title=_('Logs Financeiros') %}
 {% endblock %}
 
 {% block content %}

--- a/financeiro/templates/financeiro/relatorios.html
+++ b/financeiro/templates/financeiro/relatorios.html
@@ -4,7 +4,7 @@
 {% block title %}{% trans "Relatórios Financeiros" %}{% endblock %}
 
 {% block hero %}
-  {% include '_components/hero.html' with title=_('Relatórios') %}
+  {% include '_components/hero_financeiro.html' with title=_('Relatórios') %}
 {% endblock %}
 
 {% block content %}

--- a/financeiro/templates/financeiro/repasses.html
+++ b/financeiro/templates/financeiro/repasses.html
@@ -4,7 +4,7 @@
 {% block title %}{% trans "Repasses de Receita" %}{% endblock %}
 
 {% block hero %}
-  {% include '_components/hero.html' with title=_('Repasses') %}
+  {% include '_components/hero_financeiro.html' with title=_('Repasses') %}
 {% endblock %}
 
 {% block content %}

--- a/financeiro/templates/financeiro/task_log_detail.html
+++ b/financeiro/templates/financeiro/task_log_detail.html
@@ -4,7 +4,7 @@
 {% block title %}{{ _('Detalhes da Tarefa Financeira') }}{% endblock %}
 
 {% block hero %}
-  {% include "_components/hero.html" with title=log.nome_tarefa %}
+  {% include "_components/hero_financeiro.html" with title=log.nome_tarefa %}
 {% endblock %}
 
 {% block content %}

--- a/templates/_components/hero_financeiro.html
+++ b/templates/_components/hero_financeiro.html
@@ -1,0 +1,26 @@
+{% load i18n %}
+<section class="hero-with-neural bg-gradient-to-br from-[var(--hero-from)] to-[var(--hero-to)] text-white"
+         style="--hero-from: var(--color-primary-600); --hero-to: var(--color-primary-800);{% if style %} {{ style }}{% endif %}">
+  <div class="neural-bg-base" aria-hidden="true">
+    {% include 'backgrounds/neural_backgrounds.html' with bg_type='financeiro' only %}
+  </div>
+  <div class="hero-overlay" aria-hidden="true"></div>
+  <div class="hero-content relative z-10 w-full">
+    <div class="max-w-7xl mx-auto w-full px-4 py-12 md:py-16">
+      {% if breadcrumb_template %}
+        <div class="mb-4">{% include breadcrumb_template %}</div>
+      {% endif %}
+      <div class="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+        <div class="space-y-3 md:max-w-3xl">
+          <h1 class="text-4xl md:text-5xl font-bold text-white">{{ title }}</h1>
+          {% if subtitle %}
+            <p class="text-lg text-white/90">{{ subtitle }}</p>
+          {% endif %}
+        </div>
+        {% if action_template %}
+          <div class="flex justify-center md:justify-end md:self-start">{% include action_template %}</div>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
## Summary
- add a dedicated `_components/hero_financeiro.html` that renders the financeiro neural background
- update the financeiro templates to consume the new hero so the visual treatment is consistent across pages

## Testing
- not run (templates only)


------
https://chatgpt.com/codex/tasks/task_e_68cd5e17e0f083258a673681faf8d8a4