### PR TITLE
Ajustar tamanho de mídias nas listagens do feed

### DIFF
--- a/feed/templates/feed/_grid.html
+++ b/feed/templates/feed/_grid.html
@@ -79,16 +79,20 @@
         </a>
       </div>
       {% elif post.image %}
-      <figure class="relative z-20 overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--bg-tertiary)] shadow-sm">
-        <img src="{{ post.image.url }}" class="h-full max-h-72 w-full object-cover transition duration-500 ease-out group-hover:scale-[1.03]" alt="{% trans 'mídia do post' %}" loading="lazy">
+      <figure class="relative z-20 mx-auto w-full max-w-2xl overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--bg-tertiary)] shadow-sm">
+        <div class="relative flex max-h-[280px] w-full items-center justify-center overflow-hidden bg-[var(--bg-secondary)] sm:max-h-[320px] md:max-h-[360px] lg:max-h-[420px]">
+          <img src="{{ post.image.url }}" class="h-auto w-full max-h-[280px] object-contain transition duration-500 ease-out group-hover:scale-[1.02] sm:max-h-[320px] md:max-h-[360px] lg:max-h-[420px]" alt="{% trans 'mídia do post' %}" loading="lazy">
+        </div>
       </figure>
       {% elif post.video %}
-      <figure class="relative z-20 overflow-hidden rounded-2xl border border-[var(--border)] bg-black shadow-sm">
-        {% if post.video_preview %}
-        <video src="{{ post.video.url }}" poster="{{ post.video_preview.url }}" controls class="w-full max-h-72 rounded-none object-cover"></video>
-        {% else %}
-        <video src="{{ post.video.url }}" controls class="w-full max-h-72 rounded-none object-cover"></video>
-        {% endif %}
+      <figure class="relative z-20 mx-auto w-full max-w-2xl overflow-hidden rounded-2xl border border-[var(--border)] bg-black shadow-sm">
+        <div class="relative flex max-h-[280px] w-full items-center justify-center overflow-hidden bg-black sm:max-h-[320px] md:max-h-[360px] lg:max-h-[420px]">
+          {% if post.video_preview %}
+          <video src="{{ post.video.url }}" poster="{{ post.video_preview.url }}" controls class="h-auto w-full max-h-[280px] object-contain sm:max-h-[320px] md:max-h-[360px] lg:max-h-[420px]"></video>
+          {% else %}
+          <video src="{{ post.video.url }}" controls class="h-auto w-full max-h-[280px] object-contain sm:max-h-[320px] md:max-h-[360px] lg:max-h-[420px]"></video>
+          {% endif %}
+        </div>
       </figure>
       {% endif %}
 

--- a/feed/templates/feed/_post_list.html
+++ b/feed/templates/feed/_post_list.html
@@ -39,16 +39,20 @@
           </a>
         </div>
       {% elif post.image %}
-        <figure class="relative z-20 overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--bg-tertiary)] shadow-sm">
-          <img src="{{ post.image.url }}" alt="{% trans 'mídia do post' %}" class="h-full max-h-72 w-full object-cover" loading="lazy">
+        <figure class="relative z-20 mx-auto w-full max-w-2xl overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--bg-tertiary)] shadow-sm">
+          <div class="relative flex max-h-[280px] w-full items-center justify-center overflow-hidden bg-[var(--bg-secondary)] sm:max-h-[320px] md:max-h-[360px] lg:max-h-[420px]">
+            <img src="{{ post.image.url }}" alt="{% trans 'mídia do post' %}" class="h-auto w-full max-h-[280px] object-contain sm:max-h-[320px] md:max-h-[360px] lg:max-h-[420px]" loading="lazy">
+          </div>
         </figure>
       {% elif post.video %}
-        <figure class="relative z-20 overflow-hidden rounded-xl border border-[var(--border)] bg-black shadow-sm">
-          {% if post.video_preview %}
-            <video src="{{ post.video.url }}" poster="{{ post.video_preview.url }}" controls class="w-full max-h-72 rounded-none object-cover"></video>
-          {% else %}
-            <video src="{{ post.video.url }}" controls class="w-full max-h-72 rounded-none object-cover"></video>
-          {% endif %}
+        <figure class="relative z-20 mx-auto w-full max-w-2xl overflow-hidden rounded-xl border border-[var(--border)] bg-black shadow-sm">
+          <div class="relative flex max-h-[280px] w-full items-center justify-center overflow-hidden bg-black sm:max-h-[320px] md:max-h-[360px] lg:max-h-[420px]">
+            {% if post.video_preview %}
+              <video src="{{ post.video.url }}" poster="{{ post.video_preview.url }}" controls class="h-auto w-full max-h-[280px] object-contain sm:max-h-[320px] md:max-h-[360px] lg:max-h-[420px]"></video>
+            {% else %}
+              <video src="{{ post.video.url }}" controls class="h-auto w-full max-h-[280px] object-contain sm:max-h-[320px] md:max-h-[360px] lg:max-h-[420px]"></video>
+            {% endif %}
+          </div>
         </figure>
       {% endif %}
 


### PR DESCRIPTION
## Summary
- harmonize the image and video containers used on feed, mural and favorites lists
- limit media previews to a responsive max height and centered layout to ease scanning

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68deeff9b2108325ba249d2ebf4f4548