### PR TITLE
Adiciona etiquetas de tipo aos cards de associados

### DIFF
--- a/accounts/templates/associados/_promover_card.html
+++ b/accounts/templates/associados/_promover_card.html
@@ -1,7 +1,9 @@
-{% load i18n %}
+{% load i18n associados_extras %}
 {% url 'accounts:perfil_publico_uuid' user.public_id as profile_url %}
+{% usuario_badges user as user_badges %}
 <article class="card h-full overflow-hidden flex flex-col">
   <header class="relative">
+    {% include '_partials/cards/badge_list.html' with badges=user_badges %}
     {% if user.cover %}
       <img src="{{ user.cover.url|default:user.cover }}" alt="{% trans 'Capa do associado' %}" class="h-24 w-full object-cover" loading="lazy" />
     {% else %}
@@ -28,14 +30,10 @@
         <span class="font-normal text-[var(--text-primary)]">{{ user.cnpj }}</span>
       </p>
     {% endif %}
-    <dl class="mt-4 grid grid-cols-2 gap-3 text-xs text-[var(--text-tertiary)]">
+    <dl class="mt-4 space-y-3 text-xs text-[var(--text-tertiary)]">
       <div>
         <dt class="text-[var(--text-muted)]">{% trans 'Status' %}</dt>
         <dd class="font-medium">{% if user.is_active %}{% trans 'Ativo' %}{% else %}{% trans 'Inativo' %}{% endif %}</dd>
-      </div>
-      <div>
-        <dt class="text-[var(--text-muted)]">{% trans 'Tipo' %}</dt>
-        <dd class="font-medium">{{ user.get_user_type_display|default:user.user_type }}</dd>
       </div>
     </dl>
   </div>

--- a/accounts/templatetags/__init__.py
+++ b/accounts/templatetags/__init__.py
@@ -1,0 +1,1 @@
+# Django template tags package for accounts app

