### PR TITLE
Add automatic back button block to base template

### DIFF
--- a/Hubx/settings.py
+++ b/Hubx/settings.py
@@ -138,6 +138,7 @@ TEMPLATES = [
                 "django.contrib.messages.context_processors.messages",
                 "core.context_processors.htmx_version",
                 "core.context_processors.menu_items",
+                "core.context_processors.back_navigation",
             ],
             # Torna os filtros/tags do widget_tweaks disponíveis globalmente
             # evitando a necessidade de `{% load widget_tweaks %}` em cada template.

--- a/core/context_processors.py
+++ b/core/context_processors.py
@@ -1,5 +1,7 @@
 from django.conf import settings
 
+from core.utils import resolve_back_href
+
 
 def htmx_version(request):
     return {
@@ -13,3 +15,7 @@ def menu_items(request):
     from .menu import build_menu
 
     return {"NAV_MENU": build_menu(request)}
+
+
+def back_navigation(request):
+    return {"back_href": resolve_back_href(request)}

--- a/templates/_components/README.md
+++ b/templates/_components/README.md
@@ -93,6 +93,26 @@ executa `history.back()`. Caso contrário, utiliza o `href` informado ou um
 - `fallback_href` garante uma rota segura quando o histórico do navegador não
   está disponível (ex.: acesso direto por URL compartilhada).
 
+### Populando `back_component_config`
+
+Views que desejam personalizar o botão exibido automaticamente em
+`templates/base.html` devem preencher o dicionário `back_component_config` no
+contexto. Os campos aceitos correspondem aos parâmetros da partial e serão
+mesclados antes da inclusão:
+
+```python
+context["back_component_config"] = {
+    "href": resolve_back_href(request, fallback="minha-rota"),
+    "variant": "link",
+    "label": _("Voltar para a listagem"),
+    "show_icon": False,
+}
+```
+
+Quando `back_component_config` não é informado, o template usa `back_href`,
+preenchido automaticamente pelo context processor
+`core.context_processors.back_navigation` (que utiliza `resolve_back_href`).
+
 ## Convenções de i18n
 
 - Todo texto visível deve estar dentro de `{% trans %}` ou `{% blocktrans %}`.

--- a/templates/base.html
+++ b/templates/base.html
@@ -58,6 +58,51 @@
     <main id="main-content" class="container mx-auto p-6 flex-grow">
       {% block content %}{% endblock %}
     </main>
+    {% block back_button %}
+      {% if back_component_config %}
+        {% with
+          href=back_component_config.href
+          fallback_href=back_component_config.fallback_href
+          variant=back_component_config.variant
+          classes=back_component_config.classes
+          label=back_component_config.label
+          aria_label=back_component_config.aria_label
+          icon=back_component_config.icon
+          show_icon=back_component_config.show_icon
+          prevent_history=back_component_config.prevent_history
+          hx_get=back_component_config.hx_get
+          hx_post=back_component_config.hx_post
+          hx_put=back_component_config.hx_put
+          hx_delete=back_component_config.hx_delete
+          hx_patch=back_component_config.hx_patch
+          hx_target=back_component_config.hx_target
+          hx_swap=back_component_config.hx_swap
+          hx_trigger=back_component_config.hx_trigger
+          hx_push_url=back_component_config.hx_push_url
+          hx_include=back_component_config.hx_include
+          hx_indicator=back_component_config.hx_indicator
+          hx_confirm=back_component_config.hx_confirm
+          hx_params=back_component_config.hx_params
+          hx_ext=back_component_config.hx_ext
+          hx_on=back_component_config.hx_on
+          hx_vals=back_component_config.hx_vals
+          hx_select=back_component_config.hx_select
+          hx_select_oob=back_component_config.hx_select_oob
+          hx_replace_url=back_component_config.hx_replace_url
+          hx_headers=back_component_config.hx_headers
+          hx_prompt=back_component_config.hx_prompt
+          hx_validate=back_component_config.hx_validate
+          hx_sync=back_component_config.hx_sync
+          hx_boost=back_component_config.hx_boost
+          hx_disable=back_component_config.hx_disable
+          hx_history=back_component_config.hx_history
+        %}
+          {% include '_components/back_button.html' %}
+        {% endwith %}
+      {% elif back_href %}
+        {% include '_components/back_button.html' with href=back_href %}
+      {% endif %}
+    {% endblock %}
     {% include '_partials/toasts.html' %}
 
     {% include '_partials/footer.html' %}


### PR DESCRIPTION
## Summary
- add a reusable back button block to the base template that includes the shared component when context is provided
- expose a new back_navigation context processor to populate back_href automatically
- document how views should populate back_component_config for customisation

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68dc4d288c4883258db695ce760fa76c