### PR TITLE
Ajusta hero do detalhe de evento

### DIFF
--- a/templates/_components/hero_eventos_detail.html
+++ b/templates/_components/hero_eventos_detail.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-<section class="relative isolate overflow-hidden text-white">
+<section class="hero-with-neural relative isolate overflow-hidden text-white">
   {% if evento.cover %}
     <div class="absolute inset-0">
       <img src="{{ evento.cover.url }}" alt="" class="h-full w-full object-cover" loading="lazy">
@@ -9,7 +9,7 @@
     <div class="absolute inset-0 bg-gradient-to-r from-[var(--hero-from)] to-[var(--hero-to)]"
          style="--hero-from: var(--color-primary-500); --hero-to: var(--color-primary-700);"></div>
   {% endif %}
-  <div class="relative z-10 w-full">
+  <div class="hero-content relative z-10 w-full">
     <div class="max-w-7xl mx-auto w-full px-4 py-10 flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
       <div class="flex items-center gap-4">
         <div class="shrink-0">

--- a/templates/_components/hero_nucleo_detail.html
+++ b/templates/_components/hero_nucleo_detail.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-<section class="relative isolate overflow-hidden text-white">
+<section class="hero-with-neural relative isolate overflow-hidden text-white">
   {% if nucleo.cover %}
     <div class="absolute inset-0">
       <img src="{{ nucleo.cover.url }}" alt="" class="h-full w-full object-cover" loading="lazy">
@@ -9,8 +9,8 @@
     <div class="absolute inset-0 bg-gradient-to-r from-[var(--hero-from)] to-[var(--hero-to)]"
          style="--hero-from: var(--color-primary-500); --hero-to: var(--color-primary-700);"></div>
   {% endif %}
-  <div class="hero-content w-full">
-    <div class="relative max-w-7xl mx-auto w-full px-4 py-10 flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+  <div class="hero-content relative z-10 w-full">
+    <div class="max-w-7xl mx-auto w-full px-4 py-10 flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
       <div class="flex items-center gap-4">
         <div class="shrink-0">
           {% if nucleo.avatar %}


### PR DESCRIPTION
## Summary
- adiciona a classe `hero-with-neural` ao hero de detalhes de evento
- atualiza o contêiner interno para usar a classe `hero-content`, espelhando o componente base
- mantém o conteúdo dentro do contêiner responsivo padrão do hero
- aplica o mesmo layout do hero base ao componente de detalhes de núcleo, com `hero-with-neural` e `hero-content`

## Testing
- not run (template-only change)

------
https://chatgpt.com/codex/tasks/task_e_68d1a2b4b5b08325a0da7cd3b2910636