### PR TITLE
Use hero component on núcleo delete page

### DIFF
--- a/nucleos/templates/nucleos/delete.html
+++ b/nucleos/templates/nucleos/delete.html
@@ -4,7 +4,7 @@
 {% block title %}{% trans "Remover Núcleo" %} | Hubx{% endblock %}
 
 {% block hero %}
-  {% include '_components/hero.html' with title=_('Remover Núcleo') %}
+  {% include '_components/hero_nucleo_detail.html' with nucleo=object %}
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
## Summary
- update the núcleo delete template to reuse the hero component used on the detail page

## Testing
- no automated tests were run (not needed for this change)


------
https://chatgpt.com/codex/tasks/task_e_68d5af381bec8325af4503b31c7e64c8