### PR TITLE
Fix coordinator role availability evaluation in promotion form

### DIFF
--- a/accounts/templates/associados/promover_form.html
+++ b/accounts/templates/associados/promover_form.html
@@ -148,17 +148,15 @@
                       >
                         <option value="">{% trans 'Selecione um papel' %}</option>
                         {% for value, label in coordenador_role_choices %}
-                          {% with is_unavailable=value in nucleo.unavailable_roles and value not in nucleo.user_current_roles %}
-                            <option
-                              value="{{ value }}"
-                              data-role-value="{{ value }}"
-                              data-locked="{% if is_unavailable %}true{% else %}false{% endif %}"
-                              {% if is_unavailable %}disabled{% endif %}
-                              {% if value == (selected_coordenador_roles|get_item:nucleo.id) %}selected{% endif %}
-                            >
-                              {{ label }}{% if is_unavailable %} — {% trans 'Indisponível' %}{% endif %}
-                            </option>
-                          {% endwith %}
+                          <option
+                            value="{{ value }}"
+                            data-role-value="{{ value }}"
+                            data-locked="{% if value in nucleo.unavailable_roles and value not in nucleo.user_current_roles %}true{% else %}false{% endif %}"
+                            {% if value in nucleo.unavailable_roles and value not in nucleo.user_current_roles %}disabled{% endif %}
+                            {% if value == (selected_coordenador_roles|get_item:nucleo.id) %}selected{% endif %}
+                          >
+                            {{ label }}{% if value in nucleo.unavailable_roles and value not in nucleo.user_current_roles %} — {% trans 'Indisponível' %}{% endif %}
+                          </option>
                         {% endfor %}
                       </select>
                     </div>


### PR DESCRIPTION
## Summary
- remove invalid template assignment in the associado promotion form
- directly evaluate coordinator role availability flags when rendering the select options

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68dab5e096cc8325addaecda81beb259