### PR TITLE
Add cancel button component and standardize form actions

### DIFF
--- a/accounts/templates/associados/usuario_form.html
+++ b/accounts/templates/associados/usuario_form.html
@@ -33,7 +33,7 @@
         {% include '_forms/field.html' with field=field %}
       {% endfor %}
       <div class="flex justify-end gap-2 pt-2">
-        <a href="{% url 'accounts:associados_lista' %}" class="btn btn-secondary">{% trans 'Cancelar' %}</a>
+        {% include '_components/cancel_button.html' with config=cancel_component_config href=back_href fallback_href=cancel_component_config.fallback_href %}
         <button type="submit" class="btn btn-primary">{% trans 'Salvar' %}</button>
       </div>
     </form>

--- a/accounts/templates/perfil/partials/portfolio_confirm_delete.html
+++ b/accounts/templates/perfil/partials/portfolio_confirm_delete.html
@@ -2,12 +2,10 @@
 <section class="space-y-4">
   <h2 class="text-xl font-semibold text-error">{% trans "Remover Portfólio" %}</h2>
   <p class="text-[var(--text-secondary)]">{% trans "Tem certeza que deseja remover este item do portfólio?" %}</p>
+  {% url 'accounts:perfil_sections_portfolio' as portfolio_url %}
   <form method="post" class="flex justify-end gap-2">
     {% csrf_token %}
-    <a href="{% url 'accounts:perfil_sections_portfolio' %}" class="btn-secondary btn-sm inline-flex items-center gap-1">
-      {% lucide 'arrow-left' class='w-4 h-4' aria_hidden='true' %}
-      {% trans "Cancelar" %}
-    </a>
+    {% include '_components/cancel_button.html' with href=portfolio_url fallback_href=portfolio_url classes='btn-sm' icon='arrow-left' show_icon=True %}
     <button type="submit" class="btn-danger btn-sm inline-flex items-center gap-1">
       {% lucide 'trash' class='w-4 h-4' aria_hidden='true' %}
       {% trans "Remover" %}

--- a/accounts/templates/perfil/partials/portfolio_form.html
+++ b/accounts/templates/perfil/partials/portfolio_form.html
@@ -10,8 +10,9 @@
       {% for field in form %}
         {% include '_forms/field.html' with field=field %}
       {% endfor %}
+      {% url 'accounts:perfil_sections_portfolio' as portfolio_url %}
       <div class="flex justify-end gap-2">
-        <a href="{% url 'accounts:perfil_sections_portfolio' %}" class="btn btn-secondary">{% trans "Cancelar" %}</a>
+        {% include '_components/cancel_button.html' with href=portfolio_url fallback_href=portfolio_url %}
         <button type="submit" class="btn btn-primary">{% trans "Salvar" %}</button>
       </div>
     </div>

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -38,6 +38,8 @@ from django.views.generic import FormView, ListView, TemplateView
 from urllib.parse import urlencode
 from django_ratelimit.decorators import ratelimit
 from rest_framework import viewsets
+
+from core.utils import resolve_back_href
 from rest_framework.permissions import IsAuthenticated
 
 from accounts.serializers import UserSerializer
@@ -1328,6 +1330,21 @@ class OrganizacaoUserCreateView(NoSuperadminMixin, LoginRequiredMixin, FormView)
         kwargs = super().get_form_kwargs()
         kwargs["allowed_user_types"] = self.get_allowed_user_types()
         return kwargs
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        fallback_url = str(self.success_url)
+        back_href = resolve_back_href(self.request, fallback=fallback_url)
+        context["back_href"] = back_href
+        context["back_component_config"] = {
+            "href": back_href,
+            "fallback_href": fallback_url,
+        }
+        context["cancel_component_config"] = {
+            "href": back_href,
+            "fallback_href": fallback_url,
+        }
+        return context
 
     def form_valid(self, form):
         organizacao = getattr(self.request.user, "organizacao", None)

--- a/configuracoes/templates/configuracoes/operador_form.html
+++ b/configuracoes/templates/configuracoes/operador_form.html
@@ -60,7 +60,7 @@
             </div>
           </div>
           <div class="flex items-center justify-end gap-3">
