### PR TITLE
Restrict invite organization selection to user context

### DIFF
--- a/tests/tokens/test_api.py
+++ b/tests/tokens/test_api.py
@@ -1,11 +1,10 @@
 import pytest
-
-pytestmark = pytest.mark.skip(reason="legacy tests")
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
 
 from accounts.factories import UserFactory
+from organizacoes.factories import OrganizacaoFactory
 from tokens.models import TokenAcesso, TokenUsoLog
 
 pytestmark = pytest.mark.django_db
@@ -18,6 +17,8 @@ def api_client():
 
 def test_limite_diario(api_client):
     user = UserFactory(is_staff=True)
+    org = OrganizacaoFactory()
+    org.users.add(user)
     api_client.force_authenticate(user=user)
     url = reverse("tokens_api:token-list")
     for _ in range(5):
@@ -29,6 +30,8 @@ def test_limite_diario(api_client):
 
 def test_registro_logs(api_client):
     user = UserFactory(is_staff=True)
+    org = OrganizacaoFactory()
+    org.users.add(user)
     api_client.force_authenticate(user=user)
     url = reverse("tokens_api:token-list")
     resp = api_client.post(url, {"tipo_destino": TokenAcesso.TipoUsuario.ASSOCIADO})
@@ -57,3 +60,31 @@ def test_revogar_token(api_client):
     use_url = reverse("tokens_api:token-use", args=[token.pk])
     resp = api_client.post(use_url)
     assert resp.status_code == status.HTTP_409_CONFLICT
+
+
+def test_api_respeita_organizacao_do_usuario(api_client):
+    user = UserFactory(is_staff=True)
+    org = OrganizacaoFactory()
+    outra = OrganizacaoFactory()
+    org.users.add(user)
+    api_client.force_authenticate(user=user)
+    url = reverse("tokens_api:token-list")
+    resp = api_client.post(
+        url,
+        {
+            "tipo_destino": TokenAcesso.TipoUsuario.ASSOCIADO,
+            "organizacao": outra.pk,
+        },
+    )
+    assert resp.status_code == status.HTTP_201_CREATED
+    token = TokenAcesso.objects.get(gerado_por=user)
+    assert token.organizacao == org
+
+
+def test_api_sem_organizacao_retorna_erro(api_client):
+    user = UserFactory(is_staff=True)
+    api_client.force_authenticate(user=user)
+    url = reverse("tokens_api:token-list")
+    resp = api_client.post(url, {"tipo_destino": TokenAcesso.TipoUsuario.ASSOCIADO})
+    assert resp.status_code == status.HTTP_400_BAD_REQUEST
+    assert "organização" in resp.data["detail"].lower()

--- a/tests/tokens/test_invite_webhooks.py
+++ b/tests/tokens/test_invite_webhooks.py
@@ -9,7 +9,6 @@ from rest_framework.test import APIClient
 
 from accounts.factories import UserFactory
 from accounts.models import UserType
-from nucleos.factories import NucleoFactory
 from organizacoes.factories import OrganizacaoFactory
 from tokens.models import TokenAcesso
 from tokens.services import create_invite_token
@@ -40,12 +39,9 @@ def test_gerar_convite_triggers_webhook(monkeypatch, client):
     user = UserFactory(is_staff=True, user_type=UserType.ADMIN.value)
     org = OrganizacaoFactory()
     org.users.add(user)
-    nucleo = NucleoFactory(organizacao=org)
     client.force_login(user)
     data = {
         "tipo_destino": TokenAcesso.TipoUsuario.CONVIDADO,
-        "organizacao": org.pk,
-        "nucleos": [nucleo.pk],
     }
     client.post(reverse("tokens:gerar_convite"), data)
 

