### PR TITLE
Adicionar cards compactos no resumo de associados

### DIFF
--- a/app/static/css/hubx.css
+++ b/app/static/css/hubx.css
@@ -557,6 +557,28 @@
   .card-body   { @apply text-sm leading-6; }
   .card-footer { @apply mt-4 pt-4 border-t border-[var(--border)]; }
 
+  .card-compact { @apply p-4 sm:p-5; }
+
+  .card-compact .card-body,
+  .card-body-compact {
+    @apply p-3 sm:p-4 text-xs leading-5;
+  }
+
+  .card-compact .card-body > :first-child,
+  .card-body-compact > :first-child {
+    @apply gap-1 text-xs;
+  }
+
+  .card-compact .card-body > :first-child svg,
+  .card-body-compact > :first-child svg {
+    @apply h-4 w-4;
+  }
+
+  .card-compact .card-body > :not(:first-child),
+  .card-body-compact > :not(:first-child) {
+    margin-top: var(--space-1);
+  }
+
   /* Botões */
   .btn            { @apply inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium border transition; }
   .btn-primary    { @apply btn bg-[var(--accent)] text-[var(--on-accent)] border-transparent hover:opacity-90; }

--- a/static/tailwind.css
+++ b/static/tailwind.css
@@ -1360,6 +1360,48 @@ a:focus {
   padding-top: 1rem;
 }
 
