### PR TITLE
Add user creation flow for associados and operadores

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -12,7 +12,7 @@ from django.utils.translation import gettext_lazy as _
 from tokens.models import TOTPDevice
 from tokens.utils import get_client_ip
 
-from .models import AccountToken, SecurityEvent, UserMedia
+from .models import AccountToken, SecurityEvent, UserMedia, UserType
 from .tasks import send_confirmation_email
 from .validators import cpf_validator
 from organizacoes.utils import validate_cnpj
@@ -127,6 +127,79 @@ class CustomUserChangeForm(UserChangeForm):
         if qs.filter(cnpj=cnpj).exists():
             raise forms.ValidationError(_("CNPJ já cadastrado."))
         return cnpj
+
+
+class OrganizacaoUserCreateForm(UserCreationForm):
+    contato = forms.CharField(
+        label=_("Nome completo"),
+        max_length=150,
+        required=False,
+    )
+    email = forms.EmailField(label=_("E-mail"))
+    user_type = forms.ChoiceField(label=_("Tipo de usuário"))
+
+    class Meta(UserCreationForm.Meta):
+        model = User
+        fields = ("username", "email", "contato")
+
+    def __init__(
+        self,
+        *args,
+        allowed_user_types: list[str] | None = None,
+        **kwargs,
+    ):
+        self.allowed_user_types = allowed_user_types or []
+        super().__init__(*args, **kwargs)
+
+        type_labels = {choice[0]: choice[1] for choice in UserType.choices}
+        choices = [
+            (value, type_labels[value])
+            for value in self.allowed_user_types
+            if value in type_labels
+        ]
+        self.fields["user_type"].choices = choices
+
+        if len(choices) == 1:
+            self.fields["user_type"].initial = choices[0][0]
+            self.fields["user_type"].widget = forms.HiddenInput()
+
+        # Ajusta labels para manter consistência visual
+        self.fields["username"].label = _("Nome de usuário")
+        self.fields["password1"].label = _("Senha")
+        self.fields["password2"].label = _("Confirmar senha")
+
+        # Remove textos de ajuda padronizados que não seguem o estilo do projeto
+        self.fields["username"].help_text = ""
+        self.fields["password1"].help_text = ""
+        self.fields["password2"].help_text = ""
+
+    def clean_user_type(self):
+        user_type = self.cleaned_data.get("user_type")
+        if user_type not in self.allowed_user_types:
+            raise forms.ValidationError(_("Tipo de usuário inválido."))
+        return user_type
+
+    def clean_email(self):
+        email = self.cleaned_data.get("email")
+        if email and User.objects.filter(email__iexact=email).exists():
+            raise forms.ValidationError(_("Este e-mail já está em uso."))
+        return email
+
+    def save(self, commit: bool = True, *, organizacao) -> User:
+        if organizacao is None:
+            raise ValueError("Organização é obrigatória para criar o usuário.")
+
+        user = super().save(commit=False)
+        user.email = self.cleaned_data.get("email")
+        user.contato = self.cleaned_data.get("contato")
+        selected_type = self.cleaned_data.get("user_type")
+        user.user_type = selected_type
+        user.organizacao = organizacao
+        user.is_associado = selected_type == UserType.ASSOCIADO.value
+
+        if commit:
+            user.save()
+        return user
 
 
 class InformacoesPessoaisForm(forms.ModelForm):

--- a/accounts/templates/associados/hero_action.html
+++ b/accounts/templates/associados/hero_action.html
@@ -1,2 +1,18 @@
 {% load i18n %}
-<a href="{% url 'tokens:gerar_convite' %}" class="btn btn-primary">{% trans 'Gerar Convite' %}</a>
+<div class="flex flex-wrap items-center gap-3">
+  {% with tipo=request.user.get_tipo_usuario %}
+    {% if tipo == 'admin' or tipo == 'operador' or tipo == 'root' %}
+      <div class="flex flex-wrap gap-2">
+        <a href="{% url 'accounts:associados_adicionar' %}?tipo=associado" class="btn btn-secondary">
+          {% trans 'Adicionar associado' %}
+        </a>
+        {% if tipo == 'admin' or tipo == 'root' %}
+          <a href="{% url 'accounts:associados_adicionar' %}?tipo=operador" class="btn btn-secondary">
+            {% trans 'Adicionar operador' %}
+          </a>
+        {% endif %}
+      </div>
+    {% endif %}
+  {% endwith %}
+  <a href="{% url 'tokens:gerar_convite' %}" class="btn btn-primary">{% trans 'Gerar Convite' %}</a>
+</div>

