### PR TITLE
Padroniza layout dos templates do módulo de tokens

### DIFF
--- a/tokens/templates/tokens/_resultado.html
+++ b/tokens/templates/tokens/_resultado.html
@@ -1,14 +1,25 @@
 {% load i18n %}
-{% if codigo %}
-  <div class="p-3 rounded bg-[var(--success-light)] text-[var(--success)]" role="status">
-    {% trans "Código gerado:" %} <code class="font-mono text-lg">{{ codigo }}</code>
+<!-- HTMX partial: rendered inside existing cards, so the markup remains flat. -->
+{% if codigo or token or success or error %}
+  <div class="space-y-4">
+    {% if codigo %}
+      <div class="alert alert-success" role="status">
+        {% trans "Código gerado:" %} <code class="font-mono text-lg">{{ codigo }}</code>
+      </div>
+    {% endif %}
+
+    {% if token %}
+      <div class="alert alert-success" role="status">
+        {% trans "Token:" %} <code class="font-mono break-all">{{ token }}</code>
+      </div>
+    {% endif %}
+
+    {% if success %}
+      <div class="alert alert-success" role="status">{{ success }}</div>
+    {% endif %}
+
+    {% if error %}
+      <div class="alert alert-error" role="alert">{{ error }}</div>
+    {% endif %}
   </div>
-{% elif token %}
-  <div class="p-3 rounded bg-[var(--success-light)] text-[var(--success)]" role="status">
-    {% trans "Token:" %} <code class="font-mono break-all">{{ token }}</code>
-  </div>
-{% elif success %}
-  <div class="p-3 rounded bg-[var(--success-light)] text-[var(--success)]" role="status">{{ success }}</div>
-{% elif error %}
-  <div class="p-3 rounded bg-[var(--error-light)] text-[var(--error)]" role="alert">{{ error }}</div>
 {% endif %}

--- a/tokens/templates/tokens/gerar_token.html
+++ b/tokens/templates/tokens/gerar_token.html
@@ -1,13 +1,13 @@
 {% load widget_tweaks i18n %}
 
 <section class="max-w-xl mx-auto px-4 py-10">
-  <div class="card">
-    <div class="card-body space-y-6">
-      <header class="mb-6 text-center">
-        <h1 class="text-2xl font-bold text-[var(--text-primary)]">{% trans "Gerar Token de Acesso" %}</h1>
-        <p class="text-sm text-[var(--text-secondary)] mt-2">{% trans "Use este token para convidar novos membros ou recuperar o acesso." %}</p>
-      </header>
+  <article class="card">
+    <header class="card-header text-center">
+      <h1 class="text-2xl font-bold text-[var(--text-primary)]">{% trans "Gerar Token de Acesso" %}</h1>
+      <p class="text-sm text-[var(--text-secondary)]">{% trans "Use este token para convidar novos membros ou recuperar o acesso." %}</p>
+    </header>
 
+    <div class="card-body space-y-6">
       <form method="post" action="{% url 'tokens:gerar_convite' %}"
             hx-post="{% url 'tokens:gerar_convite' %}"
             hx-target="#resultado" hx-swap="innerHTML"
@@ -16,7 +16,6 @@
 
         {% include '_forms/field.html' with field=form.tipo_destino %}
 
-
         <div class="flex justify-end gap-3 pt-4 border-t border-[var(--border)]">
           <button type="submit" class="btn btn-primary">
             {% trans "Gerar Token" %}
@@ -24,14 +23,14 @@
         </div>
       </form>
 
-      <div id="resultado" class="mt-6 text-center" aria-live="polite">
+      <div id="resultado" class="text-center" aria-live="polite">
         {% include "tokens/_resultado.html" %}
       </div>
 
-      <footer class="mt-6">
+      <div class="flex justify-end gap-3 pt-4 border-t border-[var(--border)]">
         {% url 'tokens:listar_convites' as convites_url %}
         {% include '_components/back_button.html' with href=back_href fallback_href=convites_url %}