-            <a href="{% url 'configuracoes:operadores' %}" class="btn btn-secondary">{% trans 'Cancelar' %}</a>
+            {% include '_components/cancel_button.html' with config=cancel_component_config href=back_href fallback_href=cancel_component_config.fallback_href %}
             <button type="submit" class="btn btn-primary">{% trans 'Salvar operador' %}</button>
           </div>
         </form>

--- a/configuracoes/views.py
+++ b/configuracoes/views.py
@@ -14,6 +14,8 @@ from django.utils.translation import gettext as _
 from django.urls import reverse_lazy
 from django.views.generic import FormView, TemplateView, View
 
+from core.utils import resolve_back_href
+
 # Project‑specific imports.  These may vary depending on your actual project
 # structure.  Adjust the module paths as necessary.
 try:
@@ -299,6 +301,17 @@ class OperadorCreateView(LoginRequiredMixin, AdminRequiredMixin, FormView):
                 "hero_subtitle": _("Crie novos operadores para apoiar a gestão."),
             }
         )
+        fallback_url = str(self.success_url)
+        back_href = resolve_back_href(self.request, fallback=fallback_url)
+        context["back_href"] = back_href
+        context["back_component_config"] = {
+            "href": back_href,
+            "fallback_href": fallback_url,
+        }
+        context["cancel_component_config"] = {
+            "href": back_href,
+            "fallback_href": fallback_url,
+        }
         return context
 
     def form_valid(self, form: OperadorCreateForm) -> HttpResponse:  # type: ignore[override]

--- a/feed/templates/feed/nova_postagem.html
+++ b/feed/templates/feed/nova_postagem.html
@@ -146,7 +146,8 @@
       <div class="mt-2 text-xs text-[var(--text-secondary)]">{% trans "Campos marcados com * são obrigatórios. Informe conteúdo ou anexe um arquivo." %}</div>
 
       <!-- Ações -->
-      <div class="flex justify-end mt-6">
+      <div class="flex justify-end gap-3 mt-6">
+        {% include '_components/cancel_button.html' with config=cancel_component_config href=back_href fallback_href=cancel_component_config.fallback_href %}
         <button type="submit" class="btn btn-primary" aria-label="{% trans 'Salvar' %}">
           {% trans "Salvar" %}
         </button>

--- a/feed/templates/feed/post_delete.html
+++ b/feed/templates/feed/post_delete.html
@@ -18,7 +18,7 @@
 
     <form method="post" hx-post="{% url 'feed:post_delete' post.pk %}" class="mt-6 flex justify-center gap-3">
       {% csrf_token %}
-      <a href="{% url 'feed:post_detail' post.pk %}" class="btn btn-secondary" aria-label="{% trans 'Cancelar' %}">{% trans "Cancelar" %}</a>
+      {% include '_components/cancel_button.html' with config=cancel_component_config href=back_href fallback_href=cancel_component_config.fallback_href %}
       <button type="submit" class="btn btn-danger" aria-label="{% trans 'Remover' %}">{% trans "Remover" %}</button>
     </form>
     </div>

--- a/feed/templates/feed/post_update.html
+++ b/feed/templates/feed/post_update.html
@@ -12,12 +12,7 @@
 {% else %}
 <section class="max-w-2xl mx-auto px-4 py-10">
   <div class="mb-6 flex items-center gap-4">
-    <a href="{% url 'feed:post_detail' post.pk %}" class="btn btn-secondary" aria-label="{% trans 'Voltar' %}">
-      <svg class="mr-2" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-        <polyline points="15,18 9,12 15,6"/>
-      </svg>
-      {% trans "Voltar" %}
-    </a>
+    {% include '_components/back_button.html' with href=back_href fallback_href=back_component_config.fallback_href %}
     <div>
       <h1 class="text-2xl font-bold text-[var(--text-primary)]">{% trans "Editar Postagem" %}</h1>
       <p class="text-sm text-[var(--text-secondary)]">{% trans "Atualize sua postagem" %}</p>
@@ -87,7 +82,7 @@
     </div>
 
     <div class="flex justify-end gap-3 pt-4 border-t border-[var(--border)]">
