### PR TITLE
Move event detail actions into info card

### DIFF
--- a/eventos/templates/eventos/partials/eventos/detail.html
+++ b/eventos/templates/eventos/partials/eventos/detail.html
@@ -71,6 +71,20 @@
           {% endif %}
         </dl>
       </div>
+      {% if perms.eventos.change_evento or perms.eventos.delete_evento %}
+        <div class="mt-6 flex justify-end gap-6">
+          {% if perms.eventos.change_evento %}
+            <a href="{% url 'eventos:evento_editar' object.pk %}"
+               class="text-primary font-medium hover:underline"
+               aria-label="{% trans 'Editar evento' %}">{% trans 'Editar' %}</a>
+          {% endif %}
+          {% if perms.eventos.delete_evento %}
+            <a href="{% url 'eventos:evento_excluir' object.pk %}"
+               class="font-medium text-[var(--danger-text)] hover:underline"
+               aria-label="{% trans 'Excluir evento' %}">{% trans 'Excluir' %}</a>
+          {% endif %}
+        </div>
+      {% endif %}
     </article>
 
     {% if user.is_authenticated and user.user_type != 'admin' %}

--- a/templates/_components/hero_eventos_detail.html
+++ b/templates/_components/hero_eventos_detail.html
@@ -27,18 +27,6 @@
             <h1 class="text-3xl font-bold md:text-4xl">{{ evento.titulo }}</h1>
           </div>
         </div>
-        {% if perms.eventos.change_evento or perms.eventos.delete_evento %}
-          <div class="flex flex-wrap gap-3 md:justify-end">
-            {% if perms.eventos.change_evento %}
-              <a href="{% url 'eventos:evento_editar' evento.pk %}" class="btn btn-secondary"
-                 aria-label="{% trans 'Editar evento' %}">{% trans 'Editar' %}</a>
-            {% endif %}
-            {% if perms.eventos.delete_evento %}
-              <a href="{% url 'eventos:evento_excluir' evento.pk %}" class="btn btn-danger"
-                 aria-label="{% trans 'Excluir evento' %}">{% trans 'Excluir' %}</a>
-            {% endif %}
-          </div>
-        {% endif %}
       </div>
 
       {% if total_inscricoes is not None or total_inscricoes_confirmadas is not None or total_inscricoes_pendentes is not None or total_inscricoes_canceladas is not None or total_presentes is not None or vagas_disponiveis is not None or media_feedback is not None or total_feedbacks is not None %}


### PR DESCRIPTION
## Summary
- relocate edit and delete actions from the hero component to the event information card
- remove action buttons from the hero layout to match nucleus detail styling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d698bdbcb483259463cf043cc8d075