-      </footer>
+      </div>
     </div>
-  </div>
+  </article>
 </section>

--- a/tokens/templates/tokens/hero_action.html
+++ b/tokens/templates/tokens/hero_action.html
@@ -1,2 +1,3 @@
 {% load i18n %}
+<!-- Hero action usa o tamanho btn-sm para manter o alinhamento com o cabeçalho compacto. -->
 <a href="{% url 'tokens:gerar_convite' %}" class="btn btn-primary btn-sm">{% trans 'Gerar Token' %}</a>

--- a/tokens/templates/tokens/token_list.html
+++ b/tokens/templates/tokens/token_list.html
@@ -1,45 +1,47 @@
 {% load i18n %}
 
-<div class="py-12 px-4 space-y-6">
-  <div class="card px-4 max-w-6xl mx-auto">
-    <div class="card-body space-y-6">
+<section class="py-12">
+  <article class="card max-w-6xl mx-auto">
+    <header class="card-header">
       <h1 class="text-2xl font-bold">{% trans "Convites Emitidos" %}</h1>
+    </header>
 
+    <div class="card-body space-y-6">
       {% if convites %}
-      <div class="overflow-x-auto border border-[var(--border)] rounded-2xl card-sm">
-        <table class="min-w-full divide-y divide-[var(--border)]">
-          <thead class="bg-[var(--bg-secondary)]">
-            <tr>
-              <th class="px-4 py-2 text-left text-sm font-medium text-[var(--text-primary)]">{% trans "Tipo" %}</th>
-              <th class="px-4 py-2 text-left text-sm font-medium text-[var(--text-primary)]">{% trans "Token" %}</th>
-              <th class="px-4 py-2 text-left text-sm font-medium text-[var(--text-primary)]">{% trans "Estado" %}</th>
-            </tr>
-          </thead>
-          <tbody class="divide-y divide-[var(--border)]">
-            {% for token in convites %}
-            <tr>
-              <td class="px-4 py-2 text-sm text-[var(--text-primary)]">{{ token.get_tipo_destino_display }}</td>
-              <td class="px-4 py-2 text-sm text-[var(--text-primary)]">
-                {% if token.preview_display %}
-                <code class="font-mono text-xs break-all">{{ token.preview_display }}</code>
-                {% else %}
-                <span class="text-[var(--text-secondary)]">{% trans "Indisponível" %}</span>
-                {% endif %}
-              </td>
-              <td class="px-4 py-2 text-sm text-[var(--text-primary)]">{{ token.get_estado_display }}</td>
-            </tr>
-            {% endfor %}
-          </tbody>
-        </table>
-      </div>
+        <div class="overflow-x-auto border border-[var(--border)] rounded-2xl">
+          <table class="min-w-full divide-y divide-[var(--border)]">
+            <thead class="bg-[var(--bg-secondary)]">
+              <tr>
+                <th class="px-4 py-2 text-left text-sm font-medium text-[var(--text-primary)]">{% trans "Tipo" %}</th>
+                <th class="px-4 py-2 text-left text-sm font-medium text-[var(--text-primary)]">{% trans "Token" %}</th>
+                <th class="px-4 py-2 text-left text-sm font-medium text-[var(--text-primary)]">{% trans "Estado" %}</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-[var(--border)]">
+              {% for token in convites %}
+                <tr>
+                  <td class="px-4 py-2 text-sm text-[var(--text-primary)]">{{ token.get_tipo_destino_display }}</td>
+                  <td class="px-4 py-2 text-sm text-[var(--text-primary)]">
+                    {% if token.preview_display %}
+                      <code class="font-mono text-xs break-all">{{ token.preview_display }}</code>
+                    {% else %}
+                      <span class="text-[var(--text-secondary)]">{% trans "Indisponível" %}</span>
+                    {% endif %}
+                  </td>
+                  <td class="px-4 py-2 text-sm text-[var(--text-primary)]">{{ token.get_estado_display }}</td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
       {% else %}
