### PR TITLE
Ajusta cards de totais do hero de eventos

### DIFF
--- a/eventos/templates/eventos/partials/eventos/evento_list.html
+++ b/eventos/templates/eventos/partials/eventos/evento_list.html
@@ -1,23 +1,10 @@
 {% load i18n lucide_icons %}
 {% include "eventos/partials/_painel_hero_oob.html" %}
   <div class="py-12 px-4 space-y-6">
-    
+
     <div class="card px-4">
 
       <div class="card-body">
-      <details class="mb-6" open>
-        <summary class="cursor-pointer text-sm font-semibold text-[var(--text-primary)]">
-          {% trans 'Resumo' %}
-        </summary>
-        {% lucide 'calendar' class='h-5 w-5' as icon_eventos %}
-        {% lucide 'activity' class='h-5 w-5' as icon_ativos %}
-        {% lucide 'check' class='h-5 w-5' as icon_realizados %}
-        <div class="mt-4 card-grid">
-          {% include "_partials/cards/total_card.html" with label=_('Eventos') valor=total_eventos icon_svg=icon_eventos %}
-          {% include "_partials/cards/total_card.html" with label=_('Ativos') valor=total_eventos_ativos icon_svg=icon_ativos %}
-          {% include "_partials/cards/total_card.html" with label=_('Realizados') valor=total_eventos_concluidos icon_svg=icon_realizados %}
-        </div>
-      </details>
         <div class="grid gap-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3" role="list" aria-label="{% trans 'Lista de eventos' %}">
           {% for evento in eventos %}
             {% include '_components/card_evento.html' %}

--- a/templates/_components/hero_evento.html
+++ b/templates/_components/hero_evento.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n lucide_icons %}
 {% trans 'Eventos' as hero_default_title %}
 <section class="hero-with-neural relative isolate overflow-hidden bg-gradient-to-r from-[var(--hero-from)] to-[var(--hero-to)] text-white"
          {% if style %}style="--hero-from: var(--color-primary-500); --hero-to: var(--color-primary-700); {{ style }}"{% else %}style="--hero-from: var(--color-primary-500); --hero-to: var(--color-primary-700)"{% endif %}>
@@ -22,6 +22,24 @@
           <div class="flex justify-center md:justify-end md:self-start">{% include action_template %}</div>
         {% endif %}
       </div>
+      {% if total_eventos is not None or total_eventos_ativos is not None or total_eventos_concluidos is not None %}
+        {% lucide 'calendar' class='h-5 w-5' as icon_total_eventos %}
+        {% lucide 'activity' class='h-5 w-5' as icon_total_ativos %}
+        {% lucide 'check' class='h-5 w-5' as icon_total_concluidos %}
+        <div class="mt-10 space-y-4 text-left">
+          <div class="card-grid">
+            {% if total_eventos is not None %}
+              {% include '_partials/cards/total_card.html' with label=_('Eventos') valor=total_eventos icon_svg=icon_total_eventos card_class='card-compact' body_class='card-body-compact' %}
+            {% endif %}
+            {% if total_eventos_ativos is not None %}
+              {% include '_partials/cards/total_card.html' with label=_('Ativos') valor=total_eventos_ativos icon_svg=icon_total_ativos card_class='card-compact' body_class='card-body-compact' %}
+            {% endif %}
+            {% if total_eventos_concluidos is not None %}
+              {% include '_partials/cards/total_card.html' with label=_('Realizados') valor=total_eventos_concluidos icon_svg=icon_total_concluidos card_class='card-compact' body_class='card-body-compact' %}
+            {% endif %}
+          </div>
+        </div>
+      {% endif %}
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Summary
- remove o bloco de resumo com cards de totais da listagem de eventos
- atualiza o hero de eventos para exibir o grid de totais com ícones Lucide e layout compacto

## Testing
- not run (templates only)


------
https://chatgpt.com/codex/tasks/task_e_68d1bb7326808325897221e303633025