### PR TITLE
Adjust video layout for feed post listings

### DIFF
--- a/app/static/css/hubx.css
+++ b/app/static/css/hubx.css
@@ -29,6 +29,44 @@
   }
 }
 
+/* Layout helpers for feed media */
+.feed-video-wrapper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  background-color: #000;
+  padding: 0.5rem;
+}
+
+.feed-video-frame {
+  position: relative;
+  width: 100%;
+  max-width: 640px;
+  aspect-ratio: 16 / 9;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  border-radius: var(--radius-xl, 1rem);
+}
+
+.feed-video-player {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+@media (min-width: 768px) {
+  .feed-video-wrapper {
+    padding: 1rem;
+  }
+
+  .feed-video-frame {
+    max-width: 720px;
+  }
+}
+
 /* ========================================
    Hubx shared styles
    ======================================== */

--- a/feed/templates/feed/_grid.html
+++ b/feed/templates/feed/_grid.html
@@ -86,12 +86,14 @@
       </figure>
       {% elif post.video %}
       <figure class="relative z-20 mx-auto w-full max-w-2xl overflow-hidden rounded-2xl border border-[var(--border)] bg-black shadow-sm">
-        <div class="relative flex max-h-[280px] w-full items-center justify-center overflow-hidden bg-black sm:max-h-[320px] md:max-h-[360px] lg:max-h-[420px]">
+        <div class="feed-video-wrapper">
+          <div class="feed-video-frame">
           {% if post.video_preview %}
-          <video src="{{ post.video.url }}" poster="{{ post.video_preview.url }}" controls class="max-h-[280px] w-auto max-w-full object-contain sm:max-h-[320px] md:max-h-[360px] lg:max-h-[420px]"></video>
+          <video src="{{ post.video.url }}" poster="{{ post.video_preview.url }}" controls class="feed-video-player"></video>
           {% else %}
-          <video src="{{ post.video.url }}" controls class="max-h-[280px] w-auto max-w-full object-contain sm:max-h-[320px] md:max-h-[360px] lg:max-h-[420px]"></video>
+          <video src="{{ post.video.url }}" controls class="feed-video-player"></video>
           {% endif %}
+          </div>
         </div>
       </figure>
       {% endif %}

--- a/feed/templates/feed/_post_list.html
+++ b/feed/templates/feed/_post_list.html
@@ -46,12 +46,14 @@
         </figure>
       {% elif post.video %}
         <figure class="relative z-20 mx-auto w-full max-w-2xl overflow-hidden rounded-xl border border-[var(--border)] bg-black shadow-sm">
-          <div class="relative flex max-h-[280px] w-full items-center justify-center overflow-hidden bg-black sm:max-h-[320px] md:max-h-[360px] lg:max-h-[420px]">
-            {% if post.video_preview %}
-              <video src="{{ post.video.url }}" poster="{{ post.video_preview.url }}" controls class="max-h-[280px] w-auto max-w-full object-contain sm:max-h-[320px] md:max-h-[360px] lg:max-h-[420px]"></video>
-            {% else %}
-              <video src="{{ post.video.url }}" controls class="max-h-[280px] w-auto max-w-full object-contain sm:max-h-[320px] md:max-h-[360px] lg:max-h-[420px]"></video>
-            {% endif %}
+          <div class="feed-video-wrapper">
+            <div class="feed-video-frame">
+              {% if post.video_preview %}
+                <video src="{{ post.video.url }}" poster="{{ post.video_preview.url }}" controls class="feed-video-player"></video>
+              {% else %}
+                <video src="{{ post.video.url }}" controls class="feed-video-player"></video>
+              {% endif %}
+            </div>
           </div>
         </figure>
       {% endif %}


### PR DESCRIPTION
## Summary
- add reusable CSS helpers to control the aspect ratio and size of embedded videos in listings
- update feed, mural, and favorites listings to use the new wrapper so portrait videos render shorter and centered

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68def40585188325b1d6f2a213c00c31