### PR TITLE
Fix duplicate scripts block in promover associados template

### DIFF
--- a/accounts/templates/associados/promover_list.html
+++ b/accounts/templates/associados/promover_list.html
@@ -7,37 +7,6 @@
   {% include '_components/hero_associados.html' with title=_('Promover associado') action_template='associados/hero_action.html' total_usuarios=None total_associados=None total_nucleados=None %}
 {% endblock %}
 
-{% block scripts %}
-  {{ block.super }}
-  <script>
-    (function () {
-      const form = document.querySelector('[data-promover-search-form]');
-      if (!form) {
-        return;
-      }
-      const input = form.querySelector('[data-search-input]');
-      const clearButton = form.querySelector('[data-clear-search]');
-      if (!input || !clearButton) {
-        return;
-      }
-
-      const toggleClearButton = () => {
-        const hasValue = Boolean(input.value && input.value.trim());
-        clearButton.classList.toggle('hidden', !hasValue);
-      };
-
-      toggleClearButton();
-      input.addEventListener('input', toggleClearButton);
-      clearButton.addEventListener('click', function () {
-        input.value = '';
-        toggleClearButton();
-        input.focus();
-        form.submit();
-      });
-    })();
-  </script>
-{% endblock %}
-
 {% block content %}
 <div class="py-12 card px-4">
   <div class="card-header">
@@ -91,5 +60,19 @@
         return;
       }
 
+      const toggleClearButton = () => {
+        const hasValue = Boolean(input.value && input.value.trim());
+        clearButton.classList.toggle('hidden', !hasValue);
+      };
 
+      toggleClearButton();
+      input.addEventListener('input', toggleClearButton);
+      clearButton.addEventListener('click', function () {
+        input.value = '';
+        toggleClearButton();
+        input.focus();
+        form.submit();
+      });
+    })();
+  </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- remove the duplicate `scripts` block from the associado promotion list template
- keep the search helper script defined once so the template renders correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6e80beb608325afa32f578e96e429