### PR TITLE
Destaca etiqueta de classificação acima da capa dos cards

### DIFF
--- a/templates/_components/card_nucleo.html
+++ b/templates/_components/card_nucleo.html
@@ -1,4 +1,4 @@
 {% load i18n %}
 {% url 'nucleos:detail_uuid' nucleo.public_id as detail_url %}
 {% trans 'Ver detalhes do núcleo' as sr_label %}
-{% include '_partials/cards/base_card.html' with url=detail_url cover=nucleo.cover avatar=nucleo.avatar title=nucleo.nome details='_components/card_details_nucleo.html' sr_label=sr_label %}
+{% include '_partials/cards/base_card.html' with url=detail_url cover=nucleo.cover avatar=nucleo.avatar title=nucleo.nome details='_components/card_details_nucleo.html' sr_label=sr_label badge=nucleo.get_classificacao_display %}

--- a/templates/_partials/cards/base_card.html
+++ b/templates/_partials/cards/base_card.html
@@ -4,6 +4,16 @@
   aria-label="{{ title }}">
   <article class="card overflow-hidden" role="article">
     <header class="relative">
+      {% if badge %}
+        <div class="px-4 pt-4 pb-3">
+          <span class="inline-flex items-center gap-2 rounded-full bg-[var(--primary-soft,rgba(59,130,246,0.15))] px-3 py-1 text-[0.65rem] font-semibold uppercase tracking-wide text-[var(--primary,#2563eb)] shadow-sm ring-1 ring-[var(--primary-soft-border,rgba(59,130,246,0.3))]">
+            <svg class="h-3.5 w-3.5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+              <path d="M17.707 9.293 10.414 2H4a2 2 0 0 0-2 2v6.414l7.293 7.293a1 1 0 0 0 1.414 0l7-7a1 1 0 0 0 0-1.414ZM5.5 6.5a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3Z" />
+            </svg>
+            <span>{{ badge }}</span>
+          </span>
+        </div>
+      {% endif %}
       {% if cover %}
         <img src="{{ cover.url|default:cover }}" alt="{% trans 'Capa' %}" class="h-24 w-full object-cover" loading="lazy" />
       {% else %}


### PR DESCRIPTION
## Resumo
- move a badge de classificação para uma faixa destacada acima da imagem de capa no card base
- inclui ícone de etiqueta, fundo e contorno suave para reforçar o destaque visual

## Testes
- não executado (não solicitado)


------
https://chatgpt.com/codex/tasks/task_e_68d6acfdfe348325a3a88d6736f09fc5