### PR TITLE
Padroniza templates de configurações

### DIFF
--- a/configuracoes/templates/configuracoes/_partials/operadores_action.html
+++ b/configuracoes/templates/configuracoes/_partials/operadores_action.html
@@ -1,7 +1,8 @@
 {% load i18n %}
-<a href="{% url 'configuracoes:operadores_adicionar' %}" class="btn btn-primary inline-flex items-center gap-2">
+<a href="{% url 'configuracoes:operadores_adicionar' %}" class="btn btn-primary flex items-center gap-2">
   <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
     <path stroke-linecap="round" stroke-linejoin="round" d="M12 5v14M5 12h14" />
   </svg>
   <span>{% trans 'Adicionar operador' %}</span>
 </a>
+

--- a/configuracoes/templates/configuracoes/_partials/preferencias.html
+++ b/configuracoes/templates/configuracoes/_partials/preferencias.html
@@ -1,12 +1,17 @@
 {% load widget_tweaks i18n static %}
 {% get_current_language as LANGUAGE_CODE %}
 
-<form method="post" hx-post="{{ request.path }}" hx-target="#settings-content" class="space-y-4">
+<!-- HTMX fragment: formulário de preferências renderizado dentro do card principal -->
+<form method="post" hx-post="{{ request.path }}" hx-target="#settings-content" class="space-y-6">
   {% csrf_token %}
   {% if preferencias_form.non_field_errors %}
-    <ul class="errorlist bg-[var(--bg-secondary)] text-[var(--danger-text)] border border-[var(--danger-border)] rounded-2xl p-4">
-      {% for err in preferencias_form.non_field_errors %}<li>{{ err }}</li>{% endfor %}
-    </ul>
+    <div class="alert alert-error" role="alert">
+      <ul class="space-y-1">
+        {% for err in preferencias_form.non_field_errors %}
+          <li>{{ err }}</li>
+        {% endfor %}
+      </ul>
+    </div>
   {% endif %}
   <input type="hidden" name="section" value="preferencias">
   <input type="hidden" name="escopo_tipo" id="escopo_tipo">
@@ -20,7 +25,7 @@
   <input type="hidden" name="tema_atual" id="tema_atual" value="{{ preferencias_form.instance.tema }}">
   <input type="hidden" name="idioma_atual" id="idioma_atual" value="{{ preferencias_form.instance.idioma }}">
   <input type="hidden" name="updated_preferences" id="updated_preferences" value="{{ updated_preferences|yesno:'true,false' }}">
-  <fieldset class="space-y-4">
+  <fieldset class="space-y-6">
     <legend class="sr-only">{% trans 'Notificações' %}</legend>
     <div class="space-y-6">
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
@@ -35,7 +40,7 @@
         {% include '_forms/field.html' with field=freq_email_field %}
         {% endwith %}
       </div>
-      <div class="flex items-center gap-3">
+      <div class="flex flex-wrap items-center gap-3">
         <button
           type="button"
           class="btn btn-secondary"
@@ -63,7 +68,7 @@
         {% include '_forms/field.html' with field=freq_whats_field %}
         {% endwith %}
       </div>
-      <div class="flex items-center gap-3">
+      <div class="flex flex-wrap items-center gap-3">
         <button
           type="button"
           class="btn btn-secondary"
@@ -91,7 +96,7 @@
         {% include '_forms/field.html' with field=freq_push_field %}
         {% endwith %}
       </div>
-      <div class="flex items-center gap-3">
+      <div class="flex flex-wrap items-center gap-3">
         <button
           type="button"
           class="btn btn-secondary"
@@ -137,7 +142,7 @@
       </div>
     </div>
   </div>
-  <div class="text-right pt-2">
+  <div class="flex justify-end gap-3 pt-4 border-t border-[var(--border)]">
     <button type="submit" aria-label="{% trans 'Salvar Alterações' %}" class="btn btn-primary">{% trans 'Salvar Alterações' %}</button>
   </div>
 </form>

--- a/configuracoes/templates/configuracoes/_partials/seguranca.html
+++ b/configuracoes/templates/configuracoes/_partials/seguranca.html
@@ -1,58 +1,59 @@
 {% load widget_tweaks i18n %}
 
