### PR TITLE
Atualiza rótulos e posição de campos nos formulários de eventos

### DIFF
--- a/eventos/forms.py
+++ b/eventos/forms.py
@@ -89,7 +89,8 @@ class EventoForm(forms.ModelForm):
         for field_name, label in (
             ("contato_nome", _("Contato")),
             ("contato_email", _("Email")),
-            ("contato_whatsapp", _("Whatapp")),
+            ("contato_whatsapp", _("Whatsapp")),
+            ("cover", _("Capa")),
         ):
             if field_name in self.fields:
                 self.fields[field_name].label = label

--- a/eventos/models.py
+++ b/eventos/models.py
@@ -203,7 +203,7 @@ class Evento(TimeStampedModel, SoftDeleteModel):
     nucleo = models.ForeignKey(Nucleo, on_delete=models.SET_NULL, null=True, blank=True)
     status = models.PositiveSmallIntegerField(choices=Status.choices)
     publico_alvo = models.PositiveSmallIntegerField(
-        choices=[(0, "Público"), (1, "Somente nucleados"), (2, "Apenas associados")]
+        choices=[(0, "Público"), (1, "Nucleados"), (2, "Associados")]
     )
     numero_convidados = models.PositiveIntegerField()
     numero_presentes = models.PositiveIntegerField(default=0, editable=False)

--- a/eventos/templates/eventos/partials/eventos/create.html
+++ b/eventos/templates/eventos/partials/eventos/create.html
@@ -26,10 +26,6 @@
           </div>
 
           <div>
-            {% include '_forms/field.html' with field=form.informacoes_adicionais %}
-          </div>
-
-          <div>
             {% include '_forms/field.html' with field=form.local %}
           </div>
 
@@ -101,6 +97,10 @@
             <div>
               {% include '_forms/field.html' with field=form.contato_whatsapp %}
             </div>
+          </div>
+
+          <div>
+            {% include '_forms/field.html' with field=form.informacoes_adicionais %}
           </div>
 
           <div class="grid gap-6 md:grid-cols-2">

--- a/eventos/templates/eventos/partials/eventos/update.html
+++ b/eventos/templates/eventos/partials/eventos/update.html
@@ -21,10 +21,6 @@
       </div>
 
       <div>
-        {% include '_forms/field.html' with field=form.informacoes_adicionais %}
-      </div>
-
-      <div>
         {% include '_forms/field.html' with field=form.local %}
       </div>
 
@@ -97,6 +93,10 @@
         <div>
           {% include '_forms/field.html' with field=form.contato_whatsapp %}
         </div>
+      </div>
+
+      <div>
+        {% include '_forms/field.html' with field=form.informacoes_adicionais %}
       </div>
 
       <div class="grid gap-6 md:grid-cols-2">

--- a/eventos/templatetags/eventos_extras.py
+++ b/eventos/templatetags/eventos_extras.py
@@ -16,7 +16,7 @@ STATUS_BADGE_STYLE_MAP = {
 }
 TARGET_BADGE_MAP = {
     1: {
-        "label": _("Somente nucleados"),
+        "label": _("Nucleados"),
         "style": "--primary:#22c55e; --primary-soft:rgba(34, 197, 94, 0.15); --primary-soft-border:rgba(34, 197, 94, 0.3);",
     },
     2: {


### PR DESCRIPTION
## Summary
- renomeia as opções de público-alvo para "Nucleados" e "Associados"
- corrige os rótulos de WhatsApp e Capa no formulário de eventos
- posiciona o campo de informações adicionais após o WhatsApp e antes de avatar/capa nas telas de criação e edição

## Testing
- não executado (não aplicável)


------
https://chatgpt.com/codex/tasks/task_e_68daec788b9c8325bfd087e659ee78ef