### PR TITLE
Atualiza template de nova postagem do feed

### DIFF
--- a/feed/forms.py
+++ b/feed/forms.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from django import forms
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
+from django.utils.translation import gettext_lazy as _
 
 from accounts.models import UserType
 
@@ -61,6 +62,15 @@ class PostForm(forms.ModelForm):
 
     def __init__(self, *args, user: User | None = None, **kwargs) -> None:
         super().__init__(*args, **kwargs)
+        allowed_choices = [
+            ("global", _("Feed Público")),
+            ("usuario", _("Mural")),
+        ]
+        current_value = self.data.get("tipo_feed") or getattr(self.instance, "tipo_feed", None)
+        choice_map = dict(Post.TIPO_FEED_CHOICES)
+        if current_value and current_value not in {value for value, _ in allowed_choices}:
+            allowed_choices.append((current_value, choice_map.get(current_value, current_value)))
+        self.fields["tipo_feed"].choices = allowed_choices
         if user:
             self.user = user
             self.fields["organizacao"].queryset = Organizacao.objects.filter(users=user)

--- a/feed/static/feed/js/feed.js
+++ b/feed/static/feed/js/feed.js
@@ -80,49 +80,6 @@ function bindFeedEvents(root = document) {
     });
   }
 
-  const tagsSelect = root.querySelector("#tags-select");
-  const tagsHidden = root.querySelector("#tags");
-
-  if (tagsSelect && tagsHidden) {
-    tagsSelect.addEventListener("change", () => {
-      const values = Array.from(tagsSelect.selectedOptions)
-        .map((o) => o.value)
-        .join(",");
-      tagsHidden.value = values;
-    });
-  }
-
-  // Visibilidade/Destino: sincroniza seleção de núcleo com tipo_feed
-  const tipoGlobal = root.querySelector('input[name="tipo_feed"][value="global"]');
-  const tipoUsuario = root.querySelector('input[name="tipo_feed"][value="usuario"]');
-  const tipoNucleoHidden = root.querySelector('#tipo_feed_nucleo_hidden');
-  const nucleoRadios = root.querySelectorAll('input[name="nucleo"]');
-  if (nucleoRadios && tipoNucleoHidden) {
-    nucleoRadios.forEach(r => {
-      r.addEventListener('change', () => {
-        if (r.checked) {
-          // Marcar tipo_feed como "nucleo" quando escolher um núcleo
-          tipoNucleoHidden.checked = true;
-        }
-      });
-    });
-  }
-  const clearNucleos = () => {
-    nucleoRadios.forEach(r => {
-      r.checked = false;
-    });
-  };
-  if (tipoGlobal) {
-    tipoGlobal.addEventListener('change', () => {
-      if (tipoGlobal.checked) clearNucleos();
-    });
-  }
-  if (tipoUsuario) {
-    tipoUsuario.addEventListener('change', () => {
-      if (tipoUsuario.checked) clearNucleos();
-    });
-  }
-
   // Tags: chips input
   const tagsInput = root.querySelector('#tags-input');
   const chipsContainer = root.querySelector('#tags-chips');
@@ -187,6 +144,41 @@ function bindFeedEvents(root = document) {
           updateHiddenTags();
         }
       }
+    });
+  }
+
+  // Checkboxes exclusivos (comportamento semelhante a rádio)
+  const exclusiveCheckboxes = Array.from(root.querySelectorAll('input[type="checkbox"][data-exclusive]'));
+  if (exclusiveCheckboxes.length) {
+    const groups = exclusiveCheckboxes.reduce((acc, checkbox) => {
+      const groupName = checkbox.getAttribute('data-exclusive');
+      if (!groupName) {
+        return acc;
+      }
+      if (!acc[groupName]) {
+        acc[groupName] = [];
+      }
+      acc[groupName].push(checkbox);
+      return acc;
+    }, {});
+
+    Object.values(groups).forEach((group) => {
+      group.forEach((checkbox) => {
+        checkbox.addEventListener('change', () => {
+          if (checkbox.checked) {
+            group.forEach((other) => {
+              if (other !== checkbox) {
+                other.checked = false;
+              }
+            });
+          } else {
+            const anyChecked = group.some((item) => item.checked);
+            if (!anyChecked) {
+              checkbox.checked = true;
+            }
+          }
+        });
+      });
     });
   }
 }

--- a/feed/templates/feed/nova_postagem.html
+++ b/feed/templates/feed/nova_postagem.html
@@ -43,10 +43,40 @@
           {% endif %}
 
           <div class="space-y-4">