+<!-- HTMX fragment: formulário de segurança recarregado dinamicamente -->
 <form
   method="post"
   hx-post="{{ request.path }}"
   hx-target="#settings-content"
-  class="space-y-4"
+  class="space-y-6"
 >
   {% csrf_token %}
   {% if seguranca_form.non_field_errors %}
-    <ul class="errorlist bg-[var(--bg-secondary)] text-[var(--danger-text)] border border-[var(--danger-border)] rounded-2xl p-4">
-      {% for err in seguranca_form.non_field_errors %}<li>{{ err }}</li>{% endfor %}
-    </ul>
+    <div class="alert alert-error" role="alert">
+      <ul class="space-y-1">
+        {% for err in seguranca_form.non_field_errors %}
+          <li>{{ err }}</li>
+        {% endfor %}
+      </ul>
+    </div>
   {% endif %}
   <input type="hidden" name="section" value="seguranca" />
-  <fieldset class="space-y-4">
+  <fieldset class="space-y-6">
     <legend class="sr-only">{% trans 'Segurança da conta' %}</legend>
     {% for field in seguranca_form %}
       {% include '_forms/field.html' with field=field %}
     {% endfor %}
   </fieldset>
-  <div class="text-right pt-2">
-    <button
-      type="submit"
-      aria-label="{% trans 'Salvar Alterações' %}"
-      class="btn btn-primary"
-    >
+  <div class="flex justify-end gap-3 pt-4 border-t border-[var(--border)]">
+    <button type="submit" aria-label="{% trans 'Salvar Alterações' %}" class="btn btn-primary">
       {% trans 'Salvar Alterações' %}
     </button>
   </div>
 </form>
 
-<div class="mt-6 border-t border-[var(--border)] pt-4">
-  <h2 class="text-lg font-semibold mb-2">
-    {% trans 'Autenticação em duas etapas' %}
-  </h2>
-  {% if two_factor_enabled %}
-    <p class="text-sm mb-4">
-      {% trans '2FA está habilitado para sua conta.' %}
-    </p>
-    <a
-      href="{% url 'tokens:desativar_2fa' %}"
-      class="btn btn-secondary text-[var(--error)]"
-    >
-      {% trans 'Desativar 2FA' %}
-    </a>
-  {% else %}
-    <p class="text-sm mb-4">
-      {% trans '2FA não está habilitado.' %}
-    </p>
-    <a
-      href="{% url 'tokens:ativar_2fa' %}"
-      class="btn btn-primary"
-    >
-      {% trans 'Ativar 2FA' %}
-    </a>
-  {% endif %}
-</div>
+<article class="card">
+  <div class="card-body space-y-4">
+    <h2 class="text-lg font-semibold text-[var(--text-primary)]">
+      {% trans 'Autenticação em duas etapas' %}
+    </h2>
+    {% if two_factor_enabled %}
+      <p class="text-sm text-[var(--text-secondary)]">
+        {% trans '2FA está habilitado para sua conta.' %}
+      </p>
+      <div class="flex flex-wrap gap-3">
+        <a href="{% url 'tokens:desativar_2fa' %}" class="btn btn-danger">
+          {% trans 'Desativar 2FA' %}
+        </a>
+      </div>
+    {% else %}
+      <p class="text-sm text-[var(--text-secondary)]">
+        {% trans '2FA não está habilitado.' %}
+      </p>
+      <div class="flex flex-wrap gap-3">
+        <a href="{% url 'tokens:ativar_2fa' %}" class="btn btn-primary">
+          {% trans 'Ativar 2FA' %}
+        </a>
+      </div>
+    {% endif %}
+  </div>
+</article>

--- a/configuracoes/templates/configuracoes/configuracao_form.html
+++ b/configuracoes/templates/configuracoes/configuracao_form.html
@@ -7,16 +7,34 @@
 {% endblock %}
 
 {% block content %}
