### PR TITLE
Adjust video layout in feed listings

### DIFF
--- a/feed/templates/feed/_grid.html
+++ b/feed/templates/feed/_grid.html
@@ -88,9 +88,9 @@
       <figure class="relative z-20 mx-auto w-full max-w-2xl overflow-hidden rounded-2xl border border-[var(--border)] bg-black shadow-sm">
         <div class="relative flex max-h-[280px] w-full items-center justify-center overflow-hidden bg-black sm:max-h-[320px] md:max-h-[360px] lg:max-h-[420px]">
           {% if post.video_preview %}
-          <video src="{{ post.video.url }}" poster="{{ post.video_preview.url }}" controls class="h-auto w-full max-h-[280px] object-contain sm:max-h-[320px] md:max-h-[360px] lg:max-h-[420px]"></video>
+          <video src="{{ post.video.url }}" poster="{{ post.video_preview.url }}" controls class="max-h-[280px] w-auto max-w-full object-contain sm:max-h-[320px] md:max-h-[360px] lg:max-h-[420px]"></video>
           {% else %}
-          <video src="{{ post.video.url }}" controls class="h-auto w-full max-h-[280px] object-contain sm:max-h-[320px] md:max-h-[360px] lg:max-h-[420px]"></video>
+          <video src="{{ post.video.url }}" controls class="max-h-[280px] w-auto max-w-full object-contain sm:max-h-[320px] md:max-h-[360px] lg:max-h-[420px]"></video>
           {% endif %}
         </div>
       </figure>

--- a/feed/templates/feed/_post_list.html
+++ b/feed/templates/feed/_post_list.html
@@ -48,9 +48,9 @@
         <figure class="relative z-20 mx-auto w-full max-w-2xl overflow-hidden rounded-xl border border-[var(--border)] bg-black shadow-sm">
           <div class="relative flex max-h-[280px] w-full items-center justify-center overflow-hidden bg-black sm:max-h-[320px] md:max-h-[360px] lg:max-h-[420px]">
             {% if post.video_preview %}
-              <video src="{{ post.video.url }}" poster="{{ post.video_preview.url }}" controls class="h-auto w-full max-h-[280px] object-contain sm:max-h-[320px] md:max-h-[360px] lg:max-h-[420px]"></video>
+              <video src="{{ post.video.url }}" poster="{{ post.video_preview.url }}" controls class="max-h-[280px] w-auto max-w-full object-contain sm:max-h-[320px] md:max-h-[360px] lg:max-h-[420px]"></video>
             {% else %}
-              <video src="{{ post.video.url }}" controls class="h-auto w-full max-h-[280px] object-contain sm:max-h-[320px] md:max-h-[360px] lg:max-h-[420px]"></video>
+              <video src="{{ post.video.url }}" controls class="max-h-[280px] w-auto max-w-full object-contain sm:max-h-[320px] md:max-h-[360px] lg:max-h-[420px]"></video>
             {% endif %}
           </div>
         </figure>


### PR DESCRIPTION
## Summary
- let feed listing videos size automatically within their containers so portrait clips no longer stretch to the full width of the card

## Testing
- not run (template-only change)


------
https://chatgpt.com/codex/tasks/task_e_68def202cf24832595c3e41697720f2f