### PR TITLE
Restrict invite tokens to guests and refresh registration UI

### DIFF
--- a/accounts/templates/register/cpf.html
+++ b/accounts/templates/register/cpf.html
@@ -10,37 +10,39 @@
 {% block content %}
 <div class="card-grid">
   <div class="card">
-    <div class="mb-8">
-      {% with step=4 total=8 %}
-      <div class="mb-2 flex items-center justify-between">
-        <span class="text-sm font-medium text-[var(--primary)]">{% blocktrans with step=step total=total %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
-        {% widthratio step total 100 as progress %}
-        <span class="text-sm text-[var(--text-secondary)]">{{ progress }}%</span>
-      </div>
-      <div class="h-2 w-full rounded-xl bg-[var(--bg-tertiary)]">
-        <div class="h-full rounded-xl bg-[var(--primary)]" style="width: {{ progress }}%;"></div>
-      </div>
-      {% endwith %}
-    </div>
-
-    <div class="mb-8 text-center">
-      <h1 class="mb-2 text-3xl font-bold text-[var(--text-primary)]">{% trans "Qual seu CPF?" %}</h1>
-      <p class="text-[var(--text-secondary)]">{% trans "Precisamos para validar sua identidade e segurança" %}</p>
-    </div>
-
-    <form id="cpfForm" method="post" action="{% url 'accounts:cpf' %}" class="space-y-6">
-      {% csrf_token %}
+    <div class="card-body space-y-8">
       <div>
-        {% include "_forms/field.html" with id="cpf" name="cpf" label=_("CPF") placeholder=_("CPF") maxlength="14" required=True autofocus=True describedby="cpf_help cpf_validation" %}
-        <div class="text-sm text-[var(--error)]" id="cpf_validation"></div>
-        <small id="cpf_help" class="text-sm text-[var(--text-secondary)]">{% trans "Formato 000.000.000-00" %}</small>
+        {% with step=4 total=8 %}
+        <div class="mb-2 flex items-center justify-between">
+          <span class="text-sm font-medium text-[var(--primary)]">{% blocktrans with step=step total=total %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
+          {% widthratio step total 100 as progress %}
+          <span class="text-sm text-[var(--text-secondary)]">{{ progress }}%</span>
+        </div>
+        <div class="h-2 w-full rounded-xl bg-[var(--bg-tertiary)]">
+          <div class="h-full rounded-xl bg-[var(--primary)]" style="width: {{ progress }}%;"></div>
+        </div>
+        {% endwith %}
       </div>
 
-      <div class="flex gap-4">
-        <a href="{% url 'accounts:nome' %}" class="btn btn-secondary flex-1">{% trans "Voltar" %}</a>
-        <button type="submit" id="submitButton" class="btn btn-primary flex-1">{% trans "Continuar" %}</button>
+      <div class="space-y-2 text-center">
+        <h1 class="text-3xl font-bold text-[var(--text-primary)]">{% trans "Qual seu CPF?" %}</h1>
+        <p class="text-[var(--text-secondary)]">{% trans "Precisamos para validar sua identidade e segurança" %}</p>
       </div>
-    </form>
+
+      <form id="cpfForm" method="post" action="{% url 'accounts:cpf' %}" class="space-y-6">
+        {% csrf_token %}
+        <div>
+          {% include "_forms/field.html" with id="cpf" name="cpf" label=_("CPF") placeholder=_("CPF") maxlength="14" required=True autofocus=True describedby="cpf_help cpf_validation" %}
+          <div class="text-sm text-[var(--error)]" id="cpf_validation"></div>
+          <small id="cpf_help" class="text-sm text-[var(--text-secondary)]">{% trans "Formato 000.000.000-00" %}</small>
+        </div>
+
+        <div class="flex gap-4">
+          <a href="{% url 'accounts:nome' %}" class="btn btn-secondary flex-1">{% trans "Voltar" %}</a>
+          <button type="submit" id="submitButton" class="btn btn-primary flex-1">{% trans "Continuar" %}</button>
+        </div>
+      </form>
+    </div>
   </div>
 </div>
 {% endblock %}

--- a/accounts/templates/register/email.html
+++ b/accounts/templates/register/email.html
@@ -10,37 +10,39 @@
 {% block content %}
 <div class="card-grid">
   <div class="card">
-    <div class="mb-8">
-      {% with step=5 total=8 %}
-      <div class="mb-2 flex items-center justify-between">
-        <span class="text-sm font-medium text-[var(--primary)]">{% blocktrans with step=step total=total %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
-        {% widthratio step total 100 as progress %}
-        <span class="text-sm text-[var(--text-secondary)]">{{ progress }}%</span>
-      </div>
-      <div class="h-2 w-full rounded-xl bg-[var(--bg-tertiary)]">
-        <div class="h-full rounded-xl bg-[var(--primary)]" style="width: {{ progress }}%;"></div>
-      </div>
-      {% endwith %}
-    </div>
-
-    <div class="mb-8 text-center">
-      <h1 class="mb-2 text-3xl font-bold text-[var(--text-primary)]">{% trans "Qual seu email?" %}</h1>
-      <p class="text-[var(--text-secondary)]">{% trans "Usaremos para comunicação e recuperação de conta" %}</p>
-    </div>
-
-    <form id="emailForm" method="post" action="{% url 'accounts:email' %}" class="space-y-6">
-      {% csrf_token %}
+    <div class="card-body space-y-8">
       <div>
-        {% include "_forms/field.html" with id="email" name="email" type="email" label=_("Email") placeholder=_("Seu e-mail") required=True autofocus=True describedby="email_help email_validation" %}
-        <div class="text-sm text-[var(--error)]" id="email_validation"></div>
-        <small id="email_help" class="text-sm text-[var(--text-secondary)]">{% trans "Enviaremos um link de confirmação" %}</small>
+        {% with step=5 total=8 %}
+        <div class="mb-2 flex items-center justify-between">
+          <span class="text-sm font-medium text-[var(--primary)]">{% blocktrans with step=step total=total %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
+          {% widthratio step total 100 as progress %}
+          <span class="text-sm text-[var(--text-secondary)]">{{ progress }}%</span>
+        </div>
+        <div class="h-2 w-full rounded-xl bg-[var(--bg-tertiary)]">
+          <div class="h-full rounded-xl bg-[var(--primary)]" style="width: {{ progress }}%;"></div>
+        </div>
+        {% endwith %}
       </div>
 
-      <div class="flex gap-4">
-        <a href="{% url 'accounts:cpf' %}" class="btn btn-secondary flex-1">{% trans "Voltar" %}</a>
-        <button type="submit" id="submitButton" class="btn btn-primary flex-1">{% trans "Continuar" %}</button>
+      <div class="space-y-2 text-center">
+        <h1 class="text-3xl font-bold text-[var(--text-primary)]">{% trans "Qual seu email?" %}</h1>
+        <p class="text-[var(--text-secondary)]">{% trans "Usaremos para comunicação e recuperação de conta" %}</p>
       </div>
-    </form>
+
+      <form id="emailForm" method="post" action="{% url 'accounts:email' %}" class="space-y-6">
+        {% csrf_token %}
+        <div>
+          {% include "_forms/field.html" with id="email" name="email" type="email" label=_("Email") placeholder=_("Seu e-mail") required=True autofocus=True describedby="email_help email_validation" %}
+          <div class="text-sm text-[var(--error)]" id="email_validation"></div>
+          <small id="email_help" class="text-sm text-[var(--text-secondary)]">{% trans "Enviaremos um link de confirmação" %}</small>
+        </div>
+
+        <div class="flex gap-4">
+          <a href="{% url 'accounts:cpf' %}" class="btn btn-secondary flex-1">{% trans "Voltar" %}</a>
+          <button type="submit" id="submitButton" class="btn btn-primary flex-1">{% trans "Continuar" %}</button>
+        </div>
+      </form>
+    </div>
   </div>
 </div>
 {% endblock %}

--- a/accounts/templates/register/foto.html
+++ b/accounts/templates/register/foto.html
@@ -10,37 +10,39 @@
 {% block content %}
 <div class="card-grid">
   <div class="card">
-    <div class="mb-8">
-      {% with step=7 total=8 %}
-      <div class="mb-2 flex items-center justify-between">
-        <span class="text-sm font-medium text-[var(--primary)]">{% blocktrans with step=step total=total %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
-        {% widthratio step total 100 as progress %}
-        <span class="text-sm text-[var(--text-secondary)]">{{ progress }}%</span>
-      </div>
-      <div class="h-2 w-full rounded-xl bg-[var(--bg-tertiary)]">
-        <div class="h-full rounded-xl bg-[var(--primary)]" style="width: {{ progress }}%;"></div>
-      </div>
-      {% endwith %}
-    </div>
-
-    <div class="mb-8 text-center">
-      <h1 class="mb-2 text-3xl font-bold text-[var(--text-primary)]">{% trans "Adicione uma foto de perfil" %}</h1>
-      <p class="text-[var(--text-secondary)]">{% trans "Personalize sua presença na comunidade" %}</p>
-    </div>
-
-    <form id="fotoForm" method="post" action="{% url 'accounts:foto' %}" enctype="multipart/form-data" class="space-y-6">
-      {% csrf_token %}
+    <div class="card-body space-y-8">
       <div>
-        {% include "_forms/field.html" with id="foto" name="foto" type="file" label=_("Escolher Foto") placeholder=_("Selecione uma foto") describedby="foto_validation" attrs="accept='image/*'" %}
-        <div class="text-sm text-[var(--error)]" id="foto_validation"></div>
-        <small class="text-sm text-[var(--text-secondary)]">{% trans "Formatos aceitos: JPG, PNG. Tamanho máximo: 5MB" %}</small>
+        {% with step=7 total=8 %}
+        <div class="mb-2 flex items-center justify-between">
+          <span class="text-sm font-medium text-[var(--primary)]">{% blocktrans with step=step total=total %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
+          {% widthratio step total 100 as progress %}
+          <span class="text-sm text-[var(--text-secondary)]">{{ progress }}%</span>
+        </div>
+        <div class="h-2 w-full rounded-xl bg-[var(--bg-tertiary)]">
+          <div class="h-full rounded-xl bg-[var(--primary)]" style="width: {{ progress }}%;"></div>
+        </div>
+        {% endwith %}
       </div>
 
-      <div class="flex gap-4">
-        <a href="{% url 'accounts:senha' %}" class="btn btn-secondary flex-1">{% trans "Voltar" %}</a>
-        <button type="submit" id="submitButton" class="btn btn-primary flex-1">{% trans "Continuar" %}</button>
+      <div class="space-y-2 text-center">
+        <h1 class="text-3xl font-bold text-[var(--text-primary)]">{% trans "Adicione uma foto de perfil" %}</h1>
+        <p class="text-[var(--text-secondary)]">{% trans "Personalize sua presença na comunidade" %}</p>
       </div>
-    </form>
+
+      <form id="fotoForm" method="post" action="{% url 'accounts:foto' %}" enctype="multipart/form-data" class="space-y-6">
+        {% csrf_token %}
+        <div>
+          {% include "_forms/field.html" with id="foto" name="foto" type="file" label=_("Escolher Foto") placeholder=_("Selecione uma foto") describedby="foto_validation" attrs="accept='image/*'" %}
+          <div class="text-sm text-[var(--error)]" id="foto_validation"></div>
+          <small class="text-sm text-[var(--text-secondary)]">{% trans "Formatos aceitos: JPG, PNG. Tamanho máximo: 5MB" %}</small>
+        </div>
+
+        <div class="flex gap-4">
+          <a href="{% url 'accounts:senha' %}" class="btn btn-secondary flex-1">{% trans "Voltar" %}</a>
+          <button type="submit" id="submitButton" class="btn btn-primary flex-1">{% trans "Continuar" %}</button>
+        </div>
+      </form>
+    </div>
   </div>
 </div>
 {% endblock %}

--- a/accounts/templates/register/nome.html
+++ b/accounts/templates/register/nome.html
@@ -10,36 +10,38 @@
 {% block content %}
 <div class="card-grid">
   <div class="card">
-    <div class="mb-8">
-      {% with step=3 total=8 %}
-      <div class="mb-2 flex items-center justify-between">
-        <span class="text-sm font-medium text-[var(--primary)]">{% blocktrans with step=step total=total %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
-        {% widthratio step total 100 as progress %}
-        <span class="text-sm text-[var(--text-secondary)]">{{ progress }}%</span>
-      </div>
-      <div class="h-2 w-full rounded-xl bg-[var(--bg-tertiary)]">
-        <div class="h-full rounded-xl bg-[var(--primary)]" style="width: {{ progress }}%;"></div>
-      </div>
-      {% endwith %}
-    </div>
-
-    <div class="mb-8 text-center">
-      <h1 class="mb-2 text-3xl font-bold text-[var(--text-primary)]">{% trans "Quem será o contato principal?" %}</h1>
-      <p class="text-[var(--text-secondary)]">{% trans "Informe o nome da pessoa responsável pelo contato." %}</p>
-    </div>
-
-    <form id="nomeForm" method="post" action="{% url 'accounts:nome' %}" class="space-y-6">
-      {% csrf_token %}
+    <div class="card-body space-y-8">
       <div>
-        {% include "_forms/field.html" with id="nome" name="nome" label=_("Contato principal") placeholder=_("Nome do contato principal") required=True autofocus=True describedby="nome_validation" %}
-        <div class="text-sm text-[var(--error)]" id="nome_validation"></div>
+        {% with step=3 total=8 %}
+        <div class="mb-2 flex items-center justify-between">
+          <span class="text-sm font-medium text-[var(--primary)]">{% blocktrans with step=step total=total %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
+          {% widthratio step total 100 as progress %}
+          <span class="text-sm text-[var(--text-secondary)]">{{ progress }}%</span>
+        </div>
+        <div class="h-2 w-full rounded-xl bg-[var(--bg-tertiary)]">
+          <div class="h-full rounded-xl bg-[var(--primary)]" style="width: {{ progress }}%;"></div>
+        </div>
+        {% endwith %}
       </div>
 
-      <div class="flex gap-4">
-        <a href="{% url 'accounts:usuario' %}" class="btn btn-secondary flex-1">{% trans "Voltar" %}</a>
-        <button type="submit" id="submitButton" class="btn btn-primary flex-1">{% trans "Continuar" %}</button>
+      <div class="space-y-2 text-center">
+        <h1 class="text-3xl font-bold text-[var(--text-primary)]">{% trans "Quem será o contato principal?" %}</h1>
+        <p class="text-[var(--text-secondary)]">{% trans "Informe o nome da pessoa responsável pelo contato." %}</p>
       </div>
-    </form>
+
+      <form id="nomeForm" method="post" action="{% url 'accounts:nome' %}" class="space-y-6">
+        {% csrf_token %}
+        <div>
+          {% include "_forms/field.html" with id="nome" name="nome" label=_("Contato principal") placeholder=_("Nome do contato principal") required=True autofocus=True describedby="nome_validation" %}
+          <div class="text-sm text-[var(--error)]" id="nome_validation"></div>
+        </div>
+
+        <div class="flex gap-4">
+          <a href="{% url 'accounts:usuario' %}" class="btn btn-secondary flex-1">{% trans "Voltar" %}</a>
+          <button type="submit" id="submitButton" class="btn btn-primary flex-1">{% trans "Continuar" %}</button>
+        </div>
+      </form>
+    </div>
   </div>
 </div>
 {% endblock %}

--- a/accounts/templates/register/onboarding.html
+++ b/accounts/templates/register/onboarding.html
@@ -9,88 +9,78 @@
 
 {% block content %}
 <div class="card-grid">
-  <div class="card text-center">
-        <div class="mb-8">
-            <div class="w-20 h-20 bg-[var(--primary-light)] rounded-full flex items-center justify-center mx-auto mb-4">
-                <svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="var(--primary-600)" stroke-width="2" aria-hidden="true">
-                    <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/>
-                    <circle cx="9" cy="7" r="4"/>
-                    <path d="M23 21v-2a4 4 0 0 0-3-3.87"/>
-                    <path d="M16 3.13a4 4 0 0 1 0 7.75"/>
-                </svg>
-            </div>
-            <h1 class="text-2xl font-bold mb-6 text-[var(--text-primary)]">
-                {% trans "Junte-se ao HubX" %}
-            </h1>
-            <p class="text-[var(--text-secondary)] mb-6">
-                {% trans "Conecte-se com comunidades e organizações em uma única plataforma" %}
-            </p>
+  <div class="card">
+    <div class="card-body space-y-10 text-center">
+      <div class="space-y-4">
+        <div class="mx-auto flex h-20 w-20 items-center justify-center rounded-full bg-[var(--primary-light)]">
+          <svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="var(--primary-600)" stroke-width="2" aria-hidden="true">
+            <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/>
+            <circle cx="9" cy="7" r="4"/>
+            <path d="M23 21v-2a4 4 0 0 0-3-3.87"/>
+            <path d="M16 3.13a4 4 0 0 1 0 7.75"/>
+          </svg>
         </div>
+        <div class="space-y-2">
+          <h1 class="text-2xl font-bold text-[var(--text-primary)]">{% trans "Junte-se ao HubX" %}</h1>
+          <p class="text-[var(--text-secondary)]">{% trans "Conecte-se com comunidades e organizações em uma única plataforma" %}</p>
+        </div>
+      </div>
 
-        <div class="grid md:grid-cols-3 gap-6 mb-8">
-            <div class="text-center">
-                <div class="w-15 h-15 bg-[var(--success-light)] rounded-full flex items-center justify-center mx-auto mb-3">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--success-600)" stroke-width="2" aria-hidden="true">
-                        <path d="M9 11H5a2 2 0 0 0-2 2v7a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7a2 2 0 0 0-2-2h-4"/>
-                        <polyline points="9,11 12,14 15,11"/>
-                        <line x1="12" y1="14" x2="12" y2="3"/>
-                    </svg>
-                </div>
-                <h3 class="font-semibold text-[var(--text-primary)] mb-2">{% trans "Compartilhe" %}</h3>
-                <p class="text-sm text-[var(--text-secondary)]">
-                    {% trans "Publique conteúdo e mantenha sua comunidade informada" %}
-                </p>
-            </div>
-            <div class="text-center">
-                <div class="w-15 h-15 bg-[var(--primary-light)] rounded-full flex items-center justify-center mx-auto mb-3">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--primary-600)" stroke-width="2" aria-hidden="true">
-                        <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/>
-                        <circle cx="9" cy="7" r="4"/>
-                        <path d="M23 21v-2a4 4 0 0 0-3-3.87"/>
-                        <path d="M16 3.13a4 4 0 0 1 0 7.75"/>
-                    </svg>
-                </div>
-                <h3 class="font-semibold text-[var(--text-primary)] mb-2">{% trans "Conecte" %}</h3>
-                <p class="text-sm text-[var(--text-secondary)]">
-                    {% trans "Encontre e conecte-se com pessoas e organizações" %}
-                </p>
-            </div>
-            <div class="text-center">
-                <div class="w-15 h-15 bg-[var(--warning-light)] rounded-full flex items-center justify-center mx-auto mb-3">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--warning)" stroke-width="2" aria-hidden="true">
-                        <rect x="3" y="4" width="18" height="18" rx="2" ry="2"/>
-                        <line x1="16" y1="2" x2="16" y2="6"/>
-                        <line x1="8" y1="2" x2="8" y2="6"/>
-                        <line x1="3" y1="10" x2="21" y2="10"/>
-                    </svg>
-                </div>
-                <h3 class="font-semibold text-[var(--text-primary)] mb-2">{% trans "Organize" %}</h3>
-                <p class="text-sm text-[var(--text-secondary)]">
-                    {% trans "Crie e participe de eventos da sua comunidade" %}
-                </p>
-            </div>
+      <div class="grid gap-6 text-left md:grid-cols-3">
+        <div class="space-y-2 text-center">
+          <div class="mx-auto flex h-15 w-15 items-center justify-center rounded-full bg-[var(--success-light)]">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--success-600)" stroke-width="2" aria-hidden="true">
+              <path d="M9 11H5a2 2 0 0 0-2 2v7a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7a2 2 0 0 0-2-2h-4"/>
+              <polyline points="9,11 12,14 15,11"/>
+              <line x1="12" y1="14" x2="12" y2="3"/>
+            </svg>
+          </div>
+          <h3 class="font-semibold text-[var(--text-primary)]">{% trans "Compartilhe" %}</h3>
+          <p class="text-sm text-[var(--text-secondary)]">{% trans "Publique conteúdo e mantenha sua comunidade informada" %}</p>
         </div>
+        <div class="space-y-2 text-center">
+          <div class="mx-auto flex h-15 w-15 items-center justify-center rounded-full bg-[var(--primary-light)]">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--primary-600)" stroke-width="2" aria-hidden="true">
+              <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/>
+              <circle cx="9" cy="7" r="4"/>
+              <path d="M23 21v-2a4 4 0 0 0-3-3.87"/>
+              <path d="M16 3.13a4 4 0 0 1 0 7.75"/>
+            </svg>
+          </div>
+          <h3 class="font-semibold text-[var(--text-primary)]">{% trans "Conecte" %}</h3>
+          <p class="text-sm text-[var(--text-secondary)]">{% trans "Encontre e conecte-se com pessoas e organizações" %}</p>
+        </div>
+        <div class="space-y-2 text-center">
+          <div class="mx-auto flex h-15 w-15 items-center justify-center rounded-full bg-[var(--warning-light)]">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--warning)" stroke-width="2" aria-hidden="true">
+              <rect x="3" y="4" width="18" height="18" rx="2" ry="2"/>
+              <line x1="16" y1="2" x2="16" y2="6"/>
+              <line x1="8" y1="2" x2="8" y2="6"/>
+              <line x1="3" y1="10" x2="21" y2="10"/>
+            </svg>
+          </div>
+          <h3 class="font-semibold text-[var(--text-primary)]">{% trans "Organize" %}</h3>
+          <p class="text-sm text-[var(--text-secondary)]">{% trans "Crie e participe de eventos da sua comunidade" %}</p>
+        </div>
+      </div>
 
-        <div class="flex flex-col sm:flex-row gap-4 justify-center">
-            <a href="{% url 'tokens:token' %}" class="btn btn-primary inline-flex items-center gap-2">
-                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
-                    <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/>
-                    <circle cx="9" cy="7" r="4"/>
-                    <line x1="19" y1="8" x2="19" y2="14"/>
-                    <line x1="22" y1="11" x2="16" y2="11"/>
-                </svg>
-                {% trans "Começar Cadastro" %}
-            </a>
-            <a href="{% url 'accounts:login' %}" class="btn btn-secondary">
-                {% trans "Já tenho conta" %}
-            </a>
-        </div>
+      <div class="flex flex-col gap-4 sm:flex-row sm:justify-center">
+        <a href="{% url 'tokens:token' %}" class="btn btn-primary inline-flex items-center justify-center gap-2">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+            <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/>
+            <circle cx="9" cy="7" r="4"/>
+            <line x1="19" y1="8" x2="19" y2="14"/>
+            <line x1="22" y1="11" x2="16" y2="11"/>
+          </svg>
+          {% trans "Começar Cadastro" %}
+        </a>
+        <a href="{% url 'accounts:login' %}" class="btn btn-secondary">{% trans "Já tenho conta" %}</a>
+      </div>
 
-        <div class="mt-8 pt-6 border-t border-[var(--border)]">
-            <p class="text-xs text-[var(--text-secondary)]">
-                {% blocktrans trimmed %}Ao se cadastrar, você concorda com nossos <a href="#" class="text-[var(--primary)] hover:underline">Termos de Uso</a> e <a href="#" class="text-[var(--primary)] hover:underline">Política de Privacidade</a>{% endblocktrans %}
-            </p>
-        </div>
+      <p class="text-xs text-[var(--text-secondary)]">
+        {% blocktrans trimmed %}Ao se cadastrar, você concorda com nossos <a href="#" class="text-[var(--primary)] hover:underline">Termos de Uso</a> e <a href="#" class="text-[var(--primary)] hover:underline">Política de Privacidade</a>{% endblocktrans %}
+      </p>
+    </div>
   </div>
 </div>
 {% endblock %}

--- a/accounts/templates/register/registro_sucesso.html
+++ b/accounts/templates/register/registro_sucesso.html
@@ -9,10 +9,12 @@
 
 {% block content %}
 <div class="card-grid">
-  <div class="card p-8 text-center">
-    <h1 class="mb-4 text-3xl font-bold text-[var(--text-primary)]">{% trans "Bem-vindo ao HubX!" %}</h1>
-    <p class="mb-6 text-[var(--text-secondary)]">{% trans "Seu cadastro foi concluído. Verifique seu e-mail para ativar sua conta." %}</p>
-    <a href="{% url 'accounts:login' %}" class="btn btn-primary">{% trans "Ir para login" %}</a>
+  <div class="card">
+    <div class="card-body space-y-6 text-center">
+      <h1 class="text-3xl font-bold text-[var(--text-primary)]">{% trans "Bem-vindo ao HubX!" %}</h1>
+      <p class="text-[var(--text-secondary)]">{% trans "Seu cadastro foi concluído. Verifique seu e-mail para ativar sua conta." %}</p>
+      <a href="{% url 'accounts:login' %}" class="btn btn-primary inline-flex justify-center">{% trans "Ir para login" %}</a>
+    </div>
   </div>
 </div>
 {% endblock %}

--- a/accounts/templates/register/senha.html
+++ b/accounts/templates/register/senha.html
@@ -10,43 +10,38 @@
 {% block content %}
 <div class="card-grid">
   <div class="card">
-    <div class="mb-8">
-      {% with step=6 total=8 %}
-      <div class="mb-2 flex items-center justify-between">
-        <span class="text-sm font-medium text-[var(--primary)]">{% blocktrans with step=step total=total %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
-        {% widthratio step total 100 as progress %}
-        <span class="text-sm text-[var(--text-secondary)]">{{ progress }}%</span>
-      </div>
-      <div class="h-2 w-full rounded-xl bg-[var(--bg-tertiary)]">
-        <div class="h-full rounded-xl bg-[var(--primary)]" style="width: {{ progress }}%;"></div>
-      </div>
-      {% endwith %}
-    </div>
-
-    <div class="mb-8 text-center">
-      <h1 class="mb-2 text-3xl font-bold text-[var(--text-primary)]">{% trans "Crie uma senha segura" %}</h1>
-      <p class="text-[var(--text-secondary)]">{% trans "Proteja sua conta com uma senha forte" %}</p>
-    </div>
-
-    <form id="senhaForm" method="post" action="{% url 'accounts:senha' %}" class="space-y-6">
-      {% csrf_token %}
+    <div class="card-body space-y-8">
       <div>
-        {% include "_forms/field.html" with id="senha" name="senha" type="password" label=_("Senha") placeholder=_("Senha") required=True autofocus=True describedby="senha_help senha_validation" %}
-        <div class="text-sm text-[var(--error)]" id="senha_validation"></div>
-        <small id="senha_help" class="text-sm text-[var(--text-secondary)]">{% trans "Use ao menos 8 caracteres com letras e números" %}</small>
+        {% with step=6 total=8 %}
+        <div class="mb-2 flex items-center justify-between">
+          <span class="text-sm font-medium text-[var(--primary)]">{% blocktrans with step=step total=total %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
+          {% widthratio step total 100 as progress %}
+          <span class="text-sm text-[var(--text-secondary)]">{{ progress }}%</span>
+        </div>
+        <div class="h-2 w-full rounded-xl bg-[var(--bg-tertiary)]">
+          <div class="h-full rounded-xl bg-[var(--primary)]" style="width: {{ progress }}%;"></div>
+        </div>
+        {% endwith %}
       </div>
 
-      <div>
-        {% include "_forms/field.html" with id="confirmar_senha" name="confirmar_senha" type="password" label=_("Confirmar Senha") placeholder=_("Confirme a senha") required=True describedby="confirmar_senha_help confirmar_senha_validation" %}
-        <div class="text-sm text-[var(--error)]" id="confirmar_senha_validation"></div>
-        <small id="confirmar_senha_help" class="text-sm text-[var(--text-secondary)]">{% trans "Repita a senha para confirmação" %}</small>
+      <div class="space-y-2 text-center">
+        <h1 class="text-3xl font-bold text-[var(--text-primary)]">{% trans "Crie sua senha" %}</h1>
+        <p class="text-[var(--text-secondary)]">{% trans "Use uma senha forte para proteger sua conta" %}</p>
       </div>
 
-      <div class="flex gap-4">
-        <a href="{% url 'accounts:email' %}" class="btn btn-secondary flex-1">{% trans "Voltar" %}</a>
-        <button type="submit" id="submitButton" class="btn btn-primary flex-1">{% trans "Continuar" %}</button>
-      </div>
-    </form>
+      <form id="senhaForm" method="post" action="{% url 'accounts:senha' %}" class="space-y-6">
+        {% csrf_token %}
+        <div class="grid gap-4 md:grid-cols-2">
+          {% include "_forms/field.html" with id="senha" name="senha" type="password" label=_("Senha") placeholder=_("Digite sua senha") required=True %}
+          {% include "_forms/field.html" with id="confirmar_senha" name="confirmar_senha" type="password" label=_("Confirmar senha") placeholder=_("Repita sua senha") required=True %}
+        </div>
+
+        <div class="flex gap-4">
+          <a href="{% url 'accounts:email' %}" class="btn btn-secondary flex-1">{% trans "Voltar" %}</a>
+          <button type="submit" id="submitButton" class="btn btn-primary flex-1">{% trans "Continuar" %}</button>
+        </div>
+      </form>
+    </div>
   </div>
 </div>
 {% endblock %}

--- a/accounts/templates/register/termos.html
+++ b/accounts/templates/register/termos.html
@@ -10,54 +10,56 @@
 {% block content %}
 <div class="card-grid">
   <div class="card">
-    <div class="mb-8">
-      {% with step=8 total=8 %}
-      <div class="mb-2 flex items-center justify-between">
-        <span class="text-sm font-medium text-[var(--primary)]">{% blocktrans with step=step total=total %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
-        {% widthratio step total 100 as progress %}
-        <span class="text-sm text-[var(--text-secondary)]">{{ progress }}%</span>
+    <div class="card-body space-y-8">
+      <div>
+        {% with step=8 total=8 %}
+        <div class="mb-2 flex items-center justify-between">
+          <span class="text-sm font-medium text-[var(--primary)]">{% blocktrans with step=step total=total %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
+          {% widthratio step total 100 as progress %}
+          <span class="text-sm text-[var(--text-secondary)]">{{ progress }}%</span>
+        </div>
+        <div class="h-2 w-full rounded-xl bg-[var(--bg-tertiary)]">
+          <div class="h-full rounded-xl bg-[var(--primary)]" style="width: {{ progress }}%;"></div>
+        </div>
+        {% endwith %}
       </div>
-      <div class="h-2 w-full rounded-xl bg-[var(--bg-tertiary)]">
-        <div class="h-full rounded-xl bg-[var(--primary)]" style="width: {{ progress }}%;"></div>
+
+      <div class="space-y-2 text-center">
+        <h1 class="text-3xl font-bold text-[var(--text-primary)]">{% trans "Quase lá!" %}</h1>
+        <p class="text-[var(--text-secondary)]">{% trans "Revise e aceite os termos para finalizar" %}</p>
       </div>
-      {% endwith %}
+
+      <form id="termosForm" method="post" action="{% url 'accounts:termos' %}" class="space-y-6">
+        {% csrf_token %}
+        <div class="space-y-4 max-h-64 overflow-y-auto rounded-lg border border-[var(--border)] p-4 text-left">
+          <h3 class="font-semibold text-[var(--text-primary)]">{% trans "Termos de Uso e Política de Privacidade" %}</h3>
+          <p class="text-[var(--text-secondary)]">{% trans "Ao utilizar o HubX, você concorda com nossos termos de uso e política de privacidade. Abaixo estão os principais pontos:" %}</p>
+          <h4 class="font-medium text-[var(--text-primary)]">{% trans "1. Uso da Plataforma" %}</h4>
+          <p class="text-[var(--text-secondary)]">{% trans "O HubX é uma plataforma para comunidades, entidades e associações. Você concorda em utilizar a plataforma de acordo com as leis aplicáveis e não violar os direitos de outros usuários." %}</p>
+          <h4 class="font-medium text-[var(--text-primary)]">{% trans "2. Privacidade" %}</h4>
+          <p class="text-[var(--text-secondary)]">{% trans "Respeitamos sua privacidade. Seus dados serão utilizados apenas para os fins especificados em nossa política de privacidade." %}</p>
+          <h4 class="font-medium text-[var(--text-primary)]">{% trans "3. Conteúdo" %}</h4>
+          <p class="text-[var(--text-secondary)]">{% trans "Você é responsável pelo conteúdo que compartilha na plataforma. Não toleramos conteúdo ofensivo, ilegal ou que viole direitos de terceiros." %}</p>
+          <h4 class="font-medium text-[var(--text-primary)]">{% trans "4. Segurança" %}</h4>
+          <p class="text-[var(--text-secondary)]">{% trans "Você é responsável por manter a segurança de sua conta e senha. Notifique-nos imediatamente sobre qualquer uso não autorizado." %}</p>
+        </div>
+
+        <div class="flex items-start gap-2 text-left">
+          <input type="checkbox" id="aceitar_termos" name="aceitar_termos" class="form-checkbox mt-1 text-[var(--primary)] focus:ring-[var(--primary)]" required aria-label="Aceitar termos" aria-invalid="false" aria-describedby="aceitar_termos_desc">
+          <label for="aceitar_termos" class="text-sm text-[var(--text-primary)]" id="aceitar_termos_desc">{% blocktrans trimmed %}Eu li e concordo com os <a href="/termos/" class="text-[var(--primary)] hover:underline" target="_blank">Termos de Uso</a> e <a href="/privacidade/" class="text-[var(--primary)] hover:underline" target="_blank">Política de Privacidade</a>{% endblocktrans %}</label>
+        </div>
+
+        <div class="flex items-start gap-2 text-left">
+          <input type="checkbox" id="newsletter" name="newsletter" class="form-checkbox mt-1 text-[var(--primary)] focus:ring-[var(--primary)]" aria-label="Receber novidades" aria-invalid="false" aria-describedby="newsletter_desc">
+          <label for="newsletter" class="text-sm text-[var(--text-primary)]" id="newsletter_desc">{% trans "Quero receber atualizações e novidades do HubX" %}</label>
+        </div>
+
+        <div class="flex gap-4">
+          <a href="{% url 'accounts:foto' %}" class="btn btn-secondary flex-1">{% trans "Voltar" %}</a>
+          <button type="submit" id="submitButton" class="btn btn-primary flex-1">{% trans "Finalizar Cadastro" %}</button>
+        </div>
+      </form>
     </div>
-
-    <div class="mb-8 text-center">
-      <h1 class="mb-2 text-3xl font-bold text-[var(--text-primary)]">{% trans "Quase lá!" %}</h1>
-      <p class="text-[var(--text-secondary)]">{% trans "Revise e aceite os termos para finalizar" %}</p>
-    </div>
-
-    <form id="termosForm" method="post" action="{% url 'accounts:termos' %}" class="space-y-6">
-      {% csrf_token %}
-      <div class="space-y-4 max-h-64 overflow-y-auto p-4 border border-[var(--border)] rounded-lg">
-        <h3 class="font-semibold text-[var(--text-primary)]">{% trans "Termos de Uso e Política de Privacidade" %}</h3>
-        <p class="text-[var(--text-secondary)]">{% trans "Ao utilizar o HubX, você concorda com nossos termos de uso e política de privacidade. Abaixo estão os principais pontos:" %}</p>
-        <h4 class="font-medium text-[var(--text-primary)]">{% trans "1. Uso da Plataforma" %}</h4>
-        <p class="text-[var(--text-secondary)]">{% trans "O HubX é uma plataforma para comunidades, entidades e associações. Você concorda em utilizar a plataforma de acordo com as leis aplicáveis e não violar os direitos de outros usuários." %}</p>
-        <h4 class="font-medium text-[var(--text-primary)]">{% trans "2. Privacidade" %}</h4>
-        <p class="text-[var(--text-secondary)]">{% trans "Respeitamos sua privacidade. Seus dados serão utilizados apenas para os fins especificados em nossa política de privacidade." %}</p>
-        <h4 class="font-medium text-[var(--text-primary)]">{% trans "3. Conteúdo" %}</h4>
-        <p class="text-[var(--text-secondary)]">{% trans "Você é responsável pelo conteúdo que compartilha na plataforma. Não toleramos conteúdo ofensivo, ilegal ou que viole direitos de terceiros." %}</p>
-        <h4 class="font-medium text-[var(--text-primary)]">{% trans "4. Segurança" %}</h4>
-        <p class="text-[var(--text-secondary)]">{% trans "Você é responsável por manter a segurança de sua conta e senha. Notifique-nos imediatamente sobre qualquer uso não autorizado." %}</p>
-      </div>
-
-      <div class="flex items-start gap-2">
-        <input type="checkbox" id="aceitar_termos" name="aceitar_termos" class="form-checkbox mt-1 text-[var(--primary)] focus:ring-[var(--primary)]" required aria-label="Aceitar termos" aria-invalid="false" aria-describedby="aceitar_termos_desc">
-        <label for="aceitar_termos" class="text-sm text-[var(--text-primary)]" id="aceitar_termos_desc">{% blocktrans trimmed %}Eu li e concordo com os <a href="/termos/" class="text-[var(--primary)] hover:underline" target="_blank">Termos de Uso</a> e <a href="/privacidade/" class="text-[var(--primary)] hover:underline" target="_blank">Política de Privacidade</a>{% endblocktrans %}</label>
-      </div>
-
-      <div class="flex items-start gap-2">
-        <input type="checkbox" id="newsletter" name="newsletter" class="form-checkbox mt-1 text-[var(--primary)] focus:ring-[var(--primary)]" aria-label="Receber novidades" aria-invalid="false" aria-describedby="newsletter_desc">
-        <label for="newsletter" class="text-sm text-[var(--text-primary)]" id="newsletter_desc">{% trans "Quero receber atualizações e novidades do HubX" %}</label>
-      </div>
-
-      <div class="flex gap-4">
-        <a href="{% url 'accounts:foto' %}" class="btn btn-secondary flex-1">{% trans "Voltar" %}</a>
-        <button type="submit" id="submitButton" class="btn btn-primary flex-1">{% trans "Finalizar Cadastro" %}</button>
-      </div>
-    </form>
   </div>
 </div>
 {% endblock %}

--- a/accounts/templates/register/token.html
+++ b/accounts/templates/register/token.html
@@ -10,49 +10,53 @@
 {% block content %}
 <div class="card-grid">
   <div class="card">
-    <div class="mb-8">
-      {% with step=1 total=8 %}
-      <div class="mb-2 flex items-center justify-between">
-        <span class="text-sm font-medium text-[var(--primary)]">{% blocktrans with step=step total=total %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
-        {% widthratio step total 100 as progress %}
-        <span class="text-sm text-[var(--text-secondary)]">{{ progress }}%</span>
-      </div>
-      <div class="h-2 w-full rounded-xl bg-[var(--bg-tertiary)]">
-        <div class="h-full rounded-xl bg-[var(--primary)]" style="width: {{ progress }}%;"></div>
-      </div>
-      {% endwith %}
-    </div>
-
-    <div class="mb-8 text-center">
-      <div class="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-[var(--primary-light)]">
-        <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="var(--primary-600)" stroke-width="2" aria-hidden="true">
-          <rect x="3" y="11" width="18" height="11" rx="2" ry="2"/>
-          <circle cx="12" cy="16" r="1"/>
-          <path d="M7 11V7a5 5 0 0 1 10 0v4"/>
-        </svg>
-      </div>
-      <h1 class="mb-2 text-3xl font-bold text-[var(--text-primary)]">{% trans "Token de Convite" %}</h1>
-      <p class="text-[var(--text-secondary)]">{% trans "Digite seu token de convite para começar o cadastro" %}</p>
-    </div>
-
-    <form method="post" action="{% url 'tokens:token' %}" class="space-y-6">
-      {% csrf_token %}
+    <div class="card-body space-y-8">
       <div>
-        {% include "_forms/field.html" with id="token" name="token" label=_("Token de Convite") placeholder=_("Token de convite") required=True autofocus=True describedby="token_help" extra_classes="text-center font-mono tracking-widest" %}
-        <p id="token_help" class="mt-1 text-sm text-[var(--text-secondary)]">{% trans "O token é necessário para continuar o cadastro na plataforma" %}</p>
+        {% with step=1 total=8 %}
+        <div class="mb-2 flex items-center justify-between">
+          <span class="text-sm font-medium text-[var(--primary)]">{% blocktrans with step=step total=total %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
+          {% widthratio step total 100 as progress %}
+          <span class="text-sm text-[var(--text-secondary)]">{{ progress }}%</span>
+        </div>
+        <div class="h-2 w-full rounded-xl bg-[var(--bg-tertiary)]">
+          <div class="h-full rounded-xl bg-[var(--primary)]" style="width: {{ progress }}%;"></div>
+        </div>
+        {% endwith %}
       </div>
 
-      <div class="flex gap-4">
-        <a href="{% url 'accounts:login' %}" class="btn btn-secondary flex-1">{% trans "Voltar" %}</a>
-        <button type="submit" class="btn btn-primary flex-1">{% trans "Continuar" %}</button>
+      <div class="space-y-4 text-center">
+        <div class="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-[var(--primary-light)]">
+          <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="var(--primary-600)" stroke-width="2" aria-hidden="true">
+            <rect x="3" y="11" width="18" height="11" rx="2" ry="2"/>
+            <circle cx="12" cy="16" r="1"/>
+            <path d="M7 11V7a5 5 0 0 1 10 0v4"/>
+          </svg>
+        </div>
+        <div class="space-y-2">
+          <h1 class="text-3xl font-bold text-[var(--text-primary)]">{% trans "Token de Convite" %}</h1>
+          <p class="text-[var(--text-secondary)]">{% trans "Digite seu token de convite para começar o cadastro" %}</p>
+        </div>
       </div>
-    </form>
 
-    <div class="mt-8 text-center">
-      <p class="text-sm text-[var(--text-secondary)]">
-        {% trans "Já tem uma conta?" %}
-        <a href="{% url 'accounts:login' %}" class="font-medium text-[var(--primary)] hover:underline">{% trans "Entrar" %}</a>
-      </p>
+      <form method="post" action="{% url 'tokens:token' %}" class="space-y-6">
+        {% csrf_token %}
+        <div>
+          {% include "_forms/field.html" with id="token" name="token" label=_("Token de Convite") placeholder=_("Token de convite") required=True autofocus=True describedby="token_help" extra_classes="text-center font-mono tracking-widest" %}
+          <p id="token_help" class="mt-1 text-sm text-[var(--text-secondary)]">{% trans "O token é necessário para continuar o cadastro na plataforma" %}</p>
+        </div>
+
+        <div class="flex gap-4">
+          <a href="{% url 'accounts:login' %}" class="btn btn-secondary flex-1">{% trans "Voltar" %}</a>
+          <button type="submit" class="btn btn-primary flex-1">{% trans "Continuar" %}</button>
+        </div>
+      </form>
+
+      <div class="text-center">
+        <p class="text-sm text-[var(--text-secondary)]">
+          {% trans "Já tem uma conta?" %}
+          <a href="{% url 'accounts:login' %}" class="font-medium text-[var(--primary)] hover:underline">{% trans "Entrar" %}</a>
+        </p>
+      </div>
     </div>
   </div>
 </div>

--- a/accounts/templates/register/usuario.html
+++ b/accounts/templates/register/usuario.html
@@ -10,37 +10,39 @@
 {% block content %}
 <div class="card-grid">
   <div class="card">
-    <div class="mb-8">
-      {% with step=2 total=8 %}
-      <div class="mb-2 flex items-center justify-between">
-        <span class="text-sm font-medium text-[var(--primary)]">{% blocktrans with step=step total=total %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
-        {% widthratio step total 100 as progress %}
-        <span class="text-sm text-[var(--text-secondary)]">{{ progress }}%</span>
-      </div>
-      <div class="h-2 w-full rounded-xl bg-[var(--bg-tertiary)]">
-        <div class="h-full rounded-xl bg-[var(--primary)]" style="width: {{ progress }}%;"></div>
-      </div>
-      {% endwith %}
-    </div>
-
-    <div class="mb-8 text-center">
-      <h1 class="mb-2 text-3xl font-bold text-[var(--text-primary)]">{% trans "Escolha seu nome de usuário" %}</h1>
-      <p class="text-[var(--text-secondary)]">{% trans "Como você será identificado na plataforma" %}</p>
-    </div>
-
-    <form id="usuarioForm" method="post" action="{% url 'accounts:usuario' %}" class="space-y-6">
-      {% csrf_token %}
+    <div class="card-body space-y-8">
       <div>
-        {% include "_forms/field.html" with id="usuario" name="usuario" label=_("Nome de Usuário") placeholder=_("Nome de usuário") required=True autofocus=True describedby="usuario_help usuario_validation" %}
-        <div class="text-sm text-[var(--error)]" id="usuario_validation"></div>
-        <small id="usuario_help" class="text-sm text-[var(--text-secondary)]">{% trans "Use apenas letras, números e underscore (_)" %}</small>
+        {% with step=2 total=8 %}
+        <div class="mb-2 flex items-center justify-between">
+          <span class="text-sm font-medium text-[var(--primary)]">{% blocktrans with step=step total=total %}Passo {{ step }} de {{ total }}{% endblocktrans %}</span>
+          {% widthratio step total 100 as progress %}
+          <span class="text-sm text-[var(--text-secondary)]">{{ progress }}%</span>
+        </div>
+        <div class="h-2 w-full rounded-xl bg-[var(--bg-tertiary)]">
+          <div class="h-full rounded-xl bg-[var(--primary)]" style="width: {{ progress }}%;"></div>
+        </div>
+        {% endwith %}
       </div>
 
-      <div class="flex gap-4">
-        <a href="{% url 'tokens:token' %}" class="btn btn-secondary flex-1">{% trans "Voltar" %}</a>
-        <button type="submit" id="submitButton" class="btn btn-primary flex-1">{% trans "Continuar" %}</button>
+      <div class="space-y-2 text-center">
+        <h1 class="text-3xl font-bold text-[var(--text-primary)]">{% trans "Escolha seu nome de usuário" %}</h1>
+        <p class="text-[var(--text-secondary)]">{% trans "Como você será identificado na plataforma" %}</p>
       </div>
-    </form>
+
+      <form id="usuarioForm" method="post" action="{% url 'accounts:usuario' %}" class="space-y-6">
+        {% csrf_token %}
+        <div>
+          {% include "_forms/field.html" with id="usuario" name="usuario" label=_("Nome de Usuário") placeholder=_("Nome de usuário") required=True autofocus=True describedby="usuario_help usuario_validation" %}
+          <div class="text-sm text-[var(--error)]" id="usuario_validation"></div>
+          <small id="usuario_help" class="text-sm text-[var(--text-secondary)]">{% trans "Use apenas letras, números e underscore (_)" %}</small>
+        </div>
+
+        <div class="flex gap-4">
+          <a href="{% url 'tokens:token' %}" class="btn btn-secondary flex-1">{% trans "Voltar" %}</a>
+          <button type="submit" id="submitButton" class="btn btn-primary flex-1">{% trans "Continuar" %}</button>
+        </div>
+      </form>
+    </div>
   </div>
 </div>
 {% endblock %}

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -993,14 +993,10 @@ def termos(request):
         contato = (request.session.get("nome") or "").strip()
 
         if username and pwd_hash:
-            tipo_mapping = {
-                TokenAcesso.TipoUsuario.ASSOCIADO: UserType.ASSOCIADO,
-                TokenAcesso.TipoUsuario.CONVIDADO: UserType.CONVIDADO,
-            }
-            mapped_user_type = tipo_mapping.get(token_obj.tipo_destino)
-            if not mapped_user_type:
+            if token_obj.tipo_destino != TokenAcesso.TipoUsuario.CONVIDADO:
                 messages.error(request, _("Convite inválido."))
                 return redirect("tokens:token")
+            mapped_user_type = UserType.CONVIDADO
             try:
                 with transaction.atomic():
                     user = User.objects.create(

--- a/core/management/commands/corrigir_base_token.py
+++ b/core/management/commands/corrigir_base_token.py
@@ -28,7 +28,7 @@ class Command(BaseCommand):
         for token in tokens:
             changed = False
             if not token.tipo_destino:
-                token.tipo_destino = TokenAcesso.TipoUsuario.ASSOCIADO
+                token.tipo_destino = TokenAcesso.TipoUsuario.CONVIDADO
                 changed = True
             if not token.codigo:
                 token.codigo = uuid.uuid4().hex
@@ -43,10 +43,9 @@ class Command(BaseCommand):
 
         # Criar tokens de exemplo para testes
         exemplo_user = User.objects.filter(is_superuser=True).first() or User.objects.first()
-        for tipo in TokenAcesso.TipoUsuario.values:
-            TokenAcesso.objects.get_or_create(
-                gerado_por=exemplo_user,
-                tipo_destino=tipo,
-                defaults={"data_expiracao": timezone.now() + timedelta(days=30)},
-            )
-        self.stdout.write("Tokens de exemplo criados para os novos tipos suportados")
+        TokenAcesso.objects.get_or_create(
+            gerado_por=exemplo_user,
+            tipo_destino=TokenAcesso.TipoUsuario.CONVIDADO,
+            defaults={"data_expiracao": timezone.now() + timedelta(days=30)},
+        )
+        self.stdout.write("Token de exemplo criado para convidados")

--- a/nucleos/services.py
+++ b/nucleos/services.py
@@ -41,7 +41,7 @@ def gerar_convite_nucleo(user: User, nucleo: Nucleo, email: str, papel: str) -> 
 
     token = TokenAcesso.objects.create(
         gerado_por=user,
-        tipo_destino=TokenAcesso.TipoUsuario.ASSOCIADO,
+        tipo_destino=TokenAcesso.TipoUsuario.CONVIDADO,
         organizacao=nucleo.organizacao,
         data_expiracao=timezone.now() + timedelta(days=7),
     )

--- a/tests/tokens/test_api.py
+++ b/tests/tokens/test_api.py
@@ -4,8 +4,10 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 from accounts.factories import UserFactory
+from accounts.models import UserType
 from organizacoes.factories import OrganizacaoFactory
 from tokens.models import TokenAcesso, TokenUsoLog
+from tokens.services import create_invite_token
 
 pytestmark = pytest.mark.django_db
 
@@ -16,25 +18,25 @@ def api_client():
 
 
 def test_limite_diario(api_client):
-    user = UserFactory(is_staff=True)
     org = OrganizacaoFactory()
+    user = UserFactory(is_staff=True, user_type=UserType.ADMIN.value, organizacao=org)
     org.users.add(user)
     api_client.force_authenticate(user=user)
     url = reverse("tokens_api:token-list")
     for _ in range(5):
-        resp = api_client.post(url, {"tipo_destino": TokenAcesso.TipoUsuario.ASSOCIADO})
+        resp = api_client.post(url, {"tipo_destino": TokenAcesso.TipoUsuario.CONVIDADO.value})
         assert resp.status_code == status.HTTP_201_CREATED
-    resp = api_client.post(url, {"tipo_destino": TokenAcesso.TipoUsuario.ASSOCIADO})
+    resp = api_client.post(url, {"tipo_destino": TokenAcesso.TipoUsuario.CONVIDADO.value})
     assert resp.status_code == status.HTTP_429_TOO_MANY_REQUESTS
 
 
 def test_registro_logs(api_client):
-    user = UserFactory(is_staff=True)
     org = OrganizacaoFactory()
+    user = UserFactory(is_staff=True, user_type=UserType.ADMIN.value, organizacao=org)
     org.users.add(user)
     api_client.force_authenticate(user=user)
     url = reverse("tokens_api:token-list")
-    resp = api_client.post(url, {"tipo_destino": TokenAcesso.TipoUsuario.ASSOCIADO})
+    resp = api_client.post(url, {"tipo_destino": TokenAcesso.TipoUsuario.CONVIDADO.value})
     token_id = resp.data["id"]
     token = TokenAcesso.objects.get(id=token_id)
     assert TokenUsoLog.objects.filter(token=token, acao="geracao").exists()
@@ -46,10 +48,15 @@ def test_registro_logs(api_client):
 
 
 def test_revogar_token(api_client):
-    admin = UserFactory(is_staff=True)
+    admin_org = OrganizacaoFactory()
+    admin = UserFactory(is_staff=True, user_type=UserType.ADMIN.value, organizacao=admin_org)
     api_client.force_authenticate(user=admin)
-    token = TokenAcesso.objects.create(gerado_por=admin, tipo_destino=TokenAcesso.TipoUsuario.ASSOCIADO)
-    url = reverse("tokens_api:token-revogar", kwargs={"codigo": token.codigo})
+    token, codigo = create_invite_token(
+        gerado_por=admin,
+        tipo_destino=TokenAcesso.TipoUsuario.CONVIDADO.value,
+        organizacao=admin_org,
+    )
+    url = reverse("tokens_api:token-revogar", kwargs={"codigo": codigo})
     resp = api_client.post(url)
     assert resp.status_code == 200
     token.refresh_from_db()
@@ -63,16 +70,16 @@ def test_revogar_token(api_client):
 
 
 def test_api_respeita_organizacao_do_usuario(api_client):
-    user = UserFactory(is_staff=True)
     org = OrganizacaoFactory()
     outra = OrganizacaoFactory()
+    user = UserFactory(is_staff=True, user_type=UserType.ADMIN.value, organizacao=org)
     org.users.add(user)
     api_client.force_authenticate(user=user)
     url = reverse("tokens_api:token-list")
     resp = api_client.post(
         url,
         {
-            "tipo_destino": TokenAcesso.TipoUsuario.ASSOCIADO,
+            "tipo_destino": TokenAcesso.TipoUsuario.CONVIDADO.value,
             "organizacao": outra.pk,
         },
     )
@@ -82,9 +89,9 @@ def test_api_respeita_organizacao_do_usuario(api_client):
 
 
 def test_api_sem_organizacao_retorna_erro(api_client):
-    user = UserFactory(is_staff=True)
+    user = UserFactory(is_staff=True, user_type=UserType.ADMIN.value)
     api_client.force_authenticate(user=user)
     url = reverse("tokens_api:token-list")
-    resp = api_client.post(url, {"tipo_destino": TokenAcesso.TipoUsuario.ASSOCIADO})
+    resp = api_client.post(url, {"tipo_destino": TokenAcesso.TipoUsuario.CONVIDADO.value})
     assert resp.status_code == status.HTTP_400_BAD_REQUEST
     assert "organização" in resp.data["detail"].lower()

--- a/tests/tokens/test_audit_sanitization.py
+++ b/tests/tokens/test_audit_sanitization.py
@@ -11,11 +11,11 @@ pytestmark = pytest.mark.django_db
 
 
 def test_audit_sanitization():
-    issuer = UserFactory(user_type=UserType.COORDENADOR.value)
+    issuer = UserFactory(user_type=UserType.NUCLEADO.value)
     client = APIClient()
     client.force_authenticate(user=issuer)
     url = reverse("tokens_api:token-list")
-    resp = client.post(url, {"tipo_destino": TokenAcesso.TipoUsuario.ASSOCIADO})
+    resp = client.post(url, {"tipo_destino": TokenAcesso.TipoUsuario.CONVIDADO.value})
     assert resp.status_code == 403
     log = AuditLog.objects.latest("created_at")
     assert "codigo" not in log.metadata

--- a/tests/tokens/test_find_token_by_code.py
+++ b/tests/tokens/test_find_token_by_code.py
@@ -14,7 +14,10 @@ pytestmark = pytest.mark.django_db
 
 def test_find_token_by_code_single_query(django_assert_num_queries):
     user = UserFactory(user_type=UserType.ADMIN.value)
-    token, codigo = create_invite_token(gerado_por=user, tipo_destino=TokenAcesso.TipoUsuario.ASSOCIADO)
+    token, codigo = create_invite_token(
+        gerado_por=user,
+        tipo_destino=TokenAcesso.TipoUsuario.CONVIDADO.value,
+    )
     with django_assert_num_queries(1):
         encontrado = find_token_by_code(codigo)
     assert encontrado.id == token.id
@@ -23,7 +26,7 @@ def test_find_token_by_code_single_query(django_assert_num_queries):
 def test_find_token_by_code_legacy_not_supported():
     user = UserFactory(user_type=UserType.ADMIN.value)
     codigo = TokenAcesso.generate_code()
-    token = TokenAcesso(gerado_por=user, tipo_destino=TokenAcesso.TipoUsuario.ASSOCIADO)
+    token = TokenAcesso(gerado_por=user, tipo_destino=TokenAcesso.TipoUsuario.CONVIDADO.value)
     salt = secrets.token_bytes(16)
     digest = hashlib.pbkdf2_hmac("sha256", codigo.encode(), salt, 120000)
     token.codigo_salt = base64.b64encode(salt).decode()

--- a/tests/tokens/test_forms.py
+++ b/tests/tokens/test_forms.py
@@ -8,6 +8,7 @@ from django.utils import timezone
 from django.core.exceptions import PermissionDenied
 
 from accounts.factories import UserFactory
+from accounts.models import UserType
 
 from organizacoes.factories import OrganizacaoFactory
 
@@ -26,19 +27,26 @@ pytestmark = pytest.mark.django_db
 
 def test_token_acesso_form_choices():
     form = TokenAcessoForm()
-    choices = [c[0] for c in form.fields["tipo_destino"].choices]
-    for choice in TokenAcesso.TipoUsuario.values:
-        assert choice in choices
+    assert form.fields["tipo_destino"].choices == [
+        (
+            TokenAcesso.TipoUsuario.CONVIDADO.value,
+            TokenAcesso.TipoUsuario.CONVIDADO.label,
+        )
+    ]
 
 
 
-def test_gerar_token_convite_form_querysets():
-    user = UserFactory(is_staff=True)
-    org1 = OrganizacaoFactory()
-    org1.users.add(user)
+def test_gerar_token_convite_form_choices():
+    user = UserFactory(is_staff=True, user_type=UserType.ADMIN.value)
+    org = OrganizacaoFactory()
+    org.users.add(user)
     form = GerarTokenConviteForm(user=user)
-    assert list(form.fields["organizacao"].queryset) == [org1]
-    assert "nucleos" not in form.fields
+    assert form.fields["tipo_destino"].choices == [
+        (
+            TokenAcesso.TipoUsuario.CONVIDADO.value,
+            TokenAcesso.TipoUsuario.CONVIDADO.label,
+        )
+    ]
 
 
 

--- a/tests/tokens/test_invite_code_hashing.py
+++ b/tests/tokens/test_invite_code_hashing.py
@@ -11,7 +11,10 @@ pytestmark = pytest.mark.django_db
 
 def test_invite_code_hashing():
     user = UserFactory(user_type=UserType.ADMIN.value)
-    token, codigo = create_invite_token(gerado_por=user, tipo_destino=TokenAcesso.TipoUsuario.ASSOCIADO)
+    token, codigo = create_invite_token(
+        gerado_por=user,
+        tipo_destino=TokenAcesso.TipoUsuario.CONVIDADO.value,
+    )
     assert token.check_codigo(codigo)
     assert not token.check_codigo("wrong")
     assert len(codigo) >= 32

--- a/tests/tokens/test_invite_view_permissions.py
+++ b/tests/tokens/test_invite_view_permissions.py
@@ -16,17 +16,17 @@ def _login(client, user):
 @pytest.mark.parametrize(
     "issuer_type,allowed",
     [
-        (UserType.ROOT, [TokenAcesso.TipoUsuario.ASSOCIADO]),
-        (UserType.ADMIN, [TokenAcesso.TipoUsuario.ASSOCIADO, TokenAcesso.TipoUsuario.CONVIDADO]),
-        (UserType.COORDENADOR, [TokenAcesso.TipoUsuario.CONVIDADO]),
+        (UserType.ROOT, [TokenAcesso.TipoUsuario.CONVIDADO.value]),
+        (UserType.ADMIN, [TokenAcesso.TipoUsuario.CONVIDADO.value]),
+        (UserType.COORDENADOR, [TokenAcesso.TipoUsuario.CONVIDADO.value]),
         (UserType.NUCLEADO, []),
         (UserType.ASSOCIADO, []),
         (UserType.CONVIDADO, []),
     ],
 )
 def test_get_permissions(client, issuer_type, allowed):
-    user = UserFactory(user_type=issuer_type.value)
     org = OrganizacaoFactory()
+    user = UserFactory(user_type=issuer_type.value, organizacao=org)
     org.users.add(user)
     _login(client, user)
     resp = client.get(reverse("tokens:gerar_convite"))
@@ -58,27 +58,28 @@ def test_form_nao_mostra_campo_organizacao(client):
 @pytest.mark.parametrize(
     "issuer_type,target,expected",
     [
-        (UserType.ROOT, TokenAcesso.TipoUsuario.ASSOCIADO, 200),
-        (UserType.ROOT, TokenAcesso.TipoUsuario.CONVIDADO, 400),
-        (UserType.ADMIN, TokenAcesso.TipoUsuario.ASSOCIADO, 200),
+        (UserType.ROOT, TokenAcesso.TipoUsuario.CONVIDADO, 200),
+        (UserType.ROOT, TokenAcesso.TipoUsuario.ASSOCIADO, 400),
         (UserType.ADMIN, TokenAcesso.TipoUsuario.CONVIDADO, 200),
+        (UserType.ADMIN, TokenAcesso.TipoUsuario.ASSOCIADO, 400),
         (UserType.COORDENADOR, TokenAcesso.TipoUsuario.CONVIDADO, 200),
         (UserType.COORDENADOR, TokenAcesso.TipoUsuario.ASSOCIADO, 400),
-        (UserType.NUCLEADO, TokenAcesso.TipoUsuario.CONVIDADO, 400),
-        (UserType.ASSOCIADO, TokenAcesso.TipoUsuario.CONVIDADO, 400),
-        (UserType.CONVIDADO, TokenAcesso.TipoUsuario.CONVIDADO, 400),
+        (UserType.NUCLEADO, TokenAcesso.TipoUsuario.CONVIDADO, 403),
+        (UserType.ASSOCIADO, TokenAcesso.TipoUsuario.CONVIDADO, 403),
+        (UserType.CONVIDADO, TokenAcesso.TipoUsuario.CONVIDADO, 403),
     ],
 )
 def test_post_permissions(client, issuer_type, target, expected):
-    user = UserFactory(user_type=issuer_type.value)
     org = OrganizacaoFactory()
+    user = UserFactory(user_type=issuer_type.value, organizacao=org)
     org.users.add(user)
     _login(client, user)
-    data = {"tipo_destino": target}
+    target_value = target.value
+    data = {"tipo_destino": target_value}
     resp = client.post(reverse("tokens:gerar_convite"), data)
     assert resp.status_code == expected
     if expected == 200:
-        assert TokenAcesso.objects.filter(gerado_por=user, tipo_destino=target).exists()
+        assert TokenAcesso.objects.filter(gerado_por=user, tipo_destino=target_value).exists()
     else:
         assert not TokenAcesso.objects.filter(gerado_por=user).exists()
 

--- a/tests/tokens/test_issue_permissions.py
+++ b/tests/tokens/test_issue_permissions.py
@@ -4,6 +4,7 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 from accounts.factories import UserFactory
+from organizacoes.factories import OrganizacaoFactory
 from accounts.models import UserType
 from tokens.models import TokenAcesso
 
@@ -13,18 +14,18 @@ pytestmark = pytest.mark.django_db
 @pytest.mark.parametrize(
     "issuer_type,target,expected",
     [
-        (UserType.ROOT, TokenAcesso.TipoUsuario.ASSOCIADO, status.HTTP_201_CREATED),
-        (UserType.ROOT, TokenAcesso.TipoUsuario.CONVIDADO, status.HTTP_403_FORBIDDEN),
-        (UserType.ADMIN, TokenAcesso.TipoUsuario.ASSOCIADO, status.HTTP_201_CREATED),
+        (UserType.ROOT, TokenAcesso.TipoUsuario.CONVIDADO, status.HTTP_201_CREATED),
+        (UserType.ROOT, TokenAcesso.TipoUsuario.ASSOCIADO, status.HTTP_400_BAD_REQUEST),
         (UserType.ADMIN, TokenAcesso.TipoUsuario.CONVIDADO, status.HTTP_201_CREATED),
+        (UserType.ADMIN, TokenAcesso.TipoUsuario.ASSOCIADO, status.HTTP_400_BAD_REQUEST),
         (UserType.COORDENADOR, TokenAcesso.TipoUsuario.CONVIDADO, status.HTTP_201_CREATED),
-        (UserType.COORDENADOR, TokenAcesso.TipoUsuario.ASSOCIADO, status.HTTP_403_FORBIDDEN),
+        (UserType.COORDENADOR, TokenAcesso.TipoUsuario.ASSOCIADO, status.HTTP_400_BAD_REQUEST),
     ],
 )
 def test_issue_permissions(issuer_type, target, expected):
-    user = UserFactory(user_type=issuer_type.value)
+    user = UserFactory(user_type=issuer_type.value, organizacao=OrganizacaoFactory())
     client = APIClient()
     client.force_authenticate(user=user)
     url = reverse("tokens_api:token-list")
-    resp = client.post(url, {"tipo_destino": target})
+    resp = client.post(url, {"tipo_destino": target.value})
     assert resp.status_code == expected

--- a/tests/tokens/test_metrics.py
+++ b/tests/tokens/test_metrics.py
@@ -4,6 +4,7 @@ from rest_framework.test import APIClient
 
 from accounts.factories import UserFactory
 from accounts.models import UserType
+from organizacoes.factories import OrganizacaoFactory
 from tokens import metrics as m
 from tokens.models import TokenAcesso
 
@@ -32,11 +33,13 @@ def test_metrics_flow():
 
         cache.clear()
     reset_metrics()
-    user = UserFactory(user_type=UserType.ADMIN.value)
+    org = OrganizacaoFactory()
+    user = UserFactory(user_type=UserType.ADMIN.value, organizacao=org)
+    org.users.add(user)
     client = APIClient()
     client.force_authenticate(user=user)
     url = reverse("tokens_api:token-list")
-    resp = client.post(url, {"tipo_destino": TokenAcesso.TipoUsuario.CONVIDADO})
+    resp = client.post(url, {"tipo_destino": TokenAcesso.TipoUsuario.CONVIDADO.value})
     codigo = resp.data["codigo"]
     token_id = resp.data["id"]
     validate_url = reverse("tokens_api:token-validate") + f"?codigo={codigo}"

--- a/tests/tokens/test_use_validate_ratelimit.py
+++ b/tests/tokens/test_use_validate_ratelimit.py
@@ -14,7 +14,10 @@ def test_use_validate_ratelimit():
     user = UserFactory(user_type=UserType.ADMIN.value)
     client = APIClient()
     client.force_authenticate(user=user)
-    token, codigo = create_invite_token(gerado_por=user, tipo_destino=TokenAcesso.TipoUsuario.ASSOCIADO)
+    token, codigo = create_invite_token(
+        gerado_por=user,
+        tipo_destino=TokenAcesso.TipoUsuario.CONVIDADO.value,
+    )
     url = reverse("tokens_api:token-validate") + f"?codigo={codigo}"
     for _ in range(10):
         resp = client.get(url)

--- a/tests/tokens/test_validate_rate_limit_metrics.py
+++ b/tests/tokens/test_validate_rate_limit_metrics.py
@@ -26,7 +26,10 @@ def test_validate_ratelimit_increments_metric():
     user = UserFactory(user_type=UserType.ADMIN.value)
     client = APIClient()
     client.force_authenticate(user=user)
-    token, codigo = create_invite_token(gerado_por=user, tipo_destino=TokenAcesso.TipoUsuario.ASSOCIADO)
+    token, codigo = create_invite_token(
+        gerado_por=user,
+        tipo_destino=TokenAcesso.TipoUsuario.CONVIDADO.value,
+    )
     url = reverse("tokens_api:token-validate") + f"?codigo={codigo}"
 
     resp1 = client.get(url)

--- a/tests/tokens/test_views.py
+++ b/tests/tokens/test_views.py
@@ -25,9 +25,7 @@ def test_gerar_convite_form_fields(client):
     assert resp.status_code == 200
     content = resp.content.decode()
     assert 'name="tipo_destino"' in content
-
-    assert 'name="organizacao"' in content
-
+    assert 'name="organizacao"' not in content
     assert 'name="nucleos"' not in content
 
 
@@ -37,7 +35,7 @@ def test_gerar_token_convite_view(client):
     org.users.add(user)
     _login(client, user)
     data = {
-        "tipo_destino": TokenAcesso.TipoUsuario.CONVIDADO,
+        "tipo_destino": TokenAcesso.TipoUsuario.CONVIDADO.value,
         "organizacao": org.pk,
 
     }
@@ -59,7 +57,7 @@ def test_convite_respeita_organizacao_do_usuario(client):
     resp = client.post(
         reverse("tokens:gerar_convite"),
         {
-            "tipo_destino": TokenAcesso.TipoUsuario.CONVIDADO,
+            "tipo_destino": TokenAcesso.TipoUsuario.CONVIDADO.value,
             "organizacao": outra_org.pk,
         },
     )
@@ -69,19 +67,19 @@ def test_convite_respeita_organizacao_do_usuario(client):
 
 
 def test_convite_permission_denied(client):
-    user = UserFactory(is_staff=True, user_type=UserType.COORDENADOR.value)
+    user = UserFactory(is_staff=True, user_type=UserType.NUCLEADO.value)
     org = OrganizacaoFactory()
     org.users.add(user)
     _login(client, user)
     resp = client.post(
         reverse("tokens:gerar_convite"),
-        {"tipo_destino": TokenAcesso.TipoUsuario.ASSOCIADO},
+        {"tipo_destino": TokenAcesso.TipoUsuario.CONVIDADO.value},
     )
     assert resp.status_code == 403
 
 
 def test_convite_permission_denied_no_side_effects(client):
-    user = UserFactory(is_staff=True, user_type=UserType.COORDENADOR.value)
+    user = UserFactory(is_staff=True, user_type=UserType.NUCLEADO.value)
     org = OrganizacaoFactory()
     org.users.add(user)
     _login(client, user)
@@ -89,7 +87,7 @@ def test_convite_permission_denied_no_side_effects(client):
     assert TokenUsoLog.objects.count() == 0
     resp = client.post(
         reverse("tokens:gerar_convite"),
-        {"tipo_destino": TokenAcesso.TipoUsuario.ASSOCIADO},
+        {"tipo_destino": TokenAcesso.TipoUsuario.CONVIDADO.value},
     )
     assert resp.status_code == 403
     assert TokenAcesso.objects.count() == 0
@@ -101,7 +99,7 @@ def test_convite_daily_limit(client):
     org = OrganizacaoFactory()
     org.users.add(user)
     _login(client, user)
-    data = {"tipo_destino": TokenAcesso.TipoUsuario.CONVIDADO}
+    data = {"tipo_destino": TokenAcesso.TipoUsuario.CONVIDADO.value}
     for _ in range(5):
         resp = client.post(reverse("tokens:gerar_convite"), data)
         assert resp.status_code == 200

--- a/tokens/forms.py
+++ b/tokens/forms.py
@@ -13,6 +13,14 @@ from .services import find_token_by_code
 User = get_user_model()
 
 
+GUEST_TOKEN_CHOICES = [
+    (
+        TokenAcesso.TipoUsuario.CONVIDADO.value,
+        TokenAcesso.TipoUsuario.CONVIDADO.label,
+    )
+]
+
+
 class TokenAcessoForm(forms.ModelForm):
     class Meta:
         model = TokenAcesso
@@ -20,19 +28,17 @@ class TokenAcessoForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.fields["tipo_destino"].choices = TokenAcesso.TipoUsuario.choices
+        self.fields["tipo_destino"].choices = GUEST_TOKEN_CHOICES
 
 
 class GerarTokenConviteForm(forms.Form):
-    tipo_destino = forms.ChoiceField(choices=TokenAcesso.TipoUsuario.choices)
+    tipo_destino = forms.ChoiceField(choices=GUEST_TOKEN_CHOICES)
 
     def __init__(self, *args, user=None, **kwargs):
         self.user = user
         super().__init__(*args, **kwargs)
-        if user:
-            self.fields["tipo_destino"].choices = [
-                choice for choice in TokenAcesso.TipoUsuario.choices if can_issue_invite(user, choice[0])
-            ]
+        if user and not can_issue_invite(user, TokenAcesso.TipoUsuario.CONVIDADO.value):
+            self.fields["tipo_destino"].choices = []
 
 
 class ValidarTokenConviteForm(forms.Form):

--- a/tokens/perms.py
+++ b/tokens/perms.py
@@ -10,13 +10,16 @@ def can_issue_invite(issuer, target_role: str) -> bool:
     """Retorna True se *issuer* puder emitir convite para *target_role* (RF-05)."""
 
     issuer_type = getattr(issuer, "user_type", None)
-    if issuer_type == UserType.ROOT:
-        return target_role == TokenAcesso.TipoUsuario.ASSOCIADO
-    if issuer_type == UserType.ADMIN:
-        return target_role in {
-            TokenAcesso.TipoUsuario.ASSOCIADO,
-            TokenAcesso.TipoUsuario.CONVIDADO,
-        }
-    if issuer_type == UserType.COORDENADOR:
-        return target_role == TokenAcesso.TipoUsuario.CONVIDADO
-    return False
+    try:
+        role = TokenAcesso.TipoUsuario(target_role)
+    except ValueError:
+        return False
+
+    if role != TokenAcesso.TipoUsuario.CONVIDADO:
+        return False
+
+    return issuer_type in {
+        UserType.ROOT,
+        UserType.ADMIN,
+        UserType.COORDENADOR,
+    }

--- a/tokens/serializers.py
+++ b/tokens/serializers.py
@@ -6,6 +6,15 @@ from .models import TokenAcesso, TokenUsoLog
 
 
 class TokenAcessoSerializer(serializers.ModelSerializer):
+    tipo_destino = serializers.ChoiceField(
+        choices=[
+            (
+                TokenAcesso.TipoUsuario.CONVIDADO.value,
+                TokenAcesso.TipoUsuario.CONVIDADO.label,
+            )
+        ],
+        default=TokenAcesso.TipoUsuario.CONVIDADO.value,
+    )
     codigo = serializers.CharField(read_only=True)
     revogado_por_email = serializers.EmailField(source="revogado_por.email", default=None, read_only=True)
     ip_gerado = serializers.IPAddressField(read_only=True, allow_null=True)

--- a/tokens/services.py
+++ b/tokens/services.py
@@ -38,11 +38,19 @@ def create_invite_token(
 ) -> Tuple[TokenAcesso, str]:
     """Cria um ``TokenAcesso`` com código secreto e retorna (token, codigo)."""
 
+    try:
+        target_role = TokenAcesso.TipoUsuario(tipo_destino)
+    except ValueError as exc:  # pragma: no cover - validação defensiva
+        raise ValueError("Tipo de token inválido") from exc
+
+    if target_role != TokenAcesso.TipoUsuario.CONVIDADO:
+        raise ValueError("Somente tokens para convidados podem ser gerados.")
+
     codigo = TokenAcesso.generate_code()
     codigo_preview = TokenAcesso.build_codigo_preview(codigo)
     token = TokenAcesso(
         gerado_por=gerado_por,
-        tipo_destino=tipo_destino,
+        tipo_destino=target_role.value,
         data_expiracao=data_expiracao,
         organizacao=organizacao,
         codigo_preview=codigo_preview,


### PR DESCRIPTION
## Summary
- enforce guest-only invite tokens across the permissions, API/service layer, account signup flow, and supporting management tasks
- refresh the multi-step registration templates with the shared card-body layout and spacing tweaks
- update token-related tests to reflect guest-only invites and new webhook stubbing helpers

## Testing
- pytest tests/tokens/test_issue_permissions.py -q *(fails: coverage plugin requires 90% project-wide coverage when running the partial suite)*

------
https://chatgpt.com/codex/tasks/task_e_68daa39b32c08325a231dfc2e9a65ea3