### PR TITLE
Padroniza templates de notificações

### DIFF
--- a/notificacoes/templates/notificacoes/hero_action.html
+++ b/notificacoes/templates/notificacoes/hero_action.html
@@ -1,5 +1,5 @@
 {% load i18n %}
 <a href="{% url 'notificacoes:template_create' %}"
-   class="btn btn-primary inline-flex items-center gap-2">
+   class="btn btn-primary flex items-center gap-2">
   <span class="text-xl leading-none">+</span> {% trans 'Novo Template' %}
 </a>

--- a/notificacoes/templates/notificacoes/historico_list.html
+++ b/notificacoes/templates/notificacoes/historico_list.html
@@ -8,18 +8,27 @@
 
 {% block content %}
   <div class="max-w-6xl mx-auto card-grid">
-    <div class="card">
-      <div class="card-body">
-        <form method="get" class="grid gap-4 sm:flex sm:items-end">
-          {% for field in form %}
-            {% include '_forms/field.html' with field=field %}
-          {% endfor %}
-          <button type="submit" class="btn btn-primary">{% trans 'Filtrar' %}</button>
+    <article class="card">
+      <header class="card-header space-y-1">
+        <h2 class="text-xl font-semibold text-[var(--text-primary)]">{% trans 'Histórico de Notificações' %}</h2>
+        <p class="text-sm text-[var(--text-secondary)]">{% trans 'Consulte notificações recorrentes enviadas para os núcleos.' %}</p>
+      </header>
+      <div class="card-body space-y-6">
+        <form method="get" class="space-y-4">
+          <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {% for field in form %}
+              {% include '_forms/field.html' with field=field %}
+            {% endfor %}
+          </div>
+          <div class="flex justify-end gap-3 pt-4 border-t border-[var(--border)]">
+            <button type="submit" class="btn btn-primary">{% trans 'Filtrar' %}</button>
+          </div>
         </form>
