### PR TITLE
Refine calendario layout spacing

### DIFF
--- a/eventos/templates/eventos/partials/calendario/calendario.html
+++ b/eventos/templates/eventos/partials/calendario/calendario.html
@@ -1,83 +1,85 @@
 {% load i18n static lucide_icons %}
 {% include "eventos/partials/_painel_hero_oob.html" %}
-<section class="mx-auto max-w-6xl px-4 lg:px-6 py-6">
-  <header class="mb-4">
-    <h2 class="text-2xl font-semibold">{% trans "Últimos 30 dias com eventos" %}</h2>
-  </header>
+<section class="max-w-screen-xl mx-auto pt-8 px-6 lg:px-8">
+  <div class="space-y-6">
+    <header>
+      <h2 class="text-2xl font-bold text-[var(--text-primary)]">{% trans "Últimos 30 dias com eventos" %}</h2>
+    </header>
 
-  {% if dias_com_eventos %}
-    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-      {% for bloco in dias_com_eventos %}
-        <article class="rounded-2xl border border-[var(--border)] bg-[var(--bg-elevated)] shadow-sm hover:shadow-md transition overflow-hidden">
-          <!-- Cabeçalho do dia -->
-          <header class="flex items-center justify-between px-4 py-3 bg-[var(--surface-secondary)]">
-            <div class="flex items-baseline gap-3">
-              <span class="text-3xl font-bold leading-none text-[var(--text-primary)]">
-                {{ bloco.data|date:"d" }}
-              </span>
-              <div class="leading-tight">
-                <div class="text-sm font-medium text-[var(--text-primary)] flex items-center gap-2">
-                  {% lucide 'calendar-days' class='w-4 h-4 text-[var(--text-secondary)]' aria_hidden='true' %}
-                  {{ bloco.data|date:"l" }}
-                </div>
-                <div class="text-xs text-[var(--text-muted)]">
-                  {{ bloco.data|date:"d \\d\\e F, Y" }}
+    {% if dias_com_eventos %}
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+        {% for bloco in dias_com_eventos %}
+          <article class="rounded-2xl border border-[var(--border)] bg-[var(--bg-elevated)] shadow-sm hover:shadow-md transition overflow-hidden">
+            <!-- Cabeçalho do dia -->
+            <header class="flex items-center justify-between px-4 py-3 bg-[var(--surface-secondary)]">
+              <div class="flex items-baseline gap-3">
+                <span class="text-3xl font-bold leading-none text-[var(--text-primary)]">
+                  {{ bloco.data|date:"d" }}
+                </span>
+                <div class="leading-tight">
+                  <div class="text-sm font-medium text-[var(--text-primary)] flex items-center gap-2">
+                    {% lucide 'calendar-days' class='w-4 h-4 text-[var(--text-secondary)]' aria_hidden='true' %}
+                    {{ bloco.data|date:"l" }}
+                  </div>
+                  <div class="text-xs text-[var(--text-muted)]">
+                    {{ bloco.data|date:"d \\d\\e F, Y" }}
+                  </div>
                 </div>
               </div>
-            </div>
-            <span class="text-xs rounded-full px-2 py-1 bg-[var(--surface-tertiary)] text-[var(--text-secondary)]">
-              {{ bloco.eventos|length }} {% trans "evento(s)" %}
-            </span>
-          </header>
+              <span class="text-xs rounded-full px-2 py-1 bg-[var(--surface-tertiary)] text-[var(--text-secondary)]">
+                {{ bloco.eventos|length }} {% trans "evento(s)" %}
+              </span>
+            </header>
 
-          <!-- Timeline do dia -->
-          <ul class="divide-y divide-[var(--border)]">
-            {% for ev in bloco.eventos %}
-              <li class="px-4 py-3">
-                <div class="flex items-start justify-between gap-3">
-                  <!-- Hora -->
-                  <time class="min-w-20 text-sm font-semibold text-[var(--text-primary)]" datetime="{{ ev.data_inicio|date:'c' }}">
-                    {{ ev.data_inicio|date:"H:i" }}
-                  </time>
+            <!-- Timeline do dia -->
+            <ul class="divide-y divide-[var(--border)]">
+              {% for ev in bloco.eventos %}
+                <li class="px-4 py-3">
+                  <div class="flex items-start justify-between gap-3">
+                    <!-- Hora -->
+                    <time class="min-w-20 text-sm font-semibold text-[var(--text-primary)]" datetime="{{ ev.data_inicio|date:'c' }}">
+                      {{ ev.data_inicio|date:"H:i" }}
+                    </time>
 
