### PR TITLE
Add post action menu to feed grid

### DIFF
--- a/feed/templates/feed/_grid.html
+++ b/feed/templates/feed/_grid.html
@@ -57,6 +57,34 @@
               </time>
             </div>
           </div>
+          {% if request.user == post.autor or request.user.user_type == 'admin' or request.user.user_type == 'root' %}
+          <div class="relative z-30 flex-shrink-0">
+            <button type="button"
+                    class="post-actions-toggle relative inline-flex items-center justify-center rounded-full p-2 text-[var(--text-muted)] transition hover:bg-[var(--bg-tertiary)] focus:outline-none focus:ring-2 focus:ring-[var(--accent)] focus:ring-offset-2 focus:ring-offset-[var(--bg-secondary)]"
+                    data-menu-id="post-menu-{{ post.id }}"
+                    aria-haspopup="true"
+                    aria-expanded="false"
+                    aria-controls="post-menu-{{ post.id }}">
+              <span class="sr-only">{% trans "Ações da postagem" %}</span>
+              {% lucide 'more-horizontal' class='h-5 w-5' %}
+            </button>
+            <div id="post-menu-{{ post.id }}"
+                 class="post-actions-menu pointer-events-none invisible absolute right-0 top-full mt-2 w-44 overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--bg-primary)] p-1 text-sm shadow-xl transition duration-200 ease-out opacity-0">
+              <a href="{% url 'feed:post_update' post.id %}"
+                 class="flex items-center gap-2 rounded-lg px-3 py-2 text-[var(--text-primary)] transition hover:bg-[var(--bg-secondary)] hover:text-[var(--accent)]"
+                 data-menu-link>
+                {% lucide 'pencil' class='h-4 w-4' %}
+                {% trans "Editar" %}
+              </a>
+              <a href="{% url 'feed:post_delete' post.id %}"
+                 class="flex items-center gap-2 rounded-lg px-3 py-2 text-[var(--error)] transition hover:bg-[var(--bg-secondary)] hover:text-[var(--error)]"
+                 data-menu-link>
+                {% lucide 'trash-2' class='h-4 w-4' %}
+                {% trans "Excluir" %}
+              </a>
+            </div>
+          </div>
+          {% endif %}
         </div>
       </header>
 
@@ -167,6 +195,60 @@
         alert('{% trans "Erro ao salvar" %}');
       }
     });
+  });
+
+  const closeAllPostMenus = () => {
+    document.querySelectorAll('.post-actions-toggle').forEach(button => {
+      const menuId = button.dataset.menuId;
+      const menu = document.getElementById(menuId);
+      if (!menu) return;
+      menu.classList.add('invisible', 'opacity-0', 'pointer-events-none');
+      menu.classList.remove('opacity-100', 'pointer-events-auto');
+      button.setAttribute('aria-expanded', 'false');
+    });
+  };
+
+  document.querySelectorAll('.post-actions-toggle').forEach(button => {
+    const menuId = button.dataset.menuId;
+    const menu = document.getElementById(menuId);
+    if (!menu) {
+      return;
+    }
+
+    const openMenu = () => {
+      menu.classList.remove('invisible', 'opacity-0', 'pointer-events-none');
+      menu.classList.add('opacity-100', 'pointer-events-auto');
+      button.setAttribute('aria-expanded', 'true');
+    };
+
+    const closeMenu = () => {
+      menu.classList.add('invisible', 'opacity-0', 'pointer-events-none');
+      menu.classList.remove('opacity-100', 'pointer-events-auto');
+      button.setAttribute('aria-expanded', 'false');
+    };
+
+    button.addEventListener('click', event => {
+      event.preventDefault();
+      event.stopPropagation();
+      const isExpanded = button.getAttribute('aria-expanded') === 'true';
+      closeAllPostMenus();
+      if (!isExpanded) {
+        openMenu();
+      }
+    });
+
+    menu.querySelectorAll('[data-menu-link]').forEach(link => {
+      link.addEventListener('click', () => {
+        closeMenu();
+      });
+    });
+  });
+
+  document.addEventListener('click', closeAllPostMenus);
+  document.addEventListener('keydown', event => {
+    if (event.key === 'Escape') {
+      closeAllPostMenus();
+    }
   });
 </script>
 


### PR DESCRIPTION
## Summary
- add a contextual actions menu with lucide icons to each feed card header
- provide edit and delete shortcuts that respect the existing permission logic
- implement lightweight JavaScript to toggle and dismiss the menu accessibly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68def6c804548325ade55468dd86bc45