--- a/accounts/templates/associados/usuario_form.html
+++ b/accounts/templates/associados/usuario_form.html
@@ -1,0 +1,38 @@
+{% extends 'base.html' %}
+{% load i18n %}
+
+{% block title %}{% trans 'Adicionar usuário' %}{% endblock %}
+
+{% block hero %}
+  {% include '_components/hero_associados.html' with title=_('Adicionar usuário') subtitle=_('Cadastre novos membros para a sua organização.') total_usuarios=None total_associados=None total_nucleados=None action_template=None %}
+{% endblock %}
+
+{% block content %}
+<section class="max-w-2xl mx-auto py-8">
+  <div class="card border border-[var(--border)] bg-[var(--bg-secondary)] rounded-2xl shadow-sm p-6">
+    <h2 class="text-xl font-semibold text-[var(--text-primary)] mb-4">{% trans 'Informações do usuário' %}</h2>
+    <form method="post" class="space-y-4">
+      {% csrf_token %}
+      {% if form.non_field_errors %}
+        <div class="p-3 text-sm rounded-lg border border-[var(--error)] bg-[var(--error)]/10 text-[var(--error)]" role="alert">
+          <ul class="space-y-1">
+            {% for error in form.non_field_errors %}
+              <li>{{ error }}</li>
+            {% endfor %}
+          </ul>
+        </div>
+      {% endif %}
+      {% for hidden in form.hidden_fields %}
+        {{ hidden }}
+      {% endfor %}
+      {% for field in form.visible_fields %}
+        {% include '_forms/field.html' with field=field %}
+      {% endfor %}
+      <div class="flex justify-end gap-2 pt-2">
+        <a href="{% url 'accounts:associados_lista' %}" class="btn btn-secondary">{% trans 'Cancelar' %}</a>
+        <button type="submit" class="btn btn-primary">{% trans 'Salvar' %}</button>
+      </div>
+    </form>
+  </div>
+</section>
+{% endblock %}

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -9,6 +9,7 @@ urlpatterns = [
     path("login/", views.login_view, name="login"),
     path("logout/", views.logout_view, name="logout"),
     path("associados/", views.AssociadoListView.as_view(), name="associados_lista"),
+    path("associados/novo/", views.OrganizacaoUserCreateView.as_view(), name="associados_adicionar"),
     # Registro de usuário
     path("resend-confirmation/", views.resend_confirmation, name="resend_confirmation"),
     path("password_reset/", views.password_reset, name="password_reset"),

--- a/core/menu.py
+++ b/core/menu.py
@@ -402,7 +402,13 @@ def _get_menu_items() -> List[MenuItem]:
             classes="flex items-center hover:text-primary transition",
             children=perfil_children,
         ),
-        MenuItem("associados", reverse("associados_lista"), "Associados", ICON_USERS, ["admin", "coordenador"]),
+        MenuItem(
+            "associados",
+            reverse("associados_lista"),
+            "Associados",
+            ICON_USERS,
+            ["admin", "coordenador", "operador"],
+        ),
         MenuItem(
             "nucleos",
             nucleos_url,

--- a/core/permissions.py
+++ b/core/permissions.py
@@ -39,6 +39,20 @@ class GerenteRequiredMixin(UserPassesTestMixin):
         }
 
 
+class AssociadosRequiredMixin(UserPassesTestMixin):
+    """Permite acesso a administradores, coordenadores e operadores."""
+
+    raise_exception = True
+
+    def test_func(self):
+        return self.request.user.user_type in {
+            UserType.ROOT,
+            UserType.ADMIN,
+            UserType.COORDENADOR,
+            UserType.OPERADOR,
+        }
+
+
 class ClienteRequiredMixin(UserPassesTestMixin):
     """Permite acesso a associados e nucleados."""
 


### PR DESCRIPTION
## Summary
- add an organization-scoped user creation form restricted to admin and operator roles
- expose a dedicated view, route, and template for creating associados or operadores and surface shortcuts in the associados hero actions
- allow operador accounts to access the associados section via a dedicated permission mixin and navigation entry

## Testing
- pytest tests/accounts/test_user_type_choices.py *(fails: coverage threshold 90% not met by existing suite)*

------
https://chatgpt.com/codex/tasks/task_e_68d6867fe47883258c52ec5358d064f6