### PR TITLE
Include nucleados in associates promotion list

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1222,6 +1222,7 @@ class AssociadoPromoverListView(NoSuperadminMixin, AssociadosRequiredMixin, Logi
                         UserType.COORDENADOR.value,
                         UserType.CONSULTOR.value,
                         UserType.ASSOCIADO.value,
+                        UserType.NUCLEADO.value,
                     ]
                 )
                 | Q(is_associado=True)

--- a/tests/accounts/test_promover_form.py
+++ b/tests/accounts/test_promover_form.py
@@ -9,6 +9,39 @@ from organizacoes.factories import OrganizacaoFactory
 
 
 @pytest.mark.django_db
+def test_promover_list_includes_nucleados(client):
+    organizacao = OrganizacaoFactory()
+    nucleo = NucleoFactory(organizacao=organizacao)
+    User = get_user_model()
+
+    admin = User.objects.create_user(
+        username="admin",
+        email="admin@example.com",
+        password="pass",
+        user_type=UserType.ADMIN,
+        organizacao=organizacao,
+    )
+    nucleado = User.objects.create_user(
+        username="nucleado",
+        email="nucleado@example.com",
+        password="pass",
+        user_type=UserType.NUCLEADO,
+        organizacao=organizacao,
+        is_associado=True,
+        nucleo=nucleo,
+    )
+
+    client.force_login(admin)
+
+    url = reverse("accounts:associados_promover")
+    response = client.get(url)
+
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert nucleado.username in content
+
+
+@pytest.mark.django_db
 def test_promover_form_get(client):
     organizacao = OrganizacaoFactory()
     User = get_user_model()


### PR DESCRIPTION
## Summary
- include nucleado users in the promotion list queryset so they appear in the associate promotion cards
- add a regression test covering the presence of nucleados in the promotion view

## Testing
- pytest --no-cov tests/accounts/test_promover_form.py

------
https://chatgpt.com/codex/tasks/task_e_68d7032ac1e08325a9c0370f5c1600f3