### PR TITLE
Padroniza formulário de novo núcleo

### DIFF
--- a/nucleos/templates/nucleos/nucleo_form.html
+++ b/nucleos/templates/nucleos/nucleo_form.html
@@ -12,18 +12,22 @@
 {% endblock %}
 
 {% block content %}
-<section class="max-w-2xl mx-auto py-8">
-  <form method="post" enctype="multipart/form-data" class="space-y-4">
-    {% csrf_token %}
-    {% for field in form %}
-      {% include '_forms/field.html' with field=field %}
-    {% endfor %}
-    {% url 'nucleos:list' as cancel_url %}
-    {% if object %}{% url 'nucleos:detail_uuid' object.public_id as cancel_url %}{% endif %}
-    <div class="flex justify-end gap-2">
-      <a href="{{ cancel_url }}" class="btn btn-secondary">{% trans 'Cancelar' %}</a>
-      <button type="submit" class="btn btn-primary">{% trans 'Salvar' %}</button>
+<section class="max-w-2xl mx-auto px-4 py-8">
+  <div class="card">
+    <div class="card-body space-y-6">
+      <form method="post" enctype="multipart/form-data" class="space-y-6">
+        {% csrf_token %}
+        {% for field in form %}
+          {% include '_forms/field.html' with field=field %}
+        {% endfor %}
+        {% url 'nucleos:list' as cancel_url %}
+        {% if object %}{% url 'nucleos:detail_uuid' object.public_id as cancel_url %}{% endif %}
+        <div class="flex justify-end gap-3 pt-4 border-t border-[var(--border)]">
+          <a href="{{ cancel_url }}" class="btn btn-secondary">{% trans 'Cancelar' %}</a>
+          <button type="submit" class="btn btn-primary">{% trans 'Salvar' %}</button>
+        </div>
+      </form>
     </div>
-  </form>
+  </div>
 </section>
 {% endblock %}


### PR DESCRIPTION
## Summary
- envolve o formulário de criação/edição de núcleo em um card padrão
- ajusta espaçamentos e barra de ações para seguir os demais formulários do sistema

## Testing
- no tests were run


------
https://chatgpt.com/codex/tasks/task_e_68d6a17cac848325921c871939333659