--- a/accounts/templatetags/associados_extras.py
+++ b/accounts/templatetags/associados_extras.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from django import template
+from django.utils.translation import gettext as _
+
+from accounts.models import UserType
+
+register = template.Library()
+
+
+BADGE_STYLES = {
+    "associado": "--primary:#6366f1; --primary-soft:rgba(99, 102, 241, 0.15); --primary-soft-border:rgba(99, 102, 241, 0.3);",
+    "nucleado": "--primary:#22c55e; --primary-soft:rgba(34, 197, 94, 0.15); --primary-soft-border:rgba(34, 197, 94, 0.3);",
+    "coordenador": "--primary:#f97316; --primary-soft:rgba(249, 115, 22, 0.15); --primary-soft-border:rgba(249, 115, 22, 0.3);",
+    "consultor": "--primary:#8b5cf6; --primary-soft:rgba(139, 92, 246, 0.15); --primary-soft-border:rgba(139, 92, 246, 0.3);",
+}
+
+
+def _get_prefetched(manager, cache_key):
+    related_cache = getattr(manager, "instance", None)
+    if related_cache is not None:
+        cache = getattr(related_cache, "_prefetched_objects_cache", {})
+        if cache_key in cache:
+            return cache[cache_key]
+    return None
+
+
+@register.simple_tag
+def usuario_badges(user):
+    """Retorna metadados de etiquetas para o usuário."""
+
+    badges: list[dict[str, str]] = []
+    types_present: set[str] = set()
+
+    participacoes_manager = getattr(user, "participacoes", None)
+    participacoes = []
+    if participacoes_manager is not None:
+        prefetched = _get_prefetched(participacoes_manager, "participacoes")
+        if prefetched is not None:
+            participacoes = list(prefetched)
+        else:
+            participacoes = list(
+                participacoes_manager.select_related("nucleo").all()
+            )
+
+    for participacao in participacoes:
+        if participacao.status != "ativo" or getattr(participacao, "status_suspensao", False):
+            continue
+        nucleo = getattr(participacao, "nucleo", None)
+        nucleo_nome = getattr(nucleo, "nome", "")
+
+        if participacao.papel == "coordenador":
+            papel = participacao.get_papel_coordenador_display() if participacao.papel_coordenador else ""
+            if papel:
+                label = _("Coordenador · %(papel)s · %(nucleo)s") % {
+                    "papel": papel,
+                    "nucleo": nucleo_nome,
+                }
+            elif nucleo_nome:
+                label = _("Coordenador · %(nucleo)s") % {"nucleo": nucleo_nome}
+            else:
+                label = _("Coordenador")
+            badges.append({"label": label, "style": BADGE_STYLES["coordenador"], "type": "coordenador"})
+            types_present.add("coordenador")
+        else:
+            if nucleo_nome:
+                label = _("Nucleado · %(nucleo)s") % {"nucleo": nucleo_nome}
+            else:
+                label = _("Nucleado")
+            badges.append({"label": label, "style": BADGE_STYLES["nucleado"], "type": "nucleado"})
+            types_present.add("nucleado")
+
+    nucleos_consultoria_manager = getattr(user, "nucleos_consultoria", None)
+    consultoria = []
+    if nucleos_consultoria_manager is not None:
+        prefetched = _get_prefetched(nucleos_consultoria_manager, "nucleos_consultoria")
+        if prefetched is not None:
+            consultoria = list(prefetched)
+        else:
+            consultoria = list(nucleos_consultoria_manager.all())
+
+    for nucleo in consultoria:
+        nucleo_nome = getattr(nucleo, "nome", "")
+        if nucleo_nome:
+            label = _("Consultor · %(nucleo)s") % {"nucleo": nucleo_nome}
+        else:
+            label = _("Consultor")
+        badges.append({"label": label, "style": BADGE_STYLES["consultor"], "type": "consultor"})
+        types_present.add("consultor")
+
+    if getattr(user, "nucleo", None) and not {"coordenador", "nucleado"} & types_present:
+        nucleo_nome = getattr(user.nucleo, "nome", "")
+        if getattr(user, "is_coordenador", False):
+            if nucleo_nome:
+                label = _("Coordenador · %(nucleo)s") % {"nucleo": nucleo_nome}
+            else:
+                label = _("Coordenador")
+            badges.append({"label": label, "style": BADGE_STYLES["coordenador"], "type": "coordenador"})
+            types_present.add("coordenador")
+        else:
+            if nucleo_nome:
+                label = _("Nucleado · %(nucleo)s") % {"nucleo": nucleo_nome}
+            else:
+                label = _("Nucleado")
+            badges.append({"label": label, "style": BADGE_STYLES["nucleado"], "type": "nucleado"})
+            types_present.add("nucleado")
+
+    if getattr(user, "user_type", "") == UserType.CONSULTOR.value and "consultor" not in types_present:
+        badges.append({"label": _("Consultor"), "style": BADGE_STYLES["consultor"], "type": "consultor"})
+        types_present.add("consultor")
+
+    if getattr(user, "is_associado", False) and not types_present:
+        badges.append({"label": _("Associado"), "style": BADGE_STYLES["associado"], "type": "associado"})
+        types_present.add("associado")
+    elif getattr(user, "is_associado", False) and "associado" not in types_present and not badges:
+        badges.append({"label": _("Associado"), "style": BADGE_STYLES["associado"], "type": "associado"})
+        types_present.add("associado")
+
+    if getattr(user, "user_type", "") == UserType.ASSOCIADO.value and "associado" not in types_present and not badges:
+        badges.append({"label": _("Associado"), "style": BADGE_STYLES["associado"], "type": "associado"})
+
+    return [{"label": badge["label"], "style": badge.get("style", "")} for badge in badges]

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1128,6 +1128,7 @@ class AssociadoListView(NoSuperadminMixin, AssociadosRequiredMixin, LoginRequire
                 | Q(is_coordenador=True)
             )
             .select_related("organizacao", "nucleo")
+            .prefetch_related("participacoes__nucleo", "nucleos_consultoria")
         )
         # TODO: unify "user_type" and "is_associado" fields to avoid duplicate state
         q = self.request.GET.get("q")
@@ -1227,6 +1228,7 @@ class AssociadoPromoverListView(NoSuperadminMixin, AssociadosRequiredMixin, Logi
                 | Q(is_coordenador=True)
             )
             .select_related("organizacao", "nucleo")
+            .prefetch_related("participacoes__nucleo", "nucleos_consultoria")
         )
 
         search_term = (self.request.GET.get("q") or "").strip()

