### PR TITLE
Align sidebar and main header layout behavior

### DIFF
--- a/app/static/css/hubx.css
+++ b/app/static/css/hubx.css
@@ -113,6 +113,7 @@
   --space-12: 3rem;
   --space-16: 4rem;
   --space-20: 5rem;
+  --layout-header-height: 5rem;
 
   /* Border Radius */
   --radius-sm: 0.375rem;
@@ -643,6 +644,8 @@
   #sidebar.sidebar-collapsed .sidebar-subitem svg,
   #sidebar.sidebar-collapsed .sidebar-item img { @apply w-6 h-6 flex-shrink-0; }
 
+  #sidebar.sidebar-collapsed .sidebar-brand-label { @apply hidden; }
+
   /* Tabelas */
   .table           { @apply w-full text-sm; }
   .table thead th  { @apply text-left font-medium border-b border-[var(--border)] py-2; }
@@ -656,6 +659,10 @@
 }
 
 @layer components {
+  .layout-header {
+    min-height: var(--layout-header-height);
+  }
+
   .hero-profile {
     @apply relative overflow-hidden flex flex-col items-center justify-center text-center py-12 bg-gradient-to-r from-[var(--hero-from)] to-[var(--hero-to)];
   }

--- a/templates/_partials/header.html
+++ b/templates/_partials/header.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-<header class="bg-[var(--bg-secondary)] border-[var(--border)] px-4 py-4 flex items-center gap-4 justify-between">
+<header class="layout-header bg-[var(--bg-secondary)] border-[var(--border)] px-4 py-4 flex items-center gap-4 justify-between sticky top-0 z-30">
   <a href="/" class="text-xl font-bold text-[var(--text-primary)]" aria-label="{% trans 'Página inicial' %}">
     {% if request.user.is_authenticated and request.user.organizacao %}
       {{ request.user.organizacao.nome }}

--- a/templates/_partials/sidebar.html
+++ b/templates/_partials/sidebar.html
@@ -1,6 +1,6 @@
 {% load i18n static %}
 <aside id="sidebar" class="fixed inset-y-0 left-0 z-20 w-64 bg-[var(--bg-secondary)] border-r border-[var(--border)] flex flex-col transition-all">
-  <div class="sidebar-header flex items-center justify-between p-4 border-b border-[var(--border)]">
+  <div class="sidebar-header layout-header flex items-center justify-between px-4 py-4 border-b border-[var(--border)]">
     <a href="/" class="text-2xl font-bold text-[var(--text-primary)] flex items-center gap-2" aria-label="{% trans 'Página inicial' %}" {% if request.path == '/' %}aria-current="page"{% endif %}>
       <img src="{% static 'img/hubx_logo.png' %}" alt="{% trans 'Logo Hubx.Space' %}" class="h-16 w-auto" loading="lazy" />
       <span class="sidebar-brand-label">{% trans 'Hubx' %}</span>

--- a/templates/base.html
+++ b/templates/base.html
@@ -120,7 +120,7 @@
       const content = document.getElementById('content');
       if (sidebarToggle && sidebar && content) {
         const baseMargin = '{% if hide_nav %}ml-0{% else %}ml-64{% endif %}';
-        const sidebarLabels = Array.from(document.querySelectorAll('#sidebar .sidebar-label'));
+        const sidebarLabels = Array.from(document.querySelectorAll('#sidebar .sidebar-label, #sidebar .sidebar-brand-label'));
         const submenuToggles = Array.from(document.querySelectorAll('#sidebar [data-sidebar-submenu-toggle]'));
 
         const getSubmenu = (toggle) => {


### PR DESCRIPTION
## Summary
- add a shared layout header style so the sidebar and main headers use the same height
- make the main header sticky and adjust sidebar header spacing for visual alignment
- hide the sidebar brand label when collapsed to avoid layout breakage

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da98a07a8c8325b740ca1b66c3afb9