-<main class="container mx-auto px-4 py-6">
-  <section class="card bg-[var(--bg-elevated)] border border-[var(--border)] rounded-2xl shadow-sm">
-  <div class="card-body p-6" id="settings-content">
+<main class="container py-6">
+  <article class="card">
+    <div class="card-header">
+      <nav class="flex flex-wrap items-center gap-3" aria-label="{% trans 'Seções de configuração' %}">
+        <a
+          href="{% url 'configuracoes:configuracoes_seguranca' %}"
+          class="btn {% if tab == 'seguranca' %}btn-primary{% else %}btn-secondary{% endif %}"
+          aria-current="{% if tab == 'seguranca' %}page{% else %}false{% endif %}"
+        >
+          {% trans 'Segurança' %}
+        </a>
+        <a
+          href="{% url 'configuracoes:configuracoes_preferencias' %}"
+          class="btn {% if tab == 'preferencias' %}btn-primary{% else %}btn-secondary{% endif %}"
+          aria-current="{% if tab == 'preferencias' %}page{% else %}false{% endif %}"
+        >
+          {% trans 'Preferências' %}
+        </a>
+      </nav>
+    </div>
+    <div class="card-body space-y-6" id="settings-content">
       {% if tab == 'preferencias' %}
         {% include 'configuracoes/_partials/preferencias.html' %}
       {% else %}
         {% include 'configuracoes/_partials/seguranca.html' %}
       {% endif %}
     </div>
-  </section>
+  </article>
 </main>
 {% endblock %}
 

--- a/configuracoes/templates/configuracoes/operador_form.html
+++ b/configuracoes/templates/configuracoes/operador_form.html
@@ -8,63 +8,40 @@
 {% endblock %}
 
 {% block content %}
-  <section class="max-w-3xl mx-auto space-y-6">
-    <div class="card bg-[var(--bg-elevated)] border border-[var(--border)] rounded-2xl shadow-sm">
-      <div class="card-body p-6">
-        <header class="mb-6 space-y-2">
-          <h2 class="text-xl font-semibold text-[var(--text-primary)]">{% trans 'Dados do operador' %}</h2>
-          <p class="text-sm text-[var(--text-secondary)]">{% trans 'Informe os dados básicos para criar um novo usuário operador.' %}</p>
-        </header>
+  <section class="max-w-3xl mx-auto py-6">
+    <article class="card">
+      <div class="card-header space-y-1">
+        <h2 class="text-xl font-semibold text-[var(--text-primary)]">{% trans 'Dados do operador' %}</h2>
+        <p class="text-sm text-[var(--text-secondary)]">{% trans 'Informe os dados básicos para criar um novo usuário operador.' %}</p>
+      </div>
+      <div class="card-body space-y-6">
         <form method="post" class="space-y-6">
           {% csrf_token %}
           {% if form.non_field_errors %}
             <div class="alert alert-error" role="alert">
-              {{ form.non_field_errors }}
+              <ul class="space-y-1">
+                {% for error in form.non_field_errors %}
+                  <li>{{ error }}</li>
+                {% endfor %}
+              </ul>
             </div>
           {% endif %}
+          {% for hidden_field in form.hidden_fields %}
+            {{ hidden_field }}
+          {% endfor %}
           <div class="grid gap-6 md:grid-cols-2">
-            <div class="space-y-1">
-              <label for="id_username" class="block text-sm font-medium text-[var(--text-primary)]">{% trans 'Nome de usuário' %}</label>
-              {{ form.username }}
-              {% if form.username.errors %}
-                <p class="text-sm text-[var(--error)]">{{ form.username.errors|join:', ' }}</p>
-              {% endif %}
-            </div>
-            <div class="space-y-1">
-              <label for="id_email" class="block text-sm font-medium text-[var(--text-primary)]">{% trans 'E-mail' %}</label>
-              {{ form.email }}
-              {% if form.email.errors %}
-                <p class="text-sm text-[var(--error)]">{{ form.email.errors|join:', ' }}</p>
-              {% endif %}
-            </div>
-            <div class="space-y-1">
-              <label for="id_contato" class="block text-sm font-medium text-[var(--text-primary)]">{% trans 'Nome completo' %}</label>
-              {{ form.contato }}
-              {% if form.contato.errors %}
-                <p class="text-sm text-[var(--error)]">{{ form.contato.errors|join:', ' }}</p>
-              {% endif %}
-            </div>
-            <div class="space-y-1">
-              <label for="id_password1" class="block text-sm font-medium text-[var(--text-primary)]">{% trans 'Senha' %}</label>
-              {{ form.password1 }}
-              {% if form.password1.errors %}
-                <p class="text-sm text-[var(--error)]">{{ form.password1.errors|join:', ' }}</p>
-              {% endif %}
-            </div>
-            <div class="space-y-1">
-              <label for="id_password2" class="block text-sm font-medium text-[var(--text-primary)]">{% trans 'Confirmar senha' %}</label>
-              {{ form.password2 }}
-              {% if form.password2.errors %}
-                <p class="text-sm text-[var(--error)]">{{ form.password2.errors|join:', ' }}</p>
-              {% endif %}
-            </div>
+            {% include '_forms/field.html' with field=form.username %}
+            {% include '_forms/field.html' with field=form.email %}
+            {% include '_forms/field.html' with field=form.contato %}
+            {% include '_forms/field.html' with field=form.password1 %}
+            {% include '_forms/field.html' with field=form.password2 %}
           </div>
