### PR TITLE
Atualiza layout do perfil privado para exibir info e portfólio

### DIFF
--- a/accounts/templates/perfil/perfil.html
+++ b/accounts/templates/perfil/perfil.html
@@ -7,32 +7,83 @@
 
 {% block content %}
 
-<div class="card">
-  <div class="card-body">
-    
-    <section
-      id="perfil-content"
-      class="space-y-6"
-      data-perfil-default-url="{{ perfil_default_url }}"
-      data-perfil-default-section="{{ perfil_default_section }}"
-      data-perfil-mode="{% if is_owner %}owner{% else %}public{% endif %}"
-      data-perfil-username="{{ profile.username }}"
-      data-perfil-public-id="{{ profile.public_id }}"
-      data-perfil-loading-text="{% trans 'Carregando conteúdo...' %}"
-      data-perfil-error-text="{% trans 'Não foi possível carregar esta seção.' %}"
-      aria-live="polite"
-      aria-busy="true"
-      hx-trigger="load"
-      hx-get="{{ perfil_default_url }}"
-      hx-target="#perfil-content"
-  hx-push-url="?section={{ perfil_default_section }}"
-      hx-vals='{"section":"{{ perfil_default_section }}"}'
-    >
-      <div class="py-6 text-center text-sm text-[var(--text-secondary)]" data-perfil-placeholder>
-        {% trans "Carregando conteúdo..." %}
-      </div>
-    </section>
+<div class="space-y-6">
+  <div class="card">
+    <div class="card-body">
+      <section
+        id="perfil-info"
+        class="space-y-6"
+        data-perfil-mode="{% if is_owner %}owner{% else %}public{% endif %}"
+        data-perfil-username="{{ profile.username }}"
+        data-perfil-public-id="{{ profile.public_id }}"
+        aria-live="polite"
+        aria-busy="true"
+        hx-trigger="load"
+        hx-get="{% if perfil_default_section == 'info' %}{{ perfil_default_url }}{% else %}{% url 'accounts:perfil_info_partial' %}{% endif %}"
+        hx-target="#perfil-info"
+        {% if not is_owner %}
+          hx-vals='{"public_id":"{{ profile.public_id|escapejs }}","username":"{{ profile.username|escapejs }}"}'
+        {% endif %}
+      >
+        <div class="py-6 text-center text-sm text-[var(--text-secondary)]" data-perfil-placeholder>
+          {% trans "Carregando conteúdo..." %}
+        </div>
+      </section>
+    </div>
   </div>
+
+  <div class="card">
+    <div class="card-body">
+      <section
+        id="perfil-portfolio"
+        class="space-y-6"
+        data-perfil-mode="{% if is_owner %}owner{% else %}public{% endif %}"
+        data-perfil-username="{{ profile.username }}"
+        data-perfil-public-id="{{ profile.public_id }}"
+        aria-live="polite"
+        aria-busy="true"
+        hx-trigger="load"
+        hx-get="{% if perfil_default_section == 'portfolio' %}{{ perfil_default_url }}{% else %}{% url 'accounts:perfil_portfolio' %}{% endif %}"
+        hx-target="#perfil-portfolio"
+        {% if not is_owner %}
+          hx-vals='{"public_id":"{{ profile.public_id|escapejs }}","username":"{{ profile.username|escapejs }}"}'
+        {% endif %}
+      >
+        <div class="py-6 text-center text-sm text-[var(--text-secondary)]" data-perfil-placeholder>
+          {% trans "Carregando conteúdo..." %}
+        </div>
+      </section>
+    </div>
+  </div>
+
+  {% if perfil_default_section not in ('info', 'portfolio') %}
+    <div class="card">
+      <div class="card-body">
+        <section
+          id="perfil-content"
+          class="space-y-6"
+          data-perfil-default-url="{{ perfil_default_url }}"
+          data-perfil-default-section="{{ perfil_default_section }}"
+          data-perfil-mode="{% if is_owner %}owner{% else %}public{% endif %}"
+          data-perfil-username="{{ profile.username }}"
+          data-perfil-public-id="{{ profile.public_id }}"
+          data-perfil-loading-text="{% trans 'Carregando conteúdo...' %}"
+          data-perfil-error-text="{% trans 'Não foi possível carregar esta seção.' %}"
+          aria-live="polite"
+          aria-busy="true"
+          hx-trigger="load"
+          hx-get="{{ perfil_default_url }}"
+          hx-target="#perfil-content"
+          hx-push-url="?section={{ perfil_default_section }}"
+          hx-vals='{"section":"{{ perfil_default_section }}"{% if not is_owner %},"public_id":"{{ profile.public_id|escapejs }}","username":"{{ profile.username|escapejs }}"{% endif %}}'
+        >
+          <div class="py-6 text-center text-sm text-[var(--text-secondary)]" data-perfil-placeholder>
+            {% trans "Carregando conteúdo..." %}
+          </div>
+        </section>
+      </div>
+    </div>
+  {% endif %}
 </div>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- atualiza o template do perfil privado para carregar seções de informações e portfólio em cartões separados
- mantém suporte a carregamento dinâmico de outras seções quando selecionadas via parâmetros da página

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68debb8af94883258b8bcc6d4b2e0b4b