### PR TITLE
Refatore layout da lista de eventos

### DIFF
--- a/eventos/templates/eventos/evento_list.html
+++ b/eventos/templates/eventos/evento_list.html
@@ -1,0 +1,28 @@
+{% extends 'base.html' %}
+{% load i18n %}
+
+{% block title %}{% trans "Eventos" %}{% endblock %}
+
+{% block hero %}
+  {% with painel_title_default=_('Eventos') %}
+    {% with hero_template=painel_hero_template|default:'_components/hero_evento.html' %}
+      {% include hero_template with title=painel_title|default:painel_title_default subtitle=painel_subtitle action_template=painel_action_template breadcrumb_template=painel_breadcrumb_template neural_background=painel_neural_background style=painel_hero_style %}
+    {% endwith %}
+  {% endwith %}
+{% endblock %}
+
+{% block content %}
+  <section class="mx-auto max-w-6xl px-4 lg:px-6 py-6">
+    <div id="eventos-conteudo">
+      {% include 'eventos/partials/eventos/_evento_list_content.html' %}
+    </div>
+    <div
+      id="eventos-loading"
+      class="htmx-indicator mt-6 text-center text-sm text-[var(--text-secondary)]"
+      role="status"
+      aria-live="polite"
+    >
+      {% trans 'Carregando eventos...' %}
+    </div>
+  </section>
+{% endblock %}

--- a/eventos/templates/eventos/partials/eventos/_evento_list_content.html
+++ b/eventos/templates/eventos/partials/eventos/_evento_list_content.html
@@ -1,0 +1,30 @@
+{% load i18n %}
+
+<div class="card">
+  <div class="card-header">
+    <h2 class="text-xl font-semibold">{% trans "Eventos" %}</h2>
+  </div>
+  <div class="card-body">
+    <div
+      id="eventos-lista"
+      role="list"
+      aria-label="{% trans 'Lista de eventos' %}"
+      class="card-grid sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-2 items-stretch"
+    >
+      {% for evento in eventos %}
+        {% include '_components/card_evento.html' %}
+      {% empty %}
+        <p class="col-span-full text-center text-[var(--text-muted)]">{% trans 'Nenhum evento encontrado.' %}</p>
+      {% endfor %}
+    </div>
+    {% include '_partials/pagination.html' with page_obj=page_obj querystring=querystring hx_target='#eventos-conteudo' hx_get=request.path hx_push_url='true' hx_indicator='#eventos-loading' %}
+  </div>
+</div>
+
+<div
+  id="eventos-filter-state"
+  hx-swap-oob="true"
+  class="hidden"
+  data-current-filter="{{ current_filter|default:'todos' }}"
+  aria-hidden="true"
+></div>

--- a/eventos/templates/eventos/partials/eventos/evento_list.html
+++ b/eventos/templates/eventos/partials/eventos/evento_list.html
@@ -1,25 +1,4 @@
-{% load i18n lucide_icons %}
+{% load i18n %}
 {% include "eventos/partials/_painel_hero_oob.html" %}
 
-<div class="card">
-  <div class="card-header">
-    <h2 class="text-xl font-semibold">{% trans "Eventos" %}</h2>
-  </div>
-  <div class="card-body">
-    <div
-      role="list"
-      aria-label="{% trans 'Lista de eventos' %}"
-      class="card-grid sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-2 items-stretch"
-    >
-      {% for evento in eventos %}
-        {% include '_components/card_evento.html' %}
-      {% empty %}
-        <p class="col-span-full text-center text-[var(--text-muted)]">{% trans 'Nenhum evento encontrado.' %}</p>
-      {% endfor %}
-    </div>
-    {% include '_partials/pagination.html' with page_obj=page_obj querystring=querystring hx_target='#eventos-conteudo' hx_get=request.path hx_push_url='true' hx_indicator='#eventos-loading' %}
-  </div>
-</div>
-
-<div id="eventos-filter-state" hx-swap-oob="true" class="hidden" data-current-filter="{{ current_filter|default:'todos' }}" aria-hidden="true"></div>
-
+{% include "eventos/partials/eventos/_evento_list_content.html" %}

--- a/eventos/views.py
+++ b/eventos/views.py
@@ -125,7 +125,8 @@ class PainelRenderMixin:
 
 
 class EventoListView(PainelRenderMixin, LoginRequiredMixin, NoSuperadminMixin, ListView):
-    template_name = "eventos/partials/eventos/evento_list.html"
+    template_name = "eventos/evento_list.html"
+    partial_template_name = "eventos/partials/eventos/evento_list.html"
     painel_action_template = "eventos/partials/eventos/hero_evento_list_action.html"
     context_object_name = "eventos"
     paginate_by = 12
@@ -236,6 +237,13 @@ class EventoListView(PainelRenderMixin, LoginRequiredMixin, NoSuperadminMixin, L
         ctx["q"] = self.request.GET.get("q", "").strip()
         ctx["querystring"] = urlencode(params, doseq=True)
         return ctx
+
+    def render_to_response(self, context, **response_kwargs):
+        is_htmx_request = self.request.headers.get("HX-Request") == "true"
+        context = self.get_painel_context(context)
+        context["is_htmx"] = is_htmx_request
+        template_name = self.partial_template_name if is_htmx_request else self.template_name
+        return TemplateResponse(self.request, template_name, context, **response_kwargs)
 
 def _queryset_por_organizacao(request):
     qs = Evento.objects.prefetch_related("inscricoes").all()


### PR DESCRIPTION
## Summary
- alinhei o template de lista de eventos ao layout que herda `base.html`, replicando a estrutura da listagem de núcleos
- extraí um parcial reutilizável com o conteúdo da grade de eventos para uso tanto na página completa quanto nas respostas HTMX
- atualizei `EventoListView` para entregar o novo template completo e manter o parcial assíncrono ao detectar requisições HTMX

## Testing
- não executado (não solicitado)


------
https://chatgpt.com/codex/tasks/task_e_68dd2a44f50c83259dcb3a5994eab563