--- a/templates/_components/card_details_usuario.html
+++ b/templates/_components/card_details_usuario.html
@@ -1,12 +1,8 @@
 {% load i18n %}
 <p class="text-sm text-[var(--text-muted)]">@{{ user.username }}</p>
-<dl class="mt-3 grid grid-cols-2 gap-2 text-xs text-[var(--text-tertiary)]">
+<dl class="mt-3 space-y-2 text-xs text-[var(--text-tertiary)]">
   <div>
     <dt class="text-[var(--text-muted)]">{% trans 'Status' %}</dt>
     <dd class="font-medium">{% if user.is_active %}{% trans 'Ativo' %}{% else %}{% trans 'Inativo' %}{% endif %}</dd>
-  </div>
-  <div>
-    <dt class="text-[var(--text-muted)]">{% trans 'Tipo' %}</dt>
-    <dd class="font-medium">{{ user.get_user_type_display|default:user.user_type }}</dd>
   </div>
 </dl>

--- a/templates/_components/card_usuario.html
+++ b/templates/_components/card_usuario.html
@@ -1,4 +1,5 @@
-{% load i18n %}
+{% load i18n associados_extras %}
 {% url 'accounts:perfil_publico_uuid' user.public_id as profile_url %}
 {% trans 'Ver detalhes do usuário' as sr_label %}
-{% include '_partials/cards/base_card.html' with url=profile_url cover=user.cover avatar=user.avatar title=user.display_name details='_components/card_details_usuario.html' sr_label=sr_label %}
+{% usuario_badges user as user_badges %}
+{% include '_partials/cards/base_card.html' with url=profile_url cover=user.cover avatar=user.avatar title=user.display_name details='_components/card_details_usuario.html' sr_label=sr_label badges=user_badges %}

--- a/templates/_partials/cards/badge_list.html
+++ b/templates/_partials/cards/badge_list.html
@@ -1,0 +1,12 @@
+{% if badges %}
+  <div class="flex flex-wrap gap-2 px-4 pt-4 pb-3">
+    {% for badge in badges %}
+      <span class="inline-flex max-w-full items-center gap-2 rounded-full bg-[var(--primary-soft,rgba(59,130,246,0.15))] px-3 py-1 text-[0.6rem] font-semibold uppercase tracking-wide text-[var(--primary,#2563eb)] shadow-sm ring-1 ring-[var(--primary-soft-border,rgba(59,130,246,0.3))] whitespace-nowrap"{% if badge.style %} style="{{ badge.style }}"{% endif %}>
+        <svg class="h-3.5 w-3.5 shrink-0" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+          <path d="M17.707 9.293 10.414 2H4a2 2 0 0 0-2 2v6.414l7.293 7.293a1 1 0 0 0 1.414 0l7-7a1 1 0 0 0 0-1.414ZM5.5 6.5a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3Z" />
+        </svg>
+        <span class="truncate">{{ badge.label }}</span>
+      </span>
+    {% endfor %}
+  </div>
+{% endif %}

--- a/templates/_partials/cards/base_card.html
+++ b/templates/_partials/cards/base_card.html
@@ -4,7 +4,9 @@
   aria-label="{{ title }}">
   <article class="card overflow-hidden" role="article">
     <header class="relative">
-      {% if badge %}
+      {% if badges %}
+        {% include '_partials/cards/badge_list.html' with badges=badges %}
+      {% elif badge %}
         <div class="px-4 pt-4 pb-3">
           <span class="inline-flex max-w-full items-center gap-2 rounded-full bg-[var(--primary-soft,rgba(59,130,246,0.15))] px-3 py-1 text-[0.6rem] font-semibold uppercase tracking-wide text-[var(--primary,#2563eb)] shadow-sm ring-1 ring-[var(--primary-soft-border,rgba(59,130,246,0.3))] whitespace-nowrap"{% if badge_style %} style="{{ badge_style }}"{% endif %}>
             <svg class="h-3.5 w-3.5 shrink-0" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">


### PR DESCRIPTION
## Summary
- adiciona template tag para montar etiquetas de papéis de usuários associados
- exibe as etiquetas nos cards de listagem e promoção e remove o campo duplicado de tipo
- otimiza as consultas dos cards pré-buscando participações e núcleos atendidos

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68d6eac4de008325a0bed128dddae195