### PR TITLE
Atualiza asserts de templates em testes de briefing e material

### DIFF
--- a/eventos/tests/test_briefing_views.py
+++ b/eventos/tests/test_briefing_views.py
@@ -1,4 +1,5 @@
 import pytest
+from django.test import override_settings
 from django.urls import reverse
 from django.contrib.messages import get_messages
 from accounts.factories import UserFactory
@@ -7,6 +8,7 @@ from accounts.models import UserType
 
 
 @pytest.mark.django_db
+@override_settings(ROOT_URLCONF="Hubx.urls")
 def test_briefing_create_exibe_mensagem(client):
     evento = EventoFactory()
     user = UserFactory(user_type=UserType.ADMIN, organizacao=evento.organizacao, nucleo_obj=None)
@@ -19,6 +21,7 @@ def test_briefing_create_exibe_mensagem(client):
     }
     resp = client.post(reverse("eventos:briefing_criar"), data, follow=True)
     assert resp.status_code == 200
-    assert "eventos/briefing_list.html" in [t.name for t in resp.templates]
+    template_names = {t.name for t in resp.templates if t.name}
+    assert "eventos/painel.html" in template_names or "eventos/partials/briefing/briefing_list.html" in template_names
     messages = list(get_messages(resp.wsgi_request))
     assert any("Briefing criado com sucesso" in m.message for m in messages)

--- a/eventos/tests/test_material_views.py
+++ b/eventos/tests/test_material_views.py
@@ -1,5 +1,6 @@
 import pytest
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import override_settings
 from django.urls import reverse
 from accounts.factories import UserFactory
 from eventos.factories import EventoFactory
@@ -8,6 +9,7 @@ from accounts.models import UserType
 
 
 @pytest.mark.django_db
+@override_settings(ROOT_URLCONF="Hubx.urls")
 def test_material_list_shows_only_approved(client):
     evento = EventoFactory()
     arquivo1 = SimpleUploadedFile("file1.txt", b"x")
@@ -32,7 +34,8 @@ def test_material_list_shows_only_approved(client):
     client.force_login(user)
     resp = client.get(reverse("eventos:material_list"))
     assert resp.status_code == 200
-    assert "eventos/material_list.html" in [t.name for t in resp.templates]
+    template_names = {t.name for t in resp.templates if t.name}
+    assert "eventos/painel.html" in template_names or "eventos/partials/eventos/material_list.html" in template_names
     materiais = list(resp.context["materiais"])
     assert len(materiais) == 1
     assert materiais[0].titulo == "Aprovado"


### PR DESCRIPTION
## Summary
- atualiza os testes de briefing e material para aceitarem os novos templates do painel
- garante que os testes usem o ROOT_URLCONF principal para evitar imports de apps removidos

## Testing
- pytest eventos/tests/test_briefing_views.py eventos/tests/test_material_views.py --no-cov

------
https://chatgpt.com/codex/tasks/task_e_68d139f270348325b2ec2f61e02344a1