### PR TITLE
Adjust evento list to two columns on desktop

### DIFF
--- a/eventos/templates/eventos/partials/eventos/evento_list.html
+++ b/eventos/templates/eventos/partials/eventos/evento_list.html
@@ -7,7 +7,7 @@
           <h2 class="text-xl font-semibold">{% trans "Eventos" %}</h2>
       </div>
       <div class="card-body">
-        <div class="grid gap-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3" role="list" aria-label="{% trans 'Lista de eventos' %}">
+        <div class="grid gap-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-2" role="list" aria-label="{% trans 'Lista de eventos' %}">
           {% for evento in eventos %}
             {% include '_components/card_evento.html' %}
           {% empty %}


### PR DESCRIPTION
## Summary
- update the evento list grid to display two columns on desktop breakpoints while keeping existing layouts on smaller devices

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7076421fc83259d4d18d891a3395d