### PR TITLE
Fix missing pagination defaults on eventos list view

### DIFF
--- a/eventos/views.py
+++ b/eventos/views.py
@@ -280,6 +280,10 @@ class EventoListView(PainelRenderMixin, LoginRequiredMixin, NoSuperadminMixin, L
         ctx.setdefault("list_total_eventos_ativos", ctx.get("total_eventos_ativos"))
         ctx.setdefault("list_total_eventos_concluidos", ctx.get("total_eventos_concluidos"))
         ctx.setdefault("list_total_eventos_cancelados", ctx.get("total_eventos_cancelados"))
+        # Valores padrão para a paginação HTMX quando não forem definidos
+        ctx.setdefault("pagination_hx_target", "#eventos-conteudo")
+        ctx.setdefault("pagination_hx_get", self.request.path)
+        ctx.setdefault("pagination_hx_indicator", "#eventos-loading")
         return ctx
 
     def render_to_response(self, context, **response_kwargs):


### PR DESCRIPTION
## Summary
- provide default HTMX pagination context values in `EventoListView` to avoid missing template variables

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68dd60b43bec83258fc1ce6e3d1887a2