### PR TITLE
Ajusta badges nos cards da lista de eventos

### DIFF
--- a/eventos/templatetags/eventos_extras.py
+++ b/eventos/templatetags/eventos_extras.py
@@ -1,19 +1,26 @@
 from __future__ import annotations
-
 from django import template
 from django.utils.translation import gettext as _
+
+from eventos.models import Evento
 
 register = template.Library()
 
 PUBLIC_BADGE_STYLE = "--primary:#2563eb; --primary-soft:rgba(37, 99, 235, 0.15); --primary-soft-border:rgba(37, 99, 235, 0.3);"
 NUCLEO_BADGE_STYLE = "--primary:#0ea5e9; --primary-soft:rgba(14, 165, 233, 0.15); --primary-soft-border:rgba(14, 165, 233, 0.3);"
+STATUS_BADGE_STYLE_MAP = {
+    Evento.Status.ATIVO: "--primary:#16a34a; --primary-soft:rgba(22, 163, 74, 0.15); --primary-soft-border:rgba(22, 163, 74, 0.3);",
+    Evento.Status.CONCLUIDO: "--primary:#2563eb; --primary-soft:rgba(37, 99, 235, 0.15); --primary-soft-border:rgba(37, 99, 235, 0.3);",
+    Evento.Status.CANCELADO: "--primary:#dc2626; --primary-soft:rgba(220, 38, 38, 0.15); --primary-soft-border:rgba(220, 38, 38, 0.3);",
+    Evento.Status.PLANEJAMENTO: "--primary:#f97316; --primary-soft:rgba(249, 115, 22, 0.15); --primary-soft-border:rgba(249, 115, 22, 0.3);",
+}
 TARGET_BADGE_MAP = {
     1: {
         "label": _("Somente nucleados"),
         "style": "--primary:#22c55e; --primary-soft:rgba(34, 197, 94, 0.15); --primary-soft-border:rgba(34, 197, 94, 0.3);",
     },
     2: {
-        "label": _("Apenas associados"),
+        "label": _("Associados"),
         "style": "--primary:#6366f1; --primary-soft:rgba(99, 102, 241, 0.15); --primary-soft-border:rgba(99, 102, 241, 0.3);",
     },
 }
@@ -30,14 +37,33 @@ def evento_badges(evento):
         cover_label = _("Público")
         cover_style = PUBLIC_BADGE_STYLE
         target_badge = None
-    else:
+    elif publico_alvo == 1:
         cover_label = getattr(nucleo, "nome", "") or _("Núcleo não definido")
+        cover_style = NUCLEO_BADGE_STYLE
+        target_badge = TARGET_BADGE_MAP.get(publico_alvo)
+    else:
+        cover_label = getattr(nucleo, "nome", "")
         cover_style = NUCLEO_BADGE_STYLE
         target_badge = TARGET_BADGE_MAP.get(publico_alvo)
 
     cover_badges = []
     if cover_label:
         cover_badges.append({"label": cover_label, "style": cover_style})
+
+    status_label = ""
+    get_status_display = getattr(evento, "get_status_display", None)
+    if callable(get_status_display):
+        status_label = get_status_display()
+
+    if status_label:
+        cover_badges.append(
+            {
+                "label": status_label,
+                "style": STATUS_BADGE_STYLE_MAP.get(
+                    getattr(evento, "status", None), PUBLIC_BADGE_STYLE
+                ),
+            }
+        )
 
     return {
         "cover_badges": cover_badges,

--- a/templates/_partials/cards/evento_card_details.html
+++ b/templates/_partials/cards/evento_card_details.html
@@ -1,22 +1,12 @@
 {% load i18n %}
-<dl class="mt-3 grid grid-cols-4 gap-2 text-xs text-[var(--text-secondary)]">
+<dl class="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-2 text-xs text-[var(--text-secondary)]">
   <div>
     <dt class="text-[var(--text-secondary)]">{% trans 'Inscritos' %}</dt>
     <dd class="font-medium">{{ evento.num_inscritos|default:0 }}</dd>
   </div>
   <div>
-    <dt class="text-[var(--text-secondary)]">{% trans 'Núcleo' %}</dt>
-    <dd class="font-medium">{% if evento.nucleo %}{{ evento.nucleo.nome }}{% else %}-{% endif %}</dd>
-  </div>
-  <div>
     <dt class="text-[var(--text-secondary)]">{% trans 'Coordenador' %}</dt>
     <dd class="font-medium">{{ evento.coordenador.display_name }}</dd>
-  </div>
-  <div>
-    <dt class="text-[var(--text-secondary)]">{% trans 'Status' %}</dt>
-    <dd class="font-medium">
-      {% if evento.status == 0 %}{% trans 'Ativo' %}{% elif evento.status == 1 %}{% trans 'Concluído' %}{% else %}{% trans 'Cancelado' %}{% endif %}
-    </dd>
   </div>
 </dl>
 {% if target_badge %}


### PR DESCRIPTION
## Summary
- remove os campos de status e núcleo do detalhamento do card de evento e ajusta o layout
- exibe o status do evento como etiqueta, atualiza o rótulo de associados e evita mostrar "Núcleo não definido" para esse público

## Testing
- pytest --no-cov tests/eventos/test_views.py -k evento_list


------
https://chatgpt.com/codex/tasks/task_e_68dadcee463483258b8abb837293a877