-            {% include '_forms/field.html' with field=form.tipo_feed %}
-            {% include '_forms/field.html' with field=form.organizacao %}
-            {% include '_forms/field.html' with field=form.nucleo %}
-            {% include '_forms/field.html' with field=form.evento %}
+            <div class="space-y-2">
+              <span class="block text-sm font-medium text-[var(--text-primary)]">
+                {% trans "Tipo de feed" %} *
+              </span>
+              <div class="flex flex-col gap-2 sm:flex-row sm:items-center">
+                <label for="tipo_feed_global" class="flex items-center gap-2 rounded-xl border border-[var(--border-secondary)] bg-[var(--bg-secondary)] px-4 py-3 text-sm text-[var(--text-primary)]">
+                  <input type="checkbox"
+                         id="tipo_feed_global"
+                         name="tipo_feed"
+                         value="global"
+                         class="form-checkbox"
+                         data-exclusive="tipo-feed"
+                         {% if selected_tipo_feed|default:'global' == 'global' %}checked{% endif %}>
+                  <span>{% trans "Feed Público" %}</span>
+                </label>
+                <label for="tipo_feed_usuario" class="flex items-center gap-2 rounded-xl border border-[var(--border-secondary)] bg-[var(--bg-secondary)] px-4 py-3 text-sm text-[var(--text-primary)]">
+                  <input type="checkbox"
+                         id="tipo_feed_usuario"
+                         name="tipo_feed"
+                         value="usuario"
+                         class="form-checkbox"
+                         data-exclusive="tipo-feed"
+                         {% if selected_tipo_feed == 'usuario' %}checked{% endif %}>
+                  <span>{% trans "Mural" %}</span>
+                </label>
+              </div>
+              {% if form.tipo_feed.errors %}
+                <ul class="errorlist">
+                  {% for error in form.tipo_feed.errors %}
+                    <li>{{ error }}</li>
+                  {% endfor %}
+                </ul>
+              {% endif %}
+            </div>
           </div>
 
           {% with placeholder_value=_('O que você gostaria de compartilhar?') %}
@@ -65,9 +95,20 @@
             <input type="hidden" name="organizacao" value="{{ request.user.organizacao.id }}">
           {% endif %}
 
-          <div class="space-y-4">
-            {% include '_forms/field.html' with field=form.tags|attr:'id:tags-select' %}
-            {% include '_forms/field.html' with id='id_tags_text' name='tags_text' label=_('Novas tags') placeholder=_('Digite novas tags separadas por vírgula') value=request.POST.tags_text|default:'' help_text=_('Use vírgula para separar as tags adicionais.') %}
+          <div class="space-y-2">
+            <label for="tags-input" class="block text-sm font-medium text-[var(--text-primary)]">
+              {% trans "Tags" %}
+            </label>
+            <div id="tags-chips" class="flex flex-wrap gap-2"></div>
+            <input id="tags-input"
+                   type="text"
+                   class="form-input w-full"
+                   placeholder="{% trans 'Digite e pressione Enter para adicionar' %}">
+            <input type="hidden"
+                   id="id_tags_text"
+                   name="tags_text"
+                   value="{{ request.POST.tags_text|default:'' }}">
+            <p class="text-xs text-[var(--text-secondary)]">{% trans "Use Enter ou vírgula para separar as tags." %}</p>
           </div>
 
           <div class="space-y-4">
@@ -78,8 +119,7 @@
 
           <p class="text-xs text-[var(--text-secondary)]">{% trans "Campos marcados com * são obrigatórios. Informe conteúdo ou anexe um arquivo." %}</p>
 
-          <div class="flex justify-end gap-3 pt-4 border-t border-[var(--border)]">
-            {% include '_components/cancel_button.html' with config=cancel_component_config href=back_href fallback_href=cancel_component_config.fallback_href %}
+          <div class="flex justify-end pt-4 border-t border-[var(--border)]">
             <button type="submit" class="btn btn-primary" aria-label="{% trans 'Salvar' %}">
               {% trans "Salvar" %}
             </button>


### PR DESCRIPTION
## Summary
- limita as opções de tipo de feed a público ou mural com checkboxes exclusivos
- simplifica o template de nova postagem removendo seleção de organização, núcleo e evento e aplicando chips de tags
- ajusta o JavaScript do feed para suportar o novo campo de tags e o comportamento exclusivo dos checkboxes

## Testing
- pytest --no-cov feed/tests/test_post_form.py

------
https://chatgpt.com/codex/tasks/task_e_68ded4b20a0883258160fb6ded5ca826