### PR TITLE
Adjust event time placement in calendar template

### DIFF
--- a/eventos/templates/eventos/calendario.html
+++ b/eventos/templates/eventos/calendario.html
@@ -49,43 +49,45 @@
                         >
                           <article class="card transition hover:shadow-sm">
                             <div class="card-body">
-                              <div class="flex items-start gap-4 sm:gap-6">
-                                <time class="min-w-20 text-sm font-semibold text-[var(--text-primary)]" datetime="{{ ev.data_inicio|date:'c' }}">
+                              <div class="space-y-3">
+                                <time class="block text-sm font-semibold text-[var(--text-primary)]" datetime="{{ ev.data_inicio|date:'c' }}">
                                   {{ ev.data_inicio|date:"H:i" }}
                                 </time>
-                                <div class="shrink-0">
-                                  {% if ev.avatar %}
-                                    <img
-                                      src="{{ ev.avatar.url|default:ev.avatar }}"
-                                      alt="{{ ev.titulo }}"
-                                      class="h-12 w-12 rounded-full object-cover ring-2 ring-[var(--bg-primary)]"
-                                      loading="lazy"
-                                    />
-                                  {% else %}
-                                    <div
-                                      class="flex h-12 w-12 items-center justify-center rounded-full bg-[var(--surface-secondary)] text-xs font-semibold uppercase text-[var(--text-secondary)] ring-2 ring-[var(--bg-primary)]"
-                                      role="img"
-                                      aria-label="{{ ev.titulo }}"
-                                    >
-                                      {{ ev.titulo|first|default:'?'|upper }}
+                                <div class="flex items-start gap-4 sm:gap-6">
+                                  <div class="shrink-0">
+                                    {% if ev.avatar %}
+                                      <img
+                                        src="{{ ev.avatar.url|default:ev.avatar }}"
+                                        alt="{{ ev.titulo }}"
+                                        class="h-12 w-12 rounded-full object-cover ring-2 ring-[var(--bg-primary)]"
+                                        loading="lazy"
+                                      />
+                                    {% else %}
+                                      <div
+                                        class="flex h-12 w-12 items-center justify-center rounded-full bg-[var(--surface-secondary)] text-xs font-semibold uppercase text-[var(--text-secondary)] ring-2 ring-[var(--bg-primary)]"
+                                        role="img"
+                                        aria-label="{{ ev.titulo }}"
+                                      >
+                                        {{ ev.titulo|first|default:'?'|upper }}
+                                      </div>
+                                    {% endif %}
+                                  </div>
+                                  <div class="min-w-0 flex-1 space-y-2">
+                                    <span class="block truncate text-sm font-medium text-[var(--text-primary)] group-hover:underline">
+                                      {{ ev.titulo }}
+                                    </span>
+                                    <div class="flex flex-wrap items-center gap-2 text-[10px]">
+                                      {% if ev.tipo %}
+                                        <span class="px-1.5 py-0.5 rounded-full {% if ev.tipo == 'reuniao' %}bg-[var(--success-light)] text-[var(--success)]{% elif ev.tipo == 'palestra' %}bg-[var(--error-light)] text-[var(--error)]{% elif ev.tipo == 'workshop' %}bg-[var(--primary-light)] text-[var(--primary)]{% else %}bg-[var(--surface-secondary)] text-[var(--text-secondary)]{% endif %}">
+                                          {{ ev.get_tipo_display|default:ev.tipo }}
+                                        </span>
+                                      {% endif %}
+                                      {% if ev.local %}
+                                        <span class="px-1.5 py-0.5 rounded-full bg-[var(--surface-secondary)] text-[var(--text-secondary)]">
+                                          {{ ev.local }}
+                                        </span>
+                                      {% endif %}
                                     </div>
-                                  {% endif %}
-                                </div>
-                                <div class="min-w-0 flex-1 space-y-2">
-                                  <span class="block truncate text-sm font-medium text-[var(--text-primary)] group-hover:underline">
-                                    {{ ev.titulo }}
-                                  </span>
-                                  <div class="flex flex-wrap items-center gap-2 text-[10px]">
-                                    {% if ev.tipo %}
-                                      <span class="px-1.5 py-0.5 rounded-full {% if ev.tipo == 'reuniao' %}bg-[var(--success-light)] text-[var(--success)]{% elif ev.tipo == 'palestra' %}bg-[var(--error-light)] text-[var(--error)]{% elif ev.tipo == 'workshop' %}bg-[var(--primary-light)] text-[var(--primary)]{% else %}bg-[var(--surface-secondary)] text-[var(--text-secondary)]{% endif %}">
-                                        {{ ev.get_tipo_display|default:ev.tipo }}
-                                      </span>
-                                    {% endif %}
-                                    {% if ev.local %}
-                                      <span class="px-1.5 py-0.5 rounded-full bg-[var(--surface-secondary)] text-[var(--text-secondary)]">
-                                        {{ ev.local }}
-                                      </span>
-                                    {% endif %}
                                   </div>
                                 </div>
                               </div>


### PR DESCRIPTION
## Summary
- move the event start time onto its own line above the avatar and details in the calendar template to match the requested layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dec735a73083259f270157450885e8