### PR TITLE
Restrict token invite roles to associado and convidado

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -958,12 +958,13 @@ def termos(request):
 
         if username and pwd_hash:
             tipo_mapping = {
-                TokenAcesso.TipoUsuario.ADMIN: UserType.ADMIN,
-                TokenAcesso.TipoUsuario.COORDENADOR: UserType.COORDENADOR,
-                TokenAcesso.TipoUsuario.NUCLEADO: UserType.NUCLEADO,
                 TokenAcesso.TipoUsuario.ASSOCIADO: UserType.ASSOCIADO,
                 TokenAcesso.TipoUsuario.CONVIDADO: UserType.CONVIDADO,
             }
+            mapped_user_type = tipo_mapping.get(token_obj.tipo_destino)
+            if not mapped_user_type:
+                messages.error(request, _("Convite inválido."))
+                return redirect("tokens:token")
             try:
                 with transaction.atomic():
                     user = User.objects.create(
@@ -972,7 +973,7 @@ def termos(request):
                         contato=contato,
                         password=pwd_hash,
                         cpf=cpf_val,
-                        user_type=tipo_mapping[token_obj.tipo_destino],
+                        user_type=mapped_user_type,
                         is_active=False,
                         email_confirmed=False,
                     )

--- a/core/management/commands/corrigir_base_token.py
+++ b/core/management/commands/corrigir_base_token.py
@@ -43,10 +43,10 @@ class Command(BaseCommand):
 
         # Criar tokens de exemplo para testes
         exemplo_user = User.objects.filter(is_superuser=True).first() or User.objects.first()
-        for desc in ["admin", "coordenador", "associado"]:
+        for tipo in TokenAcesso.TipoUsuario.values:
             TokenAcesso.objects.get_or_create(
                 gerado_por=exemplo_user,
-                tipo_destino=desc,
+                tipo_destino=tipo,
                 defaults={"data_expiracao": timezone.now() + timedelta(days=30)},
             )
-        self.stdout.write("Tokens de exemplo criados para admin, gerente e cliente")
+        self.stdout.write("Tokens de exemplo criados para os novos tipos suportados")

--- a/nucleos/services.py
+++ b/nucleos/services.py
@@ -41,9 +41,7 @@ def gerar_convite_nucleo(user: User, nucleo: Nucleo, email: str, papel: str) -> 
 
     token = TokenAcesso.objects.create(
         gerado_por=user,
-        tipo_destino=(
-            TokenAcesso.TipoUsuario.COORDENADOR if papel == "coordenador" else TokenAcesso.TipoUsuario.NUCLEADO
-        ),
+        tipo_destino=TokenAcesso.TipoUsuario.ASSOCIADO,
         organizacao=nucleo.organizacao,
         data_expiracao=timezone.now() + timedelta(days=7),
     )

--- a/tests/tokens/test_api.py
+++ b/tests/tokens/test_api.py
@@ -45,7 +45,7 @@ def test_registro_logs(api_client):
 def test_revogar_token(api_client):
     admin = UserFactory(is_staff=True)
     api_client.force_authenticate(user=admin)
-    token = TokenAcesso.objects.create(gerado_por=admin, tipo_destino=TokenAcesso.TipoUsuario.ADMIN)
+    token = TokenAcesso.objects.create(gerado_por=admin, tipo_destino=TokenAcesso.TipoUsuario.ASSOCIADO)
     url = reverse("tokens_api:token-revogar", kwargs={"codigo": token.codigo})
     resp = api_client.post(url)
     assert resp.status_code == 200