-                  <!-- Conteúdo -->
-                  <div class="flex-1 min-w-0">
-                    <a href="{% url 'eventos:evento_detalhe' ev.id %}" class="group inline-flex items-baseline gap-2">
-                      <span class="truncate text-sm font-medium text-[var(--text-primary)] group-hover:underline">
-                        {{ ev.titulo }}
-                      </span>
-                      {% if ev.tipo %}
-                        <span class="text-[10px] px-1.5 py-0.5 rounded-full
-                          {% if ev.tipo == 'reuniao' %} bg-green-100 text-green-700
-                          {% elif ev.tipo == 'palestra' %} bg-red-100 text-red-700
-                          {% elif ev.tipo == 'workshop' %} bg-blue-100 text-blue-700
-                          {% else %} bg-gray-100 text-gray-700 {% endif %}">
-                          {{ ev.get_tipo_display|default:ev.tipo }}
+                    <!-- Conteúdo -->
+                    <div class="flex-1 min-w-0">
+                      <a href="{% url 'eventos:evento_detalhe' ev.id %}" class="group inline-flex items-baseline gap-2">
+                        <span class="truncate text-sm font-medium text-[var(--text-primary)] group-hover:underline">
+                          {{ ev.titulo }}
                         </span>
-                      {% endif %}
-                      {% if ev.local %}
-                        <span class="text-[10px] px-1.5 py-0.5 rounded-full bg-gray-100 text-gray-700">
-                          {{ ev.local }}
-                        </span>
-                      {% endif %}
-                    </a>
-                  </div>
+                        {% if ev.tipo %}
+                          <span class="text-[10px] px-1.5 py-0.5 rounded-full
+                            {% if ev.tipo == 'reuniao' %} bg-green-100 text-green-700
+                            {% elif ev.tipo == 'palestra' %} bg-red-100 text-red-700
+                            {% elif ev.tipo == 'workshop' %} bg-blue-100 text-blue-700
+                            {% else %} bg-gray-100 text-gray-700 {% endif %}">
+                            {{ ev.get_tipo_display|default:ev.tipo }}
+                          </span>
+                        {% endif %}
+                        {% if ev.local %}
+                          <span class="text-[10px] px-1.5 py-0.5 rounded-full bg-gray-100 text-gray-700">
+                            {{ ev.local }}
+                          </span>
+                        {% endif %}
+                      </a>
+                    </div>
 
-                  <!-- Ação rápida opcional -->
-                  <div class="shrink-0">
-                    <a href="{% url 'eventos:evento_detalhe' ev.id %}"
-                       class="text-[var(--text-secondary)] hover:text-[var(--text-primary)] text-sm underline">
-                       {% trans "Detalhes" %}
-                    </a>
+                    <!-- Ação rápida opcional -->
+                    <div class="shrink-0">
+                      <a href="{% url 'eventos:evento_detalhe' ev.id %}"
+                         class="text-[var(--text-secondary)] hover:text-[var(--text-primary)] text-sm underline">
+                         {% trans "Detalhes" %}
+                      </a>
+                    </div>
                   </div>
-                </div>
-              </li>
-            {% endfor %}
-          </ul>
-        </article>
-      {% endfor %}
-    </div>
-  {% else %}
-    <p class="text-[var(--text-secondary)]">{% trans "Nenhum evento nos últimos 30 dias." %}</p>
-  {% endif %}
+                </li>
+              {% endfor %}
+            </ul>
+          </article>
+        {% endfor %}
+      </div>
+    {% else %}
+      <p class="text-[var(--text-secondary)]">{% trans "Nenhum evento nos últimos 30 dias." %}</p>
+    {% endif %}
+  </div>
 </section>


### PR DESCRIPTION
## Summary
- align the calendar section container with the shared layout classes
- apply the shared heading style to the calendar title and adjust spacing
- update the day grid spacing to better match the event list vertical rhythm

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d17be113c0832580860ec4f8fe63f2