### PR TITLE
Use back button on núcleo delete confirmation

### DIFF
--- a/nucleos/templates/nucleos/delete.html
+++ b/nucleos/templates/nucleos/delete.html
@@ -17,9 +17,7 @@
 
     <form method="post" class="mt-6 flex justify-center gap-3">
       {% csrf_token %}
-      <a href="{% url 'nucleos:list' %}" class="btn btn-secondary text-sm" aria-label="{% trans 'Cancelar' %}">
-        {% trans "Cancelar" %}
-      </a>
+      {% include '_components/back_button.html' with classes='btn btn-secondary text-sm' %}
       <button type="submit" class="btn btn-primary text-sm" aria-label="{% trans 'Remover' %}">
         {% trans "Remover" %}
       </button>


### PR DESCRIPTION
## Summary
- replace the cancel link on the núcleo delete confirmation template with the shared back button component so the user returns to the calling page

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5b1c6695083258a7ef04d9dc5dc09