### PR TITLE
Padroniza templates do feed com layout oficial

### DIFF
--- a/feed/static/feed/js/feed.js
+++ b/feed/static/feed/js/feed.js
@@ -23,27 +23,7 @@ function bindFeedEvents(root = document) {
     textarea.addEventListener("input", updateCharCounter);
   }
 
-  const fileInput = root.querySelector('input[type="file"]');
-  const fileText = root.querySelector(".file-text");
-
-  if (fileInput && fileText) {
-    const originalText = fileText.textContent;
-
-    fileInput.addEventListener("change", (e) => {
-      const file = e.target.files[0];
-
-      if (file) {
-        const selectedText = window.gettext
-          ? gettext("Selecionado:")
-          : "Selecionado:";
-        fileText.textContent = `${selectedText} ${file.name}`;
-        fileText.style.color = "var(--success-color)";
-      } else {
-        fileText.textContent = originalText;
-        fileText.style.color = "var(--text-secondary)";
-      }
-    });
-  }
+  const fileInputs = Array.from(root.querySelectorAll('input[type="file"]'));
 
   const postForm = root.querySelector(".post-form");
 
@@ -75,7 +55,7 @@ function bindFeedEvents(root = document) {
     postForm.addEventListener('submit', (e) => {
       clearMsg();
       const content = textarea ? textarea.value.trim() : '';
-      const hasFile = fileInput && fileInput.files.length > 0;
+      const hasFile = fileInputs.some((input) => input.files && input.files.length > 0);
       if (content.length === 0 && !hasFile) {
         e.preventDefault();
         const msg = window.gettext ? gettext('Por favor, escreva algo ou selecione um arquivo antes de publicar.') : 'Por favor, escreva algo ou selecione um arquivo antes de publicar.';

--- a/feed/templates/feed/_comment.html
+++ b/feed/templates/feed/_comment.html
@@ -1,14 +1,14 @@
 {% load i18n %}
 {% if request.user.user_type != 'root' %}
 <li class="card" id="comment-{{ comment.id }}">
-  <div class="card-body">
+  <div class="card-body space-y-3">
   <p class="text-sm font-medium">{{ comment.user.display_name }}</p>
   <p class="text-xs text-[var(--text-secondary)]">{{ comment.created_at|date:"SHORT_DATETIME_FORMAT" }}</p>
   <p class="text-sm text-[var(--text-primary)]">{{ comment.texto }}</p>
-  <div class="flex gap-2">
-    <button type="button" class="btn btn-secondary text-xs" hx-on:click="setReplyTo('{{ comment.id }}')">{% trans "Responder" %}</button>
+  <div class="flex gap-3">
+    <button type="button" class="btn btn-secondary" hx-on:click="setReplyTo('{{ comment.id }}')">{% trans "Responder" %}</button>
     {% if comment.user == request.user or request.user.is_staff %}
-      <button type="button" class="btn btn-danger text-xs" hx-delete="/api/feed/comments/{{ comment.id }}/" hx-target="#comment-{{ comment.id }}" hx-swap="outerHTML" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}' hx-on:error="alert('{% trans "Erro ao excluir comentário" %}')">{% trans "Excluir" %}</button>
+      <button type="button" class="btn btn-danger" hx-delete="/api/feed/comments/{{ comment.id }}/" hx-target="#comment-{{ comment.id }}" hx-swap="outerHTML" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}' hx-on:error="alert('{% trans "Erro ao excluir comentário" %}')">{% trans "Excluir" %}</button>
     {% endif %}
   </div>
   <ul class="mt-2 space-y-2 ml-4" id="replies-{{ comment.id }}">

--- a/feed/templates/feed/_grid.html
+++ b/feed/templates/feed/_grid.html
@@ -1,4 +1,5 @@
 {% load static i18n lucide_icons %}
+{# Exceção HTMX: parcial renderizado isoladamente durante atualizações dinâmicas #}
 {% if request.user.user_type != 'root' %}
 
 <section id="feed-grid" class="card-grid auto-rows-[1fr] gap-6 sm:grid-cols-2">
@@ -8,7 +9,7 @@
     <a href="{% url 'feed:post_detail' post.id %}" class="absolute inset-0 z-10" aria-label="{% trans 'Ver detalhes do post' %}">
       <span class="sr-only">{% trans "Ver detalhes do post" %}</span>
     </a>
-    <div class="card-body flex h-full flex-col gap-6">
+    <div class="card-body flex h-full flex-col space-y-6">
       <!-- Cabeçalho com tipo de postagem acima do avatar -->
       <header class="flex flex-col gap-2">
         {% with badge_classes="relative z-20 inline-flex max-w-full items-center gap-2 self-start rounded-full bg-[var(--primary-soft,rgba(59,130,246,0.15))] px-3 py-1 text-[0.6rem] font-semibold uppercase tracking-wide text-[var(--primary,#2563eb)] shadow-sm ring-1 ring-[var(--primary-soft-border,rgba(59,130,246,0.3))] whitespace-nowrap" icon_classes="h-3.5 w-3.5 shrink-0" %}

--- a/feed/templates/feed/_moderacao.html
+++ b/feed/templates/feed/_moderacao.html
@@ -4,17 +4,21 @@
   <p class="text-xs text-warning-700 mb-2">{{ post.moderacao.get_status_display }}</p>
 {% endif %}
 {% if perms.feed.change_moderacaopost %}
-  <div class="flex flex-col gap-2">
-    <form method="post" hx-post="{% url 'feed:post_moderar' post.pk %}" hx-target="#moderacao-wrapper" hx-swap="outerHTML">
+  <div class="space-y-4">
+    <form method="post" hx-post="{% url 'feed:post_moderar' post.pk %}" hx-target="#moderacao-wrapper" hx-swap="outerHTML" class="space-y-4">
       {% csrf_token %}
       <input type="hidden" name="acao" value="aprovar">
-      <button type="submit" class="btn btn-primary">{% trans "Aprovar" %}</button>
+      <div class="flex justify-end gap-3">
+        <button type="submit" class="btn btn-primary">{% trans "Aprovar" %}</button>
+      </div>
     </form>
-    <form method="post" hx-post="{% url 'feed:post_moderar' post.pk %}" hx-target="#moderacao-wrapper" hx-swap="outerHTML" class="flex gap-2 items-start">
+    <form method="post" hx-post="{% url 'feed:post_moderar' post.pk %}" hx-target="#moderacao-wrapper" hx-swap="outerHTML" class="space-y-4">
       {% csrf_token %}
       <input type="hidden" name="acao" value="rejeitar">
-      <input type="text" name="motivo" placeholder="{% trans 'Motivo' %}" class="flex-1 px-2 py-1 border border-[var(--border-secondary)] rounded text-sm">
-      <button type="submit" class="btn btn-danger">{% trans "Rejeitar" %}</button>
+      {% include '_forms/field.html' with id='motivo-'|add:post.id name='motivo' label=_('Motivo') placeholder=_('Explique o motivo da rejeição') %}
+      <div class="flex justify-end gap-3">
+        <button type="submit" class="btn btn-danger">{% trans "Rejeitar" %}</button>
+      </div>
     </form>
   </div>
 {% endif %}

--- a/feed/templates/feed/_post_list.html
+++ b/feed/templates/feed/_post_list.html
@@ -1,11 +1,12 @@
 {% comment %}Lista de postagens reutilizável com Tailwind{% endcomment %}
 {% load static i18n lucide_icons %}
+{# Exceção HTMX: parcial utilizado em atualizações inline sem cabeçalho completo #}
 
 {% if request.user.user_type != 'root' %}
 <div class="space-y-6">
   {% for post in posts %}
     <article class="card">
-      <div class="card-body space-y-4">
+      <div class="card-body space-y-6">
 
       <div class="flex items-center gap-4">
         <div class="w-10 h-10 rounded-full bg-[var(--bg-secondary)] flex items-center justify-center text-[var(--text-secondary)] font-bold" role="img" aria-label="{{ post.autor.display_name|default:post.autor.username }}">
@@ -56,7 +57,7 @@
     </article>
   {% empty %}
     <div class="card text-center text-[var(--text-secondary)]">
-      <div class="card-body p-10">
+      <div class="card-body space-y-4 p-10">
         <div class="text-4xl mb-2">{{ empty_icon|default:"📝" }}</div>
         <h3 class="text-lg font-semibold text-[var(--text-primary)] mb-1">{{ empty_title|default:_("Nenhuma postagem ainda") }}</h3>
         <p class="text-sm mb-4">{{ empty_message|default:_("Seja o primeiro a compartilhar algo!") }}</p>

--- a/feed/templates/feed/bookmarks.html
+++ b/feed/templates/feed/bookmarks.html
@@ -11,7 +11,14 @@
   <p class="text-center text-[var(--text-muted)]">{% trans "Usuário root não tem acesso ao feed." %}</p>
 {% else %}
 
-  {% include "feed/_grid.html" with posts=posts %}
+  <article class="card">
+    <div class="card-header">
+      <h2 class="text-lg font-semibold text-[var(--text-primary)]">{% trans "Postagens salvas" %}</h2>
+    </div>
+    <div class="card-body space-y-6">
+      {% include "feed/_grid.html" with posts=posts %}
+    </div>
+  </article>
 
 {% endif %}
 {% endblock %}

--- a/feed/templates/feed/feed.html
+++ b/feed/templates/feed/feed.html
@@ -12,18 +12,16 @@
   <p class="text-center text-[var(--text-muted)]">{% trans "Usuário root não tem acesso ao feed." %}</p>
 {% else %}
 
-  <!-- Busca simples -->
   {% url 'feed:listar' as feed_list_url %}
-  <div class="py-12 card px-4">
+  <article class="card">
     <div class="card-header">
       {% include '_components/search_form.html' with q=q %}
     </div>
-    
-    <div id="feed-loading" class="htmx-indicator">{% trans "Carregando…" %}</div>
-    <div class="card-body">
+    <div class="card-body space-y-6">
+      <div id="feed-loading" class="htmx-indicator">{% trans "Carregando…" %}</div>
       {% include "feed/_grid.html" %}
     </div>
-</div> 
+  </article>
 
 <script src="{% static 'feed/js/feed.js' %}"></script>
 {% endif %}

--- a/feed/templates/feed/hero_actions.html
+++ b/feed/templates/feed/hero_actions.html
@@ -1,8 +1,9 @@
 {% load i18n lucide_icons %}
-<div class="flex gap-2">
+<div class="flex flex-wrap gap-3">
   <a href="{% url 'feed:meu_mural' %}" class="btn btn-secondary" aria-label="{% trans 'Mural' %}">{% trans 'Mural' %}</a>
   <a href="{% url 'feed:bookmarks' %}" class="btn btn-secondary" aria-label="{% trans 'Favoritos' %}">{% trans 'Favoritos' %}</a>
   {% if request.user.user_type != 'root' %}
+  {# Exceção: abertura em nova aba mantém o formulário de postagem ativo #}
   <a href="{% url 'feed:nova_postagem' %}" target="_blank" class="btn btn-primary" aria-label="{% trans 'Nova postagem' %}">
     {% lucide 'circle-plus' class='w-4 h-4' %}
     {% trans 'Nova postagem' %}

--- a/feed/templates/feed/hero_actions_bookmarks.html
+++ b/feed/templates/feed/hero_actions_bookmarks.html
@@ -1,4 +1,4 @@
 {% load i18n %}
-<div class="flex gap-2">
+<div class="flex flex-wrap gap-3">
   <a href="{% url 'feed:listar' %}" class="btn btn-secondary" aria-label="{% trans 'Voltar ao feed' %}">{% trans 'Voltar ao feed' %}</a>
 </div>

--- a/feed/templates/feed/hero_actions_mural.html
+++ b/feed/templates/feed/hero_actions_mural.html
@@ -1,8 +1,9 @@
 {% load i18n lucide_icons %}
-<div class="flex gap-2">
+<div class="flex flex-wrap gap-3">
   <a href="{% url 'feed:listar' %}" class="btn btn-secondary" aria-label="{% trans 'Ver Feed Global' %}">{% trans 'Ver Feed Global' %}</a>
   <a href="{% url 'feed:bookmarks' %}" class="btn btn-secondary" aria-label="{% trans 'Favoritos' %}">{% trans 'Favoritos' %}</a>
   {% if request.user.user_type != 'root' %}
+  {# Exceção: abertura em nova aba mantém o formulário de postagem ativo #}
   <a href="{% url 'feed:nova_postagem' %}" target="_blank" class="btn btn-primary" aria-label="{% trans 'Nova postagem' %}">
     {% lucide 'circle-plus' class='w-4 h-4' %}
     {% trans 'Nova postagem' %}

--- a/feed/templates/feed/mural.html
+++ b/feed/templates/feed/mural.html
@@ -11,7 +11,14 @@
   <p class="text-center text-[var(--text-muted)]">{% trans "Usuário root não tem acesso ao feed." %}</p>
 {% else %}
 
-    {% include "feed/_grid.html" with posts=posts %}
+  <article class="card">
+    <div class="card-header">
+      <h2 class="text-lg font-semibold text-[var(--text-primary)]">{% trans "Postagens do mural" %}</h2>
+    </div>
+    <div class="card-body space-y-6">
+      {% include "feed/_grid.html" with posts=posts %}
+    </div>
+  </article>
 
 {% endif %}
 {% endblock %}

--- a/feed/templates/feed/nova_postagem.html
+++ b/feed/templates/feed/nova_postagem.html
@@ -13,149 +13,77 @@
     <p class="text-center text-[var(--text-muted)]">{% trans "Usuário root não tem acesso ao feed." %}</p>
   {% else %}
 
-  {% with selected=selected_tipo_feed|default:"global" %}
-  <!-- Cabeçalho -->
-  <div class="mb-6">
-    <p class="text-sm text-[var(--text-secondary)] text-center">{% trans "Compartilhe algo com sua comunidade" %}</p>
-  </div>
+  <article class="card">
+    <div class="card-header">
+      <div class="flex flex-col gap-1 text-center">
+        <h1 class="text-xl font-semibold text-[var(--text-primary)]">{% trans "Nova Postagem" %}</h1>
+        <p class="text-sm text-[var(--text-secondary)]">{% trans "Compartilhe algo com sua comunidade" %}</p>
+      </div>
+    </div>
+    <div class="card-body space-y-6">
+      <div id="nova-postagem-form">
+        <form method="post"
+              action="{% url 'feed:nova_postagem' %}"
+              hx-post="{% url 'feed:nova_postagem' %}"
+              hx-target="#nova-postagem-form"
+              hx-swap="outerHTML"
+              hx-encoding="multipart/form-data"
+              enctype="multipart/form-data"
+              class="post-form space-y-6">
+          {% csrf_token %}
 
-  <!-- Container para HTMX swaps -->
-  <div id="nova-postagem-form">
-    <form method="post"
-          action="{% url 'feed:nova_postagem' %}"
-          hx-post="{% url 'feed:nova_postagem' %}"
-          hx-target="#nova-postagem-form"
-          hx-swap="outerHTML"
-          hx-encoding="multipart/form-data"
-          enctype="multipart/form-data"
-          class="post-form card">
-      <div class="card-body space-y-6">
-      {% csrf_token %}
-
-      {% if form.errors %}
-        <div class="rounded-xl border border-[var(--error)] bg-[var(--error-light)] text-[var(--error)] text-sm p-3">
-          <ul class="list-disc list-inside space-y-1">
-            {% for field in form %}
-              {% for error in field.errors %}
-                <li><strong>{{ field.label }}:</strong> {{ error }}</li>
-              {% endfor %}
-            {% endfor %}
-            {% for error in form.non_field_errors %}
-              <li>{{ error }}</li>
-            {% endfor %}
-          </ul>
-        </div>
-      {% endif %}
-
-      <!-- Visibilidade / Destino -->
-      <div>
-        <label class="block text-sm font-medium text-[var(--text-secondary)] mb-2">{% trans "Destino" %} <span class="text-red-600">*</span></label>
-        <div class="flex flex-wrap gap-4 text-sm">
-          <label class="inline-flex items-center gap-2">
-            <input type="radio" name="tipo_feed" value="global" class="accent-blue-600" {% if selected == 'global' %}checked{% endif %} />
-            <span>{% trans "Público (feed global)" %}</span>
-          </label>
-          <label class="inline-flex items-center gap-2">
-            <input type="radio" name="tipo_feed" value="usuario" class="accent-blue-600" {% if selected == 'usuario' %}checked{% endif %} />
-            <span>{% trans "Privado (seu mural)" %}</span>
-          </label>
-          <!-- Radio oculto para 'nucleo' (marcado quando um núcleo for escolhido) -->
-          <input type="radio" name="tipo_feed" value="nucleo" id="tipo_feed_nucleo_hidden" class="hidden" {% if selected == 'nucleo' %}checked{% endif %} />
-        </div>
-        {% if form.tipo_feed.errors %}
-          <p class="text-red-500 text-xs mt-1">{{ form.tipo_feed.errors|striptags }}</p>
-        {% endif %}
-
-        <!-- Núcleos do usuário como opções -->
-        <div id="nucleos-opcoes" class="mt-3">
-          {% if nucleos_do_usuario %}
-            <div class="flex flex-wrap gap-3">
-              {% for n in nucleos_do_usuario %}
-                <label class="inline-flex items-center gap-2 px-3 py-2 rounded-xl border border-[var(--border)] hover:bg-[var(--bg-tertiary)] cursor-pointer">
-                  <input type="radio" name="nucleo" value="{{ n.id }}" class="accent-blue-600"
-                         {% if selected_nucleo|stringformat:'s' == n.id|stringformat:'s' %}checked{% endif %} />
-                  <span class="text-sm text-[var(--text-primary)]">{{ n.nome }}</span>
-                </label>
-              {% endfor %}
+          {% if form.non_field_errors %}
+            <div class="rounded-xl border border-[var(--error)] bg-[var(--error-light)] p-3 text-sm text-[var(--error)]">
+              <ul class="list-disc list-inside space-y-1">
+                {% for error in form.non_field_errors %}
+                  <li>{{ error }}</li>
+                {% endfor %}
+              </ul>
             </div>
-            <p class="text-xs text-[var(--text-muted)] mt-1">{% trans "Selecione um núcleo para publicar lá." %}</p>
-          {% else %}
-            <p class="text-xs text-[var(--text-muted)] mt-1">{% trans "Você não participa de nenhum núcleo." %}</p>
           {% endif %}
-          {% if form.nucleo.errors %}
-            <p class="text-red-500 text-xs mt-1">{{ form.nucleo.errors|striptags }}</p>
+
+          <div class="space-y-4">
+            {% include '_forms/field.html' with field=form.tipo_feed %}
+            {% include '_forms/field.html' with field=form.organizacao %}
+            {% include '_forms/field.html' with field=form.nucleo %}
+            {% include '_forms/field.html' with field=form.evento %}
+          </div>
+
+          {% with placeholder_value=_('O que você gostaria de compartilhar?') %}
+          <div class="space-y-2">
+            {% include '_forms/field.html' with field=form.conteudo|attr:'rows:6'|attr:('placeholder:'|add:placeholder_value) %}
+            <span id="char-count" class="text-xs text-[var(--text-muted)]"></span>
+            <p class="text-xs text-[var(--text-secondary)]">{% trans "Compartilhe ideias, atualizações ou conteúdos com sua rede." %}</p>
+          </div>
+          {% endwith %}
+
+          {% if request.user.organizacao %}
+            <input type="hidden" name="organizacao" value="{{ request.user.organizacao.id }}">
           {% endif %}
-        </div>
-      </div>
 
-      <!-- Conteúdo -->
-      <div>
-        <label for="{{ form.conteudo.id_for_label }}" class="block text-sm font-medium text-[var(--text-secondary)]">
-          {{ form.conteudo.label }} <span class="text-red-600">*</span>
-        </label>
-        <textarea
-          id="{{ form.conteudo.id_for_label }}"
-          name="{{ form.conteudo.name }}"
-          class="mt-1 block w-full rounded-xl border border-[var(--border)] card-sm focus:ring-primary-500 focus:border-primary-500 text-sm"
-          placeholder="{% trans 'O que você gostaria de compartilhar?' %}"
-          rows="6"
-        >{{ form.conteudo.value|default_if_none:"" }}</textarea>
-        <div class="mt-1">
-          <span id="char-count" class="text-xs text-[var(--text-muted)]"></span>
-        </div>
-        {% if form.conteudo.errors %}
-          <p class="text-red-500 text-xs mt-1">{{ form.conteudo.errors }}</p>
-        {% endif %}
-        <p class="text-sm text-[var(--text-muted)] mt-1">{% trans "Compartilhe ideias, atualizações ou conteúdos com sua rede." %}</p>
-      </div>
+          <div class="space-y-4">
+            {% include '_forms/field.html' with field=form.tags|attr:'id:tags-select' %}
+            {% include '_forms/field.html' with id='id_tags_text' name='tags_text' label=_('Novas tags') placeholder=_('Digite novas tags separadas por vírgula') value=request.POST.tags_text|default:'' help_text=_('Use vírgula para separar as tags adicionais.') %}
+          </div>
 
-      {% if request.user.organizacao %}
-        <input type="hidden" name="organizacao" value="{{ request.user.organizacao.id }}">
-      {% endif %}
+          <div class="space-y-4">
+            {% include '_forms/field.html' with field=form.image %}
+            {% include '_forms/field.html' with field=form.pdf %}
+            {% include '_forms/field.html' with field=form.video %}
+          </div>
 
-      <!-- Tags (chips) -->
-      <div class="mb-4">
-        <label class="font-semibold mb-1 block">{% trans "Tags" %}</label>
-        <input type="hidden" id="id_tags_text" name="tags_text" value="{{ request.POST.tags_text|default:'' }}" />
-        <div id="tags-chips" class="flex flex-wrap gap-2 mb-2"></div>
-        <div class="flex items-center gap-2">
-          <input
-            type="text"
-            id="tags-input"
-            class="flex-1 mt-1 block rounded-xl border border-[var(--border)] card-sm focus:ring-primary-500 focus:border-primary-500 text-sm px-3 py-2"
-            placeholder="{% trans 'Digite e pressione Enter ou vírgula para adicionar' %}"
-            autocomplete="off"
-          />
-        </div>
-      </div>
+          <p class="text-xs text-[var(--text-secondary)]">{% trans "Campos marcados com * são obrigatórios. Informe conteúdo ou anexe um arquivo." %}</p>
 
-      <!-- Arquivo -->
-      <div>
-        <label for="id_file" class="block text-sm font-medium text-[var(--text-secondary)]">{% trans "Arquivo (imagem, vídeo ou PDF)" %}</label>
-        <input type="file" id="id_file" name="arquivo" accept="image/*,video/*,.pdf"
-               class="mt-2 block w-full text-sm text-[var(--text-secondary)] file:mr-4 file:py-2 file:px-4 file:rounded-xl file:border-0 file:text-sm file:font-semibold file:bg-[var(--bg-tertiary)] file:text-[var(--text-secondary)] hover:file:bg-[var(--bg-tertiary)]">
-        <span class="file-text">{% trans "Nenhum arquivo selecionado" %}</span>
-        {% if form.image.errors or form.pdf.errors or form.video.errors %}
-          <p class="text-red-500 text-xs mt-1">
-            {{ form.image.errors }} {{ form.pdf.errors }} {{ form.video.errors }}
-          </p>
-        {% endif %}
+          <div class="flex justify-end gap-3 pt-4 border-t border-[var(--border)]">
+            {% include '_components/cancel_button.html' with config=cancel_component_config href=back_href fallback_href=cancel_component_config.fallback_href %}
+            <button type="submit" class="btn btn-primary" aria-label="{% trans 'Salvar' %}">
+              {% trans "Salvar" %}
+            </button>
+          </div>
+        </form>
       </div>
-
-      <!-- Legenda de obrigatoriedade -->
-      <div class="mt-2 text-xs text-[var(--text-secondary)]">{% trans "Campos marcados com * são obrigatórios. Informe conteúdo ou anexe um arquivo." %}</div>
-
-      <!-- Ações -->
-      <div class="flex justify-end gap-3 mt-6">
-        {% include '_components/cancel_button.html' with config=cancel_component_config href=back_href fallback_href=cancel_component_config.fallback_href %}
-        <button type="submit" class="btn btn-primary" aria-label="{% trans 'Salvar' %}">
-          {% trans "Salvar" %}
-        </button>
-      </div>
-      </div>
-    </form>
-  </div>
-  {% endwith %}
+    </div>
+  </article>
 
   <script src="{% static 'feed/js/feed.js' %}"></script>
   {% endif %}

--- a/feed/templates/feed/post_delete.html
+++ b/feed/templates/feed/post_delete.html
@@ -11,18 +11,21 @@
   <p class="text-center text-[var(--text-muted)]">{% trans "Usuário root não tem acesso ao feed." %}</p>
 {% else %}
 
-  <div class="card border-red-200 text-center">
-    <div class="card-body p-6">
-    <h2 class="text-xl font-semibold text-red-700 mb-4">{% trans "Remover Postagem" %}</h2>
-    <p class="text-sm text-[var(--text-secondary)]">{% trans "Tem certeza que deseja remover esta postagem?" %}</p>
-
-    <form method="post" hx-post="{% url 'feed:post_delete' post.pk %}" class="mt-6 flex justify-center gap-3">
-      {% csrf_token %}
-      {% include '_components/cancel_button.html' with config=cancel_component_config href=back_href fallback_href=cancel_component_config.fallback_href %}
-      <button type="submit" class="btn btn-danger" aria-label="{% trans 'Remover' %}">{% trans "Remover" %}</button>
-    </form>
+  <article class="card">
+    <div class="card-header">
+      <h1 class="text-xl font-semibold text-[var(--error)]">{% trans "Remover Postagem" %}</h1>
     </div>
-  </div>
+    <div class="card-body space-y-4">
+      <p class="text-sm text-[var(--text-secondary)] text-center">{% trans "Tem certeza que deseja remover esta postagem?" %}</p>
+      <form method="post" hx-post="{% url 'feed:post_delete' post.pk %}" class="space-y-4">
+        {% csrf_token %}
+        <div class="flex justify-end gap-3 pt-4 border-t border-[var(--border)]">
+          {% include '_components/cancel_button.html' with config=cancel_component_config href=back_href fallback_href=cancel_component_config.fallback_href %}
+          <button type="submit" class="btn btn-danger" aria-label="{% trans 'Remover' %}">{% trans "Remover" %}</button>
+        </div>
+      </form>
+    </div>
+  </article>
 
 {% endif %}
 {% endblock %}

--- a/feed/templates/feed/post_detail.html
+++ b/feed/templates/feed/post_detail.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load static i18n lucide_icons %}
+{% load static i18n lucide_icons widget_tweaks %}
 {% block title %}{% trans "Postagem" %} | Hubx{% endblock %}
 
 {% block hero %}
@@ -11,7 +11,7 @@
   <p class="text-center text-[var(--text-muted)]">{% trans "Usuário root não tem acesso ao feed." %}</p>
 {% else %}
   <article class="card">
-    <div class="card-body space-y-4">
+    <div class="card-body space-y-6">
     <div class="flex items-center gap-4">
       {% if post.autor.avatar %}
         <img src="{{ post.autor.avatar.url }}" alt="{{ post.autor.display_name|default:post.autor.username }}" class="w-10 h-10 rounded-full object-cover" loading="lazy">
@@ -49,7 +49,7 @@
     {% endif %}
 
     {% if post.tags.all %}
-      <div class="mt-2 flex flex-wrap gap-2 text-xs text-[var(--text-muted)]">
+      <div class="flex flex-wrap gap-2 text-xs text-[var(--text-muted)]">
         {% for tag in post.tags.all %}
           <span class="px-2 py-1 bg-[var(--bg-tertiary)] rounded">{{ tag.nome }}</span>
         {% endfor %}
@@ -76,20 +76,19 @@
 
   <!-- Moderação desativada -->
 
-    <div class="mt-6">
+    <div class="space-y-4">
       <h3 class="text-lg font-medium">{% trans "Comentários" %}</h3>
-      <form id="comment-form" method="post" action="/api/feed/comments/" hx-post="/api/feed/comments/" hx-target="#comments" hx-swap="afterbegin" class="space-y-2" hx-on:afterRequest="this.reset(); setReplyTo(null)">
+      <form id="comment-form" method="post" action="/api/feed/comments/" hx-post="/api/feed/comments/" hx-target="#comments" hx-swap="afterbegin" class="space-y-6" hx-on:afterRequest="this.reset(); setReplyTo(null)">
         {% csrf_token %}
         {{ comment_form.post }}
         {{ comment_form.reply_to }}
-        {{ comment_form.texto }}
-        {% if comment_form.texto.errors %}
-          <p class="text-red-500 text-xs">{{ comment_form.texto.errors }}</p>
-        {% endif %}
-        <button type="submit" class="btn btn-primary" aria-label="{% trans 'Enviar comentário' %}">{% trans "Enviar" %}</button>
+        {% include '_forms/field.html' with field=comment_form.texto|attr:'rows:3' %}
+        <div class="flex justify-end gap-3 pt-4 border-t border-[var(--border)]">
+          <button type="submit" class="btn btn-primary" aria-label="{% trans 'Enviar comentário' %}">{% trans "Enviar" %}</button>
+        </div>
       </form>
 
-      <ul id="comments" class="mt-4 space-y-4">
+      <ul id="comments" class="space-y-4">
         {% for comment in post.comments.all %}
           {% include 'feed/_comment.html' with comment=comment %}
         {% endfor %}
@@ -97,9 +96,9 @@
     </div>
 
     {% if post.autor == user or user_can_moderate %}
-    <div class="flex justify-end gap-3 pt-4 border-t border-[var(--border)] text-sm">
-      <a href="{% url 'feed:post_update' post.pk %}" class="btn btn-secondary text-yellow-600" aria-label="{% trans 'Editar postagem' %}">{% trans "Editar" %}</a>
-      <a href="{% url 'feed:post_delete' post.pk %}" class="btn btn-secondary text-red-600" aria-label="{% trans 'Remover postagem' %}">{% trans "Remover" %}</a>
+    <div class="flex justify-end gap-3 pt-4 border-t border-[var(--border)]">
+      <a href="{% url 'feed:post_update' post.pk %}" class="btn btn-secondary" aria-label="{% trans 'Editar postagem' %}">{% trans "Editar" %}</a>
+      <a href="{% url 'feed:post_delete' post.pk %}" class="btn btn-danger" aria-label="{% trans 'Remover postagem' %}">{% trans "Remover" %}</a>
     </div>
     {% endif %}
     </div>

--- a/feed/templates/feed/post_update.html
+++ b/feed/templates/feed/post_update.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load static i18n lucide_icons %}
+{% load static i18n lucide_icons widget_tweaks %}
 {% block title %}{% trans "Editar Postagem" %} - Hubx{% endblock %}
 
 {% block hero %}
@@ -10,84 +10,96 @@
 {% if request.user.user_type == 'root' %}
   <p class="text-center text-[var(--text-muted)]">{% trans "Usuário root não tem acesso ao feed." %}</p>
 {% else %}
-<section class="max-w-2xl mx-auto px-4 py-10">
-  <div class="mb-6 flex items-center gap-4">
-    {% include '_components/back_button.html' with href=back_href fallback_href=back_component_config.fallback_href %}
-    <div>
-      <h1 class="text-2xl font-bold text-[var(--text-primary)]">{% trans "Editar Postagem" %}</h1>
-      <p class="text-sm text-[var(--text-secondary)]">{% trans "Atualize sua postagem" %}</p>
+
+<article class="card">
+  <div class="card-header">
+    <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+      <div class="flex items-center gap-3">
+        {% include '_components/back_button.html' with href=back_href fallback_href=back_component_config.fallback_href %}
+        <div>
+          <h1 class="text-xl font-semibold text-[var(--text-primary)]">{% trans "Editar Postagem" %}</h1>
+          <p class="text-sm text-[var(--text-secondary)]">{% trans "Atualize sua postagem" %}</p>
+        </div>
+      </div>
     </div>
   </div>
+  <div class="card-body space-y-6">
+    <form method="post"
+          enctype="multipart/form-data"
+          hx-post="{% url 'feed:post_update' post.pk %}"
+          hx-encoding="multipart/form-data"
+          class="post-form space-y-6">
+      {% csrf_token %}
 
-  <form method="post" enctype="multipart/form-data" hx-post="{% url 'feed:post_update' post.pk %}" hx-encoding="multipart/form-data" class="post-form card">
-    <div class="card-body space-y-6">
-    {% csrf_token %}
-    <div>
-      <label for="{{ form.conteudo.id_for_label }}" class="block text-sm font-medium text-[var(--text-secondary)]">
-        {{ form.conteudo.label }}
-      </label>
-        <textarea id="{{ form.conteudo.id_for_label }}" name="{{ form.conteudo.name }}" class="mt-1 block w-full rounded-xl border border-[var(--border-secondary)] card-sm focus:ring-primary-500 focus:border-primary-500 text-sm" rows="6">{{ form.conteudo.value|default_if_none:"" }}</textarea>
-      <span id="char-count"></span>
-      {% if form.conteudo.errors %}
-        <p class="text-error-500 text-xs mt-1">{{ form.conteudo.errors }}</p>
-      {% endif %}
-    </div>
-
-    <div>
-      <label for="id_tipo_feed" class="block text-sm font-medium text-[var(--text-secondary)]">{% trans "Tipo de Feed" %}</label>
-      {{ form.tipo_feed|as_widget }}
-    </div>
-
-    <div>
-      <label for="id_organizacao" class="block text-sm font-medium text-[var(--text-secondary)]">{% trans "Organização" %}</label>
-      {{ form.organizacao|as_widget }}
-    </div>
-
-    <div>
-      <label for="id_nucleo" class="block text-sm font-medium text-[var(--text-secondary)]">{% trans "Núcleo" %}</label>
-      {{ form.nucleo|as_widget }}
-    </div>
-
-    <div>
-      <label for="id_evento" class="block text-sm font-medium text-[var(--text-secondary)]">{% trans "Evento" %}</label>
-      {{ form.evento|as_widget }}
-    </div>
-
-    <div>
-      <label for="{{ form.tags.id_for_label }}" class="block text-sm font-medium text-[var(--text-secondary)]">{% trans "Tags" %}</label>
-      {{ form.tags|as_widget }}
-    </div>
-
-    <div>
-
-      <label for="id_file" class="block text-sm font-medium text-[var(--text-secondary)]">{% trans "Arquivo (imagem, vídeo ou PDF)" %}</label>
-      <input type="file" id="id_file" name="arquivo" accept="image/*,video/*,.pdf" class="mt-2 block w-full text-sm text-[var(--text-secondary)] file:mr-4 file:py-2 file:px-4 file:rounded-xl file:border-0 file:text-sm file:font-semibold file:bg-[var(--bg-tertiary)] file:text-[var(--text-secondary)] hover:file:bg-[var(--bg-tertiary)]">
-      <span class="file-text">{% trans "Nenhum arquivo selecionado" %}</span>
-      {% if form.image.errors or form.pdf.errors %}
-        <p class="text-error-500 text-xs mt-1">{{ form.image.errors }} {{ form.pdf.errors }}</p>
-      {% endif %}
-      {% if post.pdf %}
-        <div class="relative mt-2">
-          <img src="{% static 'img/pdf-placeholder.png' %}" alt="{% trans 'PDF' %}" class="max-w-xs rounded-xl object-cover" loading="lazy">
-          <a href="{{ post.pdf.url }}" target="_blank" class="btn btn-secondary absolute top-2 left-2 p-1.5">
-            {% lucide 'eye' class='w-4 h-4' %}
-          </a>
-          <a href="{{ post.pdf.url }}" download class="btn btn-secondary absolute top-2 right-2 p-1.5">
-            {% lucide 'download' class='w-4 h-4' %}
-          </a>
+      {% if form.non_field_errors %}
+        <div class="rounded-xl border border-[var(--error)] bg-[var(--error-light)] p-3 text-sm text-[var(--error)]">
+          <ul class="list-disc list-inside space-y-1">
+            {% for error in form.non_field_errors %}
+              <li>{{ error }}</li>
+            {% endfor %}
+          </ul>
         </div>
-      {% elif post.image %}
-        <img src="{{ post.image.url }}" alt="{% trans 'mídia do post' %}" class="max-w-xs rounded-xl mt-2 object-cover" loading="lazy">
       {% endif %}
-    </div>
 
-    <div class="flex justify-end gap-3 pt-4 border-t border-[var(--border)]">
-      {% include '_components/cancel_button.html' with config=cancel_component_config href=back_href fallback_href=cancel_component_config.fallback_href %}
-      <button type="submit" class="btn btn-primary" aria-label="{% trans 'Salvar' %}">{% trans "Salvar" %}</button>
-    </div>
-    </div>
-  </form>
-</section>
+      <div class="space-y-4">
+        {% include '_forms/field.html' with field=form.tipo_feed %}
+        {% include '_forms/field.html' with field=form.organizacao %}
+        {% include '_forms/field.html' with field=form.nucleo %}
+        {% include '_forms/field.html' with field=form.evento %}
+      </div>
+
+      {% with placeholder_value=_('O que você gostaria de compartilhar?') %}
+      <div class="space-y-2">
+        {% include '_forms/field.html' with field=form.conteudo|attr:'rows:6'|attr:('placeholder:'|add:placeholder_value) %}
+        <span id="char-count" class="text-xs text-[var(--text-muted)]"></span>
+      </div>
+      {% endwith %}
+
+      <div class="space-y-4">
+        {% include '_forms/field.html' with field=form.tags|attr:'id:tags-select' %}
+        {% include '_forms/field.html' with id='id_tags_text' name='tags_text' label=_('Novas tags') placeholder=_('Digite novas tags separadas por vírgula') value=request.POST.tags_text|default:'' help_text=_('Use vírgula para separar as tags adicionais.') %}
+      </div>
+
+      <div class="space-y-4">
+        <div class="space-y-4">
+          {% include '_forms/field.html' with field=form.image %}
+          {% include '_forms/field.html' with field=form.pdf %}
+          {% include '_forms/field.html' with field=form.video %}
+        </div>
+        {% if post.pdf %}
+          <div class="space-y-2">
+            <img src="{% static 'img/pdf-placeholder.png' %}" alt="{% trans 'PDF' %}" class="max-w-xs rounded-xl object-cover" loading="lazy">
+            <div class="flex gap-3">
+              <a href="{{ post.pdf.url }}" target="_blank" class="btn btn-secondary" aria-label="{% trans 'Visualizar PDF' %}">
+                {% lucide 'eye' class='w-4 h-4' %}
+              </a>
+              <a href="{{ post.pdf.url }}" download class="btn btn-secondary" aria-label="{% trans 'Baixar PDF' %}">
+                {% lucide 'download' class='w-4 h-4' %}
+              </a>
+            </div>
+          </div>
+        {% elif post.image %}
+          <div class="space-y-2">
+            <img src="{{ post.image.url }}" alt="{% trans 'mídia do post' %}" class="max-w-xs rounded-xl object-cover" loading="lazy">
+          </div>
+        {% elif post.video %}
+          <div class="space-y-2">
+            {% if post.video_preview %}
+              <video src="{{ post.video.url }}" poster="{{ post.video_preview.url }}" controls class="max-w-full rounded-xl"></video>
+            {% else %}
+              <video src="{{ post.video.url }}" controls class="max-w-full rounded-xl"></video>
+            {% endif %}
+          </div>
+        {% endif %}
+      </div>
+
+      <div class="flex justify-end gap-3 pt-4 border-t border-[var(--border)]">
+        {% include '_components/cancel_button.html' with config=cancel_component_config href=back_href fallback_href=cancel_component_config.fallback_href %}
+        <button type="submit" class="btn btn-primary" aria-label="{% trans 'Salvar' %}">{% trans "Salvar" %}</button>
+      </div>
+    </form>
+  </div>
+</article>
 <script src="{% static 'feed/js/feed.js' %}"></script>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- padroniza os formulários do feed com o layout de cartão, aproveitando `_forms/field.html` e barras de ações unificadas
- ajusta os heróis e parciais do feed para utilizar botões consistentes e comentários sobre exceções HTMX
- atualiza o JavaScript do feed para lidar com múltiplos campos de upload nativos

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68deb32529088325bbf5c48e970a978b