### PR TITLE
Ajusta navegação do botão de portfólio no perfil

### DIFF
--- a/accounts/templates/perfil/partials/portfolio.html
+++ b/accounts/templates/perfil/partials/portfolio.html
@@ -3,6 +3,7 @@
   {% include "perfil/partials/portfolio_list.html" with medias=medias is_owner=is_owner form=form show_form=show_form q=q %}
 </section>
 
+{% url 'accounts:perfil' as default_back_url %}
 <div class="mt-8 text-center">
-  <a href="{% url 'accounts:perfil' %}" class="text-sm text-primary hover:underline">← {% trans "Voltar" %}</a>
+  <a href="{{ back_url|default:default_back_url }}" class="text-sm text-primary hover:underline">← {% trans "Voltar" %}</a>
 </div>


### PR DESCRIPTION
## Summary
- adiciona utilitário que resolve uma URL de retorno segura usando os cabeçalhos do HTMX
- injeta a URL de retorno nas respostas das seções de portfólio para respeitar o template anterior
- usa a URL calculada no botão "Voltar" do portfólio

## Testing
- `pytest tests/accounts/test_views_perfil.py` *(falha por exigir cobertura mínima de 90%)*


------
https://chatgpt.com/codex/tasks/task_e_68d67f9eb53883258f2fc300d4511165