### PR TITLE
Move Núcleos summary cards into hero component

### DIFF
--- a/nucleos/templates/nucleos/nucleo_list.html
+++ b/nucleos/templates/nucleos/nucleo_list.html
@@ -1,12 +1,10 @@
 {% extends 'base.html' %}
-{% load i18n lucide_icons %}
+{% load i18n %}
 
 {% block title %}{% trans "Núcleos" %}{% endblock %}
 
 {% block hero %}
-
-  {% include '_components/hero.html' with title=_('Núcleos') action_template='nucleos/hero_actions_nucleo.html' neural_background='nucleos' %}
-
+  {% include '_components/hero_nucleo.html' with title=_('Núcleos') action_template='nucleos/hero_actions_nucleo.html' total_nucleos=total_nucleos total_membros=total_membros_org total_eventos=total_eventos_org total_eventos_ativos=total_eventos_ativos_org total_eventos_concluidos=total_eventos_concluidos_org %}
 {% endblock %}
 
 {% block content %}
@@ -18,18 +16,6 @@
       {% endif %}
     </div>
     <div class="card-body">
-      <details class="card mb-6" open>
-        <summary class="cursor-pointer text-base font-semibold text-[var(--text-primary)]">
-          {% trans "Resumo" %}
-        </summary>
-        {% lucide 'network' class='h-5 w-5' as icon_nucleos %}
-        {% lucide 'users' class='h-5 w-5' as icon_membros %}
-        
-        <div class="mt-4 card-grid">
-          {% include "_partials/cards/total_card.html" with label=_('Núcleos') valor=total_nucleos icon_svg=icon_nucleos %}
-          {% include "_partials/cards/total_card.html" with label=_('Membros') valor=total_membros_org icon_svg=icon_membros %}
-        </div>
-      </details>
       <div role="list" aria-label="{% trans 'Lista de núcleos' %}" class="card-grid sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
         {% for nucleo in object_list %}
           {% include '_components/card_nucleo.html' with nucleo=nucleo %}

--- a/templates/_components/hero_nucleo.html
+++ b/templates/_components/hero_nucleo.html
@@ -1,9 +1,11 @@
-{% load i18n %}
+{% load i18n lucide_icons %}
 <section class="hero-with-neural bg-gradient-to-br from-blue-50 to-blue-100 dark:from-gray-900 dark:to-gray-800 text-white">
-  {% include 'backgrounds/neural_backgrounds.html' with bg_type='nucleos' %}
-  <div class="hero-overlay"></div>
+  <div class="neural-bg-base" aria-hidden="true">
+    {% include 'backgrounds/neural_backgrounds.html' with bg_type='nucleos' only %}
+  </div>
+  <div class="hero-overlay" aria-hidden="true"></div>
   <div class="hero-content w-full">
-    <div class="max-w-7xl mx-auto w-full px-4 py-12 text-center md:text-left">
+    <div class="max-w-7xl mx-auto w-full px-4 py-12 text-center md:text-left md:py-16">
       {% if breadcrumb_template %}
         <div class="mb-4">{% include breadcrumb_template %}</div>
       {% endif %}
@@ -18,6 +20,35 @@
           <div class="flex justify-center md:justify-end md:self-start">{% include action_template %}</div>
         {% endif %}
       </div>
+      {% if total_nucleos is not None or total_membros is not None or total_eventos is not None or total_eventos_ativos is not None or total_eventos_concluidos is not None %}
+        <div class="mt-10 space-y-4 text-left">
+          <div class="flex items-center justify-center gap-3 text-white/80 md:justify-start">
+            <span class="inline-flex h-9 w-9 items-center justify-center rounded-full bg-white/10 text-white ring-1 ring-white/10 backdrop-blur">
+              {% lucide 'network' class='h-5 w-5' %}
+            </span>
+            <span class="text-sm font-semibold uppercase tracking-wide">
+              {% trans "Resumo" %}
+            </span>
+          </div>
+          <div class="card-grid">
+            {% if total_nucleos is not None %}
+              {% include '_partials/cards/total_card.html' with label=_('Núcleos') valor=total_nucleos icon_name='network' card_class='card-compact' body_class='card-body-compact' %}
+            {% endif %}
+            {% if total_membros is not None %}
+              {% include '_partials/cards/total_card.html' with label=_('Membros') valor=total_membros icon_name='users' card_class='card-compact' body_class='card-body-compact' %}
+            {% endif %}
+            {% if total_eventos is not None %}
+              {% include '_partials/cards/total_card.html' with label=_('Eventos') valor=total_eventos icon_name='calendar' card_class='card-compact' body_class='card-body-compact' %}
+            {% endif %}
+            {% if total_eventos_ativos is not None %}
+              {% include '_partials/cards/total_card.html' with label=_('Eventos ativos') valor=total_eventos_ativos icon_name='activity' card_class='card-compact' body_class='card-body-compact' %}
+            {% endif %}
+            {% if total_eventos_concluidos is not None %}
+              {% include '_partials/cards/total_card.html' with label=_('Eventos concluídos') valor=total_eventos_concluidos icon_name='check-circle' card_class='card-compact' body_class='card-body-compact' %}
+            {% endif %}
+          </div>
+        </div>
+      {% endif %}
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Summary
- move the Núcleos totals from the list template into the shared hero component
- extend the hero component to render summary cards for available organization and event metrics
- update the list view to pass totals to the hero and remove the inline totals section

## Testing
- not run (template-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d1ac59262083259049c8bc5b544491