### PR TITLE
Corrige contraste dos títulos em detalhes de eventos e núcleos

### DIFF
--- a/templates/_components/hero_eventos_detail.html
+++ b/templates/_components/hero_eventos_detail.html
@@ -23,7 +23,7 @@
               </div>
             {% endif %}
           </div>
-          <div class="inline-flex min-w-0 max-w-full items-center rounded-xl border border-white/15 bg-slate-950/70 px-4 py-2 shadow-lg shadow-black/40 backdrop-blur-md text-white">
+          <div class="inline-flex min-w-0 max-w-full items-center rounded-xl border border-black/10 bg-white/80 px-4 py-2 text-[var(--text-primary)] shadow-lg shadow-black/10 backdrop-blur-md dark:border-white/15 dark:bg-slate-950/70 dark:text-white dark:shadow-black/40">
             <h1 class="text-3xl font-bold md:text-4xl">{{ evento.titulo }}</h1>
           </div>
         </div>

--- a/templates/_components/hero_nucleo_detail.html
+++ b/templates/_components/hero_nucleo_detail.html
@@ -23,7 +23,7 @@
               </div>
             {% endif %}
           </div>
-          <div class="inline-flex min-w-0 max-w-full items-center rounded-xl border border-white/15 bg-slate-950/70 px-4 py-2 shadow-lg shadow-black/40 backdrop-blur-md text-white">
+          <div class="inline-flex min-w-0 max-w-full items-center rounded-xl border border-black/10 bg-white/80 px-4 py-2 text-[var(--text-primary)] shadow-lg shadow-black/10 backdrop-blur-md dark:border-white/15 dark:bg-slate-950/70 dark:text-white dark:shadow-black/40">
             <h1 class="text-3xl font-bold md:text-4xl">{{ nucleo.nome }}</h1>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- ajusta os containers dos títulos de eventos e núcleos para usarem cores compatíveis com o modo claro
- mantém o esquema atual do modo escuro com variantes `dark:` nas classes utilitárias

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbd2c28c748325a68e3663c04db47c