### PR TITLE
Fix registration flow card layout

### DIFF
--- a/accounts/templates/register/cpf.html
+++ b/accounts/templates/register/cpf.html
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="card-grid">
+<div class="max-w-2xl mx-auto">
   <div class="card">
     <div class="card-body space-y-8">
       <div>

--- a/accounts/templates/register/email.html
+++ b/accounts/templates/register/email.html
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="card-grid">
+<div class="max-w-2xl mx-auto">
   <div class="card">
     <div class="card-body space-y-8">
       <div>

--- a/accounts/templates/register/foto.html
+++ b/accounts/templates/register/foto.html
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="card-grid">
+<div class="max-w-2xl mx-auto">
   <div class="card">
     <div class="card-body space-y-8">
       <div>

--- a/accounts/templates/register/nome.html
+++ b/accounts/templates/register/nome.html
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="card-grid">
+<div class="max-w-2xl mx-auto">
   <div class="card">
     <div class="card-body space-y-8">
       <div>

--- a/accounts/templates/register/onboarding.html
+++ b/accounts/templates/register/onboarding.html
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="card-grid">
+<div class="max-w-4xl mx-auto">
   <div class="card">
     <div class="card-body space-y-10 text-center">
       <div class="space-y-4">

--- a/accounts/templates/register/registro_sucesso.html
+++ b/accounts/templates/register/registro_sucesso.html
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="card-grid">
+<div class="max-w-2xl mx-auto">
   <div class="card">
     <div class="card-body space-y-6 text-center">
       <h1 class="text-3xl font-bold text-[var(--text-primary)]">{% trans "Bem-vindo ao HubX!" %}</h1>

--- a/accounts/templates/register/senha.html
+++ b/accounts/templates/register/senha.html
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="card-grid">
+<div class="max-w-2xl mx-auto">
   <div class="card">
     <div class="card-body space-y-8">
       <div>

--- a/accounts/templates/register/termos.html
+++ b/accounts/templates/register/termos.html
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="card-grid">
+<div class="max-w-3xl mx-auto">
   <div class="card">
     <div class="card-body space-y-8">
       <div>

--- a/accounts/templates/register/token.html
+++ b/accounts/templates/register/token.html
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="card-grid">
+<div class="max-w-2xl mx-auto">
   <div class="card">
     <div class="card-body space-y-8">
       <div>

--- a/accounts/templates/register/usuario.html
+++ b/accounts/templates/register/usuario.html
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="card-grid">
+<div class="max-w-2xl mx-auto">
   <div class="card">
     <div class="card-body space-y-8">
       <div>


### PR DESCRIPTION
## Summary
- center the account registration onboarding card by replacing the list grid wrapper with a standard container
- update each registration step template to use max-width containers so single-card forms stay centered on wide screens

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dabbd1378c8325b8e04eb0d6e6465c