### PR TITLE
Use hero_nucleo on Nucleo creation form

### DIFF
--- a/nucleos/templates/nucleos/nucleo_form.html
+++ b/nucleos/templates/nucleos/nucleo_form.html
@@ -5,9 +5,9 @@
 
 {% block hero %}
   {% if object %}
-    {% include '_components/hero.html' with title=object.nome %}
+    {% include '_components/hero.html' with title=object.nome subtitle=_('Editar Núcleo') %}
   {% else %}
-    {% include '_components/hero.html' with title=_('Novo Núcleo') %}
+    {% include '_components/hero_nucleo.html' with title=_('Novo Núcleo') %}
   {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- render the specialized hero_nucleo component when creating a new núcleo
- keep the edit flow hero consistent by retaining the existing component with an "Editar Núcleo" subtitle

## Testing
- not run (template-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d1b3c734388325a0071531e7343ee6