### PR TITLE
Refatorar componente de botão de volta e integrar templates

### DIFF
--- a/accounts/templates/perfil/partials/conexoes_busca.html
+++ b/accounts/templates/perfil/partials/conexoes_busca.html
@@ -2,15 +2,17 @@
 <div class="space-y-6">
   <div class="flex items-center justify-between">
     <h2 class="text-base font-semibold text-[var(--text-primary)]">{% trans "Buscar pessoas" %}</h2>
-    <button
-      type="button"
-      class="btn-secondary btn-sm"
-      hx-get="{% url 'accounts:perfil_conexoes_partial' %}"
-      hx-target="#perfil-content"
-      hx-push-url="?section=conexoes"
-    >
-      {% trans "Voltar" %}
-    </button>
+    {% url 'accounts:perfil_conexoes_partial' as conexoes_partial_url %}
+    {% include '_components/back_button.html' with
+        variant='button'
+        size='sm'
+        use_history=False
+        hx_get=conexoes_partial_url
+        hx_target='#perfil-content'
+        hx_push_url='?section=conexoes'
+        href=conexoes_partial_url
+        label=_('Voltar')
+    %}
   </div>
 
   <form

--- a/docs/components/back_button.md
+++ b/docs/components/back_button.md
@@ -1,0 +1,64 @@
+# Componente `_components/back_button.html`
+
+O componente de botão de retorno centraliza o comportamento padrão de "voltar" na interface do HubX. Ele deve ser preferido em vez de botões avulsos com `history.back()` ou links manuais.
+
+## Uso básico
+
+```django
+{% include '_components/back_button.html' %}
+```
+
+Exibe um botão secundário com ícone de seta e texto "Voltar", tentando navegar pelo histórico do navegador quando houver uma origem válida.
+
+## Parâmetros disponíveis
+
+| Parâmetro | Tipo | Padrão | Descrição |
+| --- | --- | --- | --- |
+| `label` | string | `"Voltar"` | Texto visível no botão. |
+| `aria_label` | string | `label` | Rótulo acessível para leitores de tela. |
+| `href` | string | `#` | URL usada para navegação padrão ou abertura em nova aba. |
+| `fallback_href` | string | `None` | URL utilizada quando não há histórico válido. |
+| `use_history` | boolean | `True` | Quando ativo, tenta usar `history.back()` antes de seguir o `href`. |
+| `variant` | string | `"button"` | Aparência do componente: `button`, `link` ou `compact`. |
+| `size` | string | `"md"` | Apenas para `variant="button"`. Aceita `sm`, `md` ou `lg`. |
+| `classes` | string | `""` | Classes adicionais anexadas ao elemento principal. |
+| `icon` | string | `"arrow-left"` | Ícone Lucide exibido ao lado do texto. |
+| `hide_icon` | boolean | `False` | Remove o ícone quando verdadeiro. |
+| `element` | string | `"a"` | Elemento HTML renderizado (`a` ou `button`). |
+| `button_type` | string | `"button"` | Valor do atributo `type` quando `element="button"`. |
+| `htmx_attrs` | dict | `None` | Dicionário com atributos HTMX (chaves sem o prefixo `hx-`). |
+| `extra_attrs` | dict | `None` | Atributos arbitrários adicionais (`{"data-test": "foo"}`, por exemplo). |
+| `hx_get`, `hx_post`, ... | string | `None` | Atributos HTMX individuais suportados diretamente (`hx_get`, `hx_target`, `hx_swap`, `hx_push_url`, etc.). |
+
+## Variantes visuais
+
+- `variant="button"` (padrão): botão cheio com classes `btn btn-secondary`. Combine com `size="sm"` ou `size="lg"` quando necessário.
+- `variant="link"`: link textual com ícone.
+- `variant="compact"`: botão circular icônico com rótulo apenas visível para leitores de tela.
+
+## Integração com o histórico
+
+Todos os elementos renderizam com `data-back-button`. Um script global (injetado em `base.html`) gerencia o comportamento de histórico e fallback automaticamente.
+
+Quando `use_history=True`, o script tentará voltar à página anterior caso a origem pertença ao mesmo domínio e exista histórico. Caso contrário, usa `fallback_href` (se definido) ou respeita o `href` informado.
+
+## Uso com HTMX
+
+Informe `use_history=False` para evitar interferência com requisições HTMX e forneça os atributos necessários:
+
+```django
+{% include '_components/back_button.html' with
+    variant='button'
+    size='sm'
+    use_history=False
+    hx_get=conexoes_partial_url
+    hx_target='#perfil-content'
+    hx_push_url='?section=conexoes'
+%}
+```
+
+O componente aplicará automaticamente os atributos `hx-*` suportados.
+
+## Integração com templates base
+
+`base.html` injeta automaticamente o componente antes do bloco principal de conteúdo sempre que a view definir `back_href` ou `back_component_config`. Esse comportamento pode ser sobrescrito redefinindo o bloco `{% block back_button %}` em templates específicos.

