### PR TITLE
Atualiza etiquetas de classificação dos núcleos

### DIFF
--- a/templates/_components/card_details_nucleo.html
+++ b/templates/_components/card_details_nucleo.html
@@ -1,10 +1,6 @@
 {% load i18n %}
 <dl class="mt-3 grid grid-cols-3 gap-2 text-xs text-[var(--text-secondary)]">
   <div>
-    <dt class="text-[var(--text-secondary)]">{% trans 'Classificação' %}</dt>
-    <dd class="font-medium">{{ nucleo.get_classificacao_display }}</dd>
-  </div>
-  <div>
     <dt class="text-[var(--text-secondary)]">{% trans 'Membros' %}</dt>
     <dd class="font-medium">{{ nucleo.num_membros|default:nucleo.membros.count }}</dd>
   </div>

--- a/templates/_components/card_nucleo.html
+++ b/templates/_components/card_nucleo.html
@@ -1,4 +1,12 @@
 {% load i18n %}
 {% url 'nucleos:detail_uuid' nucleo.public_id as detail_url %}
 {% trans 'Ver detalhes do núcleo' as sr_label %}
-{% include '_partials/cards/base_card.html' with url=detail_url cover=nucleo.cover avatar=nucleo.avatar title=nucleo.nome details='_components/card_details_nucleo.html' sr_label=sr_label badge=nucleo.get_classificacao_display %}
+{% with classificacao=nucleo.classificacao %}
+  {% if classificacao == 'planejamento' %}
+    {% include '_partials/cards/base_card.html' with url=detail_url cover=nucleo.cover avatar=nucleo.avatar title=nucleo.nome details='_components/card_details_nucleo.html' sr_label=sr_label badge=nucleo.get_classificacao_display badge_style='--primary:#f97316; --primary-soft:rgba(249, 115, 22, 0.15); --primary-soft-border:rgba(249, 115, 22, 0.3);' %}
+  {% elif classificacao == 'constituido' %}
+    {% include '_partials/cards/base_card.html' with url=detail_url cover=nucleo.cover avatar=nucleo.avatar title=nucleo.nome details='_components/card_details_nucleo.html' sr_label=sr_label badge=nucleo.get_classificacao_display badge_style='--primary:#22c55e; --primary-soft:rgba(34, 197, 94, 0.15); --primary-soft-border:rgba(34, 197, 94, 0.3);' %}
+  {% else %}
+    {% include '_partials/cards/base_card.html' with url=detail_url cover=nucleo.cover avatar=nucleo.avatar title=nucleo.nome details='_components/card_details_nucleo.html' sr_label=sr_label badge=nucleo.get_classificacao_display badge_style='--primary:#2563eb; --primary-soft:rgba(37, 99, 235, 0.15); --primary-soft-border:rgba(37, 99, 235, 0.3);' %}
+  {% endif %}
+{% endwith %}

--- a/templates/_partials/cards/base_card.html
+++ b/templates/_partials/cards/base_card.html
@@ -6,7 +6,7 @@
     <header class="relative">
       {% if badge %}
         <div class="px-4 pt-4 pb-3">
-          <span class="inline-flex max-w-full items-center gap-2 rounded-full bg-[var(--primary-soft,rgba(59,130,246,0.15))] px-3 py-1 text-[0.6rem] font-semibold uppercase tracking-wide text-[var(--primary,#2563eb)] shadow-sm ring-1 ring-[var(--primary-soft-border,rgba(59,130,246,0.3))] whitespace-nowrap">
+          <span class="inline-flex max-w-full items-center gap-2 rounded-full bg-[var(--primary-soft,rgba(59,130,246,0.15))] px-3 py-1 text-[0.6rem] font-semibold uppercase tracking-wide text-[var(--primary,#2563eb)] shadow-sm ring-1 ring-[var(--primary-soft-border,rgba(59,130,246,0.3))] whitespace-nowrap"{% if badge_style %} style="{{ badge_style }}"{% endif %}>
             <svg class="h-3.5 w-3.5 shrink-0" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
               <path d="M17.707 9.293 10.414 2H4a2 2 0 0 0-2 2v6.414l7.293 7.293a1 1 0 0 0 1.414 0l7-7a1 1 0 0 0 0-1.414ZM5.5 6.5a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3Z" />
             </svg>


### PR DESCRIPTION
## Summary
- remove a informação duplicada de classificação dos cartões de núcleos, mantendo-a apenas na etiqueta
- permite personalizar o estilo das etiquetas no componente base e aplica cores específicas para cada classificação

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6c3d0efac83259c83a06fe88f3f40