### PR TITLE
Remove profile núcleos/eventos partials

### DIFF
--- a/accounts/templates/perfil/partials/detail_eventos.html
+++ b/accounts/templates/perfil/partials/detail_eventos.html
@@ -1,9 +1,0 @@
-{% load i18n %}
-<div class="card-grid">
-  {% for ins in inscricoes %}
-    {% include '_components/card_evento.html' with evento=ins.evento %}
-  {% empty %}
-    <p class="text-sm text-[var(--text-muted)]">{% trans "Nenhum evento encontrado." %}</p>
-  {% endfor %}
-</div>
-

--- a/accounts/templates/perfil/partials/detail_nucleos.html
+++ b/accounts/templates/perfil/partials/detail_nucleos.html
@@ -1,9 +1,0 @@
-{% load i18n %}
-<div class="card-grid">
-  {% for nucleo in nucleos %}
-    {% include '_components/card_nucleo.html' with nucleo=nucleo %}
-  {% empty %}
-    <p class="text-sm text-[var(--text-muted)]">{% trans "Nenhum núcleo encontrado." %}</p>
-  {% endfor %}
-</div>
-

--- a/accounts/templates/perfil/partials/publico_eventos.html
+++ b/accounts/templates/perfil/partials/publico_eventos.html
@@ -1,9 +1,0 @@
-{% load i18n %}
-<div class="card-grid" role="list" aria-label="{% trans 'Lista de eventos' %}">
-  {% for ins in inscricoes %}
-    {% include '_components/card_evento.html' with evento=ins.evento %}
-  {% empty %}
-    <p class="col-span-full text-center text-[var(--text-muted)]">{% trans "Nenhum evento encontrado." %}</p>
-  {% endfor %}
-</div>
-

--- a/accounts/templates/perfil/partials/publico_nucleos.html
+++ b/accounts/templates/perfil/partials/publico_nucleos.html
@@ -1,9 +1,0 @@
-{% load i18n %}
-<div role="list" aria-label="{% trans 'Lista de núcleos' %}" class="card-grid">
-  {% for nucleo in nucleos %}
-    {% include '_components/card_nucleo.html' with nucleo=nucleo %}
-  {% empty %}
-    <p class="col-span-full text-center text-[var(--text-muted)]">{% trans "Nenhum núcleo encontrado." %}</p>
-  {% endfor %}
-</div>
-

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -80,18 +80,6 @@ urlpatterns = [
         name="perfil_info_partial",
     ),
     path(
-        "perfil/partials/nucleos/",
-        views.perfil_section,
-        {"section": "nucleos"},
-        name="perfil_nucleos",
-    ),
-    path(
-        "perfil/partials/eventos/",
-        views.perfil_section,
-        {"section": "eventos"},
-        name="perfil_eventos",
-    ),
-    path(
         "perfil/partials/conexoes/",
         views.perfil_section,
         {"section": "conexoes"},


### PR DESCRIPTION
## Summary
- remove profile section routing to núcleos/eventos partials
- drop núcleos/eventos context data from profile view logic

## Testing
- pytest tests/accounts/test_views_perfil.py *(fails: ModuleNotFoundError: No module named 'silk')*

------
https://chatgpt.com/codex/tasks/task_e_68cd6b23b288832580c09cb0a977aee3