--- a/tests/tokens/test_invite_view_permissions.py
+++ b/tests/tokens/test_invite_view_permissions.py
@@ -16,16 +16,8 @@ def _login(client, user):
 @pytest.mark.parametrize(
     "issuer_type,allowed",
     [
-        (UserType.ROOT, [TokenAcesso.TipoUsuario.ADMIN]),
-        (
-            UserType.ADMIN,
-            [
-                TokenAcesso.TipoUsuario.COORDENADOR,
-                TokenAcesso.TipoUsuario.NUCLEADO,
-                TokenAcesso.TipoUsuario.ASSOCIADO,
-                TokenAcesso.TipoUsuario.CONVIDADO,
-            ],
-        ),
+        (UserType.ROOT, [TokenAcesso.TipoUsuario.ASSOCIADO]),
+        (UserType.ADMIN, [TokenAcesso.TipoUsuario.ASSOCIADO, TokenAcesso.TipoUsuario.CONVIDADO]),
         (UserType.COORDENADOR, [TokenAcesso.TipoUsuario.CONVIDADO]),
         (UserType.FINANCEIRO, []),
         (UserType.NUCLEADO, []),
@@ -68,10 +60,10 @@ def test_root_form_has_all_orgs_and_no_nucleos(client):
 @pytest.mark.parametrize(
     "issuer_type,target,expected",
     [
-        (UserType.ROOT, TokenAcesso.TipoUsuario.ADMIN, 200),
+        (UserType.ROOT, TokenAcesso.TipoUsuario.ASSOCIADO, 200),
         (UserType.ROOT, TokenAcesso.TipoUsuario.CONVIDADO, 400),
+        (UserType.ADMIN, TokenAcesso.TipoUsuario.ASSOCIADO, 200),
         (UserType.ADMIN, TokenAcesso.TipoUsuario.CONVIDADO, 200),
-        (UserType.ADMIN, TokenAcesso.TipoUsuario.ADMIN, 400),
         (UserType.COORDENADOR, TokenAcesso.TipoUsuario.CONVIDADO, 200),
         (UserType.COORDENADOR, TokenAcesso.TipoUsuario.ASSOCIADO, 400),
         (UserType.FINANCEIRO, TokenAcesso.TipoUsuario.CONVIDADO, 400),

--- a/tests/tokens/test_issue_permissions.py
+++ b/tests/tokens/test_issue_permissions.py
@@ -13,10 +13,10 @@ pytestmark = pytest.mark.django_db
 @pytest.mark.parametrize(
     "issuer_type,target,expected",
     [
-        (UserType.ROOT, TokenAcesso.TipoUsuario.ADMIN, status.HTTP_201_CREATED),
-        (UserType.ROOT, TokenAcesso.TipoUsuario.ASSOCIADO, status.HTTP_403_FORBIDDEN),
+        (UserType.ROOT, TokenAcesso.TipoUsuario.ASSOCIADO, status.HTTP_201_CREATED),
+        (UserType.ROOT, TokenAcesso.TipoUsuario.CONVIDADO, status.HTTP_403_FORBIDDEN),
+        (UserType.ADMIN, TokenAcesso.TipoUsuario.ASSOCIADO, status.HTTP_201_CREATED),
         (UserType.ADMIN, TokenAcesso.TipoUsuario.CONVIDADO, status.HTTP_201_CREATED),
-        (UserType.ADMIN, TokenAcesso.TipoUsuario.ADMIN, status.HTTP_403_FORBIDDEN),
         (UserType.COORDENADOR, TokenAcesso.TipoUsuario.CONVIDADO, status.HTTP_201_CREATED),
         (UserType.COORDENADOR, TokenAcesso.TipoUsuario.ASSOCIADO, status.HTTP_403_FORBIDDEN),
     ],

--- a/tests/tokens/test_models.py
+++ b/tests/tokens/test_models.py
@@ -15,7 +15,7 @@ pytestmark = pytest.mark.django_db
 
 def test_token_acesso_creation_defaults():
     user = UserFactory(is_staff=True)
-    token = TokenAcesso.objects.create(gerado_por=user, tipo_destino=TokenAcesso.TipoUsuario.ADMIN)
+    token = TokenAcesso.objects.create(gerado_por=user, tipo_destino=TokenAcesso.TipoUsuario.ASSOCIADO)
     assert len(token.codigo) == 32
     assert token.estado == TokenAcesso.Estado.NOVO
     assert token.created_at is not None
@@ -26,7 +26,7 @@ def test_token_acesso_states():
     for estado in TokenAcesso.Estado.values:
         token = TokenAcesso.objects.create(
             gerado_por=user,
-            tipo_destino=TokenAcesso.TipoUsuario.ADMIN,
+            tipo_destino=TokenAcesso.TipoUsuario.ASSOCIADO,
             estado=estado,
         )
         token.refresh_from_db()

--- a/tests/tokens/test_views.py
+++ b/tests/tokens/test_views.py
@@ -51,19 +51,19 @@ def test_gerar_token_convite_view(client):
 
 
 def test_convite_permission_denied(client):
-    user = UserFactory(is_staff=True, user_type=UserType.ADMIN.value)
+    user = UserFactory(is_staff=True, user_type=UserType.COORDENADOR.value)
     org = OrganizacaoFactory()
     org.users.add(user)
     _login(client, user)
     resp = client.post(
         reverse("tokens:gerar_convite"),
-        {"tipo_destino": TokenAcesso.TipoUsuario.ADMIN, "organizacao": org.pk},
+        {"tipo_destino": TokenAcesso.TipoUsuario.ASSOCIADO, "organizacao": org.pk},
     )
     assert resp.status_code == 403
 
 
 def test_convite_permission_denied_no_side_effects(client):
-    user = UserFactory(is_staff=True, user_type=UserType.ADMIN.value)
+    user = UserFactory(is_staff=True, user_type=UserType.COORDENADOR.value)
     org = OrganizacaoFactory()
     org.users.add(user)
     _login(client, user)
@@ -71,7 +71,7 @@ def test_convite_permission_denied_no_side_effects(client):
     assert TokenUsoLog.objects.count() == 0
     resp = client.post(
         reverse("tokens:gerar_convite"),
-        {"tipo_destino": TokenAcesso.TipoUsuario.ADMIN, "organizacao": org.pk},
+        {"tipo_destino": TokenAcesso.TipoUsuario.ASSOCIADO, "organizacao": org.pk},
     )
     assert resp.status_code == 403
     assert TokenAcesso.objects.count() == 0

--- a/tokens/models.py
+++ b/tokens/models.py
@@ -25,10 +25,7 @@ def generate_hex_uuid() -> str:
 
 class TokenAcesso(TimeStampedModel, SoftDeleteModel):
     class TipoUsuario(models.TextChoices):
-        ADMIN = "admin", "Admin"
         ASSOCIADO = "associado", "Associado"
-        NUCLEADO = "nucleado", "Nucleado"
-        COORDENADOR = "coordenador", "Coordenador"
         CONVIDADO = "convidado", "Convidado"
 
     class Estado(models.TextChoices):

--- a/tokens/perms.py
+++ b/tokens/perms.py
@@ -11,11 +11,9 @@ def can_issue_invite(issuer, target_role: str) -> bool:
 
     issuer_type = getattr(issuer, "user_type", None)
     if issuer_type == UserType.ROOT:
-        return target_role == TokenAcesso.TipoUsuario.ADMIN
+        return target_role == TokenAcesso.TipoUsuario.ASSOCIADO
     if issuer_type == UserType.ADMIN:
         return target_role in {
-            TokenAcesso.TipoUsuario.COORDENADOR,
-            TokenAcesso.TipoUsuario.NUCLEADO,
             TokenAcesso.TipoUsuario.ASSOCIADO,
             TokenAcesso.TipoUsuario.CONVIDADO,
         }


### PR DESCRIPTION
## Summary
- limit `TokenAcesso.TipoUsuario` to `associado` and `convidado`, simplifying invite permission rules
- adjust nucleus invite generation, registration mapping, and maintenance command to rely on the reduced role set
- refresh API, form, and view tests to expect only the supported invite types

## Testing
- pytest tests/tokens *(fails: suite requires project-specific configuration and multiple fixtures not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d163916a688325a78d0b8656f0175a