### PR TITLE
Increase spacing before hero social links

### DIFF
--- a/templates/_components/hero_profile.html
+++ b/templates/_components/hero_profile.html
@@ -46,7 +46,7 @@
             <!-- Linha 2: @usuario e WhatsApp -->
             {% with redes=profile.redes_sociais %}
 
-              <div class="mt-3 flex flex-wrap items-center justify-center gap-2{% if redes or profile.whatsapp %} sm:justify-between{% endif %}">
+              <div class="mt-6 flex flex-wrap items-center justify-center gap-2{% if redes or profile.whatsapp %} sm:justify-between{% endif %}">
 
                   {% if redes %}
                     {% for rede, url in redes.items %}


### PR DESCRIPTION
## Summary
- increase the top margin on the hero profile social links row so icons sit further below the avatar

## Testing
- python manage.py runserver 0.0.0.0:8000 *(fails: ModuleNotFoundError: No module named 'silk')*

------
https://chatgpt.com/codex/tasks/task_e_68cd8da8890c83258a3b5897cc442a64