-      <p class="text-sm text-[var(--text-secondary)]">{% trans "Nenhum convite encontrado." %}</p>
+        <div class="text-sm text-[var(--text-secondary)]">{% trans "Nenhum convite encontrado." %}</div>
       {% endif %}
 
-      <div>
+      <div class="flex justify-end gap-3 pt-4 border-t border-[var(--border)]">
         {% url 'accounts:perfil' as perfil_url %}
         {% include '_components/back_button.html' with href=back_href fallback_href=perfil_url %}
       </div>
     </div>
-  </div>
-</div>
+  </article>
+</section>

--- a/tokens/templates/tokens/tokens.html
+++ b/tokens/templates/tokens/tokens.html
@@ -7,8 +7,9 @@
 
 {% block content %}
 <section class="mx-auto max-w-6xl px-4 lg:px-6 py-6">
-  <div id="tokens-conteudo">
+  <div id="tokens-conteudo" class="space-y-6">
     {% if partial_template %}
+      {# Partial templates are swapped via HTMX and must include the full card layout themselves. #}
       {% include partial_template %}
     {% else %}
       {% include 'tokens/token_list.html' %}

--- a/tokens/templates/tokens/validar_token.html
+++ b/tokens/templates/tokens/validar_token.html
@@ -1,33 +1,35 @@
 {% load widget_tweaks i18n %}
 
 <section class="max-w-md mx-auto px-4 py-12">
-  <div class="card">
-    <div class="card-body">
-      <header class="text-center mb-6">
-        <h1 class="text-2xl font-bold">{% trans "Validar Token de Convite" %}</h1>
-        <p class="text-sm text-[var(--text-secondary)] mt-2">{% trans "Informe o token recebido para concluir o convite." %}</p>
-      </header>
+  <article class="card">
+    <header class="card-header text-center">
+      <h1 class="text-2xl font-bold">{% trans "Validar Token de Convite" %}</h1>
+      <p class="text-sm text-[var(--text-secondary)]">{% trans "Informe o token recebido para concluir o convite." %}</p>
+    </header>
 
+    <div class="card-body space-y-6">
       <form method="post" action="{% url 'tokens:validar_token' %}"
             hx-post="{% url 'tokens:validar_token' %}"
             hx-target="#resultado" hx-swap="innerHTML"
-            class="space-y-4">
+            class="space-y-6">
         {% csrf_token %}
         {% for field in form %}
           {% include '_forms/field.html' with field=field %}
         {% endfor %}
-        <div class="text-right">
+
+        <div class="flex justify-end gap-3 pt-4 border-t border-[var(--border)]">
           <button type="submit" class="btn btn-primary">{% trans "Validar Token" %}</button>
         </div>
       </form>
 
-      <div id="resultado" class="mt-6 text-center" aria-live="polite">
+      <div id="resultado" class="text-center" aria-live="polite">
         {% include "tokens/_resultado.html" %}
       </div>
 
-      <footer class="mt-6 text-center">
-        <a href="{% url 'configuracoes:configuracoes' %}" class="text-sm link hover:underline">{% trans "Voltar ao painel de segurança" %}</a>
-      </footer>
+      <div class="flex justify-end gap-3 pt-4 border-t border-[var(--border)]">
+        {% url 'configuracoes:configuracoes' as configuracoes_url %}
+        {% include '_components/back_button.html' with href=back_href fallback_href=configuracoes_url %}
+      </div>
     </div>
-  </div>
+  </article>
 </section>


### PR DESCRIPTION
## Summary
- ajusta os formulários de geração e validação de tokens para usar card-header/card-body e barras de ações padronizadas
- reestrutura a listagem de convites e o container principal para manter o layout-base consistente
- atualiza os parciais HTMX para utilizar componentes de alerta e documenta a exceção do botão da hero action

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68deba94e3c483258bd3e8767e5e2e1a