### PR TITLE
Refine hero profile overlap layout

### DIFF
--- a/templates/_components/hero_profile.html
+++ b/templates/_components/hero_profile.html
@@ -8,83 +8,74 @@
 
     <div class="container relative mx-auto px-4 sm:px-6 lg:px-8">
       <div class="relative mx-auto w-full max-w-5xl">
-        <div class="flex flex-col justify-end pb-4 sm:pb-6">
-
-          <div class="rounded-2xl p-4 md:p-5  ring-1 ring-white/10 shadow-2xl text-white w-full">
-            {% with display_name=hero_title|default:profile.display_name subtitle=hero_subtitle %}
-            <div class="flex flex-col items-center gap-4 sm:flex-row sm:items-start sm:gap-6">
-              <div class="h-20 w-20 md:h-24 md:w-24 rounded-full ring-4 ring-white/90 overflow-hidden bg-[var(--bg-primary)] shrink-0 mx-auto sm:mx-0">
-                {% if profile.avatar %}
-                  <img src="{{ profile.avatar_url }}" alt="{{ display_name|default:profile.username }}" class="h-full w-full object-cover" loading="lazy">
-                {% else %}
-                  <div class="h-full w-full grid place-items-center text-2xl font-semibold text-white/80">
-                    {{ profile.get_initials|default:profile.username|slice:":2"|upper }}
-                  </div>
-                {% endif %}
-              </div>
-
-              <div class="min-w-0 space-y-1.5 text-center sm:text-left">
-                <h2 class="bg-black/40 inline-block rounded-lg px-3 py-1 text-2xl md:text-3xl font-semibold drop-shadow text-white">
-                  {{ display_name|default:profile.username }}
-                </h2>
-
-                <span class="inline-flex items-center gap-1 rounded-lg bg-white/15 px-2 py-0.5 text-sm sm:text-base font-medium text-white/80">
-                  <span aria-hidden="true">@</span>{{ profile.username }}
-                </span>
-
-                {% if subtitle %}
-                  <p class="text-sm sm:text-base text-white/80">
-                    {{ subtitle }}
-                  </p>
-                {% endif %}
-
-              </div>
-
-            </div>
-            {% endwith %}
-
-            <!-- Linha 2: @usuario e WhatsApp -->
-            {% with redes=profile.redes_sociais %}
-
-              <div class="mt-6 flex flex-wrap items-center justify-center gap-2{% if redes or profile.whatsapp %} sm:justify-between{% endif %}">
-
-                  {% if redes %}
-                    {% for rede, url in redes.items %}
-                      {% if url %}
-                        <a
-                          href="{{ url }}"
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          aria-label="{{ rede|capfirst }}"
-                          class="inline-flex items-center transition hover:scale-110"
-                        >
-                          {% lucide rede class="h-6 w-6 text-white hover:text-white/90" %}
-                        </a>
-                      {% endif %}
-                    {% endfor %}
-                  {% endif %}
-
-
-                  {% if profile.whatsapp %}
-                    <a
-                      href="https://wa.me/{{ profile.whatsapp|cut:"+" }}"
-                      class="inline-flex items-center transition hover:scale-110"
-                      aria-label="WhatsApp"
-                    >
-                      {% lucide "whatsapp" width="28" height="28" %}
-                    </a>
+        <div class="flex flex-col justify-end pb-24 sm:pb-28 lg:pb-40">
+          <div class="translate-y-20 sm:translate-y-24 lg:translate-y-36 w-full">
+            <div class="relative overflow-hidden rounded-3xl bg-black/60 px-4 pb-6 pt-16 sm:px-6 sm:pb-8 sm:pt-8 md:pt-10 ring-1 ring-white/15 shadow-2xl backdrop-blur text-white w-full">
+              <div class="absolute left-1/2 top-0 z-20 -translate-y-1/2 -translate-x-1/2 sm:left-10 sm:-translate-x-0 sm:-translate-y-1/2">
+                <div class="h-24 w-24 md:h-28 md:w-28 rounded-full ring-4 ring-white/90 overflow-hidden bg-[var(--bg-primary)] shadow-xl">
+                  {% if profile.avatar %}
+                    <img src="{{ profile.avatar_url }}" alt="{{ hero_title|default:profile.display_name|default:profile.username }}" class="h-full w-full object-cover" loading="lazy">
                   {% else %}
-                    <span class="inline-flex items-center" aria-label="WhatsApp indisponível">
-                      {% lucide "whatsapp" class="h-8 w-8 text-gray-400" %}
-                    </span>
+                    <div class="h-full w-full grid place-items-center text-2xl font-semibold text-white/80">
+                      {{ profile.get_initials|default:profile.username|slice:":2"|upper }}
+                    </div>
                   {% endif %}
-
+                </div>
               </div>
 
-            {% endwith %}
+              {% with display_name=hero_title|default:profile.display_name subtitle=hero_subtitle redes=profile.redes_sociais %}
+                <div class="space-y-6">
+                  <div class="text-center sm:text-left sm:pl-40 md:pl-48 space-y-2 sm:space-y-3">
+                    <h2 class="inline-block rounded-lg bg-black/40 px-4 py-1 text-2xl md:text-3xl font-semibold drop-shadow text-white">
+                      {{ display_name|default:profile.username }}
+                    </h2>
 
+                    <span class="inline-flex items-center gap-1 rounded-lg bg-white/15 px-2 py-0.5 text-sm sm:text-base font-medium text-white/80">
+                      <span aria-hidden="true">@</span>{{ profile.username }}
+                    </span>
+
+                    {% if subtitle %}
+                      <p class="text-sm sm:text-base text-white/80">
+                        {{ subtitle }}
+                      </p>
+                    {% endif %}
+                  </div>
+
+                  <div class="flex flex-wrap items-center justify-center gap-3 text-white/90 sm:justify-start sm:pl-40 md:pl-48">
+                    {% if redes %}
+                      {% for rede, url in redes.items %}
+                        {% if url %}
+                          <a
+                            href="{{ url }}"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            aria-label="{{ rede|capfirst }}"
+                            class="inline-flex items-center transition hover:scale-110"
+                          >
+                            {% lucide rede class="h-6 w-6 text-white hover:text-white/90" %}
+                          </a>
+                        {% endif %}
+                      {% endfor %}
+                    {% endif %}
+
+                    {% if profile.whatsapp %}
+                      <a
+                        href="https://wa.me/{{ profile.whatsapp|cut:"+" }}"
+                        class="inline-flex items-center transition hover:scale-110"
+                        aria-label="WhatsApp"
+                      >
+                        {% lucide "whatsapp" width="28" height="28" %}
+                      </a>
+                    {% else %}
+                      <span class="inline-flex items-center" aria-label="WhatsApp indisponível">
+                        {% lucide "whatsapp" class="h-8 w-8 text-gray-400" %}
+                      </span>
+                    {% endif %}
+                  </div>
+                </div>
+              {% endwith %}
+            </div>
           </div>
-
         </div>
 
       </div>


### PR DESCRIPTION
## Summary
- drop the hero profile card further down in the hero section with deeper bottom padding so the content sits closer to the lower edge as requested
- rebuild the card layout so the avatar is positioned in front of the lowered card, creating the partial overlap seen in the reference while keeping the profile text and social links aligned

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd92ebd05883258f1dab76f87767e3