### PR TITLE
Align eventos list layout with nucleos

### DIFF
--- a/eventos/templates/eventos/partials/eventos/evento_list.html
+++ b/eventos/templates/eventos/partials/eventos/evento_list.html
@@ -1,23 +1,25 @@
 {% load i18n lucide_icons %}
 {% include "eventos/partials/_painel_hero_oob.html" %}
-  <div class="py-12 px-4 space-y-6">
 
-    <div class="card px-4">
-      <div class="card-header">
-          <h2 class="text-xl font-semibold">{% trans "Eventos" %}</h2>
-      </div>
-      <div class="card-body">
-        <div class="grid gap-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-2" role="list" aria-label="{% trans 'Lista de eventos' %}">
-          {% for evento in eventos %}
-            {% include '_components/card_evento.html' %}
-          {% empty %}
-            <p class="col-span-full text-center text-[var(--text-muted)]">{% trans 'Nenhum evento encontrado.' %}</p>
-          {% endfor %}
-        </div>
-        {% include '_partials/pagination.html' with page_obj=page_obj querystring=querystring hx_target='#eventos-conteudo' hx_get=request.path hx_push_url='true' hx_indicator='#eventos-loading' %}
-      </div>
-    </div>
+<div class="card">
+  <div class="card-header">
+    <h2 class="text-xl font-semibold">{% trans "Eventos" %}</h2>
   </div>
+  <div class="card-body">
+    <div
+      role="list"
+      aria-label="{% trans 'Lista de eventos' %}"
+      class="card-grid sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-2 items-stretch"
+    >
+      {% for evento in eventos %}
+        {% include '_components/card_evento.html' %}
+      {% empty %}
+        <p class="col-span-full text-center text-[var(--text-muted)]">{% trans 'Nenhum evento encontrado.' %}</p>
+      {% endfor %}
+    </div>
+    {% include '_partials/pagination.html' with page_obj=page_obj querystring=querystring hx_target='#eventos-conteudo' hx_get=request.path hx_push_url='true' hx_indicator='#eventos-loading' %}
+  </div>
+</div>
 
 <div id="eventos-filter-state" hx-swap-oob="true" class="hidden" data-current-filter="{{ current_filter|default:'todos' }}" aria-hidden="true"></div>
 


### PR DESCRIPTION
## Summary
- align the eventos list partial structure with the nucleos list layout
- switch the eventos grid to use the shared card-grid classes and remove extra padding wrappers

## Testing
- not run (template-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dd24cf23888325b44cac3aa5d7774f