### PR TITLE
Ajusta etiqueta de coordenador nos cards de associados

### DIFF
--- a/accounts/templatetags/associados_extras.py
+++ b/accounts/templatetags/associados_extras.py
@@ -52,10 +52,13 @@ def usuario_badges(user):
         if participacao.papel == "coordenador":
             papel = participacao.get_papel_coordenador_display() if participacao.papel_coordenador else ""
             if papel:
-                label = _("Coordenador · %(papel)s · %(nucleo)s") % {
-                    "papel": papel,
-                    "nucleo": nucleo_nome,
-                }
+                if nucleo_nome:
+                    label = _("%(papel)s · %(nucleo)s") % {
+                        "papel": papel,
+                        "nucleo": nucleo_nome,
+                    }
+                else:
+                    label = papel
             elif nucleo_nome:
                 label = _("Coordenador · %(nucleo)s") % {"nucleo": nucleo_nome}
             else:


### PR DESCRIPTION
## Summary
- evita duplicar o texto "Coordenador" quando o papel detalhado já inclui essa informação
- mantém a indicação do núcleo apenas quando houver nome definido

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d702029b848325b7dd1c2b7e7d1797