### PR TITLE
Ajusta estilo dos chips de tags na nova postagem

### DIFF
--- a/feed/static/feed/js/feed.js
+++ b/feed/static/feed/js/feed.js
@@ -97,13 +97,26 @@ function bindFeedEvents(root = document) {
     if (exists) return;
     const chip = document.createElement('span');
     chip.className =
-      'inline-flex items-center gap-1 bg-[var(--bg-tertiary)] text-[var(--text-primary)] rounded-full px-3 py-1 text-xs';
+      'inline-flex items-center gap-1 bg-[var(--bg-tertiary)] text-[var(--text-primary)] rounded-full px-3 py-1 text-xs normal-case';
     chip.setAttribute('data-tag', value);
-    chip.innerHTML = `${value} <button type="button" class="ml-1 btn btn-danger btn-sm" aria-label="Remover">&times;</button>`;
-    chip.querySelector('button').addEventListener('click', () => {
+
+    const label = document.createElement('span');
+    label.textContent = value;
+    label.className = 'leading-none';
+
+    const removeButton = document.createElement('button');
+    removeButton.type = 'button';
+    removeButton.setAttribute('aria-label', 'Remover');
+    removeButton.className =
+      'ml-2 flex h-5 w-5 items-center justify-center rounded-full bg-[var(--error)] text-[var(--text-inverse)] text-xs transition-colors hover:bg-[var(--color-error-700)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--error-light)]';
+    removeButton.innerHTML = '&times;';
+    removeButton.addEventListener('click', () => {
       chip.remove();
       updateHiddenTags();
     });
+
+    chip.appendChild(label);
+    chip.appendChild(removeButton);
     chipsContainer.appendChild(chip);
     updateHiddenTags();
   };


### PR DESCRIPTION
## Summary
- evita transformar as tags em caixa alta ao atualizar a criação dos chips
- adiciona um botão de remoção mais compacto e coerente com o layout dos chips

## Testing
- no automated tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68deeadac7488325abf7038d3a21340e