### PR TITLE
Atualiza hero de criação de núcleo

### DIFF
--- a/nucleos/templates/nucleos/nucleo_form.html
+++ b/nucleos/templates/nucleos/nucleo_form.html
@@ -1,13 +1,13 @@
 {% extends 'base.html' %}
 {% load i18n %}
 
-{% block title %}{% if object %}{{ object.nome }}{% else %}{% trans 'Novo Núcleo' %}{% endif %}{% endblock %}
+{% block title %}{% if object %}{{ object.nome }}{% else %}{% trans 'Adicionar núcleo' %}{% endif %}{% endblock %}
 
 {% block hero %}
   {% if object %}
     {% include '_components/hero_nucleo_detail.html' with nucleo=object %}
   {% else %}
-    {% include '_components/hero_nucleo.html' with title=_('Novo Núcleo') %}
+    {% include '_components/hero_nucleo.html' with title=_('Adicionar núcleo') subtitle=_('Cadastre novos núcleos para a sua organização.') %}
   {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- atualiza o hero da página de criação de núcleo para exibir o título "Adicionar núcleo" e um subtítulo orientativo

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6a65c72b08325b8559989e46cb8f3