### PR TITLE
Refatora layout do formulário de eventos

### DIFF
--- a/eventos/forms.py
+++ b/eventos/forms.py
@@ -86,6 +86,14 @@ class EventoForm(forms.ModelForm):
 
             nucleo_field.queryset = queryset.distinct()
 
+        for field_name, label in (
+            ("contato_nome", _("Contato")),
+            ("contato_email", _("Email")),
+            ("contato_whatsapp", _("Whatapp")),
+        ):
+            if field_name in self.fields:
+                self.fields[field_name].label = label
+
     def clean(self):
         cleaned_data = super().clean()
         publico_alvo = cleaned_data.get("publico_alvo")

--- a/eventos/templates/eventos/partials/eventos/update.html
+++ b/eventos/templates/eventos/partials/eventos/update.html
@@ -7,101 +7,111 @@
     {% csrf_token %}
     {{ form.non_field_errors }}
 
-    <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
-      <div class="md:col-span-2 xl:col-span-3">
+    <div class="space-y-6">
+      <div>
         {% include '_forms/field.html' with field=form.titulo %}
       </div>
 
-      <div class="md:col-span-2 xl:col-span-3">
+      <div>
         {% include '_forms/field.html' with field=form.descricao %}
       </div>
 
       <div>
-        {% include '_forms/field.html' with field=form.data_inicio %}
-      </div>
-      <div>
-        {% include '_forms/field.html' with field=form.data_fim %}
+        {% include '_forms/field.html' with field=form.cronograma %}
       </div>
 
-      <div class="md:col-span-2 xl:col-span-3">
+      <div>
+        {% include '_forms/field.html' with field=form.informacoes_adicionais %}
+      </div>
+
+      <div>
         {% include '_forms/field.html' with field=form.local %}
       </div>
 
-      <div>
-        {% include '_forms/field.html' with field=form.cidade %}
-      </div>
-      <div>
-        {% include '_forms/field.html' with field=form.estado %}
+      <div class="grid gap-6 md:grid-cols-2">
+        <div>
+          {% include '_forms/field.html' with field=form.data_inicio %}
+        </div>
+        <div>
+          {% include '_forms/field.html' with field=form.data_fim %}
+        </div>
       </div>
 
-      <div>
-        {% include '_forms/field.html' with field=form.cep %}
+      <div class="grid gap-6 md:grid-cols-3">
+        <div>
+          {% include '_forms/field.html' with field=form.cidade %}
+        </div>
+        <div>
+          {% include '_forms/field.html' with field=form.estado %}
+        </div>
+        <div>
+          {% include '_forms/field.html' with field=form.cep %}
+        </div>
       </div>
+
       <div>
         {% include '_forms/field.html' with field=form.coordenador %}
       </div>
 
-      <div>
-        {% include '_forms/field.html' with field=form.status %}
-      </div>
-      <div>
-        {% include '_forms/field.html' with field=form.publico_alvo %}
-      </div>
-
-      <div id="nucleo-field-container" class="md:col-span-2 xl:col-span-3">
-        {% include '_forms/field.html' with field=form.nucleo %}
-      </div>
-
-      <div>
-        {% include '_forms/field.html' with field=form.numero_convidados %}
-      </div>
-      <div>
-        {% include '_forms/field.html' with field=form.participantes_maximo %}
+      <div class="grid gap-6 md:grid-cols-3">
+        <div>
+          {% include '_forms/field.html' with field=form.status %}
+        </div>
+        <div>
+          {% include '_forms/field.html' with field=form.publico_alvo %}
+        </div>
+        <div id="nucleo-field-container">
+          {% include '_forms/field.html' with field=form.nucleo %}
+        </div>
       </div>
 
-      <div>
-        {% include '_forms/field.html' with field=form.valor_ingresso %}
+      <div class="grid gap-6 md:grid-cols-3">
+        <div>
+          {% include '_forms/field.html' with field=form.numero_convidados %}
+        </div>
+        <div>
+          {% include '_forms/field.html' with field=form.participantes_maximo %}
+        </div>
+        <div>
+          {% include '_forms/field.html' with field=form.valor_ingresso %}
+        </div>
       </div>
 
-      <div class="md:col-span-2 xl:col-span-3">
-        {% include '_forms/field.html' with field=form.cronograma %}
+      <div class="grid gap-6 md:grid-cols-2">
+        <div>
+          {% include '_forms/field.html' with field=form.briefing %}
+        </div>
+        <div>
+          {% include '_forms/field.html' with field=form.parcerias %}
+        </div>
       </div>
 
-      <div class="md:col-span-2 xl:col-span-3">
-        {% include '_forms/field.html' with field=form.informacoes_adicionais %}
+      <div class="grid gap-6 md:grid-cols-3">
+        <div>
+          {% include '_forms/field.html' with field=form.contato_nome %}
+        </div>
+        <div>
+          {% include '_forms/field.html' with field=form.contato_email %}
+        </div>
+        <div>
+          {% include '_forms/field.html' with field=form.contato_whatsapp %}
+        </div>
       </div>
 
-      <div class="md:col-span-2 xl:col-span-3">
-        {% include '_forms/field.html' with field=form.briefing %}
-      </div>
+      <div class="grid gap-6 md:grid-cols-2">
+        <div>
+          {% if object.avatar %}
+            <img src="{{ object.avatar.url }}" alt="{{ form.avatar.label }}" class="w-32 h-32 object-cover mb-2" loading="lazy">
+          {% endif %}
+          {% include '_forms/field.html' with field=form.avatar|attr:'accept:image/*' %}
+        </div>
 
-      <div class="md:col-span-2 xl:col-span-3">
-        {% include '_forms/field.html' with field=form.parcerias %}
-      </div>
-
-      <div>
-        {% include '_forms/field.html' with field=form.contato_nome %}
-      </div>
-      <div>
-        {% include '_forms/field.html' with field=form.contato_email %}
-      </div>
-
-      <div class="md:col-span-2 xl:col-span-3">
-        {% include '_forms/field.html' with field=form.contato_whatsapp %}
-      </div>
-
-      <div>
-        {% if object.avatar %}
-          <img src="{{ object.avatar.url }}" alt="{{ form.avatar.label }}" class="w-32 h-32 object-cover mb-2" loading="lazy">
-        {% endif %}
-        {% include '_forms/field.html' with field=form.avatar|attr:'accept:image/*' %}
-      </div>
-
-      <div>
-        {% if object.cover %}
-          <img src="{{ object.cover.url }}" alt="{{ form.cover.label }}" class="w-48 h-32 object-cover mb-2 rounded" loading="lazy">
-        {% endif %}
-        {% include '_forms/field.html' with field=form.cover|attr:'accept:image/*' %}
+        <div>
+          {% if object.cover %}
+            <img src="{{ object.cover.url }}" alt="{{ form.cover.label }}" class="w-48 h-32 object-cover mb-2 rounded" loading="lazy">
+          {% endif %}
+          {% include '_forms/field.html' with field=form.cover|attr:'accept:image/*' %}
+        </div>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- reorganiza o layout do formulário de eventos para agrupar campos em linhas específicas
- atualiza os rótulos dos campos de contato conforme a nova nomenclatura

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dae56ee624832598a92887a555e639