### PR TITLE
Support HTMX config for back button

### DIFF
--- a/accounts/templates/perfil/partials/conexoes_busca.html
+++ b/accounts/templates/perfil/partials/conexoes_busca.html
@@ -2,15 +2,39 @@
 <div class="space-y-6">
   <div class="flex items-center justify-between">
     <h2 class="text-base font-semibold text-[var(--text-primary)]">{% trans "Buscar pessoas" %}</h2>
-    <button
-      type="button"
-      class="btn-secondary btn-sm"
-      hx-get="{% url 'accounts:perfil_conexoes_partial' %}"
-      hx-target="#perfil-content"
-      hx-push-url="?section=conexoes"
-    >
-      {% trans "Voltar" %}
-    </button>
+    {% url 'accounts:perfil_sections_conexoes' as conexoes_partial_url %}
+    {% url 'accounts:perfil' as perfil_url %}
+    {% with partial_query='?view=buscar' full_query='?section=conexoes&view=buscar' %}
+      {% if q %}
+        {% with encoded_q=q|urlencode %}
+          {% with partial_query=partial_query|add:'&q='|add:encoded_q full_query=full_query|add:'&q='|add:encoded_q %}
+            {% include '_components/back_button.html' with
+              label=_('Voltar')
+              show_icon=False
+              classes='btn-sm'
+              hx_get=conexoes_partial_url
+              hx_target='#perfil-content'
+              hx_push_url='?section=conexoes'
+              prevent_history=True
+              href=conexoes_partial_url|add:partial_query
+              fallback_href=perfil_url|add:full_query
+            %}
+          {% endwith %}
+        {% endwith %}
+      {% else %}
+        {% include '_components/back_button.html' with
+          label=_('Voltar')
+          show_icon=False
+          classes='btn-sm'
+          hx_get=conexoes_partial_url
+          hx_target='#perfil-content'
+          hx_push_url='?section=conexoes'
+          prevent_history=True
+          href=conexoes_partial_url|add:partial_query
+          fallback_href=perfil_url|add:full_query
+        %}
+      {% endif %}
+    {% endwith %}
   </div>
 
   <form

--- a/core/templatetags/string_filters.py
+++ b/core/templatetags/string_filters.py
@@ -50,3 +50,20 @@ def get_item(mapping, key):
             return mapping[str_key]
         return None
     return getattr(mapping, key, None)
+
+
+@register.filter(name="coalesce")
+def coalesce(value, fallback):
+    """Return ``value`` unless it is empty, otherwise ``fallback``.
+
+    ``None`` and empty strings (``""``) are considered empty. Boolean ``False``
+    is treated as a meaningful value so it is preserved instead of being
+    replaced by ``fallback``. This is useful for template parameters where
+    ``False`` should propagate (e.g. HTMX attributes that accept "false").
+    """
+
+    if value is None:
+        return fallback
+    if isinstance(value, str) and value == "":
+        return fallback
+    return value

--- a/templates/_components/back_button.html
+++ b/templates/_components/back_button.html
@@ -1,4 +1,79 @@
-{% load i18n lucide_icons %}
+{% load i18n lucide_icons string_filters %}
+{% with cfg=config|default:back_component_config %}
+{% with
+  href_fallback=cfg|get_item:'href'
+  fallback_href_fallback=cfg|get_item:'fallback_href'
+  variant_fallback=cfg|get_item:'variant'
+  classes_fallback=cfg|get_item:'classes'
+  label_fallback=cfg|get_item:'label'
+  aria_label_fallback=cfg|get_item:'aria_label'
+  icon_fallback=cfg|get_item:'icon'
+  show_icon_fallback=cfg|get_item:'show_icon'
+  prevent_history_fallback=cfg|get_item:'prevent_history'
+  hx_get_fallback=cfg|get_item:'hx_get'
+  hx_post_fallback=cfg|get_item:'hx_post'
+  hx_put_fallback=cfg|get_item:'hx_put'
+  hx_delete_fallback=cfg|get_item:'hx_delete'
+  hx_patch_fallback=cfg|get_item:'hx_patch'
+  hx_target_fallback=cfg|get_item:'hx_target'
+  hx_swap_fallback=cfg|get_item:'hx_swap'
+  hx_trigger_fallback=cfg|get_item:'hx_trigger'
+  hx_push_url_fallback=cfg|get_item:'hx_push_url'
+  hx_include_fallback=cfg|get_item:'hx_include'
+  hx_indicator_fallback=cfg|get_item:'hx_indicator'
+  hx_confirm_fallback=cfg|get_item:'hx_confirm'
+  hx_params_fallback=cfg|get_item:'hx_params'
+  hx_ext_fallback=cfg|get_item:'hx_ext'
+  hx_on_fallback=cfg|get_item:'hx_on'
+  hx_vals_fallback=cfg|get_item:'hx_vals'
+  hx_select_fallback=cfg|get_item:'hx_select'
+  hx_select_oob_fallback=cfg|get_item:'hx_select_oob'
+  hx_replace_url_fallback=cfg|get_item:'hx_replace_url'
+  hx_headers_fallback=cfg|get_item:'hx_headers'
+  hx_prompt_fallback=cfg|get_item:'hx_prompt'
+  hx_validate_fallback=cfg|get_item:'hx_validate'
+  hx_sync_fallback=cfg|get_item:'hx_sync'
+  hx_boost_fallback=cfg|get_item:'hx_boost'
+  hx_disable_fallback=cfg|get_item:'hx_disable'
+  hx_history_fallback=cfg|get_item:'hx_history'
+%}
+{% with
+  href=href|coalesce:href_fallback
+  fallback_href=fallback_href|coalesce:fallback_href_fallback
+  variant=variant|coalesce:variant_fallback
+  classes=classes|coalesce:classes_fallback
+  label=label|coalesce:label_fallback
+  aria_label=aria_label|coalesce:aria_label_fallback
+  icon=icon|coalesce:icon_fallback
+  show_icon=show_icon|default_if_none:show_icon_fallback
+  prevent_history=prevent_history|default_if_none:prevent_history_fallback
+  hx_get=hx_get|coalesce:hx_get_fallback
+  hx_post=hx_post|coalesce:hx_post_fallback
+  hx_put=hx_put|coalesce:hx_put_fallback
+  hx_delete=hx_delete|coalesce:hx_delete_fallback
+  hx_patch=hx_patch|coalesce:hx_patch_fallback
+  hx_target=hx_target|coalesce:hx_target_fallback
+  hx_swap=hx_swap|coalesce:hx_swap_fallback
+  hx_trigger=hx_trigger|coalesce:hx_trigger_fallback
+  hx_push_url=hx_push_url|coalesce:hx_push_url_fallback
+  hx_include=hx_include|coalesce:hx_include_fallback
+  hx_indicator=hx_indicator|coalesce:hx_indicator_fallback
+  hx_confirm=hx_confirm|coalesce:hx_confirm_fallback
+  hx_params=hx_params|coalesce:hx_params_fallback
+  hx_ext=hx_ext|coalesce:hx_ext_fallback
+  hx_on=hx_on|coalesce:hx_on_fallback
+  hx_vals=hx_vals|coalesce:hx_vals_fallback
+  hx_select=hx_select|coalesce:hx_select_fallback
+  hx_select_oob=hx_select_oob|coalesce:hx_select_oob_fallback
+  hx_replace_url=hx_replace_url|coalesce:hx_replace_url_fallback
+  hx_headers=hx_headers|coalesce:hx_headers_fallback
+  hx_prompt=hx_prompt|coalesce:hx_prompt_fallback
+  hx_validate=hx_validate|coalesce:hx_validate_fallback
+  hx_sync=hx_sync|coalesce:hx_sync_fallback
+  hx_boost=hx_boost|coalesce:hx_boost_fallback
+  hx_disable=hx_disable|coalesce:hx_disable_fallback
+  hx_history=hx_history|coalesce:hx_history_fallback
+%}
 {% with button_label=label|default:_('Voltar') %}
 {% with resolved_variant=variant|default:'button' icon_name=icon|default:'arrow-left' %}
 <a href="{{ href|default:fallback_href|default:'#' }}"
