### PR TITLE
Centralize promotion option content

### DIFF
--- a/accounts/templates/associados/promover_form.html
+++ b/accounts/templates/associados/promover_form.html
@@ -123,11 +123,11 @@
                           >
                         </div>
                       </div>
-                      <div class="flex flex-1 flex-col gap-3">
+                      <div class="flex flex-1 flex-col items-center gap-3 text-center">
                         <span class="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-[var(--bg-tertiary)] text-primary" aria-hidden="true">
                           {% lucide 'user-round-plus' class='h-6 w-6' %}
                         </span>
-                        <div class="space-y-1">
+                        <div class="space-y-1 text-center">
                           <span class="block text-sm font-medium text-[var(--text-primary)]">{% trans 'Promover a nucleado' %}</span>
                           <span class="block text-xs text-[var(--text-secondary)]">{% trans 'Garante participação ativa como membro do núcleo escolhido.' %}</span>
                         </div>
@@ -147,11 +147,11 @@
                           >
                         </div>
                       </div>
-                      <div class="flex flex-1 flex-col gap-3">
+                      <div class="flex flex-1 flex-col items-center gap-3 text-center">
                         <span class="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-[var(--bg-tertiary)] text-[var(--error)]" aria-hidden="true">
                           {% lucide 'user-round-minus' class='h-6 w-6' %}
                         </span>
-                        <div class="space-y-1">
+                        <div class="space-y-1 text-center">
                           <span class="block text-sm font-medium text-[var(--error)]">{% trans 'Remover promoção de nucleado' %}</span>
                           <span class="block text-xs text-[var(--text-secondary)]">{% trans 'Interrompe a participação ativa do associado neste núcleo.' %}</span>
                         </div>
@@ -173,11 +173,11 @@
                           >
                         </div>
                       </div>
-                      <div class="flex flex-1 flex-col gap-3">
+                      <div class="flex flex-1 flex-col items-center gap-3 text-center">
                         <span class="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-[var(--bg-tertiary)] text-primary" aria-hidden="true">
                           {% lucide 'user-round-cog' class='h-6 w-6' %}
                         </span>
-                        <div class="space-y-1">
+                        <div class="space-y-1 text-center">
                           <span class="block text-sm font-medium text-[var(--text-primary)]">{% trans 'Promover a consultor' %}</span>
                           <span class="block text-xs text-[var(--text-secondary)]">{% trans 'Permite atuação consultiva em estratégias e ações do núcleo.' %}</span>
                         </div>
@@ -197,11 +197,11 @@
                           >
                         </div>
                       </div>
-                      <div class="flex flex-1 flex-col gap-3">
+                      <div class="flex flex-1 flex-col items-center gap-3 text-center">
                         <span class="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-[var(--bg-tertiary)] text-[var(--error)]" aria-hidden="true">
                           {% lucide 'user-round-x' class='h-6 w-6' %}
                         </span>
-                        <div class="space-y-1">
+                        <div class="space-y-1 text-center">
                           <span class="block text-sm font-medium text-[var(--error)]">{% trans 'Remover promoção de consultor' %}</span>
                           <span class="block text-xs text-[var(--text-secondary)]">{% trans 'Libera o núcleo para definir um novo consultor.' %}</span>
                         </div>
@@ -224,11 +224,11 @@
                             >
                           </div>
                         </div>
-                        <div class="flex flex-1 flex-col gap-3">
+                        <div class="flex flex-1 flex-col items-center gap-3 text-center">
                           <span class="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-[var(--bg-tertiary)] text-primary" aria-hidden="true">
                             {% lucide 'shield-check' class='h-6 w-6' %}
                           </span>
-                          <div class="space-y-1">
+                          <div class="space-y-1 text-center">
                             <span class="block text-sm font-medium text-[var(--text-primary)]">{% trans 'Promover a coordenador' %}</span>
                             <span class="block text-xs text-[var(--text-secondary)]">{% trans 'Escolha o papel de coordenação específico para este núcleo.' %}</span>
                           </div>
@@ -273,11 +273,11 @@
                           >
                         </div>
                       </div>
-                      <div class="flex flex-1 flex-col gap-3">
+                      <div class="flex flex-1 flex-col items-center gap-3 text-center">
                         <span class="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-[var(--bg-tertiary)] text-[var(--error)]" aria-hidden="true">
                           {% lucide 'shield-x' class='h-6 w-6' %}
                         </span>
-                        <div class="space-y-1">
+                        <div class="space-y-1 text-center">
                           <span class="block text-sm font-medium text-[var(--error)]">{% trans 'Remover promoção de coordenador' %}</span>
                           <span class="block text-xs text-[var(--text-secondary)]">{% trans 'Retira o papel de coordenação mantendo a participação como membro.' %}</span>
                         </div>


### PR DESCRIPTION
## Summary
- center the icon and text within the promotion option cards on the associate promotion form

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dad6c765ec83258c7f66def9a0687a