### PR TITLE
Alinha pré-visualização de mídia no formulário de post

### DIFF
--- a/feed/templates/feed/post_form.html
+++ b/feed/templates/feed/post_form.html
@@ -144,10 +144,20 @@
           {% if is_update and post %}
             <div class="space-y-4">
               {% if post.pdf %}
-                <div class="space-y-2">
-                  <img src="{% static 'img/pdf-placeholder.png' %}" alt="{% trans 'PDF' %}" class="max-w-xs rounded-xl object-cover" loading="lazy">
+                <div class="space-y-3">
+                  <div class="relative z-20 overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--bg-tertiary)] shadow-sm">
+                    <a href="{{ post.pdf.url }}" target="_blank" class="flex items-center justify-between gap-4 p-4 text-sm font-medium text-[var(--text-primary)] transition hover:text-[var(--accent)]" rel="noopener">
+                      <span class="flex items-center gap-3">
+                        <span class="flex h-12 w-12 items-center justify-center rounded-xl bg-[var(--bg-secondary)] text-[var(--primary)]">
+                          {% lucide 'file-text' class='h-6 w-6' %}
+                        </span>
+                        <span class="truncate">{% trans "Documento em PDF" %}</span>
+                      </span>
+                      {% lucide 'external-link' class='h-5 w-5 flex-shrink-0 text-[var(--text-muted)]' %}
+                    </a>
+                  </div>
                   <div class="flex gap-3">
-                    <a href="{{ post.pdf.url }}" target="_blank" class="btn btn-secondary" aria-label="{% trans 'Visualizar PDF' %}">
+                    <a href="{{ post.pdf.url }}" target="_blank" class="btn btn-secondary" aria-label="{% trans 'Visualizar PDF' %}" rel="noopener">
                       {% lucide 'eye' class='w-4 h-4' %}
                     </a>
                     <a href="{{ post.pdf.url }}" download class="btn btn-secondary" aria-label="{% trans 'Baixar PDF' %}">
@@ -156,17 +166,23 @@
                   </div>
                 </div>
               {% elif post.image %}
-                <div class="space-y-2">
-                  <img src="{{ post.image.url }}" alt="{% trans 'mídia do post' %}" class="max-w-xs rounded-xl object-cover" loading="lazy">
-                </div>
+                <figure class="relative z-20 mx-auto w-full max-w-2xl overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--bg-tertiary)] shadow-sm">
+                  <div class="relative flex max-h-[280px] w-full items-center justify-center overflow-hidden bg-[var(--bg-secondary)] sm:max-h-[320px] md:max-h-[360px] lg:max-h-[420px]">
+                    <img src="{{ post.image.url }}" alt="{% trans 'mídia do post' %}" class="h-auto w-full max-h-[280px] object-contain sm:max-h-[320px] md:max-h-[360px] lg:max-h-[420px]" loading="lazy">
+                  </div>
+                </figure>
               {% elif post.video %}
-                <div class="space-y-2">
-                  {% if post.video_preview %}
-                    <video src="{{ post.video.url }}" poster="{{ post.video_preview.url }}" controls class="max-w-full rounded-xl"></video>
-                  {% else %}
-                    <video src="{{ post.video.url }}" controls class="max-w-full rounded-xl"></video>
-                  {% endif %}
-                </div>
+                <figure class="relative z-20 mx-auto w-full max-w-2xl overflow-hidden rounded-xl border border-[var(--border)] bg-black shadow-sm">
+                  <div class="feed-video-wrapper">
+                    <div class="feed-video-frame">
+                      {% if post.video_preview %}
+                        <video src="{{ post.video.url }}" poster="{{ post.video_preview.url }}" controls class="feed-video-player"></video>
+                      {% else %}
+                        <video src="{{ post.video.url }}" controls class="feed-video-player"></video>
+                      {% endif %}
+                    </div>
+                  </div>
+                </figure>
               {% endif %}
             </div>
           {% endif %}


### PR DESCRIPTION
## Summary
- aplica o mesmo layout utilizado na listagem do feed para pré-visualizar PDFs, imagens e vídeos durante a edição de posts
- mantém os botões de ação do PDF com o novo cartão estilizado

## Testing
- não aplicável

------
https://chatgpt.com/codex/tasks/task_e_68dfcb9acd78832581f35fa4592d60e3