### PR TITLE
Fix total_card template with block usage

### DIFF
--- a/templates/_partials/cards/total_card.html
+++ b/templates/_partials/cards/total_card.html
@@ -1,9 +1,5 @@
 {% load lucide_icons %}
-{% if as_button %}
-  {% with element='button' %}
-{% else %}
-  {% with element='article' %}
-{% endif %}
+{% with element=as_button|yesno:'button,article,article' %}
 <{{ element }}
   class="card{% if card_class %} {{ card_class }}{% endif %}{% if is_active and active_class %} {{ active_class }}{% endif %}"
   {% if as_button %}type="{{ button_type|default:'button' }}" aria-pressed="{{ is_active|yesno:'true,false,false' }}"{% endif %}


### PR DESCRIPTION
## Summary
- fix the `_partials/cards/total_card.html` template so the `with` block no longer conflicts with the surrounding conditional

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68d6885dfbec8325ba0247f099c4d819