-      <a href="{% url 'feed:post_detail' post.pk %}" class="btn btn-secondary" aria-label="{% trans 'Cancelar' %}">{% trans "Cancelar" %}</a>
+      {% include '_components/cancel_button.html' with config=cancel_component_config href=back_href fallback_href=cancel_component_config.fallback_href %}
       <button type="submit" class="btn btn-primary" aria-label="{% trans 'Salvar' %}">{% trans "Salvar" %}</button>
     </div>
     </div>

--- a/feed/views.py
+++ b/feed/views.py
@@ -379,9 +379,10 @@ class NovaPostagemView(LoginRequiredMixin, NoSuperadminMixin, CreateView):
         context["back_component_config"] = {
             "href": back_href,
             "fallback_href": fallback_url,
-            "label": _("Cancelar"),
-            "aria_label": _("Cancelar"),
-            "variant": "button",
+        }
+        context["cancel_component_config"] = {
+            "href": back_href,
+            "fallback_href": fallback_url,
         }
         return context
 
@@ -531,7 +532,23 @@ def post_update(request, pk):
     else:
         form = PostForm(instance=post, user=request.user)
 
-    return render(request, "feed/post_update.html", {"form": form, "post": post})
+    fallback_url = reverse("feed:post_detail", args=[post.pk])
+    back_href = resolve_back_href(request, fallback=fallback_url)
+    context = {
+        "form": form,
+        "post": post,
+        "back_href": back_href,
+        "back_component_config": {
+            "href": back_href,
+            "fallback_href": fallback_url,
+        },
+        "cancel_component_config": {
+            "href": back_href,
+            "fallback_href": fallback_url,
+            "aria_label": _("Cancelar edição"),
+        },
+    }
+    return render(request, "feed/post_update.html", context)
 
 
 @login_required
@@ -551,7 +568,22 @@ def post_delete(request, pk):
         messages.success(request, "Postagem removida.")
         return redirect("feed:listar")
 
-    return render(request, "feed/post_delete.html", {"post": post})
+    fallback_url = reverse("feed:post_detail", args=[post.pk])
+    back_href = resolve_back_href(request, fallback=fallback_url)
+    context = {
+        "post": post,
+        "back_href": back_href,
+        "back_component_config": {
+            "href": back_href,
+            "fallback_href": fallback_url,
+        },
+        "cancel_component_config": {
+            "href": back_href,
+            "fallback_href": fallback_url,
+            "aria_label": _("Cancelar exclusão"),
+        },
+    }
+    return render(request, "feed/post_delete.html", context)
 
 
 # Moderação desativada: endpoint removido

--- a/notificacoes/templates/notificacoes/template_confirm_delete.html
+++ b/notificacoes/templates/notificacoes/template_confirm_delete.html
@@ -13,7 +13,7 @@
         <p>{% blocktrans with codigo=template.codigo %}Tem certeza que deseja excluir o template {{ codigo }}?{% endblocktrans %}</p>
         <form method="post" class="flex justify-end gap-3 pt-4 border-t border-[var(--border)]">
           {% csrf_token %}
-          <a href="{% url 'notificacoes:templates_list' %}" class="btn btn-secondary">{% trans 'Cancelar' %}</a>
+          {% include '_components/cancel_button.html' with config=cancel_component_config href=back_href fallback_href=cancel_component_config.fallback_href %}
           <button type="submit" class="btn btn-danger">{% trans 'Excluir' %}</button>
         </form>
       </div>

--- a/notificacoes/templates/notificacoes/template_form.html
+++ b/notificacoes/templates/notificacoes/template_form.html
@@ -20,7 +20,7 @@
             {% include '_forms/field.html' with field=field %}
           {% endfor %}
           <div class="flex justify-end gap-3 pt-4 border-t border-[var(--border)]">
-            <a href="{% url 'notificacoes:templates_list' %}" class="btn btn-secondary">{% trans 'Cancelar' %}</a>
+            {% include '_components/cancel_button.html' with config=cancel_component_config href=back_href fallback_href=cancel_component_config.fallback_href %}
             <button type="submit" class="btn btn-primary">{% trans 'Salvar' %}</button>
           </div>
         </form>

