### PR TITLE
Move nucleus detail actions below information card

### DIFF
--- a/nucleos/templates/nucleos/detail.html
+++ b/nucleos/templates/nucleos/detail.html
@@ -117,13 +117,19 @@
         {% endif %}
       {% endwith %}
 
-      <div class="flex justify-end">
-        {% if perms.nucleos.delete_nucleo %}
+      <div class="mt-6 flex justify-end gap-6">
+        {% if perms.nucleos.change_nucleo or request.user.user_type == 'admin' or request.user.user_type == 'coordenador' %}
+          <a
+            href="{% url 'nucleos:update' object.pk %}"
+            class="text-primary font-medium hover:underline"
+          >{% trans "Editar núcleo" %}</a>
+        {% endif %}
+        {% if perms.nucleos.delete_nucleo or request.user.user_type == 'admin' or request.user.user_type == 'coordenador' %}
           <a
             href="{% url 'nucleos:delete' object.pk %}"
-            class="btn btn-danger btn-sm"
-            hx-confirm="Deseja realmente excluir?"
-          >{% trans "Excluir" %}</a>
+            class="font-medium text-[var(--danger-text)] hover:underline"
+            hx-confirm="{% trans 'Deseja realmente excluir?' %}"
+          >{% trans "Excluir núcleo" %}</a>
         {% endif %}
       </div>
     </div>

--- a/templates/_components/hero_nucleo_detail.html
+++ b/templates/_components/hero_nucleo_detail.html
@@ -27,18 +27,7 @@
             <h1 class="text-3xl font-bold md:text-4xl">{{ nucleo.nome }}</h1>
           </div>
         </div>
-        {% if perms.nucleos.change_nucleo or perms.nucleos.delete_nucleo or request.user.user_type == 'admin' or request.user.user_type == 'coordenador' %}
-          <div class="flex flex-wrap gap-3 md:justify-end">
-            {% if perms.nucleos.change_nucleo or request.user.user_type == 'admin' or request.user.user_type == 'coordenador' %}
-              <a href="{% url 'nucleos:update' nucleo.pk %}" class="btn btn-secondary"
-                 aria-label="{% trans 'Editar núcleo' %}">{% trans 'Editar' %}</a>
-            {% endif %}
-            {% if perms.nucleos.delete_nucleo or request.user.user_type == 'admin' or request.user.user_type == 'coordenador' %}
-              <a href="{% url 'nucleos:delete' nucleo.pk %}" class="btn btn-danger"
-                 aria-label="{% trans 'Excluir núcleo' %}">{% trans 'Excluir' %}</a>
-            {% endif %}
-          </div>
-        {% endif %}
+
       </div>
 
       {% if total_membros is not None or total_eventos_ativos is not None or total_eventos_concluidos is not None %}


### PR DESCRIPTION
## Summary
- remove the edit and delete buttons from the nucleus detail hero component
- render the edit/delete actions after the information section to match the profile layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d67b796bb08325a35b0b57e8aa40b6