### PR TITLE
Add consultant and coordinator filters to associados hero

### DIFF
--- a/accounts/templates/associados/promover_list.html
+++ b/accounts/templates/associados/promover_list.html
@@ -4,7 +4,7 @@
 {% block title %}{% trans 'Promover associado' %}{% endblock %}
 
 {% block hero %}
-  {% include '_components/hero_associados.html' with title=_('Promover associado') action_template='associados/hero_action.html' total_usuarios=None total_associados=None total_nucleados=None %}
+  {% include '_components/hero_associados.html' with title=_('Promover associado') action_template='associados/hero_action.html' filter_target='#associados-grid' filter_indicator='#associados-loading' %}
 {% endblock %}
 
 {% block content %}
@@ -39,7 +39,13 @@
       </div>
     </form>
 
-    {% include 'associados/_promover_grid.html' with associados=associados page_obj=page_obj request=request has_search=has_search %}
+    <div id="associados-grid">
+      {% include 'associados/_promover_grid.html' with associados=associados page_obj=page_obj request=request has_search=has_search %}
+    </div>
+
+    <div id="associados-loading" class="htmx-indicator mt-6 text-center text-sm text-base-content/70" role="status" aria-live="polite">
+      {% trans 'Carregando associados...' %}
+    </div>
   </div>
 </div>
 
@@ -72,6 +78,40 @@
         toggleClearButton();
         input.focus();
         form.submit();
+      });
+    })();
+    (function() {
+      const stateId = 'associados-filter-state';
+
+      function parseClasses(value) {
+        return value ? value.split(/\s+/).filter(Boolean) : [];
+      }
+
+      function updateFilterButtons() {
+        const stateEl = document.getElementById(stateId);
+        if (!stateEl) {
+          return;
+        }
+        const currentFilter = stateEl.dataset.currentFilter || 'todos';
+        const buttons = document.querySelectorAll('[data-associados-filter-card]');
+
+        buttons.forEach((button) => {
+          const activeClasses = parseClasses(button.dataset.activeClass || '');
+          const isActive = button.dataset.associadosFilterCard === currentFilter;
+          button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+          activeClasses.forEach((cls) => {
+            if (cls) {
+              button.classList.toggle(cls, isActive);
+            }
+          });
+        });
+      }
+
+      document.addEventListener('DOMContentLoaded', updateFilterButtons);
+      document.body.addEventListener('htmx:afterSwap', function(event) {
+        if (event.target && event.target.id === 'associados-grid') {
+          updateFilterButtons();
+        }
       });
     })();
   </script>

--- a/templates/_components/hero_associados.html
+++ b/templates/_components/hero_associados.html
@@ -21,14 +21,24 @@
           <div class="flex justify-center md:justify-end md:self-start">{% include action_template %}</div>
         {% endif %}
       </div>
-      {% if total_usuarios is not None or total_associados is not None or total_nucleados is not None %}
+      {% if total_usuarios is not None or total_associados is not None or total_nucleados is not None or total_consultores is not None or total_coordenadores is not None %}
         <div class="mt-10 space-y-4">
+          {% with target=filter_target|default:'#associados-grid' indicator=filter_indicator|default:'#associados-loading' %}
           <div class="card-grid" data-associados-filter-buttons>
-           {% include '_partials/cards/total_card.html' with label=_('Associados') valor=total_associados icon_name='badge-check' card_class='card-compact cursor-pointer transition hover:shadow-lg focus:outline-none focus-visible:ring focus-visible:ring-white/80 focus-visible:ring-offset-2' body_class='card-body-compact' as_button=True active_class='border border-white/80 shadow-lg' is_active=is_associados_filter_active hx_get=associados_filter_url hx_target='#associados-grid' hx_push_url='true' hx_indicator='#associados-loading' extra_attributes='data-associados-filter-card="associados"' %}
+           {% include '_partials/cards/total_card.html' with label=_('Associados') valor=total_associados icon_name='badge-check' card_class='card-compact cursor-pointer transition hover:shadow-lg focus:outline-none focus-visible:ring focus-visible:ring-white/80 focus-visible:ring-offset-2' body_class='card-body-compact' as_button=True active_class='border border-white/80 shadow-lg' is_active=is_associados_filter_active hx_get=associados_filter_url hx_target=target hx_push_url='true' hx_indicator=indicator extra_attributes='data-associados-filter-card="associados"' %}
 
