### PR TITLE
Add extension blocks to Núcleo list template

### DIFF
--- a/nucleos/README.md
+++ b/nucleos/README.md
@@ -21,6 +21,10 @@ Permissões:
 - Coordenadores podem gerenciar membros e inativar núcleos.
 - Todas as views exigem autenticação.
 
+## Templates
+
+- `nucleos/nucleo_list.html` expõe os blocos vazios `list_actions` (na região do cabeçalho da listagem) e `list_footer` (logo após a paginação). Os módulos que reutilizarem esse template podem sobrescrever os blocos para adicionar filtros, botões ou totais extras quando necessário.
+
 Modelos:
 
 - `Nucleo`, `ParticipacaoNucleo` e `CoordenadorSuplente` utilizam o mixin `TimeStampedModel`.

--- a/nucleos/templates/nucleos/nucleo_list.html
+++ b/nucleos/templates/nucleos/nucleo_list.html
@@ -20,6 +20,7 @@
   <div class="card">
     <div class="card-header">
       <h2 class="text-xl font-semibold">{{ list_title|default_if_none:_("Núcleos")|default:_("Núcleos") }}</h2>
+      {% block list_actions %}{% endblock %}
     </div>
     <div class="card-body">
       <div role="list"
@@ -32,6 +33,7 @@
         {% endfor %}
       </div>
       {% include '_partials/pagination.html' with page_obj=page_obj querystring=querystring %}
+      {% block list_footer %}{% endblock %}
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add empty `list_actions` and `list_footer` blocks to the Núcleo list template so consumers can extend it
- document how modules can override the new blocks when extra controls are needed

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd36f8711483258f9e1b7d6bbf109b