### PR TITLE
Padroniza botões de retorno em formulários do feed e organizações

### DIFF
--- a/feed/templates/feed/nova_postagem.html
+++ b/feed/templates/feed/nova_postagem.html
@@ -147,15 +147,11 @@
 
       <!-- Ações -->
       <div class="flex justify-end gap-3 mt-6">
+        {% url 'feed:listar' as feed_list_url %}
+        {% include '_components/back_button.html' with href=feed_list_url label=_('Cancelar') aria_label=_('Cancelar') %}
         <button type="submit" class="btn btn-primary" aria-label="{% trans 'Salvar' %}">
           {% trans "Salvar" %}
         </button>
-        <a href="{% url 'feed:listar' %}" class="btn btn-secondary" aria-label="{% trans 'Cancelar' %}">
-          {% trans "Cancelar" %}
-        </a>
-        <a href="{% url 'feed:listar' %}" class="btn btn-secondary" aria-label="{% trans 'Voltar' %}">
-          {% trans "Voltar" %}
-        </a>
       </div>
       </div>
     </form>

--- a/organizacoes/templates/organizacoes/organizacao_form.html
+++ b/organizacoes/templates/organizacoes/organizacao_form.html
@@ -21,13 +21,7 @@
 <section class="max-w-2xl mx-auto px-4 py-10">
 
   <!-- Cabeçalho -->
-    <div class="mb-6 flex items-center gap-4">
-      <a href="{% url 'organizacoes:list' %}" class="btn btn-secondary" aria-label="{% trans 'Voltar' %}">
-        <svg class="mr-2" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-        <polyline points="15,18 9,12 15,6"/>
-      </svg>
-      {% trans 'Voltar' %}
-    </a>
+    <div class="mb-6">
       <h1 class="text-2xl font-bold text-[var(--text-primary)]">
         {% if form.instance.pk %}
           {% trans 'Editar Organização' %}
@@ -46,9 +40,12 @@
     {% endfor %}
 
       <div class="flex justify-end gap-3 pt-4 border-t border-[var(--border)]">
-        <a href="{% url 'organizacoes:list' %}" class="btn btn-secondary" aria-label="{% if form.instance.pk %}{% trans 'Cancelar edição' %}{% else %}{% trans 'Cancelar' %}{% endif %}">
-          {% trans 'Cancelar' %}
-        </a>
+        {% url 'organizacoes:list' as organizacoes_list_url %}
+        {% if form.instance.pk %}
+          {% include '_components/back_button.html' with href=organizacoes_list_url label=_('Cancelar') aria_label=_('Cancelar edição') %}
+        {% else %}
+          {% include '_components/back_button.html' with href=organizacoes_list_url label=_('Cancelar') aria_label=_('Cancelar') %}
+        {% endif %}
         <button type="submit" class="btn{% if form.instance.pk %} btn-primary{% endif %}" aria-label="{% trans 'Salvar organização' %}">
           {% trans 'Salvar' %}
         </button>


### PR DESCRIPTION
## Summary
- remove botões secundários duplicados na criação de postagens, reutilizando o componente genérico de retorno para a ação de cancelar
- simplifica o cabeçalho do formulário de organizações e padroniza o cancelamento com o mesmo componente de retorno

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dc469e7ed08325a589342b2be35089