### PR TITLE
Adjust hero profile minimum heights

### DIFF
--- a/templates/_components/hero_profile.html
+++ b/templates/_components/hero_profile.html
@@ -1,7 +1,7 @@
 {% load i18n lucide_icons %}
           
 <section class="relative isolate overflow-hidden">
-  <div class="relative flex flex-col justify-end bg-gradient-to-r from-[var(--hero-from)] to-[var(--hero-to)] min-h-[240px] sm:min-h-[280px] lg:min-h-[320px] py-10 lg:py-14">
+  <div class="relative flex flex-col justify-end bg-gradient-to-r from-[var(--hero-from)] to-[var(--hero-to)] min-h-[400px] sm:min-h-[440px] lg:min-h-[480px] py-10 lg:py-14">
     {% if profile.cover %}
       <img src="{{ profile.cover.url }}" alt="" class="absolute inset-0 h-full w-full object-cover" loading="lazy">
     {% endif %}


### PR DESCRIPTION
## Summary
- update the hero profile container to use the shared 400px baseline across responsive breakpoints
- keep the flex column layout so the hero content remains bottom-aligned

## Testing
- manual responsive check for hero height (mobile, tablet, desktop)


------
https://chatgpt.com/codex/tasks/task_e_68cd8f8a48fc8325bc5006f6fa8d3712