### PR TITLE
Refactor nucleo detail layout

### DIFF
--- a/nucleos/templates/nucleos/detail.html
+++ b/nucleos/templates/nucleos/detail.html
@@ -8,115 +8,118 @@
 {% endblock %}
 
 {% block content %}
-  <section class="max-w-5xl mx-auto py-8">
-    <div class="card px-4">
-      <div class="card-body space-y-6">
-
-        <article class="card">
-          <div class="card-header">
-            <h2 class="text-xl font-semibold">{% trans "Informações" %}</h2>
-          </div>
-          <div class="card-body">
-            <dl class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 text-sm">
-              <div class="flex flex-col gap-1 rounded-lg border border-[var(--border)] px-3 py-2">
-                <dt class="text-[var(--text-secondary)]">{% trans "Organização" %}</dt>
-                <dd class="font-medium text-[var(--text-primary)]">{{ object.organizacao.nome }}</dd>
-              </div>
-
-              <div class="flex flex-col gap-1 rounded-lg border border-[var(--border)] px-3 py-2">
-                <dt class="text-[var(--text-secondary)]">{% trans "Status" %}</dt>
-                <dd class="font-medium text-[var(--text-primary)]">
-                  {% if object.ativo %}
-                    {% trans "Ativo" %}
-                  {% else %}
-                    {% trans "Inativo" %}
-                  {% endif %}
-                </dd>
-              </div>
-
-              {% if object.mensalidade %}
-                <div class="flex flex-col gap-1 rounded-lg border border-[var(--border)] px-3 py-2">
-                  <dt class="text-[var(--text-secondary)]">{% trans "Mensalidade" %}</dt>
-                  <dd class="font-medium text-[var(--text-primary)]">{{ object.mensalidade|localize }}</dd>
-                </div>
-              {% endif %}
-
-              <div class="flex flex-col gap-1 rounded-lg border border-[var(--border)] px-3 py-2">
-                <dt class="text-[var(--text-secondary)]">{% trans "Membros" %}</dt>
-                <dd class="font-medium text-[var(--text-primary)]">{{ total_membros }}</dd>
-              </div>
-
-              <div class="flex flex-col gap-1 rounded-lg border border-[var(--border)] px-3 py-2">
-                <dt class="text-[var(--text-secondary)]">{% trans "Coordenadores" %}</dt>
-                <dd class="font-medium text-[var(--text-primary)]">{{ coordenadores|length }}</dd>
-              </div>
-
-              <div class="flex flex-col gap-1 rounded-lg border border-[var(--border)] px-3 py-2">
-                <dt class="text-[var(--text-secondary)]">{% trans "Eventos" %}</dt>
-                <dd class="font-medium text-[var(--text-primary)]">{{ total_eventos }}</dd>
-              </div>
-
-              <div class="flex flex-col gap-1 rounded-lg border border-[var(--border)] px-3 py-2">
-                <dt class="text-[var(--text-secondary)]">{% trans "Eventos ativos" %}</dt>
-                <dd class="font-medium text-[var(--text-primary)]">{{ total_eventos_ativos }}</dd>
-              </div>
-
-              <div class="flex flex-col gap-1 rounded-lg border border-[var(--border)] px-3 py-2">
-                <dt class="text-[var(--text-secondary)]">{% trans "Eventos concluídos" %}</dt>
-                <dd class="font-medium text-[var(--text-primary)]">{{ total_eventos_concluidos }}</dd>
-              </div>
-
-              {% if object.created_at %}
-                <div class="flex flex-col gap-1 rounded-lg border border-[var(--border)] px-3 py-2">
-                  <dt class="text-[var(--text-secondary)]">{% trans "Criado em" %}</dt>
-                  <dd class="font-medium text-[var(--text-primary)]">{{ object.created_at|date:'SHORT_DATETIME_FORMAT' }}</dd>
-                </div>
-              {% endif %}
-
-              {% if object.updated_at %}
-                <div class="flex flex-col gap-1 rounded-lg border border-[var(--border)] px-3 py-2">
-                  <dt class="text-[var(--text-secondary)]">{% trans "Atualizado em" %}</dt>
-                  <dd class="font-medium text-[var(--text-primary)]">{{ object.updated_at|date:'SHORT_DATETIME_FORMAT' }}</dd>
-                </div>
-              {% endif %}
-
-              {% if object.descricao %}
-                <div class="flex flex-col gap-1 rounded-lg border border-[var(--border)] px-3 py-2 sm:col-span-2 lg:col-span-3">
-                  <dt class="text-[var(--text-secondary)]">{% trans "Descrição" %}</dt>
-                  <dd class="font-medium text-[var(--text-primary)] whitespace-pre-line">{{ object.descricao }}</dd>
-                </div>
-              {% endif %}
-            </dl>
-          </div>
-        </article>
-
-        {% with section=current_section|default:"membros" %}
-          {% if section == 'membros' %}
-            <section id="nucleo-membros" class="space-y-6">
-              {% url 'nucleos:membros_list' object.pk as membros_list_url %}
-              <div
-                id="membros-list"
-                hx-get="{{ membros_list_url }}?page={{ page_obj.number }}{% if querystring %}&{{ querystring }}{% endif %}"
-                hx-trigger="load"
-                hx-target="#membros-list"
-                hx-swap="innerHTML"
-              >
-                {% include 'nucleos/partials/membros_list.html' %}
-              </div>
-            </section>
-          
-          {% endif %}
-        {% endwith %}
-
-        <div class="flex justify-end">
-          {% if perms.nucleos.delete_nucleo %}
-            <a
-              href="{% url 'nucleos:delete' object.pk %}"
-              class="btn btn-danger btn-sm"
-              hx-confirm="Deseja realmente excluir?"
-            >{% trans "Excluir" %}</a>
-          {% endif %}
+  <section class="max-w-5xl mx-auto py-8 px-4">
+    <div class="flex flex-col gap-6">
+      <article class="card">
+        <div class="card-header">
+          <h2 class="text-xl font-semibold">{% trans "Informações" %}</h2>
         </div>
