### PR TITLE
feat: destacar etiquetas de público nos cards de eventos

### DIFF
--- a/eventos/templatetags/eventos_extras.py
+++ b/eventos/templatetags/eventos_extras.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from django import template
+from django.utils.translation import gettext as _
+
+register = template.Library()
+
+PUBLIC_BADGE_STYLE = "--primary:#2563eb; --primary-soft:rgba(37, 99, 235, 0.15); --primary-soft-border:rgba(37, 99, 235, 0.3);"
+NUCLEO_BADGE_STYLE = "--primary:#0ea5e9; --primary-soft:rgba(14, 165, 233, 0.15); --primary-soft-border:rgba(14, 165, 233, 0.3);"
+TARGET_BADGE_MAP = {
+    1: {
+        "label": _("Somente nucleados"),
+        "style": "--primary:#22c55e; --primary-soft:rgba(34, 197, 94, 0.15); --primary-soft-border:rgba(34, 197, 94, 0.3);",
+    },
+    2: {
+        "label": _("Apenas associados"),
+        "style": "--primary:#6366f1; --primary-soft:rgba(99, 102, 241, 0.15); --primary-soft-border:rgba(99, 102, 241, 0.3);",
+    },
+}
+
+
+@register.simple_tag
+def evento_badges(evento):
+    """Retorna dados de etiquetas para o card de evento."""
+
+    publico_alvo = getattr(evento, "publico_alvo", None)
+    nucleo = getattr(evento, "nucleo", None)
+
+    if publico_alvo == 0:
+        cover_label = _("Público")
+        cover_style = PUBLIC_BADGE_STYLE
+        target_badge = None
+    else:
+        cover_label = getattr(nucleo, "nome", "") or _("Núcleo não definido")
+        cover_style = NUCLEO_BADGE_STYLE
+        target_badge = TARGET_BADGE_MAP.get(publico_alvo)
+
+    cover_badges = []
+    if cover_label:
+        cover_badges.append({"label": cover_label, "style": cover_style})
+
+    return {
+        "cover_badges": cover_badges,
+        "target_badge": target_badge,
+    }

--- a/templates/_components/card_evento.html
+++ b/templates/_components/card_evento.html
@@ -1,4 +1,5 @@
-{% load i18n %}
+{% load i18n eventos_extras %}
 {% url 'eventos:evento_detalhe' evento.pk as detail_url %}
 {% trans 'Ver detalhes do evento' as sr_label %}
-{% include '_partials/cards/base_card.html' with url=detail_url cover=evento.cover avatar=evento.avatar title=evento.titulo details='_partials/cards/evento_card_details.html' sr_label=sr_label %}
+{% evento_badges evento as evento_badge_data %}
+{% include '_partials/cards/base_card.html' with url=detail_url cover=evento.cover avatar=evento.avatar title=evento.titulo details='_partials/cards/evento_card_details.html' sr_label=sr_label badges=evento_badge_data.cover_badges target_badge=evento_badge_data.target_badge %}

--- a/templates/_partials/cards/evento_card_details.html
+++ b/templates/_partials/cards/evento_card_details.html
@@ -19,3 +19,10 @@
     </dd>
   </div>
 </dl>
+{% if target_badge %}
+  <div class="mt-4">
+    <span class="inline-flex max-w-full items-center gap-2 rounded-full bg-[var(--primary-soft,rgba(59,130,246,0.15))] px-3 py-1 text-[0.6rem] font-semibold uppercase tracking-wide text-[var(--primary,#2563eb)] shadow-sm ring-1 ring-[var(--primary-soft-border,rgba(59,130,246,0.3))] whitespace-nowrap"{% if target_badge.style %} style="{{ target_badge.style }}"{% endif %}>
+      <span class="truncate">{{ target_badge.label }}</span>
+    </span>
+  </div>
+{% endif %}


### PR DESCRIPTION
## Summary
- adiciona template tag para centralizar os dados de etiquetas dos eventos
- exibe a etiqueta com o núcleo ou indicação de evento público acima da capa
- mostra uma etiqueta colorida para o público-alvo abaixo das informações do card

## Testing
- python -m compileall eventos/templatetags/eventos_extras.py

------
https://chatgpt.com/codex/tasks/task_e_68d70a2808e883258396754f6c87e8d2