### PR TITLE
Refatora navegação dos templates financeiros

### DIFF
--- a/financeiro/templates/financeiro/_navigation.html
+++ b/financeiro/templates/financeiro/_navigation.html
@@ -1,0 +1,59 @@
+{% load i18n %}
+{% with current=request.resolver_match.url_name %}
+<nav class="flex flex-wrap items-center gap-2" aria-label="{% trans 'Navegação financeira' %}">
+  {% if request.user.user_type == 'associado' %}
+    <a
+      href="{% url 'financeiro:extrato' %}"
+      class="btn btn-sm {% if current == 'extrato' %}btn-primary{% else %}btn-secondary{% endif %}"
+      {% if current == 'extrato' %}aria-current="page"{% endif %}
+    >
+      {% trans 'Extrato' %}
+    </a>
+    <a
+      href="{% url 'financeiro:aportes_form' %}"
+      class="btn btn-sm {% if current == 'aportes_form' %}btn-primary{% else %}btn-secondary{% endif %}"
+      {% if current == 'aportes_form' %}aria-current="page"{% endif %}
+    >
+      {% trans 'Registrar aporte' %}
+    </a>
+  {% endif %}
+
+  {% if request.user.user_type == 'admin' or request.user.user_type == 'financeiro' %}
+    <a
+      href="{% url 'financeiro:importar_pagamentos' %}"
+      class="btn btn-sm {% if current == 'importar_pagamentos' %}btn-primary{% else %}btn-secondary{% endif %}"
+      {% if current == 'importar_pagamentos' %}aria-current="page"{% endif %}
+    >
+      {% trans 'Importar pagamentos' %}
+    </a>
+    <a
+      href="{% url 'financeiro:importacoes' %}"
+      class="btn btn-sm {% if current == 'importacoes' %}btn-primary{% else %}btn-secondary{% endif %}"
+      {% if current == 'importacoes' %}aria-current="page"{% endif %}
+    >
+      {% trans 'Histórico de importações' %}
+    </a>
+    <a
+      href="{% url 'financeiro:lancamentos' %}"
+      class="btn btn-sm {% if current == 'lancamentos' %}btn-primary{% else %}btn-secondary{% endif %}"
+      {% if current == 'lancamentos' %}aria-current="page"{% endif %}
+    >
+      {% trans 'Lançamentos' %}
+    </a>
+    <a
+      href="{% url 'financeiro:relatorios' %}"
+      class="btn btn-sm {% if current == 'relatorios' %}btn-primary{% else %}btn-secondary{% endif %}"
+      {% if current == 'relatorios' %}aria-current="page"{% endif %}
+    >
+      {% trans 'Relatórios' %}
+    </a>
+    <a
+      href="{% url 'financeiro:repasses' %}"
+      class="btn btn-sm {% if current == 'repasses' %}btn-primary{% else %}btn-secondary{% endif %}"
+      {% if current == 'repasses' %}aria-current="page"{% endif %}
+    >
+      {% trans 'Repasses' %}
+    </a>
+  {% endif %}
+</nav>
+{% endwith %}

--- a/financeiro/templates/financeiro/aportes_form.html
+++ b/financeiro/templates/financeiro/aportes_form.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 <div class="card max-w-md">
   <div class="card-body">
-    <form method="post" class="space-y-2" aria-live="assertive">
+    <form method="post" action="{% url 'financeiro:aportes_form' %}" class="space-y-2" aria-live="assertive">
       {% csrf_token %}
       <div>
         <label for="id_centro" class="block text-sm font-medium">{{ _('Centro de Custo') }}</label>

--- a/financeiro/templates/financeiro/extrato.html
+++ b/financeiro/templates/financeiro/extrato.html
@@ -4,7 +4,7 @@
 {% block title %}{{ _('Extrato') }}{% endblock %}
 
 {% block hero %}
-  {% include '_components/hero_financeiro.html' with title=_('Extrato') %}
+  {% include '_components/hero_financeiro.html' with title=_('Extrato') action_template='financeiro/_navigation.html' %}
 {% endblock %}
 
 {% block content %}

--- a/financeiro/templates/financeiro/importacoes_list.html
+++ b/financeiro/templates/financeiro/importacoes_list.html
@@ -4,7 +4,7 @@
 {% block title %}{% trans "Importações" %}{% endblock %}
 
 {% block hero %}
-  {% include '_components/hero_financeiro.html' with title=_('Importações de Pagamentos') %}
+  {% include '_components/hero_financeiro.html' with title=_('Importações de Pagamentos') action_template='financeiro/_navigation.html' %}
 {% endblock %}
 
 {% block content %}

--- a/financeiro/templates/financeiro/importar_pagamentos.html
+++ b/financeiro/templates/financeiro/importar_pagamentos.html
@@ -4,7 +4,7 @@
 {% block title %}{% trans "Importar Pagamentos" %}{% endblock %}
 
 {% block hero %}
-  {% include '_components/hero_financeiro.html' with title=_('Importar Pagamentos') %}
+  {% include '_components/hero_financeiro.html' with title=_('Importar Pagamentos') action_template='financeiro/_navigation.html' %}
 {% endblock %}
 
 {% block content %}

--- a/financeiro/templates/financeiro/lancamentos_list.html
+++ b/financeiro/templates/financeiro/lancamentos_list.html
@@ -4,7 +4,7 @@
 {% block title %}{% trans "Lançamentos" %}{% endblock %}
 
 {% block hero %}
-  {% include '_components/hero_financeiro.html' with title=_('Lançamentos Financeiros') %}
+  {% include '_components/hero_financeiro.html' with title=_('Lançamentos Financeiros') action_template='financeiro/_navigation.html' %}
 {% endblock %}
 
 {% block content %}

--- a/financeiro/templates/financeiro/relatorios.html
+++ b/financeiro/templates/financeiro/relatorios.html
@@ -4,7 +4,7 @@
 {% block title %}{% trans "Relatórios" %}{% endblock %}
 
 {% block hero %}
-  {% include '_components/hero_financeiro.html' with title=_('Relatórios Financeiros') %}
+  {% include '_components/hero_financeiro.html' with title=_('Relatórios Financeiros') action_template='financeiro/_navigation.html' %}
 {% endblock %}
 
 {% block content %}

--- a/financeiro/templates/financeiro/repasses.html
+++ b/financeiro/templates/financeiro/repasses.html
@@ -4,7 +4,7 @@
 {% block title %}{% trans "Repasses" %}{% endblock %}
 
 {% block hero %}
-  {% include '_components/hero_financeiro.html' with title=_('Repasses') %}
+  {% include '_components/hero_financeiro.html' with title=_('Repasses') action_template='financeiro/_navigation.html' %}
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
## Summary
- adiciona parcial de navegação financeira com links usando nomes de rotas do Django
- injeta a nova navegação nos heros das páginas financeiras e define o action do formulário de aportes

## Testing
- pytest --no-cov financeiro/tests/test_templates_htmx.py financeiro/tests/test_extrato.py

------
https://chatgpt.com/codex/tasks/task_e_68d54f68b89883258fc9040e5d5ce14e