### PR TITLE
Adjust hero profile layout for small screens

### DIFF
--- a/templates/_components/hero_profile.html
+++ b/templates/_components/hero_profile.html
@@ -11,8 +11,8 @@
         
         <div class="rounded-2xl p-4 md:p-5  ring-1 ring-white/10 shadow-2xl text-white w-full">
           {% with display_name=hero_title|default:profile.display_name subtitle=hero_subtitle %}
-          <div class="flex items-center gap-4">
-            <div class="h-20 w-20 md:h-24 md:w-24 rounded-full ring-4 ring-white/90 overflow-hidden bg-[var(--bg-primary)] shrink-0">
+          <div class="flex flex-col items-center gap-4 sm:flex-row sm:items-start sm:gap-6">
+            <div class="h-20 w-20 md:h-24 md:w-24 rounded-full ring-4 ring-white/90 overflow-hidden bg-[var(--bg-primary)] shrink-0 mx-auto sm:mx-0">
               {% if profile.avatar %}
                 <img src="{{ profile.avatar_url }}" alt="{{ display_name|default:profile.username }}" class="h-full w-full object-cover" loading="lazy">
               {% else %}
@@ -22,7 +22,7 @@
               {% endif %}
             </div>
 
-            <div class="min-w-0 space-y-1">
+            <div class="min-w-0 space-y-1 text-center sm:text-left">
               <h2 class="bg-black/40 inline-block rounded-lg px-3 py-1 text-2xl md:text-3xl font-semibold drop-shadow text-white">
                 {{ display_name|default:profile.username }}
               </h2>


### PR DESCRIPTION
## Summary
- adjust the hero profile layout to stack vertically on small screens while keeping horizontal alignment on larger viewports
- center the headline block on mobile and restore left alignment from the small breakpoint upward
- keep the avatar proportions and centering by adding conditional margins

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd6e142da483259b8e8fe8033ea554