### PR TITLE
Atualizar estilo das etiquetas do feed

### DIFF
--- a/feed/templates/feed/_grid.html
+++ b/feed/templates/feed/_grid.html
@@ -11,18 +11,31 @@
     <div class="card-body flex h-full flex-col gap-6">
       <!-- Cabeçalho com tipo de postagem acima do avatar -->
       <header class="flex flex-col gap-2">
-        <span class="relative z-20 inline-flex items-center gap-2 self-start rounded-full bg-[var(--bg-tertiary)] px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--text-secondary)] shadow-sm ring-1 ring-[var(--border)]">
-          <span class="h-1.5 w-1.5 rounded-full bg-[var(--accent)]"></span>
+        {% with badge_classes="relative z-20 inline-flex max-w-full items-center gap-2 self-start rounded-full bg-[var(--primary-soft,rgba(59,130,246,0.15))] px-3 py-1 text-[0.6rem] font-semibold uppercase tracking-wide text-[var(--primary,#2563eb)] shadow-sm ring-1 ring-[var(--primary-soft-border,rgba(59,130,246,0.3))] whitespace-nowrap" icon_classes="h-3.5 w-3.5 shrink-0" %}
           {% if post.tipo_feed == 'nucleo' %}
-            {% blocktrans with nome=post.nucleo.nome %}Núcleo • {{ nome }}{% endblocktrans %}
+            {% blocktrans with nome=post.nucleo.nome asvar badge_label %}Núcleo · {{ nome }}{% endblocktrans %}
+            <span class="{{ badge_classes }}" style="--primary:#22c55e; --primary-soft:rgba(34,197,94,0.15); --primary-soft-border:rgba(34,197,94,0.3);">
+              {% lucide 'users' class=icon_classes aria_hidden='true' %}
+              <span class="truncate">{{ badge_label }}</span>
+            </span>
           {% elif post.tipo_feed == 'evento' %}
-            {% blocktrans with titulo=post.evento.titulo %}Evento • {{ titulo }}{% endblocktrans %}
+            {% blocktrans with titulo=post.evento.titulo asvar badge_label %}Evento · {{ titulo }}{% endblocktrans %}
+            <span class="{{ badge_classes }}" style="--primary:#0ea5e9; --primary-soft:rgba(14,165,233,0.15); --primary-soft-border:rgba(14,165,233,0.3);">
+              {% lucide 'calendar-days' class=icon_classes aria_hidden='true' %}
+              <span class="truncate">{{ badge_label }}</span>
+            </span>
           {% elif post.tipo_feed == 'usuario' %}
-            {% trans "Mural" %}
+            <span class="{{ badge_classes }}" style="--primary:#8b5cf6; --primary-soft:rgba(139,92,246,0.15); --primary-soft-border:rgba(139,92,246,0.3);">
+              {% lucide 'user' class=icon_classes aria_hidden='true' %}
+              <span class="truncate">{% trans "Mural" %}</span>
+            </span>
           {% else %}
-            {% trans "Público" %}
+            <span class="{{ badge_classes }}" style="--primary:#f97316; --primary-soft:rgba(249,115,22,0.15); --primary-soft-border:rgba(249,115,22,0.3);">
+              {% lucide 'globe-2' class=icon_classes aria_hidden='true' %}
+              <span class="truncate">{% trans "Público" %}</span>
+            </span>
           {% endif %}
-        </span>
+        {% endwith %}
         <div class="flex items-start justify-between gap-4">
           <div class="flex items-center gap-3">
             <a href="{% url 'accounts:perfil_publico_uuid' post.autor.public_id %}" class="relative z-20 flex-shrink-0">


### PR DESCRIPTION
## Summary
- alinhei as etiquetas do tipo de postagem no feed ao padrão visual dos cards de associados
- adicionei ícones e paleta de cores específicas para os rótulos de núcleo, evento, mural e público

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dade365da88325b034ee0bf74f3485