### PR TITLE
Atualiza hero out-of-band no painel de eventos

### DIFF
--- a/eventos/templates/eventos/partials/_painel_hero_oob.html
+++ b/eventos/templates/eventos/partials/_painel_hero_oob.html
@@ -1,24 +1,10 @@
-{% extends 'base.html' %}
-{% load i18n static %}
-
-{% block hero %}
-  <div id="painel-hero">
+{% load i18n %}
+{% if is_htmx %}
+  <div hx-swap-oob="innerHTML:#painel-hero">
     {% with painel_title_default=_('Eventos') %}
       {% with hero_template=painel_hero_template|default:'_components/hero_evento.html' %}
         {% include hero_template with title=painel_title|default:painel_title_default subtitle=painel_subtitle action_template=painel_action_template breadcrumb_template=painel_breadcrumb_template neural_background=painel_neural_background style=painel_hero_style %}
       {% endwith %}
     {% endwith %}
   </div>
-{% endblock %}
-
-{% block content %}
-<section class="mx-auto max-w-6xl px-4 lg:px-6 py-6">
-  <div id="eventos-conteudo">
-    {% if partial_template %}
-      {% include partial_template %}
-    {% elif dias_com_eventos is not None %}
-      {% include 'eventos/partials/calendario/calendario.html' %}
-    {% endif %}
-  </div>
-</section>
-{% endblock %}
+{% endif %}

--- a/eventos/templates/eventos/partials/briefing/briefing_form.html
+++ b/eventos/templates/eventos/partials/briefing/briefing_form.html
@@ -1,4 +1,5 @@
 {% load i18n widget_tweaks %}
+{% include "eventos/partials/_painel_hero_oob.html" %}
 <section class="max-w-screen-xl mx-auto pt-8 px-6 lg:px-8">
   <h1 class="text-2xl font-bold text-[var(--text-primary)] mb-6">
     {% if object %}{% trans "Editar Briefing" %}{% else %}{% trans "Novo Briefing" %}{% endif %}

--- a/eventos/templates/eventos/partials/briefing/briefing_list.html
+++ b/eventos/templates/eventos/partials/briefing/briefing_list.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% include "eventos/partials/_painel_hero_oob.html" %}
 <div id="briefing-container" class="py-12 px-4 space-y-6">
   {% include "eventos/partials/eventos/_nav.html" with current_section='briefings' %}
   <div class="card">

--- a/eventos/templates/eventos/partials/calendario/calendario.html
+++ b/eventos/templates/eventos/partials/calendario/calendario.html
@@ -1,4 +1,5 @@
 {% load i18n static lucide_icons %}
+{% include "eventos/partials/_painel_hero_oob.html" %}
 <section class="mx-auto max-w-6xl px-4 lg:px-6 py-6">
   <header class="mb-4">
     <h2 class="text-2xl font-semibold">{% trans "Últimos 30 dias com eventos" %}</h2>

--- a/eventos/templates/eventos/partials/eventos/avaliacao_form.html
+++ b/eventos/templates/eventos/partials/eventos/avaliacao_form.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% include "eventos/partials/_painel_hero_oob.html" %}
   <div class="py-12 card px-4">
     <div class="card-body">
       <form method="post" class="space-y-4">

--- a/eventos/templates/eventos/partials/eventos/create.html
+++ b/eventos/templates/eventos/partials/eventos/create.html
@@ -1,4 +1,5 @@
  {% load i18n widget_tweaks %}
+{% include "eventos/partials/_painel_hero_oob.html" %}
 <section class="max-w-screen-xl mx-auto pt-8 px-6 lg:px-8">
   <h1 class="text-2xl font-bold text-[var(--text-primary)] mb-6">{% trans "Cadastrar Evento" %}</h1>
 

--- a/eventos/templates/eventos/partials/eventos/delete.html
+++ b/eventos/templates/eventos/partials/eventos/delete.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% include "eventos/partials/_painel_hero_oob.html" %}
 <section class="max-w-screen-xl mx-auto pt-8 px-6 lg:px-8">
   <div class="bg-[var(--bg-secondary)] border border-[var(--error-light)] rounded-2xl card-sm p-6 text-center">
     <h2 class="text-xl font-semibold text-[var(--error)] mb-4">{% trans "Remover Evento" %}</h2>

--- a/eventos/templates/eventos/partials/eventos/detail.html
+++ b/eventos/templates/eventos/partials/eventos/detail.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% include "eventos/partials/_painel_hero_oob.html" %}
 <section class="py-12 px-4">
 
   <div class="flex flex-col gap-6">

--- a/eventos/templates/eventos/partials/eventos/evento_list.html
+++ b/eventos/templates/eventos/partials/eventos/evento_list.html
@@ -1,4 +1,5 @@
 {% load i18n lucide_icons %}
+{% include "eventos/partials/_painel_hero_oob.html" %}
   <div class="py-12 px-4 space-y-6">
     
     <div class="card px-4">

--- a/eventos/templates/eventos/partials/eventos/update.html
+++ b/eventos/templates/eventos/partials/eventos/update.html
@@ -1,4 +1,5 @@
 {% load i18n widget_tweaks %}
+{% include "eventos/partials/_painel_hero_oob.html" %}
 <section class="max-w-screen-xl mx-auto pt-8 px-6 lg:px-8">
   <h1 class="text-2xl font-bold text-[var(--text-primary)] mb-6">{% trans "Editar Evento" %}</h1>
 

