### PR TITLE
Add promote associates view and template

### DIFF
--- a/Hubx/urls.py
+++ b/Hubx/urls.py
@@ -30,6 +30,11 @@ urlpatterns = [
         include(("configuracoes.urls", "configuracoes"), namespace="configuracoes"),
     ),
     path("associados/", views.AssociadoListView.as_view(), name="associados_lista"),
+    path(
+        "associados/promover/",
+        views.AssociadoPromoverListView.as_view(),
+        name="associados_promover",
+    ),
     path("jsi18n/", JavaScriptCatalog.as_view(), name="javascript-catalog"),
     path("select2/", include("django_select2.urls")),
     # APIs REST (subcaminhos específicos)

--- a/accounts/templates/associados/_promover_card.html
+++ b/accounts/templates/associados/_promover_card.html
@@ -1,0 +1,45 @@
+{% load i18n %}
+{% url 'accounts:perfil_publico_uuid' user.public_id as profile_url %}
+<article class="card h-full overflow-hidden flex flex-col">
+  <header class="relative">
+    {% if user.cover %}
+      <img src="{{ user.cover.url|default:user.cover }}" alt="{% trans 'Capa do associado' %}" class="h-24 w-full object-cover" loading="lazy" />
+    {% else %}
+      <div class="h-24 w-full bg-gradient-to-r from-[var(--hero-from)] to-[var(--hero-to)]"></div>
+    {% endif %}
+    <div class="absolute -bottom-8 left-4">
+      {% if user.avatar %}
+        <img src="{{ user.avatar.url|default:user.avatar }}" alt="{{ user.display_name|default:user.username }}" class="h-16 w-16 rounded-full ring-4 ring-[var(--bg-primary)] object-cover" loading="lazy" />
+      {% else %}
+        <div class="h-16 w-16 rounded-full ring-4 ring-[var(--bg-primary)] bg-[var(--bg-tertiary)] flex items-center justify-center text-lg font-semibold text-[var(--text-primary)]" role="img" aria-label="{{ user.display_name|default:user.username }}">
+          {{ user.display_name|default:user.username|first|upper }}
+        </div>
+      {% endif %}
+    </div>
+  </header>
+  <div class="card-body pt-10 flex-1">
+    <h3 class="text-base font-semibold text-[var(--text-primary)]">
+      <a href="{{ profile_url }}" class="hover:underline focus:outline-none focus-visible:ring focus-visible:ring-primary/40 rounded">{{ user.display_name|default:user.username }}</a>
+    </h3>
+    <p class="mt-1 text-sm text-[var(--text-muted)]">@{{ user.username }}</p>
+    {% if user.cnpj %}
+      <p class="mt-3 text-xs text-[var(--text-secondary)]">
+        <span class="font-medium text-[var(--text-muted)]">{% trans 'CNPJ' %}:</span>
+        <span class="font-normal text-[var(--text-primary)]">{{ user.cnpj }}</span>
+      </p>
+    {% endif %}
+    <dl class="mt-4 grid grid-cols-2 gap-3 text-xs text-[var(--text-tertiary)]">
+      <div>
+        <dt class="text-[var(--text-muted)]">{% trans 'Status' %}</dt>
+        <dd class="font-medium">{% if user.is_active %}{% trans 'Ativo' %}{% else %}{% trans 'Inativo' %}{% endif %}</dd>
+      </div>
+      <div>
+        <dt class="text-[var(--text-muted)]">{% trans 'Tipo' %}</dt>
+        <dd class="font-medium">{{ user.get_user_type_display|default:user.user_type }}</dd>
+      </div>
+    </dl>
+  </div>
+  <div class="card-footer border-t border-[var(--border)] bg-[var(--bg-secondary)] p-4">
+    <button type="button" class="btn btn-secondary w-full" data-promover-associado-button data-user-id="{{ user.pk }}">{% trans 'Promover' %}</button>
+  </div>
+</article>

--- a/accounts/templates/associados/_promover_grid.html
+++ b/accounts/templates/associados/_promover_grid.html
@@ -1,0 +1,19 @@
+{% load i18n %}
+{% if associados %}
+  <div role="list" class="card-grid sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
+    {% for user in associados %}
+      <div role="listitem">
+        {% include 'associados/_promover_card.html' with user=user %}
+      </div>
+    {% endfor %}
+  </div>
+  {% include '_partials/pagination.html' with page_obj=page_obj querystring=request.GET.urlencode %}
+{% else %}
+  <div class="text-sm text-[var(--text-muted)]">
+    {% if has_search %}
+      {% trans 'Nenhum associado encontrado para a busca informada.' %}
+    {% else %}
+      {% trans 'Nenhum associado disponível para promoção no momento.' %}
+    {% endif %}
+  </div>
+{% endif %}

