### PR TITLE
Adjust feed grid to single column

### DIFF
--- a/feed/templates/feed/_grid.html
+++ b/feed/templates/feed/_grid.html
@@ -2,7 +2,7 @@
 {# Exceção HTMX: parcial renderizado isoladamente durante atualizações dinâmicas #}
 {% if request.user.user_type != 'root' %}
 
-<section id="feed-grid" class="card-grid auto-rows-[1fr] gap-6 sm:grid-cols-2">
+<section id="feed-grid" class="card-grid auto-rows-[1fr] gap-6 sm:grid-cols-1 md:grid-cols-1 lg:grid-cols-1 xl:grid-cols-1 2xl:grid-cols-1">
   {% for post in posts %}
   <article class="card group relative flex h-full flex-col overflow-hidden border border-transparent bg-[var(--bg-secondary)] shadow-lg transition-all duration-300 hover:-translate-y-1 hover:border-[var(--accent)] hover:shadow-2xl">
     <span aria-hidden="true" class="pointer-events-none absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-[var(--primary)] via-[var(--accent-light)] to-[var(--accent)] opacity-80 transition-opacity duration-300 group-hover:opacity-100"></span>


### PR DESCRIPTION
## Summary
- force the feed card grid to render a single column layout across all breakpoints so desktop and mobile match the desired design

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dece3069608325bd1010814b317283