### PR TITLE
Fix lucide icon name for completed events summary card

### DIFF
--- a/templates/_components/hero_nucleo.html
+++ b/templates/_components/hero_nucleo.html
@@ -44,7 +44,7 @@
               {% include '_partials/cards/total_card.html' with label=_('Eventos ativos') valor=total_eventos_ativos icon_name='activity' card_class='card-compact' body_class='card-body-compact' %}
             {% endif %}
             {% if total_eventos_concluidos is not None %}
-              {% include '_partials/cards/total_card.html' with label=_('Eventos concluídos') valor=total_eventos_concluidos icon_name='check-circle' card_class='card-compact' body_class='card-body-compact' %}
+              {% include '_partials/cards/total_card.html' with label=_('Eventos concluídos') valor=total_eventos_concluidos icon_name='circle-check' card_class='card-compact' body_class='card-body-compact' %}
             {% endif %}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- replace the nonexistent `check-circle` lucide icon with the valid `circle-check` option in the nucleus hero totals card

## Testing
- python manage.py check *(fails: ModuleNotFoundError: No module named 'silk')*


------
https://chatgpt.com/codex/tasks/task_e_68d1b03616348325b0e6aa7244edd46b