--- a/tokens/api.py
+++ b/tokens/api.py
@@ -83,12 +83,18 @@ class TokenViewSet(viewsets.GenericViewSet):
 
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
+        organizacao = getattr(request.user, "organizacao", None)
+        if not organizacao:
+            return Response(
+                {"detail": _("Seu usuário não está associado a nenhuma organização.")},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         with transaction.atomic():
             token, codigo = create_invite_token(
                 gerado_por=request.user,
                 tipo_destino=serializer.validated_data["tipo_destino"],
                 data_expiracao=serializer.validated_data.get("data_expiracao"),
-                organizacao=serializer.validated_data.get("organizacao"),
+                organizacao=organizacao,
             )
             token.ip_gerado = ip
             token.save(update_fields=["ip_gerado"])

--- a/tokens/forms.py
+++ b/tokens/forms.py
@@ -3,10 +3,6 @@ from django import forms
 from django.contrib.auth import get_user_model
 from django.utils import timezone
 
-from nucleos.models import Nucleo
-from organizacoes.models import Organizacao
-
-from accounts.models import UserType
 from .models import CodigoAutenticacao, TokenAcesso
 from .perms import can_issue_invite
 from .services import find_token_by_code
@@ -26,19 +22,11 @@ class TokenAcessoForm(forms.ModelForm):
 
 class GerarTokenConviteForm(forms.Form):
     tipo_destino = forms.ChoiceField(choices=TokenAcesso.TipoUsuario.choices)
-    organizacao = forms.ModelChoiceField(queryset=None)
-    nucleos = forms.ModelMultipleChoiceField(queryset=None, required=False)
 
     def __init__(self, *args, user=None, **kwargs):
+        self.user = user
         super().__init__(*args, **kwargs)
         if user:
-            if user.user_type == UserType.ROOT:
-                self.fields["organizacao"].queryset = Organizacao.objects.all()
-                self.fields.pop("nucleos", None)
-            else:
-                self.fields["organizacao"].queryset = Organizacao.objects.filter(users=user)
-                self.fields["nucleos"].queryset = Nucleo.objects.filter(organizacao__users=user)
-
             self.fields["tipo_destino"].choices = [
                 choice for choice in TokenAcesso.TipoUsuario.choices if can_issue_invite(user, choice[0])
             ]

--- a/tokens/serializers.py
+++ b/tokens/serializers.py
@@ -35,6 +35,7 @@ class TokenAcessoSerializer(serializers.ModelSerializer):
             "estado",
             "gerado_por",
             "usuario",
+            "organizacao",
             "ip_gerado",
             "ip_utilizado",
             "revogado_em",

--- a/tokens/templates/tokens/gerar_token.html
+++ b/tokens/templates/tokens/gerar_token.html
@@ -14,11 +14,9 @@
             class="space-y-6">
         {% csrf_token %}
 
-        {% for field in form %}
-          {% if user.user_type != 'root' or field.name != 'nucleos' %}
-            {% include '_forms/field.html' with field=field %}
-          {% endif %}
-        {% endfor %}
+        {% if form %}
+          {% include '_forms/field.html' with field=form.tipo_destino %}
+        {% endif %}
 
         <div class="flex justify-end gap-3 pt-4 border-t border-[var(--border)]">
           <button type="submit" class="btn btn-primary">

--- a/tokens/views.py
+++ b/tokens/views.py
@@ -9,7 +9,6 @@ from django.contrib import messages
 from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.http import JsonResponse
 from django.shortcuts import redirect, render
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
@@ -81,15 +80,19 @@ def listar_convites(request):
 
 class GerarTokenConviteView(LoginRequiredMixin, View):
     def get(self, request, *args, **kwargs):
-        choices = [choice for choice in TokenAcesso.TipoUsuario.choices if can_issue_invite(request.user, choice[0])]
-        if not choices:
+        form = GerarTokenConviteForm(user=request.user)
+        if not form.fields["tipo_destino"].choices:
             messages.error(
                 request,
                 _("Seu perfil não permite gerar convites."),
             )
             return redirect("accounts:perfil")
-        form = GerarTokenConviteForm(user=request.user)
-        form.fields["tipo_destino"].choices = choices
+        if not getattr(request.user, "organizacao", None):
+            messages.error(
+                request,
+                _("Seu usuário não está associado a nenhuma organização."),
+            )
+            return redirect("accounts:perfil")
         if request.headers.get("Hx-Request") == "true":
             return render(request, "tokens/gerar_token.html", {"form": form})
         return render(request, "tokens/tokens.html", {"partial_template": "tokens/gerar_token.html", "form": form})
@@ -115,38 +118,61 @@ class GerarTokenConviteView(LoginRequiredMixin, View):
                 )
             else:
                 messages.error(request, _("Muitas requisições, tente novamente mais tarde."))
