### PR TITLE
Use hero_eventos component on event creation page

### DIFF
--- a/eventos/templates/eventos/create.html
+++ b/eventos/templates/eventos/create.html
@@ -3,7 +3,7 @@
 {% block title %}{% trans "Novo Evento" %} | Hubx{% endblock %}
 
 {% block hero %}
-  {% include '_components/hero.html' with title=_('Novo Evento') %}
+  {% include '_components/hero_eventos.html' with title=_('Novo Evento') %}
 {% endblock %}
 
 {% block content %}

--- a/templates/_components/hero_eventos.html
+++ b/templates/_components/hero_eventos.html
@@ -1,0 +1,1 @@
+{% include '_components/hero_evento.html' %}


### PR DESCRIPTION
## Summary
- add a dedicated hero_eventos component that reuses the event hero styling
- switch the Novo Evento template to use the hero_eventos partial for consistent visuals

## Testing
- not run (template-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cd60ad28048325b27ecdc7dd987af3