### PR TITLE
Reorder eventos submenu to prioritize event creation

### DIFF
--- a/core/menu.py
+++ b/core/menu.py
@@ -339,6 +339,13 @@ def _get_menu_items() -> List[MenuItem]:
 
     eventos_children = [
         MenuItem(
+            id="eventos_novo",
+            path=reverse("eventos:evento_novo"),
+            label="Adicionar evento",
+            icon=ICON_PLUS,
+            permissions=["admin"],
+        ),
+        MenuItem(
             id="eventos_calendario",
             path=reverse("eventos:calendario"),
             label="Calendário",
@@ -350,13 +357,6 @@ def _get_menu_items() -> List[MenuItem]:
                 "associado",
                 "convidado",
             ],
-        ),
-        MenuItem(
-            id="eventos_novo",
-            path=reverse("eventos:evento_novo"),
-            label="Adicionar evento",
-            icon=ICON_PLUS,
-            permissions=["admin"],
         ),
     ]
 


### PR DESCRIPTION
## Summary
- reorder the eventos submenu items so "Adicionar evento" appears before "Calendário"

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6d060104c832595240df39a9e84f2