+        <div class="card-body">
+          <dl class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 text-sm">
+            <div class="flex flex-col gap-1 rounded-lg border border-[var(--border)] px-3 py-2">
+              <dt class="text-[var(--text-secondary)]">{% trans "Organização" %}</dt>
+              <dd class="font-medium text-[var(--text-primary)]">{{ object.organizacao.nome }}</dd>
+            </div>
+
+            <div class="flex flex-col gap-1 rounded-lg border border-[var(--border)] px-3 py-2">
+              <dt class="text-[var(--text-secondary)]">{% trans "Status" %}</dt>
+              <dd class="font-medium text-[var(--text-primary)]">
+                {% if object.ativo %}
+                  {% trans "Ativo" %}
+                {% else %}
+                  {% trans "Inativo" %}
+                {% endif %}
+              </dd>
+            </div>
+
+            {% if object.mensalidade %}
+              <div class="flex flex-col gap-1 rounded-lg border border-[var(--border)] px-3 py-2">
+                <dt class="text-[var(--text-secondary)]">{% trans "Mensalidade" %}</dt>
+                <dd class="font-medium text-[var(--text-primary)]">{{ object.mensalidade|localize }}</dd>
+              </div>
+            {% endif %}
+
+            <div class="flex flex-col gap-1 rounded-lg border border-[var(--border)] px-3 py-2">
+              <dt class="text-[var(--text-secondary)]">{% trans "Membros" %}</dt>
+              <dd class="font-medium text-[var(--text-primary)]">{{ total_membros }}</dd>
+            </div>
+
+            <div class="flex flex-col gap-1 rounded-lg border border-[var(--border)] px-3 py-2">
+              <dt class="text-[var(--text-secondary)]">{% trans "Coordenadores" %}</dt>
+              <dd class="font-medium text-[var(--text-primary)]">{{ coordenadores|length }}</dd>
+            </div>
+
+            <div class="flex flex-col gap-1 rounded-lg border border-[var(--border)] px-3 py-2">
+              <dt class="text-[var(--text-secondary)]">{% trans "Eventos" %}</dt>
+              <dd class="font-medium text-[var(--text-primary)]">{{ total_eventos }}</dd>
+            </div>
+
+            <div class="flex flex-col gap-1 rounded-lg border border-[var(--border)] px-3 py-2">
+              <dt class="text-[var(--text-secondary)]">{% trans "Eventos ativos" %}</dt>
+              <dd class="font-medium text-[var(--text-primary)]">{{ total_eventos_ativos }}</dd>
+            </div>
+
+            <div class="flex flex-col gap-1 rounded-lg border border-[var(--border)] px-3 py-2">
+              <dt class="text-[var(--text-secondary)]">{% trans "Eventos concluídos" %}</dt>
+              <dd class="font-medium text-[var(--text-primary)]">{{ total_eventos_concluidos }}</dd>
+            </div>
+
+            {% if object.created_at %}
+              <div class="flex flex-col gap-1 rounded-lg border border-[var(--border)] px-3 py-2">
+                <dt class="text-[var(--text-secondary)]">{% trans "Criado em" %}</dt>
+                <dd class="font-medium text-[var(--text-primary)]">{{ object.created_at|date:'SHORT_DATETIME_FORMAT' }}</dd>
+              </div>
+            {% endif %}
+
+            {% if object.updated_at %}
+              <div class="flex flex-col gap-1 rounded-lg border border-[var(--border)] px-3 py-2">
+                <dt class="text-[var(--text-secondary)]">{% trans "Atualizado em" %}</dt>
+                <dd class="font-medium text-[var(--text-primary)]">{{ object.updated_at|date:'SHORT_DATETIME_FORMAT' }}</dd>
+              </div>
+            {% endif %}
+
+            {% if object.descricao %}
+              <div class="flex flex-col gap-1 rounded-lg border border-[var(--border)] px-3 py-2 sm:col-span-2 lg:col-span-3">
+                <dt class="text-[var(--text-secondary)]">{% trans "Descrição" %}</dt>
+                <dd class="font-medium text-[var(--text-primary)] whitespace-pre-line">{{ object.descricao }}</dd>
+              </div>
+            {% endif %}
+          </dl>
+        </div>
+      </article>
+
+      {% with section=current_section|default:"membros" %}
+        {% if section == 'membros' %}
+          <article class="card">
+            <div class="card-header">
+              <h2 class="text-xl font-semibold">{% trans "Membros" %}</h2>
+            </div>
+            <div class="card-body space-y-6">
+              <section id="nucleo-membros" class="space-y-6">
+                {% url 'nucleos:membros_list' object.pk as membros_list_url %}
+                <div
+                  id="membros-list"
+                  hx-get="{{ membros_list_url }}?page={{ page_obj.number }}{% if querystring %}&{{ querystring }}{% endif %}"
+                  hx-trigger="load"
+                  hx-target="#membros-list"
+                  hx-swap="innerHTML"
+                >
+                  {% include 'nucleos/partials/membros_list.html' %}
+                </div>
+              </section>
+            </div>
+          </article>
+        {% endif %}
+      {% endwith %}
+
+      <div class="flex justify-end">
+        {% if perms.nucleos.delete_nucleo %}
+          <a
+            href="{% url 'nucleos:delete' object.pk %}"
+            class="btn btn-danger btn-sm"
+            hx-confirm="Deseja realmente excluir?"
+          >{% trans "Excluir" %}</a>
+        {% endif %}
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- restructure the núcleo detail template to mirror the event detail layout
- display núcleo information in a dedicated card using the new grid style
- wrap the membros listing in its own card for clearer separation

## Testing
- not run (template-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d5b722f98083259db3c4d350ffa523