--- a/eventos/templates/eventos/partials/inscricao/checkin_form.html
+++ b/eventos/templates/eventos/partials/inscricao/checkin_form.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% include "eventos/partials/_painel_hero_oob.html" %}
   <div class="py-12 card px-4">
     <div class="card-body">
       <form method="post" action="{% url 'eventos:inscricao_checkin' inscricao.id %}" id="checkin-form" class="space-y-4">

--- a/eventos/templates/eventos/partials/inscricao/inscricao_form.html
+++ b/eventos/templates/eventos/partials/inscricao/inscricao_form.html
@@ -1,4 +1,5 @@
 {% load i18n widget_tweaks %}
+{% include "eventos/partials/_painel_hero_oob.html" %}
 <section class="max-w-screen-xl mx-auto pt-8 px-6 lg:px-8">
   <h1 class="text-2xl font-bold text-[var(--text-primary)] mb-6">{% trans "Inscrição" %}</h1>
   <form method="post" enctype="multipart/form-data" class="bg-[var(--bg-secondary)] border border-[var(--border)] rounded-2xl card-sm p-6 space-y-6">

--- a/eventos/templates/eventos/partials/inscricao/inscricao_list.html
+++ b/eventos/templates/eventos/partials/inscricao/inscricao_list.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% include "eventos/partials/_painel_hero_oob.html" %}
 <div id="inscricao-container" class="py-12 px-4 space-y-6">
   {% include "eventos/partials/eventos/_nav.html" with current_section='inscricoes' %}
   <div class="card">

--- a/eventos/templates/eventos/partials/parceria/parceria_avaliar.html
+++ b/eventos/templates/eventos/partials/parceria/parceria_avaliar.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% include "eventos/partials/_painel_hero_oob.html" %}
   <div class="py-12 card px-4">
     <div class="card-body">
       <form id="avaliacao-form" method="post" action="{% url 'eventos_api:parceria-avaliar' parceria.pk %}" class="space-y-4">

--- a/eventos/templates/eventos/partials/parceria/parceria_confirm_delete.html
+++ b/eventos/templates/eventos/partials/parceria/parceria_confirm_delete.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% include "eventos/partials/_painel_hero_oob.html" %}
 <section class="max-w-screen-xl mx-auto pt-8 px-6 lg:px-8">
   <div class="bg-[var(--bg-secondary)] border border-[var(--error-light)] rounded-2xl card-sm p-6 text-center">
     <h2 class="text-xl font-semibold text-[var(--error)] mb-4">{% trans 'Remover Parceria' %}</h2>

--- a/eventos/templates/eventos/partials/parceria/parceria_form.html
+++ b/eventos/templates/eventos/partials/parceria/parceria_form.html
@@ -1,4 +1,5 @@
 {% load i18n widget_tweaks %}
+{% include "eventos/partials/_painel_hero_oob.html" %}
 <section class="max-w-screen-xl mx-auto pt-8 px-6 lg:px-8">
   <h1 class="text-2xl font-bold text-[var(--text-primary)] mb-6">{% trans "Parceria" %}</h1>
   <form method="post" enctype="multipart/form-data" class="bg-[var(--bg-secondary)] border border-[var(--border)] rounded-2xl card-sm p-6 space-y-6">

--- a/eventos/templates/eventos/partials/parceria/parceria_list.html
+++ b/eventos/templates/eventos/partials/parceria/parceria_list.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% include "eventos/partials/_painel_hero_oob.html" %}
   <div class="py-12 px-4 space-y-6">
     {% include "eventos/partials/eventos/_nav.html" with current_section='parcerias' %}
     <div class="card px-4">

--- a/eventos/templates/eventos/partials/tarefas/tarefa_detail.html
+++ b/eventos/templates/eventos/partials/tarefas/tarefa_detail.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% include "eventos/partials/_painel_hero_oob.html" %}
 <section class="py-12 px-4">
   <div class="card-grid gap-6">
     <article class="card">

--- a/eventos/templates/eventos/partials/tarefas/tarefa_form.html
+++ b/eventos/templates/eventos/partials/tarefas/tarefa_form.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% include "eventos/partials/_painel_hero_oob.html" %}
 <section class="max-w-screen-xl mx-auto pt-8 px-6 lg:px-8">
   <h1 class="text-2xl font-bold text-[var(--text-primary)] mb-6">
     {% if object %}{% trans "Editar Tarefa" %}{% else %}{% trans "Cadastrar Tarefa" %}{% endif %}

--- a/eventos/templates/eventos/partials/tarefas/tarefa_list.html
+++ b/eventos/templates/eventos/partials/tarefas/tarefa_list.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% include "eventos/partials/_painel_hero_oob.html" %}
 <section class="max-w-screen-xl mx-auto pt-8 px-6 lg:px-8 space-y-6">
   {% include "eventos/partials/eventos/_nav.html" with current_section='tarefas' %}
   <header class="flex items-center justify-between">


### PR DESCRIPTION
## Summary
- encapsulate the painel hero include in an identifiable container and expose a shared OOB hero snippet for HTMX responses
- ensure views populate painel title/hero information and HTMX flags even for partial renders
- update eventos, tarefas, inscrições, parcerias e briefings partials to inject the OOB hero block during HTMX swaps

## Testing
- pytest tests/eventos -q *(fails: ModuleNotFoundError: No module named 'silk')*

------
https://chatgpt.com/codex/tasks/task_e_68d161f4f730832598bfe25105634ca2