### PR TITLE
Enable hero eventos filters

### DIFF
--- a/eventos/templates/eventos/painel.html
+++ b/eventos/templates/eventos/painel.html
@@ -20,5 +20,54 @@
       {% include 'eventos/partials/calendario/calendario.html' %}
     {% endif %}
   </div>
+  <div id="eventos-loading" class="htmx-indicator mt-6 text-center text-sm text-[var(--text-secondary)]" role="status" aria-live="polite">
+    {% trans 'Carregando eventos...' %}
+  </div>
 </section>
+{% endblock %}
+
+{% block scripts %}
+  {{ block.super }}
+  <script>
+    (function() {
+      const stateId = 'eventos-filter-state';
+
+      function parseClasses(value) {
+        return value ? value.split(/\s+/).filter(Boolean) : [];
+      }
+
+      function updateFilterButtons() {
+        const stateEl = document.getElementById(stateId);
+        if (!stateEl) {
+          return;
+        }
+        const currentFilter = stateEl.dataset.currentFilter || 'todos';
+        const buttons = document.querySelectorAll('[data-eventos-filter-card]');
+
+        buttons.forEach((button) => {
+          const activeClasses = parseClasses(button.dataset.activeClass || '');
+          const isActive = button.dataset.eventosFilterCard === currentFilter;
+          button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+          activeClasses.forEach((cls) => {
+            if (cls) {
+              button.classList.toggle(cls, isActive);
+            }
+          });
+        });
+      }
+
+      document.addEventListener('DOMContentLoaded', updateFilterButtons);
+      document.body.addEventListener('htmx:afterSwap', function(event) {
+        if (event.target && event.target.id === 'eventos-conteudo') {
+          updateFilterButtons();
+        }
+      });
+      document.body.addEventListener('htmx:oobAfterSwap', function(event) {
+        const target = event.detail && event.detail.target;
+        if (target && target.id === stateId) {
+          updateFilterButtons();
+        }
+      });
+    })();
+  </script>
 {% endblock %}

--- a/eventos/templates/eventos/partials/eventos/evento_list.html
+++ b/eventos/templates/eventos/partials/eventos/evento_list.html
@@ -12,8 +12,10 @@
             <p class="col-span-full text-center text-[var(--text-muted)]">{% trans 'Nenhum evento encontrado.' %}</p>
           {% endfor %}
         </div>
-        {% include '_partials/pagination.html' with page_obj=page_obj querystring=querystring %}
+        {% include '_partials/pagination.html' with page_obj=page_obj querystring=querystring hx_target='#eventos-conteudo' hx_get=request.path hx_push_url='true' hx_indicator='#eventos-loading' %}
       </div>
     </div>
   </div>
- 
+
+<div id="eventos-filter-state" hx-swap-oob="true" class="hidden" data-current-filter="{{ current_filter|default:'todos' }}" aria-hidden="true"></div>
+

--- a/templates/_components/hero_evento.html
+++ b/templates/_components/hero_evento.html
@@ -21,19 +21,20 @@
 
       </div>
       {% if total_eventos is not None or total_eventos_ativos is not None or total_eventos_concluidos is not None %}
-        
+
         {% lucide 'activity' class='h-5 w-5' as icon_total_ativos %}
         {% lucide 'check' class='h-5 w-5' as icon_total_concluidos %}
         <div class="mt-10 space-y-4 text-left">
-          <div class="card-grid">
+          <div class="card-grid" data-eventos-filter-buttons>
 
             {% if total_eventos_ativos is not None %}
-              {% include '_partials/cards/total_card.html' with label=_('Ativos') valor=total_eventos_ativos icon_svg=icon_total_ativos card_class='card-compact' body_class='card-body-compact' %}
+              {% include '_partials/cards/total_card.html' with label=_('Ativos') valor=total_eventos_ativos icon_svg=icon_total_ativos card_class='card-compact cursor-pointer transition hover:shadow-lg focus:outline-none focus-visible:ring focus-visible:ring-white/80 focus-visible:ring-offset-2' body_class='card-body-compact' as_button=True active_class='border border-white/80 shadow-lg' is_active=is_ativos_filter_active hx_get=ativos_filter_url hx_target='#eventos-conteudo' hx_push_url='true' hx_indicator='#eventos-loading' extra_attributes='data-eventos-filter-card="ativos"' %}
             {% endif %}
             {% if total_eventos_concluidos is not None %}
-              {% include '_partials/cards/total_card.html' with label=_('Realizados') valor=total_eventos_concluidos icon_svg=icon_total_concluidos card_class='card-compact' body_class='card-body-compact' %}
+              {% include '_partials/cards/total_card.html' with label=_('Realizados') valor=total_eventos_concluidos icon_svg=icon_total_concluidos card_class='card-compact cursor-pointer transition hover:shadow-lg focus:outline-none focus-visible:ring focus-visible:ring-white/80 focus-visible:ring-offset-2' body_class='card-body-compact' as_button=True active_class='border border-white/80 shadow-lg' is_active=is_realizados_filter_active hx_get=realizados_filter_url hx_target='#eventos-conteudo' hx_push_url='true' hx_indicator='#eventos-loading' extra_attributes='data-eventos-filter-card="realizados"' %}
             {% endif %}
           </div>
+          <div id="eventos-filter-state" class="hidden" data-current-filter="{{ current_filter|default:'todos' }}" aria-hidden="true"></div>
         </div>
       {% endif %}
     </div>


### PR DESCRIPTION
## Summary
- add HTMX-enabled filter buttons to the eventos hero cards so the list can be filtered by status
- teach the eventos list view and templates to understand the new status filter and keep button state in sync
- cover the new behaviour with a focused view test

## Testing
- pytest --no-cov tests/eventos/test_views.py::test_evento_list_filters_by_status

------
https://chatgpt.com/codex/tasks/task_e_68d69de34d348325a6cc2f9c9770d881