+        {# HTMX alvo que atualiza a tabela de histórico mantendo o cartão intacto #}
+        <div id="historico-container">
+          {% include 'notificacoes/historico_table.html' %}
+        </div>
       </div>
-    </div>
-    <div id="historico-container">
-      {% include 'notificacoes/historico_table.html' %}
-    </div>
+    </article>
   </div>
 {% endblock %}

--- a/notificacoes/templates/notificacoes/historico_rows.html
+++ b/notificacoes/templates/notificacoes/historico_rows.html
@@ -1,14 +1,15 @@
 {% load i18n %}
+{# Linhas renderizadas dentro da tabela de histórico atualizada via HTMX #}
 {% for item in historicos %}
-<tr>
-  <td class="px-4 py-2 whitespace-nowrap">{{ item.enviado_em|date:'Y-m-d H:i' }}</td>
-  <td class="px-4 py-2 whitespace-nowrap">{{ item.data_referencia|date:'Y-m-d' }}</td>
-  <td class="px-4 py-2">{{ item.get_canal_display }}</td>
-  <td class="px-4 py-2">{{ item.get_frequencia_display }}</td>
-  <td class="px-4 py-2">{{ item.conteudo|join:", " }}</td>
-</tr>
+  <tr>
+    <td class="px-4 py-2 whitespace-nowrap">{{ item.enviado_em|date:'Y-m-d H:i' }}</td>
+    <td class="px-4 py-2 whitespace-nowrap">{{ item.data_referencia|date:'Y-m-d' }}</td>
+    <td class="px-4 py-2">{{ item.get_canal_display }}</td>
+    <td class="px-4 py-2">{{ item.get_frequencia_display }}</td>
+    <td class="px-4 py-2">{{ item.conteudo|join:", " }}</td>
+  </tr>
 {% empty %}
-<tr>
-  <td colspan="5" class="px-4 py-2 text-center text-[var(--text-secondary)]">{% trans 'Nenhuma notificação' %}</td>
-</tr>
+  <tr>
+    <td colspan="5" class="px-4 py-6 text-center text-[var(--text-secondary)]">{% trans 'Nenhuma notificação' %}</td>
+  </tr>
 {% endfor %}

--- a/notificacoes/templates/notificacoes/historico_table.html
+++ b/notificacoes/templates/notificacoes/historico_table.html
@@ -1,19 +1,22 @@
 {% load i18n %}
-<div class="overflow-x-auto border border-[var(--border)] rounded-2xl card-sm">
-  <table class="min-w-full divide-y divide-[var(--border)] text-sm">
-    <caption class="sr-only">{% trans 'Histórico de notificações enviadas' %}</caption>
-    <thead class="bg-[var(--bg-tertiary)]">
-      <tr>
-        <th class="px-4 py-2 text-left font-medium text-[var(--text-secondary)]">{% trans 'Enviado em' %}</th>
-        <th class="px-4 py-2 text-left font-medium text-[var(--text-secondary)]">{% trans 'Referência' %}</th>
-        <th class="px-4 py-2 text-left font-medium text-[var(--text-secondary)]">{% trans 'Canal' %}</th>
-        <th class="px-4 py-2 text-left font-medium text-[var(--text-secondary)]">{% trans 'Frequência' %}</th>
-        <th class="px-4 py-2 text-left font-medium text-[var(--text-secondary)]">{% trans 'Conteúdo' %}</th>
-      </tr>
-    </thead>
-    <tbody class="divide-y divide-[var(--border)]">
-      {% include 'notificacoes/historico_rows.html' %}
-    </tbody>
-  </table>
+{# Parcial injetado via HTMX para atualizar a tabela do histórico dentro do cartão principal #}
+<div class="space-y-4">
+  <div class="overflow-x-auto">
+    <table class="min-w-full divide-y divide-[var(--border)] text-sm">
+      <caption class="sr-only">{% trans 'Histórico de notificações enviadas' %}</caption>
+      <thead class="bg-[var(--bg-tertiary)]">
+        <tr>
+          <th class="px-4 py-2 text-left font-medium text-[var(--text-secondary)]">{% trans 'Enviado em' %}</th>
+          <th class="px-4 py-2 text-left font-medium text-[var(--text-secondary)]">{% trans 'Referência' %}</th>
+          <th class="px-4 py-2 text-left font-medium text-[var(--text-secondary)]">{% trans 'Canal' %}</th>
+          <th class="px-4 py-2 text-left font-medium text-[var(--text-secondary)]">{% trans 'Frequência' %}</th>
+          <th class="px-4 py-2 text-left font-medium text-[var(--text-secondary)]">{% trans 'Conteúdo' %}</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-[var(--border)]">
+        {% include 'notificacoes/historico_rows.html' %}
+      </tbody>
+    </table>
+  </div>
+  {% include '_partials/pagination.html' with page_obj=historicos querystring=request.GET.urlencode %}
 </div>
-{% include '_partials/pagination.html' with page_obj=historicos querystring=request.GET.urlencode %}

--- a/notificacoes/templates/notificacoes/logs_list.html
+++ b/notificacoes/templates/notificacoes/logs_list.html
@@ -8,18 +8,27 @@
 
 {% block content %}
   <div class="max-w-6xl mx-auto card-grid">
-    <div class="card">
-      <div class="card-body">
-        <form method="get" class="grid gap-4 sm:flex sm:items-end">
-          {% for field in form %}
-            {% include '_forms/field.html' with field=field %}
-          {% endfor %}
-          <button type="submit" class="btn btn-primary">{% trans 'Filtrar' %}</button>
+    <article class="card">
+      <header class="card-header space-y-1">
+        <h2 class="text-xl font-semibold text-[var(--text-primary)]">{% trans 'Logs de Notificação' %}</h2>
+        <p class="text-sm text-[var(--text-secondary)]">{% trans 'Acompanhe os envios e resultados das notificações.' %}</p>
+      </header>
+      <div class="card-body space-y-6">
+        <form method="get" class="space-y-4">
+          <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {% for field in form %}
+              {% include '_forms/field.html' with field=field %}
+            {% endfor %}
+          </div>
+          <div class="flex justify-end gap-3 pt-4 border-t border-[var(--border)]">
+            <button type="submit" class="btn btn-primary">{% trans 'Filtrar' %}</button>
+          </div>
         </form>
+        {# HTMX alvo que atualiza apenas a tabela mantendo o layout do cartão #}
+        <div id="logs-container">
+          {% include 'notificacoes/logs_table.html' %}
+        </div>
       </div>
-    </div>
-    <div id="logs-container">
-      {% include 'notificacoes/logs_table.html' %}
-    </div>
+    </article>
   </div>
 {% endblock %}

--- a/notificacoes/templates/notificacoes/logs_rows.html
+++ b/notificacoes/templates/notificacoes/logs_rows.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{# Linhas renderizadas dentro da tabela de logs atualizada via HTMX #}
 {% for log in logs %}
   <tr>
     <td class="px-4 py-2">{{ log.data_envio|date:"SHORT_DATETIME_FORMAT" }}</td>
@@ -10,6 +11,6 @@
   </tr>
 {% empty %}
   <tr>
-    <td colspan="6" class="px-4 py-2 text-center text-[var(--text-secondary)]">{% trans 'Nenhum log encontrado.' %}</td>
+    <td colspan="6" class="px-4 py-6 text-center text-[var(--text-secondary)]">{% trans 'Nenhum log encontrado.' %}</td>
   </tr>
 {% endfor %}

--- a/notificacoes/templates/notificacoes/logs_table.html
+++ b/notificacoes/templates/notificacoes/logs_table.html
@@ -1,21 +1,23 @@
 {% load i18n %}
-{# Necessary for translation tags when rendering via HTMX #}
-<div class="overflow-x-auto border border-[var(--border)] rounded-2xl card-sm">
-  <table class="min-w-full divide-y divide-[var(--border)] text-sm">
-    <caption class="sr-only">{% trans 'Logs de notificações' %}</caption>
-    <thead class="bg-[var(--bg-tertiary)]">
-      <tr>
-        <th class="px-4 py-2 text-left font-medium text-[var(--text-secondary)]">{% trans 'Data' %}</th>
-        <th class="px-4 py-2 text-left font-medium text-[var(--text-secondary)]">{% trans 'Usuário' %}</th>
-        <th class="px-4 py-2 text-left font-medium text-[var(--text-secondary)]">{% trans 'Template' %}</th>
-        <th class="px-4 py-2 text-left font-medium text-[var(--text-secondary)]">{% trans 'Canal' %}</th>
-        <th class="px-4 py-2 text-left font-medium text-[var(--text-secondary)]">{% trans 'Status' %}</th>
-        <th class="px-4 py-2 text-left font-medium text-[var(--text-secondary)]">{% trans 'Erro' %}</th>
-      </tr>
-    </thead>
-    <tbody class="divide-y divide-[var(--border)]">
-      {% include 'notificacoes/logs_rows.html' %}
-    </tbody>
-  </table>
+{# Parcial injetado via HTMX para atualizar apenas a tabela de logs dentro do cartão principal #}
+<div class="space-y-4">
+  <div class="overflow-x-auto">
+    <table class="min-w-full divide-y divide-[var(--border)] text-sm">
+      <caption class="sr-only">{% trans 'Logs de notificações' %}</caption>
+      <thead class="bg-[var(--bg-tertiary)]">
+        <tr>
+          <th class="px-4 py-2 text-left font-medium text-[var(--text-secondary)]">{% trans 'Data' %}</th>
+          <th class="px-4 py-2 text-left font-medium text-[var(--text-secondary)]">{% trans 'Usuário' %}</th>
+          <th class="px-4 py-2 text-left font-medium text-[var(--text-secondary)]">{% trans 'Template' %}</th>
+          <th class="px-4 py-2 text-left font-medium text-[var(--text-secondary)]">{% trans 'Canal' %}</th>
+          <th class="px-4 py-2 text-left font-medium text-[var(--text-secondary)]">{% trans 'Status' %}</th>
+          <th class="px-4 py-2 text-left font-medium text-[var(--text-secondary)]">{% trans 'Erro' %}</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-[var(--border)]">
+        {% include 'notificacoes/logs_rows.html' %}
+      </tbody>
+    </table>
+  </div>
+  {% include '_partials/pagination.html' with page_obj=logs querystring=request.GET.urlencode %}
 </div>
-{% include '_partials/pagination.html' with page_obj=logs querystring=request.GET.urlencode %}

--- a/notificacoes/templates/notificacoes/metrics.html
+++ b/notificacoes/templates/notificacoes/metrics.html
@@ -8,36 +8,63 @@
 
 {% block content %}
   <div class="max-w-6xl mx-auto card-grid">
-    <div class="card">
-      <div class="card-body">
-        <form method="get" class="flex flex-col sm:flex-row gap-4 sm:items-end">
-          {% for field in form %}
-            {% include '_forms/field.html' with field=field %}
-          {% endfor %}
-          <button type="submit" class="btn btn-primary">{% trans 'Filtrar' %}</button>
-        </form>
-      </div>
-    </div>
-    <div class="card">
+    <article class="card">
+      <header class="card-header space-y-1">
+        <h2 class="text-xl font-semibold text-[var(--text-primary)]">{% trans 'Métricas de Notificações' %}</h2>
+        <p class="text-sm text-[var(--text-secondary)]">{% trans 'Visualize indicadores por canal para acompanhar a performance das mensagens.' %}</p>
+      </header>
       <div class="card-body space-y-6">
-        <div>
-          <h2 class="text-xl font-semibold text-[var(--text-primary)] mb-2">{% trans 'Total por canal' %}</h2>
-          <ul class="list-disc list-inside text-[var(--text-secondary)] space-y-1">
-            <li>{% trans 'E-mail' %}: {{ total_por_canal.email|default:0 }}</li>
-            <li>{% trans 'Push' %}: {{ total_por_canal.push|default:0 }}</li>
-            <li>{% trans 'WhatsApp' %}: {{ total_por_canal.whatsapp|default:0 }}</li>
-          </ul>
-        </div>
-        <div>
-          <h2 class="text-xl font-semibold text-[var(--text-primary)] mb-2">{% trans 'Falhas por canal' %}</h2>
-          <ul class="list-disc list-inside text-[var(--text-secondary)] space-y-1">
-            <li>{% trans 'E-mail' %}: {{ falhas_por_canal.email|default:0 }}</li>
-            <li>{% trans 'Push' %}: {{ falhas_por_canal.push|default:0 }}</li>
-            <li>{% trans 'WhatsApp' %}: {{ falhas_por_canal.whatsapp|default:0 }}</li>
-          </ul>
-        </div>
-        <p class="text-[var(--text-secondary)]">{% trans 'Total de templates' %}: {{ templates_total|default:0 }}</p>
+        <form method="get" class="space-y-4">
+          <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {% for field in form %}
+              {% include '_forms/field.html' with field=field %}
+            {% endfor %}
+          </div>
+          <div class="flex justify-end gap-3 pt-4 border-t border-[var(--border)]">
+            <button type="submit" class="btn btn-primary">{% trans 'Filtrar' %}</button>
+          </div>
+        </form>
+        <section class="space-y-6">
+          <div class="space-y-4">
+            <h3 class="text-lg font-semibold text-[var(--text-primary)]">{% trans 'Total por canal' %}</h3>
+            <dl class="space-y-2 text-[var(--text-secondary)]">
+              <div class="flex items-center justify-between">
+                <dt>{% trans 'E-mail' %}</dt>
+                <dd class="font-medium text-[var(--text-primary)]">{{ total_por_canal.email|default:0 }}</dd>
+              </div>
+              <div class="flex items-center justify-between">
+                <dt>{% trans 'Push' %}</dt>
+                <dd class="font-medium text-[var(--text-primary)]">{{ total_por_canal.push|default:0 }}</dd>
+              </div>
+              <div class="flex items-center justify-between">
+                <dt>{% trans 'WhatsApp' %}</dt>
+                <dd class="font-medium text-[var(--text-primary)]">{{ total_por_canal.whatsapp|default:0 }}</dd>
+              </div>
+            </dl>
+          </div>
+          <div class="space-y-4">
+            <h3 class="text-lg font-semibold text-[var(--text-primary)]">{% trans 'Falhas por canal' %}</h3>
+            <dl class="space-y-2 text-[var(--text-secondary)]">
+              <div class="flex items-center justify-between">
+                <dt>{% trans 'E-mail' %}</dt>
+                <dd class="font-medium text-[var(--text-primary)]">{{ falhas_por_canal.email|default:0 }}</dd>
+              </div>
+              <div class="flex items-center justify-between">
+                <dt>{% trans 'Push' %}</dt>
+                <dd class="font-medium text-[var(--text-primary)]">{{ falhas_por_canal.push|default:0 }}</dd>
+              </div>
+              <div class="flex items-center justify-between">
+                <dt>{% trans 'WhatsApp' %}</dt>
+                <dd class="font-medium text-[var(--text-primary)]">{{ falhas_por_canal.whatsapp|default:0 }}</dd>
+              </div>
+            </dl>
+          </div>
+          <div class="space-y-2">
+            <h3 class="text-lg font-semibold text-[var(--text-primary)]">{% trans 'Resumo geral' %}</h3>
+            <p class="text-[var(--text-secondary)]">{% trans 'Total de templates cadastrados' %}: <span class="font-medium text-[var(--text-primary)]">{{ templates_total|default:0 }}</span></p>
+          </div>
+        </section>
       </div>
-    </div>
+    </article>
   </div>
 {% endblock %}

--- a/notificacoes/templates/notificacoes/template_confirm_delete.html
+++ b/notificacoes/templates/notificacoes/template_confirm_delete.html
@@ -8,15 +8,21 @@
 
 {% block content %}
   <div class="max-w-2xl mx-auto card-grid">
-    <div class="card">
+    <article class="card">
+      <header class="card-header space-y-1">
+        <h2 class="text-xl font-semibold text-[var(--danger)]">{% trans 'Confirmar exclusão' %}</h2>
+        <p class="text-sm text-[var(--text-secondary)]">{% trans 'Esta ação não poderá ser desfeita.' %}</p>
+      </header>
       <div class="card-body space-y-4">
         <p>{% blocktrans with codigo=template.codigo %}Tem certeza que deseja excluir o template {{ codigo }}?{% endblocktrans %}</p>
-        <form method="post" class="flex justify-end gap-3 pt-4 border-t border-[var(--border)]">
+        <form method="post" class="space-y-4">
           {% csrf_token %}
-          {% include '_components/cancel_button.html' with config=cancel_component_config href=back_href fallback_href=cancel_component_config.fallback_href %}
-          <button type="submit" class="btn btn-danger">{% trans 'Excluir' %}</button>
+          <div class="flex justify-end gap-3 pt-4 border-t border-[var(--border)]">
+            {% include '_components/cancel_button.html' with config=cancel_component_config href=back_href fallback_href=cancel_component_config.fallback_href %}
+            <button type="submit" class="btn btn-danger">{% trans 'Excluir' %}</button>
+          </div>
         </form>
       </div>
-    </div>
+    </article>
   </div>
 {% endblock %}

--- a/notificacoes/templates/notificacoes/template_form.html
+++ b/notificacoes/templates/notificacoes/template_form.html
@@ -12,11 +12,32 @@
 
 {% block content %}
   <div class="max-w-xl mx-auto card-grid">
-    <div class="card">
+    <article class="card">
+      <header class="card-header space-y-1">
+        {% if form.instance.pk %}
+          <h2 class="text-xl font-semibold text-[var(--text-primary)]">{% trans 'Editar Template' %}</h2>
+          <p class="text-sm text-[var(--text-secondary)]">{% trans 'Atualize as informações do template de notificação.' %}</p>
+        {% else %}
+          <h2 class="text-xl font-semibold text-[var(--text-primary)]">{% trans 'Cadastrar Template' %}</h2>
+          <p class="text-sm text-[var(--text-secondary)]">{% trans 'Defina os detalhes do novo template de notificação.' %}</p>
+        {% endif %}
+      </header>
       <div class="card-body space-y-6">
-        <form method="post" class="space-y-4">
+        <form method="post" class="space-y-6">
           {% csrf_token %}
-          {% for field in form %}
+          {% if form.non_field_errors %}
+            <div class="alert alert-error" role="alert">
+              <ul class="space-y-1">
+                {% for error in form.non_field_errors %}
+                  <li>{{ error }}</li>
+                {% endfor %}
+              </ul>
+            </div>
+          {% endif %}
+          {% for hidden_field in form.hidden_fields %}
+            {{ hidden_field }}
+          {% endfor %}
+          {% for field in form.visible_fields %}
             {% include '_forms/field.html' with field=field %}
           {% endfor %}
           <div class="flex justify-end gap-3 pt-4 border-t border-[var(--border)]">
@@ -25,6 +46,6 @@
           </div>
         </form>
       </div>
-    </div>
+    </article>
   </div>
 {% endblock %}

--- a/notificacoes/templates/notificacoes/templates_list.html
+++ b/notificacoes/templates/notificacoes/templates_list.html
@@ -7,56 +7,66 @@
 
 {% block content %}
   <div class="max-w-6xl mx-auto card-grid">
-    {% if templates %}
-    <div class="overflow-x-auto border border-[var(--border)] rounded-2xl card-sm">
-      <table class="min-w-full divide-y divide-[var(--border)] text-sm">
-        <caption class="sr-only">{% trans 'Lista de templates de notificação' %}</caption>
-        <thead class="bg-[var(--bg-tertiary)]">
-          <tr>
-            <th class="px-4 py-2 text-left font-medium text-[var(--text-secondary)]">{% trans 'Código' %}</th>
-            <th class="px-4 py-2 text-left font-medium text-[var(--text-secondary)]">{% trans 'Assunto' %}</th>
-            <th class="px-4 py-2 text-left font-medium text-[var(--text-secondary)]">{% trans 'Canal' %}</th>
-            <th class="px-4 py-2 text-left font-medium text-[var(--text-secondary)]">{% trans 'Ativo' %}</th>
-            <th class="px-4 py-2 text-left font-medium text-[var(--text-secondary)]">{% trans 'Ações' %}</th>
-          </tr>
-        </thead>
-        <tbody class="divide-y divide-[var(--border)]" id="templates_table">
-          {% for tpl in templates %}
-          <tr>
-            <td class="px-4 py-2 font-mono">{{ tpl.codigo }}</td>
-            <td class="px-4 py-2">{{ tpl.assunto }}</td>
-            <td class="px-4 py-2">{{ tpl.get_canal_display }}</td>
-            <td class="px-4 py-2">{{ tpl.ativo|yesno:_('Sim,Não') }}</td>
-            <td class="px-4 py-2">
-              <div class="flex items-center gap-2">
-                <a href="{% url 'notificacoes:template_edit' tpl.codigo %}" class="text-sm text-primary hover:underline">{% trans 'Editar' %}</a>
-                {% if tpl.ativo %}
-                  <form method="post" action="{% url 'notificacoes:template_toggle' tpl.codigo %}" class="inline">
-                    {% csrf_token %}
-                    <button type="submit" class="btn btn-secondary btn-sm">{% trans 'Desativar' %}</button>
-                  </form>
-                {% else %}
-                  <form method="post" action="{% url 'notificacoes:template_toggle' tpl.codigo %}" class="inline">
-                    {% csrf_token %}
-                    <button type="submit" class="btn btn-secondary btn-sm">{% trans 'Ativar' %}</button>
-                  </form>
-                {% endif %}
-                <form method="post" action="{% url 'notificacoes:template_delete' tpl.codigo %}" class="inline">
-                  {% csrf_token %}
-                  <button type="submit" class="btn btn-danger btn-sm">{% trans 'Excluir' %}</button>
-                </form>
-              </div>
-            </td>
-          </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-    </div>
-    {% if templates.has_other_pages %}
-      {% include '_partials/pagination.html' with page_obj=templates querystring=request.GET.urlencode %}
-    {% endif %}
-    {% else %}
-      <p class="text-center text-[var(--text-secondary)]">{% trans 'Nenhum template cadastrado.' %}</p>
-    {% endif %}
+    <article class="card">
+      <header class="card-header flex flex-wrap items-start justify-between gap-4">
+        <div class="space-y-1">
+          <h2 class="text-xl font-semibold text-[var(--text-primary)]">{% trans 'Templates de Notificação' %}</h2>
+          <p class="text-sm text-[var(--text-secondary)]">{% trans 'Gerencie as mensagens utilizadas nos envios.' %}</p>
+        </div>
+        {% include 'notificacoes/hero_action.html' %}
+      </header>
+      <div class="card-body space-y-6">
+        {% if templates %}
+          <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-[var(--border)] text-sm">
+              <caption class="sr-only">{% trans 'Lista de templates de notificação' %}</caption>
+              <thead class="bg-[var(--bg-tertiary)]">
+                <tr>
+                  <th class="px-4 py-2 text-left font-medium text-[var(--text-secondary)]">{% trans 'Código' %}</th>
+                  <th class="px-4 py-2 text-left font-medium text-[var(--text-secondary)]">{% trans 'Assunto' %}</th>
+                  <th class="px-4 py-2 text-left font-medium text-[var(--text-secondary)]">{% trans 'Canal' %}</th>
+                  <th class="px-4 py-2 text-left font-medium text-[var(--text-secondary)]">{% trans 'Ativo' %}</th>
+                  <th class="px-4 py-2 text-left font-medium text-[var(--text-secondary)]">{% trans 'Ações' %}</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-[var(--border)]" id="templates_table">
+                {% for tpl in templates %}
+                <tr>
+                  <td class="px-4 py-2 font-mono">{{ tpl.codigo }}</td>
+                  <td class="px-4 py-2">{{ tpl.assunto }}</td>
+                  <td class="px-4 py-2">{{ tpl.get_canal_display }}</td>
+                  <td class="px-4 py-2">{{ tpl.ativo|yesno:_('Sim,Não') }}</td>
+                  <td class="px-4 py-2">
+                    <div class="flex flex-wrap items-center gap-3">
+                      <a href="{% url 'notificacoes:template_edit' tpl.codigo %}" class="btn btn-secondary btn-sm">{% trans 'Editar' %}</a>
+                      <form method="post" action="{% url 'notificacoes:template_toggle' tpl.codigo %}">
+                        {% csrf_token %}
+                        {% if tpl.ativo %}
+                          <button type="submit" class="btn btn-secondary btn-sm">{% trans 'Desativar' %}</button>
+                        {% else %}
+                          <button type="submit" class="btn btn-secondary btn-sm">{% trans 'Ativar' %}</button>
+                        {% endif %}
+                      </form>
+                      <form method="post" action="{% url 'notificacoes:template_delete' tpl.codigo %}">
+                        {% csrf_token %}
+                        <button type="submit" class="btn btn-danger btn-sm">{% trans 'Excluir' %}</button>
+                      </form>
+                    </div>
+                  </td>
+                </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+          {% if templates.has_other_pages %}
+            {% include '_partials/pagination.html' with page_obj=templates querystring=request.GET.urlencode %}
+          {% endif %}
+        {% else %}
+          <div class="space-y-4 text-center">
+            <p class="text-[var(--text-secondary)]">{% trans 'Nenhum template cadastrado.' %}</p>
+          </div>
+        {% endif %}
+      </div>
+    </article>
   </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- padroniza os templates de listagem, formulários e confirmações de notificação com o layout oficial de cartões
- unifica formulários de filtro e tabelas de logs/histórico dentro do mesmo cartão com suporte a atualizações HTMX
- reorganiza a tela de métricas para reutilizar o padrão de formulário e exibição consolidada de indicadores

## Testing
- not run (templates-only change)


------
https://chatgpt.com/codex/tasks/task_e_68deceb268f88325a777796425f17c42