@@ -78,5 +153,8 @@
   {% endif %}
   <span class="{% if resolved_variant == 'compact' %}text-xs{% elif resolved_variant == 'link' %}text-sm{% else %}text-sm font-medium{% endif %}">{{ button_label }}</span>
 </a>
+{% endwith %}
+{% endwith %}
+{% endwith %}
 {% endwith %}
 {% endwith %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -60,45 +60,7 @@
     </main>
     {% block back_button %}
       {% if back_component_config %}
-        {% with
-          href=back_component_config.href
-          fallback_href=back_component_config.fallback_href
-          variant=back_component_config.variant
-          classes=back_component_config.classes
-          label=back_component_config.label
-          aria_label=back_component_config.aria_label
-          icon=back_component_config.icon
-          show_icon=back_component_config.show_icon
-          prevent_history=back_component_config.prevent_history
-          hx_get=back_component_config.hx_get
-          hx_post=back_component_config.hx_post
-          hx_put=back_component_config.hx_put
-          hx_delete=back_component_config.hx_delete
-          hx_patch=back_component_config.hx_patch
-          hx_target=back_component_config.hx_target
-          hx_swap=back_component_config.hx_swap
-          hx_trigger=back_component_config.hx_trigger
-          hx_push_url=back_component_config.hx_push_url
-          hx_include=back_component_config.hx_include
-          hx_indicator=back_component_config.hx_indicator
-          hx_confirm=back_component_config.hx_confirm
-          hx_params=back_component_config.hx_params
-          hx_ext=back_component_config.hx_ext
-          hx_on=back_component_config.hx_on
-          hx_vals=back_component_config.hx_vals
-          hx_select=back_component_config.hx_select
-          hx_select_oob=back_component_config.hx_select_oob
-          hx_replace_url=back_component_config.hx_replace_url
-          hx_headers=back_component_config.hx_headers
-          hx_prompt=back_component_config.hx_prompt
-          hx_validate=back_component_config.hx_validate
-          hx_sync=back_component_config.hx_sync
-          hx_boost=back_component_config.hx_boost
-          hx_disable=back_component_config.hx_disable
-          hx_history=back_component_config.hx_history
-        %}
-          {% include '_components/back_button.html' %}
-        {% endwith %}
+          {% include '_components/back_button.html' with config=back_component_config href=back_href %}
       {% elif back_href %}
         {% include '_components/back_button.html' with href=back_href %}
       {% endif %}


### PR DESCRIPTION
## Summary
- allow the reusable back button component to read HTMX options from a config dictionary using the new `coalesce` filter
- simplify the base template include so the back button can consume the entire configuration object directly
- update the conexões search partial to render the back button component with the appropriate HTMX attributes and prevent-history flag

## Testing
- pytest tests/accounts/test_connections.py *(fails due to project-wide coverage threshold `fail-under=90` after the tests themselves pass)*

------
https://chatgpt.com/codex/tasks/task_e_68dc539831fc8325b09b277835d314a5