--- a/accounts/templates/associados/promover_list.html
+++ b/accounts/templates/associados/promover_list.html
@@ -1,0 +1,76 @@
+{% extends 'base.html' %}
+{% load i18n %}
+
+{% block title %}{% trans 'Promover associado' %}{% endblock %}
+
+{% block hero %}
+  {% include '_components/hero_associados.html' with title=_('Promover associado') action_template='associados/hero_action.html' total_usuarios=None total_associados=None total_nucleados=None %}
+{% endblock %}
+
+{% block content %}
+<div class="py-12 card px-4">
+  <div class="card-header">
+    <h2 class="text-xl font-semibold">{% trans 'Promover associado' %}</h2>
+  </div>
+  <div class="card-body space-y-8">
+    <form method="get" class="space-y-3" data-promover-search-form>
+      <div>
+        <label for="associado-search" class="block text-sm font-medium text-[var(--text-muted)]">{% trans 'Buscar associado' %}</label>
+        <div class="mt-1 flex flex-col gap-3 sm:flex-row sm:items-center">
+          <div class="relative flex-1">
+            <input
+              id="associado-search"
+              name="q"
+              type="search"
+              value="{{ search_term }}"
+              placeholder="{% trans 'Busque por nome ou CNPJ' %}"
+              class="w-full rounded-lg border border-[var(--border)] bg-[var(--bg-primary)] px-4 py-2 text-sm text-[var(--text-primary)] focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary"
+              data-search-input
+            />
+            <button
+              type="button"
+              class="absolute inset-y-0 right-2 flex items-center px-2 text-xs font-semibold text-[var(--text-muted)] hover:text-[var(--text-primary)] focus:outline-none focus-visible:ring focus-visible:ring-primary/40 rounded hidden"
+              data-clear-search
+              aria-label="{% trans 'Limpar busca' %}"
+            >[x]</button>
+          </div>
+          <button type="submit" class="btn btn-primary self-start sm:self-auto">{% trans 'Buscar' %}</button>
+        </div>
+      </div>
+    </form>
+
+    {% include 'associados/_promover_grid.html' with associados=associados page_obj=page_obj request=request has_search=has_search %}
+  </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+  {{ block.super }}
+  <script>
+    (function () {
+      const form = document.querySelector('[data-promover-search-form]');
+      if (!form) {
+        return;
+      }
+      const input = form.querySelector('[data-search-input]');
+      const clearButton = form.querySelector('[data-clear-search]');
+      if (!input || !clearButton) {
+        return;
+      }
+
+      const toggleClearButton = () => {
+        const hasValue = Boolean(input.value && input.value.trim());
+        clearButton.classList.toggle('hidden', !hasValue);
+      };
+
+      toggleClearButton();
+      input.addEventListener('input', toggleClearButton);
+      clearButton.addEventListener('click', function () {
+        input.value = '';
+        toggleClearButton();
+        input.focus();
+        form.submit();
+      });
+    })();
+  </script>
+{% endblock %}

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -9,6 +9,11 @@ urlpatterns = [
     path("login/", views.login_view, name="login"),
     path("logout/", views.logout_view, name="logout"),
     path("associados/", views.AssociadoListView.as_view(), name="associados_lista"),
+    path(
+        "associados/promover/",
+        views.AssociadoPromoverListView.as_view(),
+        name="associados_promover",
+    ),
     path("associados/novo/", views.OrganizacaoUserCreateView.as_view(), name="associados_adicionar"),
     # Registro de usuário
     path("resend-confirmation/", views.resend_confirmation, name="resend_confirmation"),

--- a/core/menu.py
+++ b/core/menu.py
@@ -331,10 +331,17 @@ def _get_menu_items() -> List[MenuItem]:
         MenuItem(
             id="associados_adicionar",
             path=reverse("accounts:associados_adicionar"),
-            label="Adicionar usuário",
+            label="Adicionar associado",
             icon=ICON_PLUS,
             permissions=["admin", "operador"],
-        )
+        ),
+        MenuItem(
+            id="associados_promover",
+            path=reverse("accounts:associados_promover"),
+            label="Promover associado",
+            icon=ICON_STAR,
+            permissions=["admin", "coordenador", "operador"],
+        ),
     ]
 
     eventos_children = [


### PR DESCRIPTION
## Summary
- add a dedicated view for promoting associates with filtering for coordinators, consultants, and associates
- create new promotion templates with search, clear control, and promote action buttons
- expose the promotion page via new routes and menu entry while renaming the add associate label

## Testing
- pytest --no-cov tests/accounts/test_associados.py

------
https://chatgpt.com/codex/tasks/task_e_68d6d5747bd48325922e26fd1a3cc7a3