### PR TITLE
Fix pagination push URL context default for event list

### DIFF
--- a/eventos/views.py
+++ b/eventos/views.py
@@ -284,6 +284,7 @@ class EventoListView(PainelRenderMixin, LoginRequiredMixin, NoSuperadminMixin, L
         ctx.setdefault("pagination_hx_target", "#eventos-conteudo")
         ctx.setdefault("pagination_hx_get", self.request.path)
         ctx.setdefault("pagination_hx_indicator", "#eventos-loading")
+        ctx.setdefault("pagination_hx_push_url", "true")
         return ctx
 
     def render_to_response(self, context, **response_kwargs):


### PR DESCRIPTION
## Summary
- ensure the event list view always defines the pagination HX push URL context variable to match template expectations

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68dd63683a748325903b74633d08f999