### PR TITLE
Atualiza título e subtítulo do hero de criação de eventos

### DIFF
--- a/eventos/locale/en/LC_MESSAGES/django.po
+++ b/eventos/locale/en/LC_MESSAGES/django.po
@@ -266,8 +266,12 @@ msgstr ""
 
 #: eventos/templates/eventos/partials/eventos/create.html:3
 #: eventos/views.py:285
-msgid "Cadastrar Evento"
-msgstr ""
+msgid "Adicionar evento"
+msgstr "Add event"
+
+#: eventos/views.py:286
+msgid "Cadastre novos eventos para a sua organização."
+msgstr "Register new events for your organization."
 
 #: eventos/templates/eventos/partials/eventos/delete.html:4
 #: eventos/views.py:360

--- a/eventos/locale/pt_BR/LC_MESSAGES/django.po
+++ b/eventos/locale/pt_BR/LC_MESSAGES/django.po
@@ -266,7 +266,11 @@ msgstr ""
 
 #: eventos/templates/eventos/partials/eventos/create.html:3
 #: eventos/views.py:285
-msgid "Cadastrar Evento"
+msgid "Adicionar evento"
+msgstr ""
+
+#: eventos/views.py:286
+msgid "Cadastre novos eventos para a sua organização."
 msgstr ""
 
 #: eventos/templates/eventos/partials/eventos/delete.html:4

--- a/eventos/views.py
+++ b/eventos/views.py
@@ -328,7 +328,8 @@ class EventoCreateView(
     form_class = EventoForm
     template_name = "eventos/partials/eventos/create.html"
     success_url = reverse_lazy("eventos:calendario")
-    painel_title = _("Cadastrar Evento")
+    painel_title = _("Adicionar evento")
+    painel_subtitle = _("Cadastre novos eventos para a sua organização.")
     painel_hero_template = "_components/hero_evento.html"
 
     permission_required = "eventos.add_evento"


### PR DESCRIPTION
## Summary
- update the event creation hero to show "Adicionar evento" instead of "Cadastrar Evento"
- add a descriptive subtitle in the event creation hero similar to the user creation flow
- refresh Portuguese and English locale catalogs to include the new hero strings

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6a8701cdc8325980930072b31c410