--- a/notificacoes/views.py
+++ b/notificacoes/views.py
@@ -6,9 +6,12 @@ from django.contrib import messages
 from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.auth.decorators import login_required, permission_required
 from django.core.paginator import Paginator
-from django.shortcuts import get_object_or_404, redirect, render
 from django.db.models import Count
+from django.shortcuts import get_object_or_404, redirect, render
+from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
+
+from core.utils import resolve_back_href
 
 from .forms import NotificationTemplateForm
 from .models import (
@@ -55,7 +58,22 @@ def create_template(request):
             return redirect("notificacoes:templates_list")
     else:
         form = NotificationTemplateForm()
-    return render(request, "notificacoes/template_form.html", {"form": form})
+
+    fallback_url = reverse("notificacoes:templates_list")
+    back_href = resolve_back_href(request, fallback=fallback_url)
+    context = {
+        "form": form,
+        "back_href": back_href,
+        "back_component_config": {
+            "href": back_href,
+            "fallback_href": fallback_url,
+        },
+        "cancel_component_config": {
+            "href": back_href,
+            "fallback_href": fallback_url,
+        },
+    }
+    return render(request, "notificacoes/template_form.html", context)
 
 
 @login_required
@@ -70,7 +88,24 @@ def edit_template(request, codigo: str):
             return redirect("notificacoes:templates_list")
     else:
         form = NotificationTemplateForm(instance=template)
-    return render(request, "notificacoes/template_form.html", {"form": form, "template": template})
+
+    fallback_url = reverse("notificacoes:templates_list")
+    back_href = resolve_back_href(request, fallback=fallback_url)
+    context = {
+        "form": form,
+        "template": template,
+        "back_href": back_href,
+        "back_component_config": {
+            "href": back_href,
+            "fallback_href": fallback_url,
+        },
+        "cancel_component_config": {
+            "href": back_href,
+            "fallback_href": fallback_url,
+            "aria_label": _("Cancelar edição"),
+        },
+    }
+    return render(request, "notificacoes/template_form.html", context)
 
 
 @login_required
@@ -148,10 +183,25 @@ def delete_template(request, codigo: str):
             messages.success(request, _("Template excluído com sucesso."))
         return redirect("notificacoes:templates_list")
 
+    fallback_url = reverse("notificacoes:templates_list")
+    back_href = resolve_back_href(request, fallback=fallback_url)
+    context = {
+        "template": template,
+        "back_href": back_href,
+        "back_component_config": {
+            "href": back_href,
+            "fallback_href": fallback_url,
+        },
+        "cancel_component_config": {
+            "href": back_href,
+            "fallback_href": fallback_url,
+            "aria_label": _("Cancelar exclusão"),
+        },
+    }
     return render(
         request,
         "notificacoes/template_confirm_delete.html",
-        {"template": template},
+        context,
     )
 
 

--- a/nucleos/templates/nucleos/nucleo_form.html
+++ b/nucleos/templates/nucleos/nucleo_form.html
@@ -30,7 +30,8 @@
         {% for field in form %}
           {% include '_forms/field.html' with field=field %}
         {% endfor %}
-        <div class="flex justify-end pt-4 border-t border-[var(--border)]">
+        <div class="flex justify-end gap-3 pt-4 border-t border-[var(--border)]">
+          {% include '_components/cancel_button.html' with config=cancel_component_config href=back_href fallback_href=cancel_component_config.fallback_href %}
           <button type="submit" class="btn btn-primary">{% trans 'Salvar' %}</button>
         </div>
       </form>

--- a/nucleos/templates/nucleos/suplente_form.html
+++ b/nucleos/templates/nucleos/suplente_form.html
@@ -15,7 +15,7 @@
       {% include '_forms/field.html' with field=field %}
     {% endfor %}
     <div class="flex justify-end gap-2">
-      <a href="{% url 'nucleos:detail' pk %}" class="btn btn-secondary">{% trans 'Cancelar' %}</a>
+      {% include '_components/cancel_button.html' with config=cancel_component_config href=back_href fallback_href=cancel_component_config.fallback_href %}
       <button type="submit" class="btn btn-primary">{% trans 'Salvar' %}</button>
     </div>
   </form>

--- a/nucleos/views.py
+++ b/nucleos/views.py
@@ -293,9 +293,11 @@ class NucleoCreateView(NoSuperadminMixin, AdminRequiredMixin, LoginRequiredMixin
         context["back_component_config"] = {
             "href": back_href,
             "fallback_href": fallback_url,
-            "label": _("Cancelar"),
-            "aria_label": _("Cancelar"),
             "variant": "compact",
+        }
+        context["cancel_component_config"] = {
+            "href": back_href,
+            "fallback_href": fallback_url,
         }
         return context
 
@@ -332,9 +334,12 @@ class NucleoUpdateView(NoSuperadminMixin, GerenteRequiredMixin, LoginRequiredMix
         context["back_component_config"] = {
             "href": back_href,
             "fallback_href": fallback_url,
-            "label": _("Cancelar"),
-            "aria_label": _("Cancelar"),
             "variant": "compact",
+        }
+        context["cancel_component_config"] = {
+            "href": back_href,
+            "fallback_href": fallback_url,
+            "aria_label": _("Cancelar edição"),
         }
         return context
 
@@ -715,6 +720,17 @@ class SuplenteCreateView(NoSuperadminMixin, GerenteRequiredMixin, LoginRequiredM
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
         ctx["pk"] = self.kwargs["pk"]
+        fallback_url = reverse("nucleos:detail", kwargs={"pk": self.kwargs["pk"]})
+        back_href = resolve_back_href(self.request, fallback=fallback_url)
+        ctx["back_href"] = back_href
+        ctx["back_component_config"] = {
+            "href": back_href,
+            "fallback_href": fallback_url,
+        }
+        ctx["cancel_component_config"] = {
+            "href": back_href,
+            "fallback_href": fallback_url,
+        }
         return ctx
 
 

--- a/organizacoes/templates/organizacoes/delete.html
+++ b/organizacoes/templates/organizacoes/delete.html
@@ -18,7 +18,7 @@
 
       <form method="post" class="mt-6 flex justify-center gap-3">
         {% csrf_token %}
-        <a href="{% url 'organizacoes:list' %}" class="btn btn-secondary">{% trans 'Cancelar' %}</a>
+        {% include '_components/cancel_button.html' with href=back_href fallback_href=back_component_config.fallback_href %}
         <button type="submit" class="btn btn-danger">{% trans 'Remover' %}</button>
       </form>
     </div>

--- a/organizacoes/templates/organizacoes/organizacao_form.html
+++ b/organizacoes/templates/organizacoes/organizacao_form.html
@@ -39,7 +39,8 @@
       {% include '_forms/field.html' with field=field %}
     {% endfor %}
 
-      <div class="flex justify-end pt-4 border-t border-[var(--border)]">
+      <div class="flex justify-end gap-3 pt-4 border-t border-[var(--border)]">
+        {% include '_components/cancel_button.html' with config=cancel_component_config href=back_href fallback_href=cancel_component_config.fallback_href %}
         <button type="submit" class="btn{% if form.instance.pk %} btn-primary{% endif %}" aria-label="{% trans 'Salvar organização' %}">
           {% trans 'Salvar' %}
         </button>

--- a/organizacoes/views.py
+++ b/organizacoes/views.py
@@ -159,9 +159,10 @@ class OrganizacaoCreateView(SuperadminRequiredMixin, LoginRequiredMixin, CreateV
         context["back_component_config"] = {
             "href": back_href,
             "fallback_href": fallback_url,
-            "label": _("Cancelar"),
-            "aria_label": _("Cancelar"),
-            "variant": "button",
+        }
+        context["cancel_component_config"] = {
+            "href": back_href,
+            "fallback_href": fallback_url,
         }
         return context
 
@@ -197,9 +198,11 @@ class OrganizacaoUpdateView(SuperadminRequiredMixin, LoginRequiredMixin, UpdateV
         context["back_component_config"] = {
             "href": back_href,
             "fallback_href": fallback_url,
-            "label": _("Cancelar"),
+        }
+        context["cancel_component_config"] = {
+            "href": back_href,
+            "fallback_href": fallback_url,
             "aria_label": _("Cancelar edição"),
-            "variant": "button",
         }
         return context
 
@@ -245,6 +248,22 @@ class OrganizacaoDeleteView(SuperadminRequiredMixin, LoginRequiredMixin, DeleteV
     model = Organizacao
     template_name = "organizacoes/delete.html"
     success_url = reverse_lazy("organizacoes:list")
+
+    def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
+        context = super().get_context_data(**kwargs)
+        fallback_url = str(self.success_url)
+        back_href = resolve_back_href(self.request, fallback=fallback_url)
+        context["back_href"] = back_href
+        context["back_component_config"] = {
+            "href": back_href,
+            "fallback_href": fallback_url,
+        }
+        context["cancel_component_config"] = {
+            "href": back_href,
+            "fallback_href": fallback_url,
+            "aria_label": _("Cancelar exclusão"),
+        }
+        return context
 
     def get_queryset(self):
         return super().get_queryset().filter(inativa=False)

--- a/templates/_components/README.md
+++ b/templates/_components/README.md
@@ -113,6 +113,37 @@ Quando `back_component_config` não é informado, o template usa `back_href`,
 preenchido automaticamente pelo context processor
 `core.context_processors.back_navigation` (que utiliza `resolve_back_href`).
 
+## cancel_button.html
+
+Partial especializada para ações de cancelamento. É um _wrapper_ do
+`back_button.html`, com `label`, `aria_label` e `variant` padronizados para os
+valores de cancelamento. Dessa forma, os formulários exibem sempre
+`gettext('Cancelar')` (com ícone oculto por padrão) e mantêm a semântica de
+"voltar" apenas quando o usuário realmente está navegando.
+
+### Parâmetros
+
+Aceita os mesmos parâmetros de `back_button.html`. Apenas os padrões mudam:
+
+| Nome | Padrão | Observação |
+| --- | --- | --- |
+| `label` | `gettext('Cancelar')` | O texto visível sempre utiliza o fallback traduzido. |
+| `aria_label` | igual a `label` | Pode ser sobrescrito para casos específicos (ex.: `Cancelar edição`). |
+| `variant` | `'button'` | Mantém visual de botão secundário. |
+| `icon` | `'x'` | O ícone só aparece quando `show_icon=True`. |
+| `show_icon` | `False` | Evita ícone redundante em ações de cancelamento. |
+
+### Boas práticas
+
+- Inclua o componente ao lado do botão principal do formulário, utilizando os
+  `href`/`fallback_href` vindos da view.
+- Utilize `cancel_component_config` quando precisar reutilizar as mesmas
+  configurações em múltiplos pontos do template.
+- Só apresente "Cancelar" e "Voltar" simultaneamente quando forem ações com
+  propósitos distintos (por exemplo, cancelar o formulário vs. navegar para a
+  página anterior). Caso ambas levem para o mesmo destino, mantenha apenas o
+  botão de cancelamento ou o `back_button` no cabeçalho.
+
 ## Convenções de i18n
 
 - Todo texto visível deve estar dentro de `{% trans %}` ou `{% blocktrans %}`.

--- a/templates/_components/cancel_button.html
+++ b/templates/_components/cancel_button.html
@@ -1,0 +1,79 @@
+{% load i18n string_filters %}
+{% with cfg=config|default:cancel_component_config %}
+{% with
+  href=href|coalesce:cfg|get_item:'href'
+  fallback_href=fallback_href|coalesce:cfg|get_item:'fallback_href'
+  variant=variant|coalesce:cfg|get_item:'variant'|default:'button'
+  classes=classes|coalesce:cfg|get_item:'classes'
+  label=label|coalesce:cfg|get_item:'label'|default:_('Cancelar')
+  aria_label=aria_label|coalesce:cfg|get_item:'aria_label'|default:label
+  icon=icon|coalesce:cfg|get_item:'icon'|default:'x'
+  show_icon=show_icon|default_if_none:cfg|get_item:'show_icon'|default:False
+  prevent_history=prevent_history|default_if_none:cfg|get_item:'prevent_history'
+  hx_get=hx_get|coalesce:cfg|get_item:'hx_get'
+  hx_post=hx_post|coalesce:cfg|get_item:'hx_post'
+  hx_put=hx_put|coalesce:cfg|get_item:'hx_put'
+  hx_delete=hx_delete|coalesce:cfg|get_item:'hx_delete'
+  hx_patch=hx_patch|coalesce:cfg|get_item:'hx_patch'
+  hx_target=hx_target|coalesce:cfg|get_item:'hx_target'
+  hx_swap=hx_swap|coalesce:cfg|get_item:'hx_swap'
+  hx_trigger=hx_trigger|coalesce:cfg|get_item:'hx_trigger'
+  hx_push_url=hx_push_url|coalesce:cfg|get_item:'hx_push_url'
+  hx_include=hx_include|coalesce:cfg|get_item:'hx_include'
+  hx_indicator=hx_indicator|coalesce:cfg|get_item:'hx_indicator'
+  hx_confirm=hx_confirm|coalesce:cfg|get_item:'hx_confirm'
+  hx_params=hx_params|coalesce:cfg|get_item:'hx_params'
+  hx_ext=hx_ext|coalesce:cfg|get_item:'hx_ext'
+  hx_on=hx_on|coalesce:cfg|get_item:'hx_on'
+  hx_vals=hx_vals|coalesce:cfg|get_item:'hx_vals'
+  hx_select=hx_select|coalesce:cfg|get_item:'hx_select'
+  hx_select_oob=hx_select_oob|coalesce:cfg|get_item:'hx_select_oob'
+  hx_replace_url=hx_replace_url|coalesce:cfg|get_item:'hx_replace_url'
+  hx_headers=hx_headers|coalesce:cfg|get_item:'hx_headers'
+  hx_prompt=hx_prompt|coalesce:cfg|get_item:'hx_prompt'
+  hx_validate=hx_validate|coalesce:cfg|get_item:'hx_validate'
+  hx_sync=hx_sync|coalesce:cfg|get_item:'hx_sync'
+  hx_boost=hx_boost|coalesce:cfg|get_item:'hx_boost'
+  hx_disable=hx_disable|coalesce:cfg|get_item:'hx_disable'
+  hx_history=hx_history|coalesce:cfg|get_item:'hx_history'
+%}
+{% include '_components/back_button.html' with
+  config=cfg
+  href=href
+  fallback_href=fallback_href
+  variant=variant
+  classes=classes
+  label=label
+  aria_label=aria_label
+  icon=icon
+  show_icon=show_icon
+  prevent_history=prevent_history
+  hx_get=hx_get
+  hx_post=hx_post
+  hx_put=hx_put
+  hx_delete=hx_delete
+  hx_patch=hx_patch
+  hx_target=hx_target
+  hx_swap=hx_swap
+  hx_trigger=hx_trigger
+  hx_push_url=hx_push_url
+  hx_include=hx_include
+  hx_indicator=hx_indicator
+  hx_confirm=hx_confirm
+  hx_params=hx_params
+  hx_ext=hx_ext
+  hx_on=hx_on
+  hx_vals=hx_vals
+  hx_select=hx_select
+  hx_select_oob=hx_select_oob
+  hx_replace_url=hx_replace_url
+  hx_headers=hx_headers
+  hx_prompt=hx_prompt
+  hx_validate=hx_validate
+  hx_sync=hx_sync
+  hx_boost=hx_boost
+  hx_disable=hx_disable
+  hx_history=hx_history
+%}
+{% endwith %}
+{% endwith %}


### PR DESCRIPTION
## Summary
- add a reusable `cancel_button` template component that wraps the back button with cancel defaults
- update feed, organizações, núcleos, configurações, notificações e contas para fornecer configs e renderizar o novo botão ao lado das ações principais
- documentar a convenção de quando usar "Cancelar" versus "Voltar" para evitar ações redundantes

## Testing
- python -m compileall configuracoes feed organizacoes nucleos notificacoes accounts

------
https://chatgpt.com/codex/tasks/task_e_68dc57ccc54483258c89d4fd9410574b