### PR TITLE
Allow configuring Núcleo list card template

### DIFF
--- a/nucleos/templates/nucleos/nucleo_list.html
+++ b/nucleos/templates/nucleos/nucleo_list.html
@@ -26,7 +26,7 @@
         aria-label="{{ list_aria_label|default_if_none:_('Lista de núcleos')|default:_('Lista de núcleos') }}"
         class="card-grid sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-2 items-stretch">
         {% for nucleo in object_list %}
-          {% include '_components/card_nucleo.html' with nucleo=nucleo %}
+          {% include list_card_template|default:'_components/card_nucleo.html' with item=nucleo nucleo=nucleo item_context_name=item_context_name %}
         {% empty %}
           <p class="col-span-full text-center text-[var(--text-muted)]">{{ empty_message|default_if_none:_('Nenhum núcleo encontrado.')|default:_('Nenhum núcleo encontrado.') }}</p>
         {% endfor %}

--- a/nucleos/views.py
+++ b/nucleos/views.py
@@ -127,6 +127,8 @@ class NucleoListView(NoSuperadminMixin, LoginRequiredMixin, ListView):
         ctx.setdefault("empty_message", _("Nenhum núcleo encontrado."))
         ctx.setdefault("list_hero_template", "_components/hero_nucleo.html")
         ctx.setdefault("list_hero_action_template", "nucleos/hero_actions_nucleo.html")
+        ctx.setdefault("list_card_template", "_components/card_nucleo.html")
+        ctx.setdefault("item_context_name", "nucleo")
         ctx["form"] = NucleoSearchForm(self.request.GET or None)
         # Totais: número de núcleos e membros ativos na organização do usuário
         qs = self.get_queryset()

--- a/templates/_components/card_nucleo.html
+++ b/templates/_components/card_nucleo.html
@@ -1,12 +1,16 @@
 {% load i18n %}
-{% url 'nucleos:detail_uuid' nucleo.public_id as detail_url %}
-{% trans 'Ver detalhes do núcleo' as sr_label %}
-{% with classificacao=nucleo.classificacao %}
-  {% if classificacao == 'planejamento' %}
-    {% include '_partials/cards/base_card.html' with url=detail_url cover=nucleo.cover avatar=nucleo.avatar title=nucleo.nome details='_components/card_details_nucleo.html' sr_label=sr_label badge=nucleo.get_classificacao_display badge_style='--primary:#f97316; --primary-soft:rgba(249, 115, 22, 0.15); --primary-soft-border:rgba(249, 115, 22, 0.3);' %}
-  {% elif classificacao == 'constituido' %}
-    {% include '_partials/cards/base_card.html' with url=detail_url cover=nucleo.cover avatar=nucleo.avatar title=nucleo.nome details='_components/card_details_nucleo.html' sr_label=sr_label badge=nucleo.get_classificacao_display badge_style='--primary:#22c55e; --primary-soft:rgba(34, 197, 94, 0.15); --primary-soft-border:rgba(34, 197, 94, 0.3);' %}
-  {% else %}
-    {% include '_partials/cards/base_card.html' with url=detail_url cover=nucleo.cover avatar=nucleo.avatar title=nucleo.nome details='_components/card_details_nucleo.html' sr_label=sr_label badge=_('Formação') badge_style='--primary:#2563eb; --primary-soft:rgba(37, 99, 235, 0.15); --primary-soft-border:rgba(37, 99, 235, 0.3);' %}
+{% with resolved_nucleo=item|default:nucleo %}
+  {% if resolved_nucleo %}
+    {% url 'nucleos:detail_uuid' resolved_nucleo.public_id as detail_url %}
+    {% trans 'Ver detalhes do núcleo' as sr_label %}
+    {% with classificacao=resolved_nucleo.classificacao %}
+      {% if classificacao == 'planejamento' %}
+        {% include '_partials/cards/base_card.html' with url=detail_url cover=resolved_nucleo.cover avatar=resolved_nucleo.avatar title=resolved_nucleo.nome details='_components/card_details_nucleo.html' sr_label=sr_label badge=resolved_nucleo.get_classificacao_display badge_style='--primary:#f97316; --primary-soft:rgba(249, 115, 22, 0.15); --primary-soft-border:rgba(249, 115, 22, 0.3);' %}
+      {% elif classificacao == 'constituido' %}
+        {% include '_partials/cards/base_card.html' with url=detail_url cover=resolved_nucleo.cover avatar=resolved_nucleo.avatar title=resolved_nucleo.nome details='_components/card_details_nucleo.html' sr_label=sr_label badge=resolved_nucleo.get_classificacao_display badge_style='--primary:#22c55e; --primary-soft:rgba(34, 197, 94, 0.15); --primary-soft-border:rgba(34, 197, 94, 0.3);' %}
+      {% else %}
+        {% include '_partials/cards/base_card.html' with url=detail_url cover=resolved_nucleo.cover avatar=resolved_nucleo.avatar title=resolved_nucleo.nome details='_components/card_details_nucleo.html' sr_label=sr_label badge=_('Formação') badge_style='--primary:#2563eb; --primary-soft:rgba(37, 99, 235, 0.15); --primary-soft-border:rgba(37, 99, 235, 0.3);' %}
+      {% endif %}
+    {% endwith %}
   {% endif %}
 {% endwith %}


### PR DESCRIPTION
## Summary
- allow the Núcleo list template to include a configurable card partial with a default fallback
- update the default Núcleo card component to work with the generic `item` context
- set default context values for the card partial in the list view

## Testing
- python -m compileall nucleos/views.py

------
https://chatgpt.com/codex/tasks/task_e_68dd35406c5c8325b09a6c7670424c25