### PR TITLE
Atualiza menu de eventos para carregar listagem por padrão

### DIFF
--- a/core/menu.py
+++ b/core/menu.py
@@ -310,7 +310,7 @@ def _get_menu_items() -> List[MenuItem]:
     perfil_url = reverse("accounts:perfil")
     configuracoes_url = reverse("configuracoes:configuracoes")
     nucleos_url = reverse("nucleos:list")
-    eventos_url = reverse("eventos:painel")
+    eventos_url = reverse("eventos:lista")
     feed_url = reverse("feed:listar")
     financeiro_repasses = reverse("financeiro:repasses")
 
@@ -371,20 +371,6 @@ def _get_menu_items() -> List[MenuItem]:
             path=reverse("eventos:calendario"),
             label="Calendário",
             icon=ICON_EVENTOS,
-            permissions=[
-                "admin",
-                "financeiro",
-                "coordenador",
-                "nucleado",
-                "associado",
-                "convidado",
-            ],
-        ),
-        MenuItem(
-            id="eventos_listar",
-            path=reverse("eventos:lista"),
-            label="Listar",
-            icon=ICON_TABLE,
             permissions=[
                 "admin",
                 "financeiro",

--- a/templates/_partials/sidebar.html
+++ b/templates/_partials/sidebar.html
@@ -19,11 +19,11 @@
           {% if item.children %}
             <div class="sidebar-parent">
               {% if item.id == 'eventos' and resolver_match and resolver_match.app_name == 'eventos' %}
-                {% url 'eventos:calendario' as eventos_calendario_partial_url %}
+                {% url 'eventos:lista' as eventos_lista_partial_url %}
               {% endif %}
               <a href="{{ item.path }}" class="sidebar-item{% if item.is_active %} sidebar-item-active{% endif %}{% if item.classes %} {{ item.classes }}{% endif %}" {% if item.is_current %}aria-current="page"{% endif %}
                  {% if item.id == 'eventos' and resolver_match and resolver_match.app_name == 'eventos' %}
-                   hx-get="{{ eventos_calendario_partial_url }}" hx-target="#eventos-conteudo" hx-swap="innerHTML" hx-push-url="true"
+                   hx-get="{{ eventos_lista_partial_url }}" hx-target="#eventos-conteudo" hx-swap="innerHTML" hx-push-url="true"
                  {% endif %}>
                 {% if item.id == 'perfil' and user.avatar %}
                   <img src="{{ user.avatar.url }}" alt="{{ user.username }}" class="w-6 h-6 rounded-full object-cover" loading="lazy" />


### PR DESCRIPTION
## Summary
- aponta o item principal de Eventos para a listagem padrão
- remove a opção redundante de listagem do submenu de eventos
- ajusta o carregamento HTMX da entrada de Eventos para reutilizar a nova URL padrão

## Testing
- not run (motivation: alterações de configuração simples)


------
https://chatgpt.com/codex/tasks/task_e_68d18b3fc12483258d791470ad47bd5c