### PR TITLE
Update hero titles in tokens views and template

### DIFF
--- a/tokens/templates/tokens/tokens.html
+++ b/tokens/templates/tokens/tokens.html
@@ -2,7 +2,7 @@
 {% load i18n static %}
 
 {% block hero %}
-  {% include '_components/hero_tokens.html' with title=_('Tokens') action_template='tokens/hero_action.html' %}
+  {% include '_components/hero_tokens.html' with title=hero_title|default:_('Tokens') action_template='tokens/hero_action.html' %}
 {% endblock %}
 
 {% block content %}

--- a/tokens/views.py
+++ b/tokens/views.py
@@ -77,8 +77,12 @@ def listar_convites(request):
     context = {"convites": convites, "totais": totais}
     if request.headers.get("Hx-Request") == "true":
         return render(request, "tokens/token_list.html", context)
-    context["partial_template"] = "tokens/token_list.html"
-    return render(request, "tokens/tokens.html", context)
+    full_context = {
+        **context,
+        "partial_template": "tokens/token_list.html",
+        "hero_title": _("Tokens"),
+    }
+    return render(request, "tokens/tokens.html", full_context)
 
 
 
@@ -101,7 +105,15 @@ class GerarTokenConviteView(LoginRequiredMixin, View):
             return redirect("accounts:perfil")
         if request.headers.get("Hx-Request") == "true":
             return render(request, "tokens/gerar_token.html", {"form": form})
-        return render(request, "tokens/tokens.html", {"partial_template": "tokens/gerar_token.html", "form": form})
+        return render(
+            request,
+            "tokens/tokens.html",
+            {
+                "partial_template": "tokens/gerar_token.html",
+                "form": form,
+                "hero_title": _("Gerar Token"),
+            },
+        )
 
     def post(self, request, *args, **kwargs):
         ip = get_client_ip(request)
@@ -128,7 +140,11 @@ class GerarTokenConviteView(LoginRequiredMixin, View):
                 resp = render(
                     request,
                     "tokens/tokens.html",
-                    {"partial_template": "tokens/gerar_token.html", "form": form},
+                    {
+                        "partial_template": "tokens/gerar_token.html",
+                        "form": form,
+                        "hero_title": _("Gerar Token"),
+                    },
                     status=429,
                 )
             if rl.retry_after:
@@ -153,6 +169,7 @@ class GerarTokenConviteView(LoginRequiredMixin, View):
                     "partial_template": "tokens/gerar_token.html",
                     "form": form,
                     "error": message,
+                    "hero_title": _("Gerar Token"),
                 },
                 status=400,
             )
@@ -174,6 +191,7 @@ class GerarTokenConviteView(LoginRequiredMixin, View):
                     "partial_template": "tokens/gerar_token.html",
                     "form": form,
                     "error": message,
+                    "hero_title": _("Gerar Token"),
                 },
                 status=403,
             )
@@ -201,7 +219,12 @@ class GerarTokenConviteView(LoginRequiredMixin, View):
                 return render(
                     request,
                     "tokens/tokens.html",
-                    {"partial_template": "tokens/gerar_token.html", "form": form, "error": _("Limite diário atingido.")},
+                    {
+                        "partial_template": "tokens/gerar_token.html",
+                        "form": form,
+                        "error": _("Limite diário atingido."),
+                        "hero_title": _("Gerar Token"),
+                    },
                     status=429,
                 )
 
@@ -233,7 +256,12 @@ class GerarTokenConviteView(LoginRequiredMixin, View):
             return render(
                 request,
                 "tokens/tokens.html",
-                {"partial_template": "tokens/gerar_token.html", "form": form, "token": codigo},
+                {
+                    "partial_template": "tokens/gerar_token.html",
+                    "form": form,
+                    "token": codigo,
+                    "hero_title": _("Gerar Token"),
+                },
             )
         if request.headers.get("HX-Request") == "true":
             return render(
@@ -246,7 +274,12 @@ class GerarTokenConviteView(LoginRequiredMixin, View):
         return render(
             request,
             "tokens/tokens.html",
-            {"partial_template": "tokens/gerar_token.html", "form": form, "error": _("Dados inválidos")},
+            {
+                "partial_template": "tokens/gerar_token.html",
+                "form": form,
+                "error": _("Dados inválidos"),
+                "hero_title": _("Gerar Token"),
+            },
             status=400,
         )
 


### PR DESCRIPTION
## Summary
- provide a `hero_title` when rendering `tokens/tokens.html` from the invite list and generation views
- allow the tokens layout template to fall back to the translated default when no hero title is supplied

## Testing
- python manage.py shell (manual hero checks)
- pytest tokens -k tokens --maxfail=1


------
https://chatgpt.com/codex/tasks/task_e_68d19daaba2083258f1cd6f66d285ca7