### PR TITLE
Mostrar ações diretas nos cards do feed

### DIFF
--- a/feed/static/feed/js/feed.js
+++ b/feed/static/feed/js/feed.js
@@ -1,7 +1,4 @@
 // Feed JavaScript - Funcionalidades essenciais
-const POST_ACTION_BUTTON_SELECTOR = '.post-actions-toggle';
-const POST_ACTION_MENU_SELECTOR = '.post-actions-menu';
-
 const getCookie = (name) => {
   if (typeof document === 'undefined') {
     return null;
@@ -14,68 +11,6 @@ const getCookie = (name) => {
     }
   }
   return null;
-};
-
-const hidePostMenu = (menu, button) => {
-  if (!menu) return;
-  menu.hidden = true;
-  menu.dataset.state = 'closed';
-  menu.setAttribute('aria-hidden', 'true');
-  menu.classList.add('pointer-events-none', 'opacity-0', 'invisible');
-  menu.classList.remove('pointer-events-auto', 'opacity-100');
-  if (button) {
-    button.setAttribute('aria-expanded', 'false');
-  }
-};
-
-const showPostMenu = (menu, button) => {
-  if (!menu) return;
-  menu.hidden = false;
-  menu.dataset.state = 'open';
-  menu.setAttribute('aria-hidden', 'false');
-  menu.classList.remove('pointer-events-none', 'invisible', 'opacity-0');
-  menu.classList.add('pointer-events-auto', 'opacity-100');
-  if (button) {
-    button.setAttribute('aria-expanded', 'true');
-  }
-};
-
-const closeAllPostMenus = (exceptionId = null) => {
-  const menus = document.querySelectorAll(POST_ACTION_MENU_SELECTOR);
-  menus.forEach((menu) => {
-    if (exceptionId && menu.id === exceptionId) {
-      return;
-    }
-    const button = document.querySelector(`${POST_ACTION_BUTTON_SELECTOR}[data-menu-id="${menu.id}"]`);
-    hidePostMenu(menu, button);
-  });
-};
-
-let postMenuGlobalsRegistered = false;
-
-const registerPostMenuGlobals = () => {
-  if (postMenuGlobalsRegistered) {
-    return;
-  }
-
-  document.addEventListener('click', (event) => {
-    if (event.defaultPrevented) return;
-    const rawTarget = event.target;
-    const target = rawTarget instanceof Element ? rawTarget : rawTarget && rawTarget.parentElement;
-    if (!target) return;
-    if (target.closest(POST_ACTION_BUTTON_SELECTOR) || target.closest(POST_ACTION_MENU_SELECTOR)) {
-      return;
-    }
-    closeAllPostMenus();
-  });
-
-  document.addEventListener('keydown', (event) => {
-    if (event.key === 'Escape') {
-      closeAllPostMenus();
-    }
-  });
-
-  postMenuGlobalsRegistered = true;
 };
 
 function bindFeedEvents(root = document) {
@@ -319,45 +254,6 @@ function bindFeedEvents(root = document) {
     });
   }
 
