### PR TITLE
Adjust hero detail layout width

### DIFF
--- a/templates/_components/hero_nucleo_detail.html
+++ b/templates/_components/hero_nucleo_detail.html
@@ -9,31 +9,33 @@
     <div class="absolute inset-0 bg-gradient-to-r from-[var(--hero-from)] to-[var(--hero-to)]"
          style="--hero-from: var(--color-primary-500); --hero-to: var(--color-primary-700);"></div>
   {% endif %}
-  <div class="relative max-w-7xl mx-auto px-4 py-10 flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
-    <div class="flex items-center gap-4">
-      <div class="shrink-0">
-        {% if nucleo.avatar %}
-          <img src="{{ nucleo.avatar.url }}" alt="{{ nucleo.nome }}" class="h-20 w-20 rounded-full object-cover ring-4 ring-white/50" loading="lazy">
-        {% else %}
-          <div class="flex h-20 w-20 items-center justify-center rounded-full bg-white/20 text-3xl font-semibold uppercase ring-4 ring-white/30"
-               role="img" aria-label="{{ nucleo.nome }}">
-            {{ nucleo.nome|slice:':1'|upper }}
-          </div>
-        {% endif %}
+  <div class="hero-content w-full">
+    <div class="relative max-w-7xl mx-auto w-full px-4 py-10 flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+      <div class="flex items-center gap-4">
+        <div class="shrink-0">
+          {% if nucleo.avatar %}
+            <img src="{{ nucleo.avatar.url }}" alt="{{ nucleo.nome }}" class="h-20 w-20 rounded-full object-cover ring-4 ring-white/50" loading="lazy">
+          {% else %}
+            <div class="flex h-20 w-20 items-center justify-center rounded-full bg-white/20 text-3xl font-semibold uppercase ring-4 ring-white/30"
+                 role="img" aria-label="{{ nucleo.nome }}">
+              {{ nucleo.nome|slice:':1'|upper }}
+            </div>
+          {% endif %}
+        </div>
+        <h1 class="text-3xl font-bold md:text-4xl">{{ nucleo.nome }}</h1>
       </div>
-      <h1 class="text-3xl font-bold md:text-4xl">{{ nucleo.nome }}</h1>
+      {% if perms.nucleos.change_nucleo or perms.nucleos.delete_nucleo or request.user.user_type == 'admin' or request.user.user_type == 'coordenador' %}
+        <div class="flex flex-wrap gap-3 md:justify-end">
+          {% if perms.nucleos.change_nucleo or request.user.user_type == 'admin' or request.user.user_type == 'coordenador' %}
+            <a href="{% url 'nucleos:update' nucleo.pk %}" class="btn btn-secondary"
+               aria-label="{% trans 'Editar núcleo' %}">{% trans 'Editar' %}</a>
+          {% endif %}
+          {% if perms.nucleos.delete_nucleo or request.user.user_type == 'admin' or request.user.user_type == 'coordenador' %}
+            <a href="{% url 'nucleos:delete' nucleo.pk %}" class="btn btn-danger"
+               aria-label="{% trans 'Excluir núcleo' %}">{% trans 'Excluir' %}</a>
+          {% endif %}
+        </div>
+      {% endif %}
     </div>
-    {% if perms.nucleos.change_nucleo or perms.nucleos.delete_nucleo or request.user.user_type == 'admin' or request.user.user_type == 'coordenador' %}
-      <div class="flex flex-wrap gap-3 md:justify-end">
-        {% if perms.nucleos.change_nucleo or request.user.user_type == 'admin' or request.user.user_type == 'coordenador' %}
-          <a href="{% url 'nucleos:update' nucleo.pk %}" class="btn btn-secondary"
-             aria-label="{% trans 'Editar núcleo' %}">{% trans 'Editar' %}</a>
-        {% endif %}
-        {% if perms.nucleos.delete_nucleo or request.user.user_type == 'admin' or request.user.user_type == 'coordenador' %}
-          <a href="{% url 'nucleos:delete' nucleo.pk %}" class="btn btn-danger"
-             aria-label="{% trans 'Excluir núcleo' %}">{% trans 'Excluir' %}</a>
-        {% endif %}
-      </div>
-    {% endif %}
   </div>
 </section>


### PR DESCRIPTION
## Summary
- wrap the núcleo detail hero content with a `hero-content` container and add `w-full` to match the layout width handling used elsewhere

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d19d50bed4832591020db871fb0b32