### PR TITLE
Add tokens hero component

### DIFF
--- a/templates/_components/hero_tokens.html
+++ b/templates/_components/hero_tokens.html
@@ -1,0 +1,29 @@
+{% load i18n %}
+<section class="hero-with-neural bg-gradient-to-br from-[var(--hero-from)] to-[var(--hero-to)] text-white"
+         style="--hero-from: #38bdf8; --hero-to: #1e3a8a;{% if style %} {{ style }}{% endif %}">
+  <div class="neural-bg-base" aria-hidden="true">
+    {% include 'backgrounds/neural_backgrounds.html' with bg_type='tokens' only %}
+  </div>
+  <div class="hero-overlay" aria-hidden="true"></div>
+  <div class="hero-content relative z-10 w-full">
+    <div class="max-w-7xl mx-auto w-full px-4 py-12 md:py-16">
+      {% if breadcrumb_template %}
+        <div class="mb-4">{% include breadcrumb_template %}</div>
+      {% endif %}
+      <div class="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+        <div class="space-y-3 md:max-w-3xl">
+          <h1 class="text-4xl md:text-5xl font-bold text-white">{{ title }}</h1>
+          {% if subtitle %}
+            <p class="text-lg text-white/90">{{ subtitle }}</p>
+          {% endif %}
+        </div>
+        {% if action_template %}
+          <div class="flex justify-center md:justify-end md:self-start">{% include action_template %}</div>
+        {% endif %}
+      </div>
+      {% if helper_text %}
+        <p class="mt-6 text-base text-white/80">{{ helper_text }}</p>
+      {% endif %}
+    </div>
+  </div>
+</section>

--- a/tokens/templates/tokens/api_tokens.html
+++ b/tokens/templates/tokens/api_tokens.html
@@ -3,7 +3,7 @@
 {% block title %}{% trans "Tokens de API" %} | HubX{% endblock %}
 
 {% block hero %}
-  {% include '_components/hero.html' with title=_('Tokens de API') %}
+  {% include '_components/hero_tokens.html' with title=_('Tokens de API') %}
 {% endblock %}
 
 {% block content %}

--- a/tokens/templates/tokens/ativar_2fa.html
+++ b/tokens/templates/tokens/ativar_2fa.html
@@ -4,7 +4,7 @@
 {% block title %}{% trans "Ativar 2FA" %} | HubX{% endblock %}
 
 {% block hero %}
-  {% include '_components/hero.html' with title=_('Ativar Autenticação de Dois Fatores') %}
+  {% include '_components/hero_tokens.html' with title=_('Ativar Autenticação de Dois Fatores') %}
 {% endblock %}
 
 {% block content %}

--- a/tokens/templates/tokens/gerar_token.html
+++ b/tokens/templates/tokens/gerar_token.html
@@ -3,7 +3,7 @@
 {% block title %}{% trans "Gerar Token de Acesso" %} | HubX{% endblock %}
 
 {% block hero %}
-  {% include '_components/hero.html' with title=_('Gerar Token de Acesso') %}
+  {% include '_components/hero_tokens.html' with title=_('Gerar Token de Acesso') %}
 {% endblock %}
 
 {% block content %}

--- a/tokens/templates/tokens/listar_convites.html
+++ b/tokens/templates/tokens/listar_convites.html
@@ -3,7 +3,7 @@
 {% block title %}{% trans "Convites Emitidos" %} | HubX{% endblock %}
 
 {% block hero %}
-  {% include '_components/hero.html' with title=_('Convites Emitidos') action_template='tokens/hero_action.html' %}
+  {% include '_components/hero_tokens.html' with title=_('Convites Emitidos') action_template='tokens/hero_action.html' %}
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
## Summary
- add a dedicated hero_tokens component that renders the tokens neural background
- update tokens templates to use the new hero so pages share the same visual identity

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd6428f8608325bf46d77cffd6f0b8