### PR TITLE
Ajusta contraste do checkbox no modo escuro

### DIFF
--- a/static/tailwind.css
+++ b/static/tailwind.css
@@ -758,11 +758,23 @@ select {
   caret-color: #f1f5f9;
 }
 
+.dark .form-checkbox,
+  .dark .form-radio {
+  background-color: #0f172a;
+  border-color: #475569;
+  color: var(--primary);
+}
+
 .dark input:focus,
   .dark textarea:focus,
   .dark select:focus {
   border-color: #64748b;
   background-color: #0f172a;
+}
+
+.dark .form-checkbox:focus,
+  .dark .form-radio:focus {
+  --tw-ring-offset-color: #0f172a;
 }
 
 .dark input::-moz-placeholder, .dark textarea::-moz-placeholder {


### PR DESCRIPTION
## Summary
- ajusta os estilos dos checkboxes e radios no tema escuro para manter contraste do ícone
- alinha a cor do anel de foco desses controles no modo escuro com o fundo

## Testing
- não executado (alterações apenas de estilos)

------
https://chatgpt.com/codex/tasks/task_e_68ded821b9cc8325a93d70cad65c0eba