### PR TITLE
Refatora botões de retorno para usar componente reutilizável

### DIFF
--- a/eventos/templates/eventos/partials/eventos/create.html
+++ b/eventos/templates/eventos/partials/eventos/create.html
@@ -114,7 +114,8 @@
         </div>
 
         <div class="flex justify-end gap-3 pt-4 border-t border-[var(--border)]">
-          <a id="btn-voltar" href="{% url 'eventos:calendario' %}" data-fallback-url="{% url 'eventos:calendario' %}" class="btn btn-secondary" aria-label="{% trans 'Voltar' %}" data-behavior="back">{% trans "Voltar" %}</a>
+          {% url 'eventos:calendario' as calendario_url %}
+          {% include '_components/back_button.html' with href=back_href fallback_href=calendario_url %}
           <button type="submit" class="btn btn-primary" aria-label="{% trans 'Salvar' %}">{% trans "Salvar" %}</button>
         </div>
       </form>
@@ -124,27 +125,6 @@
 
 {% block extra_js %}
 <script>
-  // Comportamento do botão Voltar: tenta voltar no histórico; se não houver origem válida, usa fallback
-  (function(){
-    const btn = document.getElementById('btn-voltar');
-    if(!btn) return;
-    btn.addEventListener('click', function(e){
-      const ref = document.referrer;
-      const fallback = btn.getAttribute('data-fallback-url');
-      const sameOrigin = ref && ref.startsWith(window.location.origin);
-      // Evita voltar para a própria página ou páginas de criação/edição em loop
-      const invalid = !sameOrigin || ref === window.location.href;
-      if(invalid || window.history.length <= 1) {
-        if(fallback) {
-          e.preventDefault();
-          window.location.href = fallback;
-        }
-      } else {
-        e.preventDefault();
-        window.history.back();
-      }
-    });
-  })();
   document.addEventListener('DOMContentLoaded', function () {
     const publicoAlvoSelect = document.getElementById('id_publico_alvo');
     const nucleoInput = document.getElementById('id_nucleo');

--- a/eventos/templates/eventos/partials/eventos/update.html
+++ b/eventos/templates/eventos/partials/eventos/update.html
@@ -117,7 +117,8 @@
     </div>
 
     <div class="flex justify-end gap-3 pt-4 border-t border-[var(--border)]">
-      <a id="btn-voltar" href="{% url 'eventos:calendario' %}" data-fallback-url="{% url 'eventos:calendario' %}" class="btn btn-secondary" aria-label="{% trans 'Voltar' %}" data-behavior="back">{% trans "Voltar" %}</a>
+      {% url 'eventos:calendario' as calendario_url %}
+      {% include '_components/back_button.html' with href=back_href fallback_href=calendario_url %}
       <button type="submit" class="btn btn-primary" aria-label="{% trans 'Salvar' %}">{% trans "Salvar" %}</button>
     </div>
   </form>
@@ -126,25 +127,6 @@
 
 {% block extra_js %}
 <script>
-  (function(){
-    const btn = document.getElementById('btn-voltar');
-    if(!btn) return;
-    btn.addEventListener('click', function(e){
-      const ref = document.referrer;
-      const fallback = btn.getAttribute('data-fallback-url');
-      const sameOrigin = ref && ref.startsWith(window.location.origin);
-      const invalid = !sameOrigin || ref === window.location.href;
-      if(invalid || window.history.length <= 1) {
-        if(fallback) {
-          e.preventDefault();
-          window.location.href = fallback;
-        }
-      } else {
-        e.preventDefault();
-        window.history.back();
-      }
-    });
-  })();
   document.addEventListener('DOMContentLoaded', function () {
     const publicoAlvoSelect = document.getElementById('id_publico_alvo');
     const nucleoInput = document.getElementById('id_nucleo');

--- a/tokens/templates/tokens/gerar_token.html
+++ b/tokens/templates/tokens/gerar_token.html
@@ -29,7 +29,8 @@
       </div>
 
       <footer class="mt-6">
-        <button type="button" class="btn btn-secondary" onclick="history.back()">{% trans "Voltar" %}</button>
+        {% url 'tokens:listar_convites' as convites_url %}
+        {% include '_components/back_button.html' with href=back_href fallback_href=convites_url %}
       </footer>
     </div>
   </div>

--- a/tokens/templates/tokens/token_list.html
+++ b/tokens/templates/tokens/token_list.html
@@ -37,7 +37,8 @@
       {% endif %}
 
       <div>
-        <button type="button" class="btn btn-secondary" onclick="history.back()">{% trans "Voltar" %}</button>
+        {% url 'accounts:perfil' as perfil_url %}
+        {% include '_components/back_button.html' with href=back_href fallback_href=perfil_url %}
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- substitui os scripts inline de retorno nas telas de criação/edição de eventos pelo componente `back_button`
- atualiza templates de tokens para usar o mesmo componente, definindo fallbacks explícitos

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc516641488325957d20df5b70d422