### PR TITLE
Add submenu for creating associados users

### DIFF
--- a/core/menu.py
+++ b/core/menu.py
@@ -327,6 +327,16 @@ def _get_menu_items() -> List[MenuItem]:
         )
     ]
 
+    associados_children = [
+        MenuItem(
+            id="associados_adicionar",
+            path=reverse("accounts:associados_adicionar"),
+            label="Adicionar usuário",
+            icon=ICON_PLUS,
+            permissions=["admin", "operador"],
+        )
+    ]
+
     eventos_children = [
         MenuItem(
             id="eventos_calendario",
@@ -408,6 +418,7 @@ def _get_menu_items() -> List[MenuItem]:
             "Associados",
             ICON_USERS,
             ["admin", "coordenador", "operador"],
+            children=associados_children,
         ),
         MenuItem(
             "nucleos",


### PR DESCRIPTION
## Summary
- add an "Adicionar usuário" child entry under the Associados menu
- point the new submenu to the existing associados creation view and restrict it to admins and operadores

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d68cecff50832595e5ed66d94c7f57