### PR TITLE
Fix template error on Núcleos list view

### DIFF
--- a/nucleos/templates/nucleos/nucleo_list.html
+++ b/nucleos/templates/nucleos/nucleo_list.html
@@ -23,19 +23,18 @@
       {% block list_actions %}{% endblock %}
     </div>
     <div class="card-body">
-      {% with
-        card_template=list_card_template|default_if_none:'_components/card_nucleo.html'|default:'_components/card_nucleo.html'
-        card_item_name=item_context_name|default_if_none:'nucleo'|default:'nucleo'
-      %}
-        <div role="list"
-          aria-label="{{ list_aria_label|default_if_none:_('Lista de núcleos')|default:_('Lista de núcleos') }}"
-          class="card-grid sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-2 items-stretch">
-          {% for nucleo in object_list %}
-            {% include card_template with item=nucleo nucleo=nucleo item_context_name=card_item_name %}
-          {% empty %}
-            <p class="col-span-full text-center text-[var(--text-muted)]">{{ empty_message|default_if_none:_('Nenhum núcleo encontrado.')|default:_('Nenhum núcleo encontrado.') }}</p>
-          {% endfor %}
-        </div>
+      {% with card_template=list_card_template|default_if_none:'_components/card_nucleo.html'|default:'_components/card_nucleo.html' %}
+        {% with card_item_name=item_context_name|default_if_none:'nucleo'|default:'nucleo' %}
+          <div role="list"
+            aria-label="{{ list_aria_label|default_if_none:_('Lista de núcleos')|default:_('Lista de núcleos') }}"
+            class="card-grid sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-2 items-stretch">
+            {% for nucleo in object_list %}
+              {% include card_template with item=nucleo nucleo=nucleo item_context_name=card_item_name %}
+            {% empty %}
+              <p class="col-span-full text-center text-[var(--text-muted)]">{{ empty_message|default_if_none:_('Nenhum núcleo encontrado.')|default:_('Nenhum núcleo encontrado.') }}</p>
+            {% endfor %}
+          </div>
+        {% endwith %}
       {% endwith %}
       {% include '_partials/pagination.html' with page_obj=page_obj querystring=querystring %}
       {% block list_footer %}{% endblock %}


### PR DESCRIPTION
## Summary
- restore scoped `with` blocks to provide default card template and context name values without parse issues
- render the card grid using the computed defaults to keep the Núcleos listing intact

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68dd3eea799c8325a7688771b880a268