### PR TITLE
Move associados totals into hero banner

### DIFF
--- a/accounts/templates/associados/associado_list.html
+++ b/accounts/templates/associados/associado_list.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load i18n lucide_icons %}
+{% load i18n %}
 
 {% block title %}{% trans 'Associados' %}{% endblock %}
 
@@ -16,21 +16,6 @@
       {% trans "Carregando..." %}
     </div>
   </div>
-  <!-- Cards de totais -->
-  <details class="card mb-6" open>
-    <summary class="cursor-pointer text-base font-semibold text-[var(--text-primary)]">
-      {% trans "Resumo" %}
-    </summary>
-    {% lucide 'users' class='h-5 w-5' as icon_usuarios %}
-    {% lucide 'badge-check' class='h-5 w-5' as icon_associados %}
-    {% lucide 'network' class='h-5 w-5' as icon_nucleados %}
-
-    <div class="mt-4 card-grid">
-      {% include "_partials/cards/total_card.html" with label=_('Usuários') valor=total_usuarios icon_svg=icon_usuarios %}
-      {% include "_partials/cards/total_card.html" with label=_('Associados') valor=total_associados icon_svg=icon_associados %}
-      {% include "_partials/cards/total_card.html" with label=_('Nucleados') valor=total_nucleados icon_svg=icon_nucleados %}
-    </div>
-  </details>
   <div id="associados-grid">
     {% include 'associados/_grid.html' with associados=associados page_obj=page_obj request=request %}
   </div>

--- a/templates/_components/hero_associados.html
+++ b/templates/_components/hero_associados.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n lucide_icons %}
 <section class="hero-with-neural bg-gradient-to-br from-[var(--hero-from)] to-[var(--hero-to)] text-white"
          style="--hero-from: var(--color-primary-500); --hero-to: var(--color-primary-700);{% if style %} {{ style }}{% endif %}">
   <div class="neural-bg-base" aria-hidden="true">
@@ -21,6 +21,23 @@
           <div class="flex justify-center md:justify-end md:self-start">{% include action_template %}</div>
         {% endif %}
       </div>
+      {% if total_usuarios is not None or total_associados is not None or total_nucleados is not None %}
+        <div class="mt-10 space-y-4">
+          <div class="flex items-center gap-3 text-white/80">
+            <span class="inline-flex h-9 w-9 items-center justify-center rounded-full bg-white/10 text-white ring-1 ring-white/10 backdrop-blur">
+              {% lucide 'chart-pie' class='h-5 w-5' %}
+            </span>
+            <span class="text-sm font-semibold uppercase tracking-wide">
+              {% trans "Resumo" %}
+            </span>
+          </div>
+          <div class="card-grid">
+            {% include '_partials/cards/total_card.html' with label=_('Usuários') valor=total_usuarios icon_name='users' %}
+            {% include '_partials/cards/total_card.html' with label=_('Associados') valor=total_associados icon_name='badge-check' %}
+            {% include '_partials/cards/total_card.html' with label=_('Nucleados') valor=total_nucleados icon_name='network' %}
+          </div>
+        </div>
+      {% endif %}
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Summary
- load lucide icons in the associados hero and render a highlighted "Resumo" section with the total cards
- remove the duplicated totals accordion from the associados list now that the hero displays the metrics
- correct the hero summary icon to use the available `chart-pie` glyph

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d18d961b18832584dec515c6b53987