### PR TITLE
Adjust nucleo list grid layout

### DIFF
--- a/nucleos/templates/nucleos/nucleo_list.html
+++ b/nucleos/templates/nucleos/nucleo_list.html
@@ -11,7 +11,9 @@
   <div class="py-12 card px-4">
 
     <div class="card-body">
-      <div role="list" aria-label="{% trans 'Lista de núcleos' %}" class="card-grid sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
+      <div role="list"
+        aria-label="{% trans 'Lista de núcleos' %}"
+        class="card-grid sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-2 items-stretch">
         {% for nucleo in object_list %}
           {% include '_components/card_nucleo.html' with nucleo=nucleo %}
         {% empty %}


### PR DESCRIPTION
## Summary
- update the Núcleos list grid to show only two columns on large screens
- stretch grid items to keep cards aligned for a more polished presentation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6ab6670f88325bd84115a6a7ed3ce