-  const postActionButtons = Array.from(root.querySelectorAll(POST_ACTION_BUTTON_SELECTOR));
-  if (postActionButtons.length) {
-    registerPostMenuGlobals();
-    postActionButtons.forEach((button) => {
-      if (button.dataset.postMenuBound === 'true') {
-        return;
-      }
-      const menuId = button.getAttribute('data-menu-id');
-      if (!menuId) {
-        return;
-      }
-      const menu = document.getElementById(menuId);
-      if (!menu) {
-        return;
-      }
-
-      button.dataset.postMenuBound = 'true';
-      hidePostMenu(menu, button);
-
-      button.addEventListener('click', (event) => {
-        event.preventDefault();
-        event.stopPropagation();
-        const isExpanded = button.getAttribute('aria-expanded') === 'true';
-        if (isExpanded) {
-          hidePostMenu(menu, button);
-        } else {
-          closeAllPostMenus(menuId);
-          showPostMenu(menu, button);
-        }
-      });
-
-      const menuLinks = menu.querySelectorAll('[data-menu-link]');
-      menuLinks.forEach((link) => {
-        link.addEventListener('click', () => {
-          hidePostMenu(menu, button);
-        });
-      });
-    });
-  }
 }
 
 document.addEventListener("DOMContentLoaded", () => {

--- a/feed/templates/feed/_grid.html
+++ b/feed/templates/feed/_grid.html
@@ -58,34 +58,17 @@
             </div>
           </div>
           {% if request.user == post.autor or request.user.user_type == 'admin' or request.user.user_type == 'root' %}
-          <div class="post-actions-area relative z-30 mr-2 flex-shrink-0 pt-1">
-            <button type="button"
-                    class="post-actions-toggle relative inline-flex items-center justify-center rounded-full p-2 text-[var(--text-muted)] transition hover:bg-[var(--bg-tertiary)] focus:outline-none focus:ring-2 focus:ring-[var(--accent)] focus:ring-offset-2 focus:ring-offset-[var(--bg-secondary)]"
-                    data-menu-id="post-menu-{{ post.id }}"
-                    aria-haspopup="true"
-                    aria-expanded="false"
-                    aria-controls="post-menu-{{ post.id }}">
-              <span class="sr-only">{% trans "Ações da postagem" %}</span>
-              {% lucide 'ellipsis' class='h-5 w-5' %}
-            </button>
-            <div id="post-menu-{{ post.id }}"
-                 class="post-actions-menu pointer-events-none invisible absolute right-0 top-full mt-2 w-44 overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--bg-primary)] p-1 text-sm shadow-xl transition duration-200 ease-out opacity-0"
-                 hidden
-                 aria-hidden="true"
-                 data-state="closed">
-              <a href="{% url 'feed:post_update' post.id %}"
-                 class="flex items-center gap-2 rounded-lg px-3 py-2 text-[var(--text-primary)] transition hover:bg-[var(--bg-secondary)] hover:text-[var(--accent)]"
-                 data-menu-link>
-                {% lucide 'pencil' class='h-4 w-4' %}
-                {% trans "Editar" %}
-              </a>
-              <a href="{% url 'feed:post_delete' post.id %}"
-                 class="flex items-center gap-2 rounded-lg px-3 py-2 text-[var(--error)] transition hover:bg-[var(--bg-secondary)] hover:text-[var(--error)]"
-                 data-menu-link>
-                {% lucide 'trash-2' class='h-4 w-4' %}
-                {% trans "Excluir" %}
-              </a>
-            </div>
+          <div class="post-actions-area relative z-30 mr-2 flex items-center gap-2 pt-1">
+            <a href="{% url 'feed:post_update' post.id %}"
+               class="relative inline-flex items-center justify-center rounded-full p-2 text-[var(--text-muted)] transition hover:bg-[var(--bg-tertiary)] hover:text-[var(--accent)] focus:outline-none focus:ring-2 focus:ring-[var(--accent)] focus:ring-offset-2 focus:ring-offset-[var(--bg-secondary)]"
+               aria-label="{% trans 'Editar postagem' %}">
+              {% lucide 'pencil' class='h-5 w-5' %}
+            </a>
+            <a href="{% url 'feed:post_delete' post.id %}"
+               class="relative inline-flex items-center justify-center rounded-full p-2 text-[var(--error)] transition hover:bg-[var(--bg-tertiary)] focus:outline-none focus:ring-2 focus:ring-[var(--error)] focus:ring-offset-2 focus:ring-offset-[var(--bg-secondary)]"
+               aria-label="{% trans 'Excluir postagem' %}">
+              {% lucide 'trash-2' class='h-5 w-5' %}
+            </a>
           </div>
           {% endif %}
         </div>


### PR DESCRIPTION
## Summary
- substitui o menu de três pontos por botões de editar e excluir nos cards do feed/mural/favoritos
- remove o JavaScript que manipulava o menu antigo

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68deff583ff08325a083e2c3beb32292