### PR TITLE
Add planning and canceled event filter cards

### DIFF
--- a/eventos/views.py
+++ b/eventos/views.py
@@ -130,9 +130,11 @@ class EventoListView(PainelRenderMixin, LoginRequiredMixin, NoSuperadminMixin, L
     context_object_name = "eventos"
     paginate_by = 12
 
-    def get_queryset(self):
+    def get_base_queryset(self):
+        if hasattr(self, "_base_queryset_cache"):
+            return self._base_queryset_cache
+
         user = self.request.user
-        from django.db.models import Count
 
         qs = (
             Evento.objects.filter(organizacao=user.organizacao)
@@ -149,11 +151,29 @@ class EventoListView(PainelRenderMixin, LoginRequiredMixin, NoSuperadminMixin, L
 
         q = self.request.GET.get("q", "").strip()
         if q:
-            qs = qs.filter(Q(titulo__icontains=q) | Q(descricao__icontains=q) | Q(nucleo__nome__icontains=q))
+            qs = qs.filter(
+                Q(titulo__icontains=q)
+                | Q(descricao__icontains=q)
+                | Q(nucleo__nome__icontains=q)
+            )
+
+        self._base_queryset_cache = qs
+        return qs
+
+    def get_queryset(self):
+        from django.db.models import Count
+
+        qs = self.get_base_queryset()
 
         status_filter = self.request.GET.get("status")
+        now = timezone.now()
         status_map = {"ativos": 0, "realizados": 1}
-        if status_filter in status_map:
+
+        if status_filter == "planejamento":
+            qs = qs.filter(status=0, data_inicio__gt=now)
+        elif status_filter == "cancelados":
+            qs = qs.filter(status=2)
+        elif status_filter in status_map:
             qs = qs.filter(status=status_map[status_filter])
 
         # anotar número de inscritos por evento
@@ -165,7 +185,7 @@ class EventoListView(PainelRenderMixin, LoginRequiredMixin, NoSuperadminMixin, L
         user = self.request.user
         ctx["is_admin_org"] = user.get_tipo_usuario in {UserType.ADMIN.value}
         current_filter = self.request.GET.get("status") or ""
-        if current_filter not in {"ativos", "realizados"}:
+        if current_filter not in {"ativos", "realizados", "planejamento", "cancelados"}:
             current_filter = "todos"
         params = self.request.GET.copy()
         try:
@@ -175,7 +195,7 @@ class EventoListView(PainelRenderMixin, LoginRequiredMixin, NoSuperadminMixin, L
 
         def build_url(filter_value: str | None) -> str:
             query_params = params.copy()
-            if filter_value in {"ativos", "realizados"}:
+            if filter_value in {"ativos", "realizados", "planejamento", "cancelados"}:
                 query_params["status"] = filter_value
             else:
                 query_params.pop("status", None)
@@ -185,15 +205,24 @@ class EventoListView(PainelRenderMixin, LoginRequiredMixin, NoSuperadminMixin, L
         ctx["current_filter"] = current_filter
         ctx["ativos_filter_url"] = build_url("ativos")
         ctx["realizados_filter_url"] = build_url("realizados")
+        ctx["planejamento_filter_url"] = build_url("planejamento")
+        ctx["cancelados_filter_url"] = build_url("cancelados")
         ctx["todos_filter_url"] = build_url(None)
         ctx["is_ativos_filter_active"] = current_filter == "ativos"
         ctx["is_realizados_filter_active"] = current_filter == "realizados"
+        ctx["is_planejamento_filter_active"] = current_filter == "planejamento"
+        ctx["is_cancelados_filter_active"] = current_filter == "cancelados"
 
         # Totais baseados no queryset filtrado (sem paginação)
+        base_qs = self.get_base_queryset()
         qs = self.get_queryset()
-        ctx["total_eventos"] = qs.count()
-        ctx["total_eventos_ativos"] = qs.filter(status=0).count()
-        ctx["total_eventos_concluidos"] = qs.filter(status=1).count()
+        now = timezone.now()
+
+        ctx["total_eventos"] = base_qs.count()
+        ctx["total_eventos_planejamento"] = base_qs.filter(status=0, data_inicio__gt=now).count()
+        ctx["total_eventos_ativos"] = base_qs.filter(status=0).count()
+        ctx["total_eventos_concluidos"] = base_qs.filter(status=1).count()
+        ctx["total_eventos_cancelados"] = base_qs.filter(status=2).count()
         ctx["total_inscritos"] = InscricaoEvento.objects.filter(evento__in=qs).count()
         ctx["q"] = self.request.GET.get("q", "").strip()
         ctx["querystring"] = urlencode(params, doseq=True)

--- a/templates/_components/hero_evento.html
+++ b/templates/_components/hero_evento.html
@@ -20,18 +20,26 @@
         </div>
 
       </div>
-      {% if total_eventos is not None or total_eventos_ativos is not None or total_eventos_concluidos is not None %}
+      {% if total_eventos is not None or total_eventos_ativos is not None or total_eventos_concluidos is not None or total_eventos_planejamento is not None or total_eventos_cancelados is not None %}
 
+        {% lucide 'calendar-clock' class='h-5 w-5' as icon_total_planejamento %}
         {% lucide 'activity' class='h-5 w-5' as icon_total_ativos %}
         {% lucide 'check' class='h-5 w-5' as icon_total_concluidos %}
+        {% lucide 'ban' class='h-5 w-5' as icon_total_cancelados %}
         <div class="mt-10 space-y-4 text-left">
           <div class="card-grid" data-eventos-filter-buttons>
 
+            {% if total_eventos_planejamento is not None %}
+              {% include '_partials/cards/total_card.html' with label=_('Em planejamento') valor=total_eventos_planejamento icon_svg=icon_total_planejamento card_class='card-compact cursor-pointer transition hover:shadow-lg focus:outline-none focus-visible:ring focus-visible:ring-white/80 focus-visible:ring-offset-2' body_class='card-body-compact' as_button=True active_class='border border-white/80 shadow-lg' is_active=is_planejamento_filter_active hx_get=planejamento_filter_url hx_target='#eventos-conteudo' hx_push_url='true' hx_indicator='#eventos-loading' extra_attributes='data-eventos-filter-card="planejamento"' %}
+            {% endif %}
             {% if total_eventos_ativos is not None %}
               {% include '_partials/cards/total_card.html' with label=_('Ativos') valor=total_eventos_ativos icon_svg=icon_total_ativos card_class='card-compact cursor-pointer transition hover:shadow-lg focus:outline-none focus-visible:ring focus-visible:ring-white/80 focus-visible:ring-offset-2' body_class='card-body-compact' as_button=True active_class='border border-white/80 shadow-lg' is_active=is_ativos_filter_active hx_get=ativos_filter_url hx_target='#eventos-conteudo' hx_push_url='true' hx_indicator='#eventos-loading' extra_attributes='data-eventos-filter-card="ativos"' %}
             {% endif %}
             {% if total_eventos_concluidos is not None %}
               {% include '_partials/cards/total_card.html' with label=_('Realizados') valor=total_eventos_concluidos icon_svg=icon_total_concluidos card_class='card-compact cursor-pointer transition hover:shadow-lg focus:outline-none focus-visible:ring focus-visible:ring-white/80 focus-visible:ring-offset-2' body_class='card-body-compact' as_button=True active_class='border border-white/80 shadow-lg' is_active=is_realizados_filter_active hx_get=realizados_filter_url hx_target='#eventos-conteudo' hx_push_url='true' hx_indicator='#eventos-loading' extra_attributes='data-eventos-filter-card="realizados"' %}
+            {% endif %}
+            {% if total_eventos_cancelados is not None %}
+              {% include '_partials/cards/total_card.html' with label=_('Cancelados') valor=total_eventos_cancelados icon_svg=icon_total_cancelados card_class='card-compact cursor-pointer transition hover:shadow-lg focus:outline-none focus-visible:ring focus-visible:ring-white/80 focus-visible:ring-offset-2' body_class='card-body-compact' as_button=True active_class='border border-white/80 shadow-lg' is_active=is_cancelados_filter_active hx_get=cancelados_filter_url hx_target='#eventos-conteudo' hx_push_url='true' hx_indicator='#eventos-loading' extra_attributes='data-eventos-filter-card="cancelados"' %}
             {% endif %}
           </div>
           <div id="eventos-filter-state" class="hidden" data-current-filter="{{ current_filter|default:'todos' }}" aria-hidden="true"></div>

--- a/tests/eventos/test_views.py
+++ b/tests/eventos/test_views.py
@@ -169,6 +169,119 @@ def test_evento_list_filters_by_status(usuario_logado, organizacao, client, even
     assert response.context["ativos_filter_url"].endswith("?status=ativos")
 
 
+def test_evento_list_filters_by_planejamento(usuario_logado, organizacao, client):
+    evento_planejado = Evento.objects.create(
+        titulo="Evento Planejado",
+        descricao="Evento futuro",
+        data_inicio=make_aware(datetime.now() + timedelta(days=5)),
+        data_fim=make_aware(datetime.now() + timedelta(days=6)),
+        local="Rua Futuro, 789",
+        cidade="Cidade Futuro",
+        estado="ST",
+        cep="12345-678",
+        coordenador=usuario_logado,
+        organizacao=organizacao,
+        status=0,
+        publico_alvo=0,
+        numero_convidados=50,
+        numero_presentes=0,
+        valor_ingresso=30.00,
+        participantes_maximo=80,
+        contato_nome="Contato Futuro",
+        contato_email="futuro@teste.com",
+        contato_whatsapp="12999997777",
+    )
+    Evento.objects.create(
+        titulo="Evento Passado",
+        descricao="Evento não planejado",
+        data_inicio=make_aware(datetime.now() - timedelta(days=5)),
+        data_fim=make_aware(datetime.now() - timedelta(days=4)),
+        local="Rua Passado, 101",
+        cidade="Cidade Passado",
+        estado="ST",
+        cep="12345-678",
+        coordenador=usuario_logado,
+        organizacao=organizacao,
+        status=0,
+        publico_alvo=0,
+        numero_convidados=50,
+        numero_presentes=0,
+        valor_ingresso=30.00,
+        participantes_maximo=80,
+        contato_nome="Contato Passado",
+        contato_email="passado@teste.com",
+        contato_whatsapp="12999996666",
+    )
+
+    url = reverse("eventos:lista")
+    response = client.get(url, {"status": "planejamento"})
+
+    assert response.status_code == 200
+    eventos = list(response.context["eventos"])
+    assert evento_planejado in eventos
+    assert len(eventos) == 1
+    assert response.context["current_filter"] == "planejamento"
+    assert response.context["is_planejamento_filter_active"] is True
+    assert response.context["planejamento_filter_url"].endswith("?status=planejamento")
+    assert response.context["total_eventos_planejamento"] == 1
+
+
+def test_evento_list_filters_by_cancelados(usuario_logado, organizacao, client):
+    evento_cancelado = Evento.objects.create(
+        titulo="Evento Cancelado",
+        descricao="Evento cancelado",
+        data_inicio=make_aware(datetime.now() + timedelta(days=1)),
+        data_fim=make_aware(datetime.now() + timedelta(days=2)),
+        local="Rua Cancelada, 202",
+        cidade="Cidade Cancelada",
+        estado="ST",
+        cep="12345-678",
+        coordenador=usuario_logado,
+        organizacao=organizacao,
+        status=2,
+        publico_alvo=0,
+        numero_convidados=40,
+        numero_presentes=0,
+        valor_ingresso=25.00,
+        participantes_maximo=60,
+        contato_nome="Contato Cancelado",
+        contato_email="cancelado@teste.com",
+        contato_whatsapp="12999995555",
+    )
+    Evento.objects.create(
+        titulo="Evento Ativo",
+        descricao="Evento ativo",
+        data_inicio=make_aware(datetime.now() + timedelta(days=3)),
+        data_fim=make_aware(datetime.now() + timedelta(days=4)),
+        local="Rua Ativa, 303",
+        cidade="Cidade Ativa",
+        estado="ST",
+        cep="12345-678",
+        coordenador=usuario_logado,
+        organizacao=organizacao,
+        status=0,
+        publico_alvo=0,
+        numero_convidados=40,
+        numero_presentes=0,
+        valor_ingresso=25.00,
+        participantes_maximo=60,
+        contato_nome="Contato Ativo",
+        contato_email="ativo@teste.com",
+        contato_whatsapp="12999994444",
+    )
+
+    url = reverse("eventos:lista")
+    response = client.get(url, {"status": "cancelados"})
+
+    assert response.status_code == 200
+    eventos = list(response.context["eventos"])
+    assert eventos == [evento_cancelado]
+    assert response.context["current_filter"] == "cancelados"
+    assert response.context["is_cancelados_filter_active"] is True
+    assert response.context["cancelados_filter_url"].endswith("?status=cancelados")
+    assert response.context["total_eventos_cancelados"] == 1
+
+
 def test_evento_create_view_post_invalido(usuario_logado, client):
     url = reverse("eventos:evento_novo")
     response = client.post(url, data={"titulo": ""})  # inválido


### PR DESCRIPTION
## Summary
- extend the event list view to expose planning and canceled status filters and totals
- render new planning and canceled filter cards in the eventos hero component
- cover the new filters with dedicated view tests

## Testing
- pytest tests/eventos/test_views.py -k "planejamento or cancelados" -q *(fails: coverage fail-under threshold is 90%)*

------
https://chatgpt.com/codex/tasks/task_e_68dac3c4368c8325a2da9b16d8299b31