### PR TITLE
Wrap hero detail titles in translucent panel

### DIFF
--- a/templates/_components/hero_eventos_detail.html
+++ b/templates/_components/hero_eventos_detail.html
@@ -11,7 +11,7 @@
   {% endif %}
   <div class="hero-content relative z-10 w-full">
     <div class="max-w-7xl mx-auto w-full px-4 py-10 flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
-      <div class="flex items-center gap-4">
+      <div class="flex flex-wrap items-center gap-3 sm:gap-4">
         <div class="shrink-0">
           {% if evento.avatar %}
             <img src="{{ evento.avatar.url }}" alt="{{ evento.titulo }}" class="h-20 w-20 rounded-full object-cover ring-4 ring-white/50" loading="lazy">
@@ -22,7 +22,9 @@
             </div>
           {% endif %}
         </div>
-        <h1 class="text-3xl font-bold md:text-4xl">{{ evento.titulo }}</h1>
+        <div class="inline-flex min-w-0 max-w-full items-center bg-white/80 px-4 py-2 rounded shadow-md backdrop-blur-sm text-gray-900">
+          <h1 class="text-3xl font-bold md:text-4xl">{{ evento.titulo }}</h1>
+        </div>
       </div>
       {% if perms.eventos.change_evento or perms.eventos.delete_evento %}
         <div class="flex flex-wrap gap-3 md:justify-end">

--- a/templates/_components/hero_nucleo_detail.html
+++ b/templates/_components/hero_nucleo_detail.html
@@ -11,7 +11,7 @@
   {% endif %}
   <div class="hero-content relative z-10 w-full">
     <div class="max-w-7xl mx-auto w-full px-4 py-10 flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
-      <div class="flex items-center gap-4">
+      <div class="flex flex-wrap items-center gap-3 sm:gap-4">
         <div class="shrink-0">
           {% if nucleo.avatar %}
             <img src="{{ nucleo.avatar.url }}" alt="{{ nucleo.nome }}" class="h-20 w-20 rounded-full object-cover ring-4 ring-white/50" loading="lazy">
@@ -22,7 +22,9 @@
             </div>
           {% endif %}
         </div>
-        <h1 class="text-3xl font-bold md:text-4xl">{{ nucleo.nome }}</h1>
+        <div class="inline-flex min-w-0 max-w-full items-center bg-white/80 px-4 py-2 rounded shadow-md backdrop-blur-sm text-gray-900">
+          <h1 class="text-3xl font-bold md:text-4xl">{{ nucleo.nome }}</h1>
+        </div>
       </div>
       {% if perms.nucleos.change_nucleo or perms.nucleos.delete_nucleo or request.user.user_type == 'admin' or request.user.user_type == 'coordenador' %}
         <div class="flex flex-wrap gap-3 md:justify-end">


### PR DESCRIPTION
## Summary
- wrap the hero title in the núcleo detail component with a translucent panel to improve legibility across cover variants
- mirror the translucent panel treatment on the eventos detail hero and tweak spacing so the avatar, title, and actions stay aligned responsively

## Testing
- not run (templates only)


------
https://chatgpt.com/codex/tasks/task_e_68d1a9ba91048325ad206dba76bd37df