### PR TITLE
Adjust núcleo card badge styling

### DIFF
--- a/templates/_partials/cards/base_card.html
+++ b/templates/_partials/cards/base_card.html
@@ -6,11 +6,11 @@
     <header class="relative">
       {% if badge %}
         <div class="px-4 pt-4 pb-3">
-          <span class="inline-flex items-center gap-2 rounded-full bg-[var(--primary-soft,rgba(59,130,246,0.15))] px-3 py-1 text-[0.65rem] font-semibold uppercase tracking-wide text-[var(--primary,#2563eb)] shadow-sm ring-1 ring-[var(--primary-soft-border,rgba(59,130,246,0.3))]">
-            <svg class="h-3.5 w-3.5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+          <span class="inline-flex max-w-full items-center gap-2 rounded-full bg-[var(--primary-soft,rgba(59,130,246,0.15))] px-3 py-1 text-[0.6rem] font-semibold uppercase tracking-wide text-[var(--primary,#2563eb)] shadow-sm ring-1 ring-[var(--primary-soft-border,rgba(59,130,246,0.3))] whitespace-nowrap">
+            <svg class="h-3.5 w-3.5 shrink-0" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
               <path d="M17.707 9.293 10.414 2H4a2 2 0 0 0-2 2v6.414l7.293 7.293a1 1 0 0 0 1.414 0l7-7a1 1 0 0 0 0-1.414ZM5.5 6.5a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3Z" />
             </svg>
-            <span>{{ badge }}</span>
+            <span class="truncate">{{ badge }}</span>
           </span>
         </div>
       {% endif %}


### PR DESCRIPTION
## Summary
- ensure núcleo card badges use a single-line layout without wrapping
- shrink badge text size slightly and prevent icon shrinkage to keep all labels visible

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6c05e81648325b7459effc0cd124a