-           {% include '_partials/cards/total_card.html' with label=_('Nucleados') valor=total_nucleados icon_name='network' card_class='card-compact cursor-pointer transition hover:shadow-lg focus:outline-none focus-visible:ring focus-visible:ring-white/80 focus-visible:ring-offset-2' body_class='card-body-compact' as_button=True active_class='border border-white/80 shadow-lg' is_active=is_nucleados_filter_active hx_get=nucleados_filter_url hx_target='#associados-grid' hx_push_url='true' hx_indicator='#associados-loading' extra_attributes='data-associados-filter-card="nucleados"' %}
+           {% include '_partials/cards/total_card.html' with label=_('Nucleados') valor=total_nucleados icon_name='network' card_class='card-compact cursor-pointer transition hover:shadow-lg focus:outline-none focus-visible:ring focus-visible:ring-white/80 focus-visible:ring-offset-2' body_class='card-body-compact' as_button=True active_class='border border-white/80 shadow-lg' is_active=is_nucleados_filter_active hx_get=nucleados_filter_url hx_target=target hx_push_url='true' hx_indicator=indicator extra_attributes='data-associados-filter-card="nucleados"' %}
+
+           {% if total_consultores is not None %}
+            {% include '_partials/cards/total_card.html' with label=_('Consultores') valor=total_consultores icon_name='briefcase' card_class='card-compact cursor-pointer transition hover:shadow-lg focus:outline-none focus-visible:ring focus-visible:ring-white/80 focus-visible:ring-offset-2' body_class='card-body-compact' as_button=True active_class='border border-white/80 shadow-lg' is_active=is_consultores_filter_active hx_get=consultores_filter_url hx_target=target hx_push_url='true' hx_indicator=indicator extra_attributes='data-associados-filter-card="consultores"' %}
+           {% endif %}
+
+           {% if total_coordenadores is not None %}
+            {% include '_partials/cards/total_card.html' with label=_('Coordenadores') valor=total_coordenadores icon_name='users' card_class='card-compact cursor-pointer transition hover:shadow-lg focus:outline-none focus-visible:ring focus-visible:ring-white/80 focus-visible:ring-offset-2' body_class='card-body-compact' as_button=True active_class='border border-white/80 shadow-lg' is_active=is_coordenadores_filter_active hx_get=coordenadores_filter_url hx_target=target hx_push_url='true' hx_indicator=indicator extra_attributes='data-associados-filter-card="coordenadores"' %}
+           {% endif %}
 
           </div>
+          {% endwith %}
           <div id="associados-filter-state" class="hidden" data-current-filter="{{ current_filter|default:'todos' }}" aria-hidden="true"></div>
         </div>
       {% endif %}

--- a/tests/accounts/test_associados.py
+++ b/tests/accounts/test_associados.py
@@ -118,6 +118,19 @@ def test_associados_filter_actions(client):
         organizacao=org,
         nucleo=nucleo,
     )
+    consultor = create_user(
+        "consultor@example.com",
+        "consultor",
+        UserType.CONSULTOR,
+        organizacao=org,
+    )
+    coordenador = create_user(
+        "coordenador@example.com",
+        "coordenador",
+        UserType.COORDENADOR,
+        organizacao=org,
+        is_coordenador=True,
+    )
 
     client.force_login(admin)
     url = reverse("accounts:associados_lista")
@@ -127,16 +140,36 @@ def test_associados_filter_actions(client):
     content = resp.content.decode()
     assert 'data-associados-filter-card="associados"' in content
     assert 'data-associados-filter-card="nucleados"' in content
+    assert 'data-associados-filter-card="consultores"' in content
+    assert 'data-associados-filter-card="coordenadores"' in content
     assert resp.context["associados_filter_url"].endswith("?tipo=associados")
     assert resp.context["nucleados_filter_url"].endswith("?tipo=nucleados")
+    assert resp.context["consultores_filter_url"].endswith("?tipo=consultores")
+    assert resp.context["coordenadores_filter_url"].endswith("?tipo=coordenadores")
     assert 'id="associados-filter-state"' in content
 
     resp = client.get(url, {"tipo": "associados"})
     content = resp.content.decode()
     assert associado.username in content
     assert nucleado.username not in content
+    assert "consultor@example.com" not in content
+    assert "coordenador@example.com" not in content
 
     resp = client.get(url, {"tipo": "nucleados"})
     content = resp.content.decode()
     assert nucleado.username in content
     assert associado.username not in content
+    assert "consultor@example.com" not in content
+
+    resp = client.get(url, {"tipo": "consultores"})
+    content = resp.content.decode()
+    assert "consultor@example.com" in content
+    assert associado.username not in content
+    assert nucleado.username not in content
+
+    resp = client.get(url, {"tipo": "coordenadores"})
+    content = resp.content.decode()
+    assert "coordenador@example.com" in content
+    assert "consultor@example.com" not in content
+    assert associado.username not in content
+    assert nucleado.username not in content


### PR DESCRIPTION
## Summary
- add consultant and coordinator total cards to the associados hero component with configurable HTMX targets
- extend the associados listing and promotion views to support consultant/coordinator filters, totals, and HTMX partial rendering
- surface the hero totals on the promotion page and cover the new behaviour with unit tests

## Testing
- pytest tests/accounts/test_associados.py::test_associados_filter_actions *(fails: coverage threshold triggered when running a subset of tests)*


------
https://chatgpt.com/codex/tasks/task_e_68da95ff151883258381673372ad0949