+                form = GerarTokenConviteForm(user=request.user)
                 resp = render(
                     request,
                     "tokens/tokens.html",
-                    {"partial_template": "tokens/gerar_token.html", "form": GerarTokenConviteForm(user=request.user)},
+                    {"partial_template": "tokens/gerar_token.html", "form": form},
                     status=429,
                 )
             if rl.retry_after:
                 resp["Retry-After"] = str(rl.retry_after)
             return resp
         form = GerarTokenConviteForm(request.POST, user=request.user)
-        choices = [choice for choice in TokenAcesso.TipoUsuario.choices if can_issue_invite(request.user, choice[0])]
-        form.fields["tipo_destino"].choices = choices
-        if form.is_valid():
-            target_role = form.cleaned_data["tipo_destino"]
-            if not can_issue_invite(request.user, target_role):
-                if request.headers.get("HX-Request") == "true":
-                    return render(
-                        request,
-                        "tokens/_resultado.html",
-                        {"error": _("Seu perfil não permite gerar convites para este tipo de usuário.")},
-                        status=403,
-                    )
-                messages.error(
-                    request,
-                    _("Seu perfil não permite gerar convites para este tipo de usuário."),
-                )
+        organizacao = getattr(request.user, "organizacao", None)
+        if not organizacao:
+            message = _("Seu usuário não está associado a nenhuma organização.")
+            if request.headers.get("HX-Request") == "true":
                 return render(
                     request,
-                    "tokens/tokens.html",
-                    {"partial_template": "tokens/gerar_token.html", "form": form, "error": _("Seu perfil não permite gerar convites para este tipo de usuário.")},
+                    "tokens/_resultado.html",
+                    {"error": message},
+                    status=400,
+                )
+            messages.error(request, message)
+            return render(
+                request,
+                "tokens/tokens.html",
+                {
+                    "partial_template": "tokens/gerar_token.html",
+                    "form": form,
+                    "error": message,
+                },
+                status=400,
+            )
+        requested_role = request.POST.get("tipo_destino")
+        if requested_role and not can_issue_invite(request.user, requested_role):
+            message = _("Seu perfil não permite gerar convites para este tipo de usuário.")
+            if request.headers.get("HX-Request") == "true":
+                return render(
+                    request,
+                    "tokens/_resultado.html",
+                    {"error": message},
                     status=403,
                 )
+            messages.error(request, message)
+            return render(
+                request,
+                "tokens/tokens.html",
+                {
+                    "partial_template": "tokens/gerar_token.html",
+                    "form": form,
+                    "error": message,
+                },
+                status=403,
+            )
+        if form.is_valid():
+            target_role = form.cleaned_data["tipo_destino"]
 
             start_day = timezone.now().replace(hour=0, minute=0, second=0, microsecond=0)
             end_day = start_day + timezone.timedelta(days=1)
@@ -177,8 +203,7 @@ class GerarTokenConviteView(LoginRequiredMixin, View):
                 gerado_por=request.user,
                 tipo_destino=target_role,
                 data_expiracao=timezone.now() + timezone.timedelta(days=30),
-                organizacao=form.cleaned_data.get("organizacao"),
-                nucleos=form.cleaned_data.get("nucleos"),
+                organizacao=organizacao,
             )
 
             ip = get_client_ip(request)
@@ -199,7 +224,6 @@ class GerarTokenConviteView(LoginRequiredMixin, View):
                 return render(request, "tokens/_resultado.html", {"token": codigo})
             messages.success(request, _("Token gerado"))
             form = GerarTokenConviteForm(user=request.user)
-            form.fields["tipo_destino"].choices = choices
             return render(
                 request,
                 "tokens/tokens.html",


### PR DESCRIPTION
## Summary
- ensure `GerarTokenConviteForm` only exposes `tipo_destino`, tracking the submitting user
- require invite views and API endpoints to use `request.user.organizacao`, returning clear errors when absent
- simplify the invite template and update tests to verify admins cannot override their organization in web or API flows

## Testing
- `pytest tests/tokens` *(fails: suite expects full project configuration/coverage; environment lacks required setup)*

------
https://chatgpt.com/codex/tasks/task_e_68d17dedda7483258af4a299f5c6f445