--- a/eventos/templates/eventos/partials/eventos/create.html
+++ b/eventos/templates/eventos/partials/eventos/create.html
@@ -114,7 +114,6 @@
         </div>
 
         <div class="flex justify-end gap-3 pt-4 border-t border-[var(--border)]">
-          <a id="btn-voltar" href="{% url 'eventos:calendario' %}" data-fallback-url="{% url 'eventos:calendario' %}" class="btn btn-secondary" aria-label="{% trans 'Voltar' %}" data-behavior="back">{% trans "Voltar" %}</a>
           <button type="submit" class="btn btn-primary" aria-label="{% trans 'Salvar' %}">{% trans "Salvar" %}</button>
         </div>
       </form>
@@ -124,27 +123,6 @@
 
 {% block extra_js %}
 <script>
-  // Comportamento do botão Voltar: tenta voltar no histórico; se não houver origem válida, usa fallback
-  (function(){
-    const btn = document.getElementById('btn-voltar');
-    if(!btn) return;
-    btn.addEventListener('click', function(e){
-      const ref = document.referrer;
-      const fallback = btn.getAttribute('data-fallback-url');
-      const sameOrigin = ref && ref.startsWith(window.location.origin);
-      // Evita voltar para a própria página ou páginas de criação/edição em loop
-      const invalid = !sameOrigin || ref === window.location.href;
-      if(invalid || window.history.length <= 1) {
-        if(fallback) {
-          e.preventDefault();
-          window.location.href = fallback;
-        }
-      } else {
-        e.preventDefault();
-        window.history.back();
-      }
-    });
-  })();
   document.addEventListener('DOMContentLoaded', function () {
     const publicoAlvoSelect = document.getElementById('id_publico_alvo');
     const nucleoInput = document.getElementById('id_nucleo');

--- a/eventos/templates/eventos/partials/eventos/detail.html
+++ b/eventos/templates/eventos/partials/eventos/detail.html
@@ -181,8 +181,4 @@
     </article>
   </div>
 
-  <div class="flex justify-end mt-6">
-    {% url 'eventos:calendario' as calendario_url %}
-    {% include '_components/back_button.html' with href=back_href|default:calendario_url %}
-  </div>
 </section>

--- a/eventos/templates/eventos/partials/eventos/update.html
+++ b/eventos/templates/eventos/partials/eventos/update.html
@@ -117,7 +117,6 @@
     </div>
 
     <div class="flex justify-end gap-3 pt-4 border-t border-[var(--border)]">
-      <a id="btn-voltar" href="{% url 'eventos:calendario' %}" data-fallback-url="{% url 'eventos:calendario' %}" class="btn btn-secondary" aria-label="{% trans 'Voltar' %}" data-behavior="back">{% trans "Voltar" %}</a>
       <button type="submit" class="btn btn-primary" aria-label="{% trans 'Salvar' %}">{% trans "Salvar" %}</button>
     </div>
   </form>
@@ -126,25 +125,6 @@
 
 {% block extra_js %}
 <script>
-  (function(){
-    const btn = document.getElementById('btn-voltar');
-    if(!btn) return;
-    btn.addEventListener('click', function(e){
-      const ref = document.referrer;
-      const fallback = btn.getAttribute('data-fallback-url');
-      const sameOrigin = ref && ref.startsWith(window.location.origin);
-      const invalid = !sameOrigin || ref === window.location.href;
-      if(invalid || window.history.length <= 1) {
-        if(fallback) {
-          e.preventDefault();
-          window.location.href = fallback;
-        }
-      } else {
-        e.preventDefault();
-        window.history.back();
-      }
-    });
-  })();
   document.addEventListener('DOMContentLoaded', function () {
     const publicoAlvoSelect = document.getElementById('id_publico_alvo');
     const nucleoInput = document.getElementById('id_nucleo');

--- a/eventos/views.py
+++ b/eventos/views.py
@@ -393,6 +393,16 @@ class EventoCreateView(
         kwargs["request"] = self.request
         return kwargs
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        calendario_url = reverse("eventos:calendario")
+        context["back_component_config"] = {
+            "href": calendario_url,
+            "fallback_href": calendario_url,
+            "use_history": True,
+        }
+        return context
+
     def dispatch(self, request, *args, **kwargs):
         if request.user.user_type == UserType.ROOT:
             raise PermissionDenied("Usuário root não pode criar eventos.")
@@ -438,6 +448,12 @@ class EventoUpdateView(
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["evento"] = self.object
+        calendario_url = reverse("eventos:calendario")
+        context["back_component_config"] = {
+            "href": calendario_url,
+            "fallback_href": calendario_url,
+            "use_history": True,
+        }
         return context
 
     def form_valid(self, form):  # pragma: no cover

--- a/nucleos/templates/nucleos/delete.html
+++ b/nucleos/templates/nucleos/delete.html
@@ -17,9 +17,6 @@
 
     <form method="post" class="mt-6 flex justify-center gap-3">
       {% csrf_token %}
-
-      {% include '_components/back_button.html' with href=back_href classes='btn btn-secondary text-sm' %}
-
       <button type="submit" class="btn btn-primary text-sm" aria-label="{% trans 'Remover' %}">
         {% trans "Remover" %}
       </button>

--- a/nucleos/templates/nucleos/nucleo_form.html
+++ b/nucleos/templates/nucleos/nucleo_form.html
@@ -19,7 +19,6 @@
   {% with back_link=back_href|default:cancel_url %}
   <div class="card">
     <div class="card-header flex items-center justify-between gap-3">
-      {% include '_components/back_button.html' with href=back_link classes='btn btn-secondary btn-sm' %}
       <h2 class="text-xl font-semibold">
         {% if object %}
           {% trans "Editar núcleo" %}

--- a/nucleos/views.py
+++ b/nucleos/views.py
@@ -294,6 +294,16 @@ class NucleoCreateView(NoSuperadminMixin, AdminRequiredMixin, LoginRequiredMixin
             return resp
         return response
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        lista_url = reverse("nucleos:list")
+        context["back_component_config"] = {
+            "href": lista_url,
+            "fallback_href": lista_url,
+            "use_history": True,
+        }
+        return context
+
 
 class NucleoUpdateView(NoSuperadminMixin, GerenteRequiredMixin, LoginRequiredMixin, UpdateView):
     model = Nucleo

--- a/templates/_components/back_button.html
+++ b/templates/_components/back_button.html
@@ -1,7 +1,40 @@
-{% load i18n %}
-<a href="{{ href|default:'#' }}"
-   class="{{ classes|default:'btn btn-secondary' }}"
-   aria-label="{% if aria_label %}{{ aria_label }}{% else %}{% trans 'Voltar' %}{% endif %}"
-   onclick="if (document.referrer) { try { var u = new URL(document.referrer); if (u.origin === window.location.origin) { history.back(); return false; } } catch (e) {} }">
-  {% if label %}{{ label }}{% else %}{% trans 'Voltar' %}{% endif %}
-</a>
+{% load i18n lucide_icons %}
+{#
+  Componente padronizado de botão de retorno.
+
+  Parâmetros disponíveis:
+    - label: texto visível do botão. Padrão "Voltar".
+    - aria_label: rótulo acessível. Caso não seja informado, utiliza o label.
+    - href: URL primária para navegação padrão.
+    - fallback_href: URL utilizada quando não há histórico válido.
+    - use_history: quando verdadeiro (padrão), tenta voltar no histórico antes de usar href/fallback.
+    - variant: "button" (padrão), "link" ou "compact".
+    - size: tamanho aplicado quando variant == "button" (ex.: "sm").
+    - classes: classes extras adicionadas ao elemento.
+    - icon: nome do ícone Lucide (padrão "arrow-left").
+    - hide_icon: desativa o ícone quando verdadeiro.
+    - element: "a" (padrão) ou "button" para alterar o elemento renderizado.
+    - button_type: tipo do botão quando element == "button" (padrão "button").
+    - htmx_attrs: dicionário com atributos HTMX (ex.: { 'get': url, 'target': '#id' }).
+    - extra_attrs: dicionário com atributos adicionais arbitrários.
+#}
+
+{% with raw_use_history=use_history %}
+  {% if raw_use_history is not None and raw_use_history != '' %}
+    {% with normalized_use_history=raw_use_history|stringformat:'s'|lower %}
+      {% if normalized_use_history == 'false' or normalized_use_history == '0' %}
+        {% with resolved_use_history=False %}
+          {% include '_components/back_button_core.html' %}
+        {% endwith %}
+      {% else %}
+        {% with resolved_use_history=True %}
+          {% include '_components/back_button_core.html' %}
+        {% endwith %}
+      {% endif %}
+    {% endwith %}
+  {% else %}
+    {% with resolved_use_history=True %}
+      {% include '_components/back_button_core.html' %}
+    {% endwith %}
+  {% endif %}
+{% endwith %}

--- a/templates/_components/back_button_core.html
+++ b/templates/_components/back_button_core.html
@@ -1,0 +1,54 @@
+{% load i18n %}
+{% with
+  resolved_label=label|default:_('Voltar')
+  resolved_aria_label=aria_label|default:label|default:_('Voltar')
+  resolved_variant=variant|default:'button'
+  resolved_element=element|default:'a'
+  resolved_size=size|default:'md'
+  resolved_icon=icon|default:'arrow-left'
+  resolved_hide_icon=hide_icon|default_if_none:False
+  resolved_button_type=button_type|default:'button'
+%}
+  {% if resolved_variant == 'link' %}
+    {% with
+      variant_classes='inline-flex items-center gap-2 text-sm font-medium text-[var(--text-secondary)] hover:text-[var(--text-primary)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--focus)] transition-colors'
+      icon_classes='w-4 h-4'
+    %}
+      {% include '_components/back_button_element.html' %}
+    {% endwith %}
+  {% elif resolved_variant == 'compact' %}
+    {% with
+      variant_classes='inline-flex h-10 w-10 items-center justify-center rounded-full border border-[var(--border)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:border-[var(--border-stronger)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--focus)] transition-colors bg-[var(--bg-primary)]'
+      icon_classes='w-5 h-5'
+    %}
+      {% include '_components/back_button_element.html' %}
+    {% endwith %}
+  {% else %}
+    {% if resolved_size == 'sm' %}
+      {% with size_suffix=' btn-sm' %}
+        {% with
+          variant_classes='btn btn-secondary inline-flex items-center gap-2'|add:size_suffix
+          icon_classes='w-4 h-4'
+        %}
+          {% include '_components/back_button_element.html' %}
+        {% endwith %}
+      {% endwith %}
+    {% elif resolved_size == 'lg' %}
+      {% with size_suffix=' btn-lg' %}
+        {% with
+          variant_classes='btn btn-secondary inline-flex items-center gap-2'|add:size_suffix
+          icon_classes='w-4 h-4'
+        %}
+          {% include '_components/back_button_element.html' %}
+        {% endwith %}
+      {% endwith %}
+    {% else %}
+      {% with
+        variant_classes='btn btn-secondary inline-flex items-center gap-2'
+        icon_classes='w-4 h-4'
+      %}
+        {% include '_components/back_button_element.html' %}
+      {% endwith %}
+    {% endif %}
+  {% endif %}
+{% endwith %}

--- a/templates/_components/back_button_element.html
+++ b/templates/_components/back_button_element.html
@@ -1,0 +1,11 @@
+{% with base_classes=variant_classes %}
+  {% if classes %}
+    {% with final_classes=base_classes|add:' '|add:classes %}
+      {% include '_components/back_button_tag.html' %}
+    {% endwith %}
+  {% else %}
+    {% with final_classes=base_classes %}
+      {% include '_components/back_button_tag.html' %}
+    {% endwith %}
+  {% endif %}
+{% endwith %}

--- a/templates/_components/back_button_tag.html
+++ b/templates/_components/back_button_tag.html
@@ -1,0 +1,14 @@
+{% load i18n lucide_icons %}
+{% with
+  final_href=href|default:fallback_href|default:'#'
+  computed_fallback=fallback_href|default_if_none:None
+  back_mode=resolved_use_history|yesno:'history,href'
+%}
+  {% if not computed_fallback and resolved_element == 'button' %}
+    {% with computed_fallback=final_href %}
+      {% include '_components/back_button_tag_inner.html' %}
+    {% endwith %}
+  {% else %}
+    {% include '_components/back_button_tag_inner.html' %}
+  {% endif %}
+{% endwith %}

--- a/templates/_components/back_button_tag_inner.html
+++ b/templates/_components/back_button_tag_inner.html
@@ -1,0 +1,78 @@
+{% load i18n lucide_icons %}
+  {% if resolved_element == 'button' %}
+    <button
+      type="{{ resolved_button_type }}"
+      class="{{ final_classes }}"
+      aria-label="{{ resolved_aria_label }}"
+      data-back-button="true"
+      data-back-mode="{{ back_mode }}"
+      {% if computed_fallback %}data-back-fallback="{{ computed_fallback }}"{% endif %}
+      {% if extra_attrs %}{% for attr, value in extra_attrs.items %} {{ attr }}="{{ value }}"{% endfor %}{% endif %}
+      {% if htmx_attrs %}{% for attr, value in htmx_attrs.items %} hx-{{ attr|slugify }}="{{ value }}"{% endfor %}{% endif %}
+      {% if hx_get %} hx-get="{{ hx_get }}"{% endif %}
+      {% if hx_post %} hx-post="{{ hx_post }}"{% endif %}
+      {% if hx_put %} hx-put="{{ hx_put }}"{% endif %}
+      {% if hx_delete %} hx-delete="{{ hx_delete }}"{% endif %}
+      {% if hx_patch %} hx-patch="{{ hx_patch }}"{% endif %}
+      {% if hx_target %} hx-target="{{ hx_target }}"{% endif %}
+      {% if hx_trigger %} hx-trigger="{{ hx_trigger }}"{% endif %}
+      {% if hx_confirm %} hx-confirm="{{ hx_confirm }}"{% endif %}
+      {% if hx_swap %} hx-swap="{{ hx_swap }}"{% endif %}
+      {% if hx_swap_oob %} hx-swap-oob="{{ hx_swap_oob }}"{% endif %}
+      {% if hx_push_url %} hx-push-url="{{ hx_push_url }}"{% endif %}
+      {% if hx_select %} hx-select="{{ hx_select }}"{% endif %}
+      {% if hx_select_oob %} hx-select-oob="{{ hx_select_oob }}"{% endif %}
+      {% if hx_include %} hx-include="{{ hx_include }}"{% endif %}
+      {% if hx_params %} hx-params="{{ hx_params }}"{% endif %}
+      {% if hx_vals %} hx-vals="{{ hx_vals }}"{% endif %}
+      {% if hx_ext %} hx-ext="{{ hx_ext }}"{% endif %}
+      {% if hx_headers %} hx-headers="{{ hx_headers }}"{% endif %}
+    >
+      {% if not resolved_hide_icon %}
+        {% lucide resolved_icon class=icon_classes aria_hidden='true' %}
+      {% endif %}
+      {% if resolved_variant == 'compact' %}
+        <span class="sr-only">{{ resolved_label }}</span>
+      {% else %}
+        <span>{{ resolved_label }}</span>
+      {% endif %}
+    </button>
+  {% else %}
+    <a
+      href="{{ final_href }}"
+      class="{{ final_classes }}"
+      aria-label="{{ resolved_aria_label }}"
+      data-back-button="true"
+      data-back-mode="{{ back_mode }}"
+      {% if computed_fallback %}data-back-fallback="{{ computed_fallback }}"{% endif %}
+      {% if extra_attrs %}{% for attr, value in extra_attrs.items %} {{ attr }}="{{ value }}"{% endfor %}{% endif %}
+      {% if htmx_attrs %}{% for attr, value in htmx_attrs.items %} hx-{{ attr|slugify }}="{{ value }}"{% endfor %}{% endif %}
+      {% if hx_get %} hx-get="{{ hx_get }}"{% endif %}
+      {% if hx_post %} hx-post="{{ hx_post }}"{% endif %}
+      {% if hx_put %} hx-put="{{ hx_put }}"{% endif %}
+      {% if hx_delete %} hx-delete="{{ hx_delete }}"{% endif %}
+      {% if hx_patch %} hx-patch="{{ hx_patch }}"{% endif %}
+      {% if hx_target %} hx-target="{{ hx_target }}"{% endif %}
+      {% if hx_trigger %} hx-trigger="{{ hx_trigger }}"{% endif %}
+      {% if hx_confirm %} hx-confirm="{{ hx_confirm }}"{% endif %}
+      {% if hx_swap %} hx-swap="{{ hx_swap }}"{% endif %}
+      {% if hx_swap_oob %} hx-swap-oob="{{ hx_swap_oob }}"{% endif %}
+      {% if hx_push_url %} hx-push-url="{{ hx_push_url }}"{% endif %}
+      {% if hx_select %} hx-select="{{ hx_select }}"{% endif %}
+      {% if hx_select_oob %} hx-select-oob="{{ hx_select_oob }}"{% endif %}
+      {% if hx_include %} hx-include="{{ hx_include }}"{% endif %}
+      {% if hx_params %} hx-params="{{ hx_params }}"{% endif %}
+      {% if hx_vals %} hx-vals="{{ hx_vals }}"{% endif %}
+      {% if hx_ext %} hx-ext="{{ hx_ext }}"{% endif %}
+      {% if hx_headers %} hx-headers="{{ hx_headers }}"{% endif %}
+    >
+      {% if not resolved_hide_icon %}
+        {% lucide resolved_icon class=icon_classes aria_hidden='true' %}
+      {% endif %}
+      {% if resolved_variant == 'compact' %}
+        <span class="sr-only">{{ resolved_label }}</span>
+      {% else %}
+        <span>{{ resolved_label }}</span>
+      {% endif %}
+    </a>
+  {% endif %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -56,6 +56,32 @@
     {% include '_partials/header.html' %}
     {% block hero %}{% endblock %}
     <main id="main-content" class="container mx-auto p-6 flex-grow">
+      {% block back_button %}
+        {% if back_component_config %}
+          <div class="mb-6">
+            {% include '_components/back_button.html' with
+              label=back_component_config.label
+              aria_label=back_component_config.aria_label
+              href=back_component_config.href
+              fallback_href=back_component_config.fallback_href
+              use_history=back_component_config.use_history
+              variant=back_component_config.variant
+              size=back_component_config.size
+              classes=back_component_config.classes
+              icon=back_component_config.icon
+              hide_icon=back_component_config.hide_icon
+              element=back_component_config.element
+              button_type=back_component_config.button_type
+              htmx_attrs=back_component_config.htmx_attrs
+              extra_attrs=back_component_config.extra_attrs
+            %}
+          </div>
+        {% elif back_href %}
+          <div class="mb-6">
+            {% include '_components/back_button.html' with href=back_href %}
+          </div>
+        {% endif %}
+      {% endblock %}
       {% block content %}{% endblock %}
     </main>
     {% include '_partials/toasts.html' %}
@@ -77,6 +103,99 @@
         alert(gettext('Você não tem permissão para realizar esta ação.'));
       }
     });
+  </script>
+  <script>
+    (function () {
+      if (window.__hubxBackButtonInitialized) {
+        return;
+      }
+      window.__hubxBackButtonInitialized = true;
+
+      const shouldUseHistory = (referer) => {
+        if (!referer) {
+          return false;
+        }
+        try {
+          const refUrl = new URL(referer, window.location.href);
+          return refUrl.origin === window.location.origin;
+        } catch (error) {
+          return false;
+        }
+      };
+
+      const navigateTo = (url) => {
+        if (!url) {
+          return false;
+        }
+        window.location.href = url;
+        return true;
+      };
+
+      const handleClick = (event) => {
+        const target = event.currentTarget;
+        if (!target) {
+          return;
+        }
+
+        const mode = target.dataset.backMode || 'history';
+        const fallback = target.dataset.backFallback || '';
+        const referer = document.referrer;
+        const currentUrl = window.location.href;
+
+        if (mode === 'history') {
+          const canGoBack = shouldUseHistory(referer) && window.history.length > 1 && referer !== currentUrl;
+          if (canGoBack) {
+            event.preventDefault();
+            window.history.back();
+            return;
+          }
+
+          if (fallback) {
+            const href = typeof target.getAttribute === 'function' ? target.getAttribute('href') : null;
+            if (
+              !href ||
+              href === '#' ||
+              href === '' ||
+              href === currentUrl ||
+              target.tagName !== 'A'
+            ) {
+              event.preventDefault();
+              navigateTo(fallback);
+            }
+          }
+          return;
+        }
+
+        if (mode === 'href' && target.tagName !== 'A') {
+          const href = typeof target.getAttribute === 'function' ? target.getAttribute('href') : null;
+          const destination = href && href !== '#' ? href : fallback;
+          if (destination) {
+            event.preventDefault();
+            navigateTo(destination);
+          }
+        }
+      };
+
+      const initialise = (element) => {
+        if (!element || element.dataset.backBound === 'true') {
+          return;
+        }
+        element.addEventListener('click', handleClick);
+        element.dataset.backBound = 'true';
+      };
+
+      const bindAll = () => {
+        document.querySelectorAll('[data-back-button]').forEach(initialise);
+      };
+
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', bindAll);
+      } else {
+        bindAll();
+      }
+
+      document.addEventListener('htmx:afterSwap', bindAll);
+    })();
   </script>
   <script>
     (function () {

--- a/tokens/templates/tokens/gerar_token.html
+++ b/tokens/templates/tokens/gerar_token.html
@@ -28,9 +28,6 @@
         {% include "tokens/_resultado.html" %}
       </div>
 
-      <footer class="mt-6">
-        <button type="button" class="btn btn-secondary" onclick="history.back()">{% trans "Voltar" %}</button>
-      </footer>
     </div>
   </div>
 </section>

--- a/tokens/templates/tokens/token_list.html
+++ b/tokens/templates/tokens/token_list.html
@@ -36,9 +36,6 @@
       <p class="text-sm text-[var(--text-secondary)]">{% trans "Nenhum convite encontrado." %}</p>
       {% endif %}
 
-      <div>
-        <button type="button" class="btn btn-secondary" onclick="history.back()">{% trans "Voltar" %}</button>
-      </div>
     </div>
   </div>
 </div>

--- a/tokens/views.py
+++ b/tokens/views.py
@@ -10,6 +10,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.shortcuts import redirect, render
+from django.urls import reverse
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from django.views import View
@@ -77,7 +78,13 @@ def listar_convites(request):
         convite.preview_display = preview
         convites.append(convite)
 
-    context = {"convites": convites, "totais": totais}
+    fallback_url = reverse("core:home")
+    back_button = {
+        "href": fallback_url,
+        "fallback_href": fallback_url,
+        "use_history": True,
+    }
+    context = {"convites": convites, "totais": totais, "back_component_config": back_button}
     if request.headers.get("Hx-Request") == "true":
         return render(request, "tokens/token_list.html", context)
     full_context = {
@@ -106,8 +113,13 @@ class GerarTokenConviteView(LoginRequiredMixin, View):
                 _("Seu usuário não está associado a nenhuma organização."),
             )
             return redirect("accounts:perfil")
+        back_button = {
+            "href": reverse("tokens:listar_convites"),
+            "fallback_href": reverse("tokens:listar_convites"),
+            "use_history": True,
+        }
         if request.headers.get("Hx-Request") == "true":
-            return render(request, "tokens/gerar_token.html", {"form": form})
+            return render(request, "tokens/gerar_token.html", {"form": form, "back_component_config": back_button})
         return render(
             request,
             "tokens/tokens.html",
@@ -115,6 +127,7 @@ class GerarTokenConviteView(LoginRequiredMixin, View):
                 "partial_template": "tokens/gerar_token.html",
                 "form": form,
                 "hero_title": _("Gerar Token"),
+                "back_component_config": back_button,
             },
         )
 


### PR DESCRIPTION
## Summary
- evolui o `_components/back_button.html` adicionando variantes, suporte a HTMX e fallback configurável
- injeta automaticamente o botão de retorno em `base.html` com script compartilhado para histórico e atualiza a documentação
- ajusta views e templates de eventos, núcleos, tokens e conexões para usar a nova API sem scripts inline

## Testing
- python -m compileall eventos nucleos tokens

------
https://chatgpt.com/codex/tasks/task_e_68dc3a3208a08325b0e1436a92f4aa64