+.card-compact {
+  padding: 1rem;
+}
+
+@media (min-width: 640px) {
+  .card-compact {
+    padding: 1.25rem;
+  }
+}
+
+.card-compact .card-body,
+  .card-body-compact {
+  padding: 0.75rem;
+  font-size: 0.75rem;
+  line-height: 1.25rem;
+}
+
+@media (min-width: 640px) {
+  .card-compact .card-body,
+  .card-body-compact {
+    padding: 1rem;
+  }
+}
+
+.card-compact .card-body > :first-child,
+  .card-body-compact > :first-child {
+  gap: 0.25rem;
+  font-size: 0.75rem;
+  line-height: 1rem;
+}
+
+.card-compact .card-body > :first-child svg,
+  .card-body-compact > :first-child svg {
+  height: 1rem;
+  width: 1rem;
+}
+
+.card-compact .card-body > :not(:first-child),
+  .card-body-compact > :not(:first-child) {
+  margin-top: var(--space-1);
+}
+
 /* Botões */
 
 .btn {
@@ -1375,9 +1417,7 @@ a:focus {
   font-size: 0.875rem;
   line-height: 1.25rem;
   font-weight: 500;
-  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, -webkit-backdrop-filter;
   transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;
-  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter, -webkit-backdrop-filter;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;
 }
@@ -1440,9 +1480,7 @@ a:focus {
   font-size: 0.875rem;
   line-height: 1.25rem;
   font-weight: 500;
-  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, -webkit-backdrop-filter;
   transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;
-  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter, -webkit-backdrop-filter;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;
   border-color: transparent;
@@ -1512,9 +1550,7 @@ a:focus {
   font-size: 0.875rem;
   line-height: 1.25rem;
   font-weight: 500;
-  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, -webkit-backdrop-filter;
   transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;
-  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter, -webkit-backdrop-filter;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;
   border-color: var(--border);
@@ -1538,9 +1574,7 @@ a:focus {
   padding-top: 0.5rem;
   padding-bottom: 0.5rem;
   color: var(--text-secondary);
-  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, -webkit-backdrop-filter;
   transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;
-  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter, -webkit-backdrop-filter;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;
 }
@@ -1579,9 +1613,7 @@ a:focus {
   border-radius: calc(var(--radius) - 2px);
   padding: 0.5rem;
   color: var(--text-secondary);
-  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, -webkit-backdrop-filter;
   transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;
-  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter, -webkit-backdrop-filter;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;
 }
@@ -1636,9 +1668,7 @@ a:focus {
   font-size: 0.875rem;
   line-height: 1.25rem;
   color: var(--text-secondary);
-  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, -webkit-backdrop-filter;
   transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;
-  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter, -webkit-backdrop-filter;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;
 }
@@ -2006,6 +2036,10 @@ a:focus {
   height: 2rem;
 }
 
+.h-9 {
+  height: 2.25rem;
+}
+
 .h-full {
   height: 100%;
 }
@@ -2056,6 +2090,10 @@ a:focus {
 
 .w-8 {
   width: 2rem;
+}
+
+.w-9 {
+  width: 2.25rem;
 }
 
 .w-auto {
@@ -2116,10 +2154,6 @@ a:focus {
 
 .cursor-move {
   cursor: move;
-}
-
-.cursor-pointer {
-  cursor: pointer;
 }
 
 .list-disc {
@@ -2400,6 +2434,10 @@ a:focus {
   background-color: transparent;
 }
 
+.bg-white\/10 {
+  background-color: rgb(255 255 255 / 0.1);
+}
+
 .bg-white\/20 {
   background-color: rgb(255 255 255 / 0.2);
 }
@@ -2656,6 +2694,10 @@ a:focus {
   text-transform: uppercase;
 }
 
+.tracking-wide {
+  letter-spacing: 0.025em;
+}
+
 .tracking-widest {
   letter-spacing: 0.1em;
 }
@@ -2771,16 +2813,18 @@ a:focus {
   filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
 }
 
+.backdrop-blur {
+  --tw-backdrop-blur: blur(8px);
+  backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);
+}
+
 .backdrop-blur-sm {
   --tw-backdrop-blur: blur(4px);
-  -webkit-backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);
   backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);
 }
 
 .transition {
-  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, -webkit-backdrop-filter;
   transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;
-  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter, -webkit-backdrop-filter;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;
 }

--- a/templates/_components/hero_associados.html
+++ b/templates/_components/hero_associados.html
@@ -34,9 +34,9 @@
             </span>
           </div>
           <div class="card-grid">
-            {% include '_partials/cards/total_card.html' with label=_('Usuários') valor=total_usuarios icon_name='users' %}
-            {% include '_partials/cards/total_card.html' with label=_('Associados') valor=total_associados icon_name='badge-check' %}
-            {% include '_partials/cards/total_card.html' with label=_('Nucleados') valor=total_nucleados icon_name='network' %}
+            {% include '_partials/cards/total_card.html' with label=_('Usuários') valor=total_usuarios icon_name='users' card_class='card-compact' body_class='card-body-compact' %}
+            {% include '_partials/cards/total_card.html' with label=_('Associados') valor=total_associados icon_name='badge-check' card_class='card-compact' body_class='card-body-compact' %}
+            {% include '_partials/cards/total_card.html' with label=_('Nucleados') valor=total_nucleados icon_name='network' card_class='card-compact' body_class='card-body-compact' %}
           </div>
         </div>
       {% endif %}

--- a/templates/_partials/cards/total_card.html
+++ b/templates/_partials/cards/total_card.html
@@ -1,7 +1,7 @@
 {% load lucide_icons %}
 {# Card de total #}
-<article class="card">
-  <div class="card-body">
+<article class="card{% if card_class %} {{ card_class }}{% endif %}">
+  <div class="card-body{% if body_class %} {{ body_class }}{% endif %}">
     <div class="flex items-center gap-2 text-sm text-[var(--text-secondary)]">
 
       {% if icon_name %}


### PR DESCRIPTION
## Summary
- adiciona variantes `card-compact` e `card-body-compact` para reduzir espaçamentos dos cards e recompila o CSS gerado
- permite que o parcial de total receba classes opcionais para o card e para o corpo
- aplica os estilos compactos aos cartões do resumo na hero de associados

## Testing
- npm run build:css
- python manage.py runserver 0.0.0.0:8000 (verificação visual manual)


------
https://chatgpt.com/codex/tasks/task_e_68d19694839483258a1065fc064503fc