-          <div class="flex items-center justify-end gap-3">
+          <div class="flex justify-end gap-3 pt-4 border-t border-[var(--border)]">
             {% include '_components/cancel_button.html' with config=cancel_component_config href=back_href fallback_href=cancel_component_config.fallback_href %}
             <button type="submit" class="btn btn-primary">{% trans 'Salvar operador' %}</button>
           </div>
         </form>
       </div>
-    </div>
+    </article>
   </section>
 {% endblock %}

--- a/configuracoes/templates/configuracoes/operadores_list.html
+++ b/configuracoes/templates/configuracoes/operadores_list.html
@@ -8,63 +8,67 @@
 {% endblock %}
 
 {% block content %}
-  <section class="space-y-6">
-    <div class="card bg-[var(--bg-elevated)] border border-[var(--border)] rounded-2xl shadow-sm">
-      <div class="card-body p-6 space-y-6">
-        <header class="space-y-1">
-          <h2 class="text-xl font-semibold text-[var(--text-primary)]">{% trans 'Lista de operadores' %}</h2>
-          <p class="text-sm text-[var(--text-secondary)]">{% trans 'Veja quem já possui acesso como operador e mantenha as informações sempre atualizadas.' %}</p>
-        </header>
+  <section class="container py-6 space-y-6">
+    <article class="card">
+      <div class="card-header space-y-1">
+        <h2 class="text-xl font-semibold text-[var(--text-primary)]">{% trans 'Lista de operadores' %}</h2>
+        <p class="text-sm text-[var(--text-secondary)]">{% trans 'Veja quem já possui acesso como operador e mantenha as informações sempre atualizadas.' %}</p>
+      </div>
+      <div class="card-body space-y-6">
         {% if operadores %}
           <div class="grid gap-4 md:grid-cols-2">
             {% for operador in operadores %}
-              <article class="border border-[var(--border)] rounded-xl p-4 bg-[var(--bg-secondary)] flex flex-col gap-3 shadow-sm">
-                <div class="flex items-start justify-between gap-4">
-                  <div>
-                    <h3 class="text-lg font-semibold text-[var(--text-primary)]">{{ operador.contato|default:operador.username }}</h3>
-                    <p class="text-sm text-[var(--text-secondary)]">@{{ operador.username }}</p>
+              <article class="card h-full">
+                <div class="card-body space-y-4">
+                  <div class="flex items-start justify-between gap-4">
+                    <div class="space-y-1">
+                      <h3 class="text-lg font-semibold text-[var(--text-primary)]">{{ operador.contato|default:operador.username }}</h3>
+                      <p class="text-sm text-[var(--text-secondary)]">@{{ operador.username }}</p>
+                    </div>
+                    <span class="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10 text-primary font-semibold uppercase">
+                      {{ operador.contato|default:operador.username|slice:':1'|upper }}
+                    </span>
                   </div>
-                  <span class="inline-flex items-center justify-center w-10 h-10 rounded-full bg-primary/10 text-primary font-semibold uppercase">
-                    {{ operador.contato|default:operador.username|slice:':1'|upper }}
-                  </span>
+                  <dl class="space-y-2 text-sm">
+                    <div class="flex items-center gap-2">
+                      <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 text-[var(--text-secondary)]" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M16 12a4 4 0 1 1-8 0 4 4 0 0 1 8 0Z" />
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 14c-4.97 0-9 2.686-9 6v1h18v-1c0-3.314-4.03-6-9-6Z" />
+                      </svg>
+                      <span class="text-[var(--text-secondary)]">{% trans 'Vinculado à organização:' %}</span>
+                      <strong class="text-[var(--text-primary)]">{{ operador.organizacao.nome|default:_('Nenhuma') }}</strong>
+                    </div>
+                    <div class="flex items-center gap-2 break-all">
+                      <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 text-[var(--text-secondary)]" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M4 4h16a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2Z" />
+                        <path stroke-linecap="round" stroke-linejoin="round" d="m22 6-10 7L2 6" />
+                      </svg>
+                      <span class="text-[var(--text-secondary)]">{{ operador.email }}</span>
+                    </div>
+                    <div class="flex items-center gap-2">
+                      <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 text-[var(--text-secondary)]" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 8v4l3 3" />
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10Z" />
+                      </svg>
+                      <span class="text-[var(--text-secondary)]">{% blocktrans with created=operador.date_joined|date:'d/m/Y H:i' %}Criado em {{ created }}{% endblocktrans %}</span>
+                    </div>
+                  </dl>
                 </div>
-                <dl class="space-y-2 text-sm">
-                  <div class="flex items-center gap-2">
-                    <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-[var(--text-secondary)]" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                      <path stroke-linecap="round" stroke-linejoin="round" d="M16 12a4 4 0 1 1-8 0 4 4 0 0 1 8 0Z" />
-                      <path stroke-linecap="round" stroke-linejoin="round" d="M12 14c-4.97 0-9 2.686-9 6v1h18v-1c0-3.314-4.03-6-9-6Z" />
-                    </svg>
-                    <span class="text-[var(--text-secondary)]">{% trans 'Vinculado à organização:' %}</span>
-                    <strong class="text-[var(--text-primary)]">{{ operador.organizacao.nome|default:_('Nenhuma') }}</strong>
-                  </div>
-                  <div class="flex items-center gap-2 break-all">
-                    <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-[var(--text-secondary)]" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                      <path stroke-linecap="round" stroke-linejoin="round" d="M4 4h16a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2Z" />
-                      <path stroke-linecap="round" stroke-linejoin="round" d="m22 6-10 7L2 6" />
-                    </svg>
-                    <span class="text-[var(--text-secondary)]">{{ operador.email }}</span>
-                  </div>
-                  <div class="flex items-center gap-2">
-                    <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-[var(--text-secondary)]" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                      <path stroke-linecap="round" stroke-linejoin="round" d="M12 8v4l3 3" />
-                      <path stroke-linecap="round" stroke-linejoin="round" d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10Z" />
-                    </svg>
-                    <span class="text-[var(--text-secondary)]">{% blocktrans with created=operador.date_joined|date:'d/m/Y H:i' %}Criado em {{ created }}{% endblocktrans %}</span>
-                  </div>
-                </dl>
               </article>
             {% endfor %}
           </div>
         {% else %}
-          <div class="py-10 text-center border border-dashed border-[var(--border)] rounded-xl bg-[var(--bg-secondary)]">
-            <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="w-12 h-12 mx-auto text-[var(--text-secondary)]" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M16 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2" />
-              <circle cx="9" cy="7" r="4" />
-            </svg>
-            <p class="mt-4 text-sm text-[var(--text-secondary)]">{% trans 'Ainda não há operadores cadastrados. Clique no botão acima para adicionar o primeiro.' %}</p>
-          </div>
+          <article class="card border-dashed">
+            <div class="card-body space-y-4 text-center">
+              <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="mx-auto h-12 w-12 text-[var(--text-secondary)]" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M16 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2" />
+                <circle cx="9" cy="7" r="4" />
+              </svg>
+              <p class="text-sm text-[var(--text-secondary)]">{% trans 'Ainda não há operadores cadastrados. Clique no botão acima para adicionar o primeiro.' %}</p>
+            </div>
+          </article>
         {% endif %}
       </div>
-    </div>
+    </article>
   </section>
 {% endblock %}


### PR DESCRIPTION
## Summary
- reorganiza o template principal de configurações para usar layout de cartão com navegação entre abas
- padroniza os formulários de operadores e parciais HTMX com `_forms/field.html`, alerts de erro e barras de ação compartilhadas
- ajusta a listagem de operadores e a ação do hero para reutilizar componentes de cartão e botões oficiais

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68deb570d5c08325bb4a08ac03a9d0ed