### PR TITLE
Padroniza layouts dos templates de portfólio do perfil

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -339,6 +339,16 @@ class InformacoesPessoaisForm(forms.ModelForm):
         return user
 
 
+class PortfolioFilterForm(forms.Form):
+    q = forms.CharField(
+        label=_("Buscar"),
+        required=False,
+        widget=forms.TextInput(
+            attrs={"placeholder": _("Buscar por descrição ou tags...")}
+        ),
+    )
+
+
 class MediaForm(forms.ModelForm):
     tags_field = forms.CharField(
         required=False,

--- a/accounts/templates/perfil/partials/portfolio.html
+++ b/accounts/templates/perfil/partials/portfolio.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{# Esta seção é carregada via HTMX e já está dentro de um card no layout pai; mantenha esta exceção ao ajustar o markup. #}
 <section id="portfolio" class="perfil-section active">
-  {% include "perfil/partials/portfolio_list.html" with medias=medias is_owner=is_owner form=form show_form=show_form q=q %}
+  {% include "perfil/partials/portfolio_list.html" with medias=medias is_owner=is_owner form=form show_form=show_form q=q filter_form=filter_form %}
 </section>

--- a/accounts/templates/perfil/partials/portfolio_confirm_delete.html
+++ b/accounts/templates/perfil/partials/portfolio_confirm_delete.html
@@ -1,14 +1,44 @@
 {% load i18n lucide_icons %}
+
 <section class="space-y-4">
-  <h2 class="text-xl font-semibold text-error">{% trans "Remover Portfólio" %}</h2>
-  <p class="text-[var(--text-secondary)]">{% trans "Tem certeza que deseja remover este item do portfólio?" %}</p>
-  {% url 'accounts:perfil_sections_portfolio' as portfolio_url %}
-  <form method="post" class="flex justify-end gap-2">
-    {% csrf_token %}
-    {% include '_components/cancel_button.html' with href=portfolio_url fallback_href=portfolio_url classes='btn-sm' icon='arrow-left' show_icon=True %}
-    <button type="submit" class="btn-danger btn-sm inline-flex items-center gap-1">
-      {% lucide 'trash' class='w-4 h-4' aria_hidden='true' %}
-      {% trans "Remover" %}
-    </button>
-  </form>
+  <article class="card">
+    <div class="card-header bg-[var(--error-light)] text-[var(--error)]">
+      <h2 class="text-xl font-semibold">{% trans "Remover Portfólio" %}</h2>
+    </div>
+    <div class="card-body space-y-4">
+      <p class="text-[var(--text-secondary)]">{% trans "Tem certeza que deseja remover este item do portfólio?" %}</p>
+      {% url 'accounts:perfil_sections_portfolio' as portfolio_url %}
+      <form method="post" class="space-y-4">
+        {% csrf_token %}
+        {% if messages %}
+          {% for message in messages %}
+            {% if 'success' in message.tags %}
+              {% with alert_class='alert alert-success' alert_role='status' %}
+                <div class="{{ alert_class }}" role="{{ alert_role }}">{{ message }}</div>
+              {% endwith %}
+            {% elif 'error' in message.tags or 'danger' in message.tags %}
+              {% with alert_class='alert alert-error' alert_role='alert' %}
+                <div class="{{ alert_class }}" role="{{ alert_role }}">{{ message }}</div>
+              {% endwith %}
+            {% elif 'warning' in message.tags %}
+              {% with alert_class='alert alert-warning' alert_role='alert' %}
+                <div class="{{ alert_class }}" role="{{ alert_role }}">{{ message }}</div>
+              {% endwith %}
+            {% else %}
+              {% with alert_class='alert alert-info' alert_role='status' %}
+                <div class="{{ alert_class }}" role="{{ alert_role }}">{{ message }}</div>
+              {% endwith %}
+            {% endif %}
+          {% endfor %}
+        {% endif %}
+        <div class="flex justify-end gap-3 pt-4 border-t border-[var(--border)]">
+          {% include '_components/cancel_button.html' with href=portfolio_url fallback_href=portfolio_url classes='btn btn-secondary btn-sm' icon='arrow-left' show_icon=True %}
+          <button type="submit" class="btn btn-danger btn-sm inline-flex items-center gap-2">
+            {% lucide 'trash' class='w-4 h-4' aria_hidden='true' %}
+            {% trans "Remover" %}
+          </button>
+        </div>
+      </form>
+    </div>
+  </article>
 </section>

--- a/accounts/templates/perfil/partials/portfolio_detail.html
+++ b/accounts/templates/perfil/partials/portfolio_detail.html
@@ -1,35 +1,55 @@
 {% load i18n lucide_icons %}
+
 <section class="space-y-4">
-  {% if media.media_type == 'image' %}
-    <img src="{{ media.file.url }}" alt="{{ media.descricao }}" class="rounded card max-w-full mx-auto object-cover" loading="lazy" />
-  {% elif media.media_type == 'video' %}
-    <video src="{{ media.file.url }}" class="rounded card max-w-full mx-auto" controls aria-label="{{ media.descricao }}">
-      {% trans "Seu navegador não suporta o elemento de vídeo." %}
-    </video>
-  {% elif media.media_type == 'pdf' %}
-    <object data="{{ media.file.url }}" type="application/pdf" class="rounded card max-w-full mx-auto" aria-label="{{ media.descricao }}" width="100%" height="600">
-      <embed src="{{ media.file.url }}" type="application/pdf" />
-      <p class="text-center text-[var(--text-secondary)]">
-        {% trans "Este navegador não suporta visualização de PDF." %}
-        <a href="{{ media.file.url }}" class="inline-flex items-center gap-1 text-primary hover:underline" download>
-          {% lucide 'download' class='w-4 h-4' aria_hidden='true' %}
-          {% trans "Baixar PDF" %}
+  <article class="card">
+    <div class="card-header">
+      <div>
+        <h2 class="text-xl font-semibold text-[var(--text-primary)]">{% trans "Detalhes do portfólio" %}</h2>
+        {% if media.descricao %}
+          <p class="text-sm text-[var(--text-secondary)]">{{ media.descricao }}</p>
+        {% endif %}
+      </div>
+    </div>
+    <div class="card-body space-y-6">
+      <div class="mx-auto w-full max-w-3xl space-y-4">
+        {% if media.media_type == 'image' %}
+          <div class="aspect-video overflow-hidden rounded-lg bg-[var(--bg-tertiary)]">
+            <img src="{{ media.file.url }}" alt="{{ media.descricao }}" class="h-full w-full object-cover" loading="lazy" />
+          </div>
+        {% elif media.media_type == 'video' %}
+          <div class="aspect-video overflow-hidden rounded-lg bg-[var(--bg-tertiary)]">
+            <video src="{{ media.file.url }}" class="h-full w-full" controls aria-label="{{ media.descricao }}">
+              {% trans "Seu navegador não suporta o elemento de vídeo." %}
+            </video>
+          </div>
+        {% elif media.media_type == 'pdf' %}
+          <div class="overflow-hidden rounded-lg bg-[var(--bg-tertiary)]">
+            <object data="{{ media.file.url }}" type="application/pdf" class="h-[32rem] w-full" aria-label="{{ media.descricao }}">
+              <embed src="{{ media.file.url }}" type="application/pdf" />
+              <p class="px-4 py-3 text-center text-sm text-[var(--text-secondary)]">
+                {% trans "Este navegador não suporta visualização de PDF." %}
+                <a href="{{ media.file.url }}" class="inline-flex items-center gap-2 text-primary hover:underline" download>
+                  {% lucide 'download' class='w-4 h-4' aria_hidden='true' %}
+                  {% trans "Baixar PDF" %}
+                </a>
+              </p>
+            </object>
+          </div>
+        {% else %}
+          <div class="flex justify-center">
+            <a href="{{ media.file.url }}" class="btn btn-secondary" download>
+              {% lucide 'download' class='w-4 h-4' aria_hidden='true' %}
+              {{ media.file.name }}
+            </a>
+          </div>
+        {% endif %}
+      </div>
+      <div class="flex justify-end gap-3 pt-4 border-t border-[var(--border)]">
+        <a href="{% url 'accounts:perfil_sections_portfolio' %}" class="btn btn-secondary inline-flex items-center gap-2">
+          {% lucide 'arrow-left' class='w-4 h-4' aria_hidden='true' %}
+          {% trans "Voltar para portfólio" %}
         </a>
-      </p>
-    </object>
-  {% else %}
-    <p class="text-center">
-      <a href="{{ media.file.url }}" class="inline-flex items-center gap-1 text-primary hover:underline" download>
-        {% lucide 'download' class='w-4 h-4' aria_hidden='true' %}
-        {{ media.file.name }}
-      </a>
-    </p>
-  {% endif %}
-  <p class="text-center text-[var(--text-primary)]">{{ media.descricao }}</p>
-  <div class="text-center">
-    <a href="{% url 'accounts:perfil_sections_portfolio' %}" class="inline-flex items-center gap-1 text-sm text-primary hover:underline">
-      {% lucide 'arrow-left' class='w-4 h-4' aria_hidden='true' %}
-      {% trans "Voltar para portfólio" %}
-    </a>
-  </div>
+      </div>
+    </div>
+  </article>
 </section>

--- a/accounts/templates/perfil/partials/portfolio_form.html
+++ b/accounts/templates/perfil/partials/portfolio_form.html
@@ -1,20 +1,50 @@
 {% load i18n %}
-<section class="space-y-6">
-  <h2 class="text-xl font-semibold">
-    {% if form.instance.pk %}{% trans "Editar Portfólio" %}{% else %}{% trans "Cadastrar Portfólio" %}{% endif %}
-  </h2>
 
-  <form method="post" enctype="multipart/form-data" class="card">
-    <div class="card-body space-y-4">
-      {% csrf_token %}
-      {% for field in form %}
-        {% include '_forms/field.html' with field=field %}
-      {% endfor %}
-      {% url 'accounts:perfil_sections_portfolio' as portfolio_url %}
-      <div class="flex justify-end gap-2">
-        {% include '_components/cancel_button.html' with href=portfolio_url fallback_href=portfolio_url %}
-        <button type="submit" class="btn btn-primary">{% trans "Salvar" %}</button>
-      </div>
+<section class="space-y-6">
+  <article class="card">
+    <div class="card-header">
+      <h2 class="text-xl font-semibold text-[var(--text-primary)]">
+        {% if form.instance.pk %}{% trans "Editar Portfólio" %}{% else %}{% trans "Cadastrar Portfólio" %}{% endif %}
+      </h2>
     </div>
-  </form>
+    <div class="card-body space-y-6">
+      <form method="post" enctype="multipart/form-data" class="space-y-6">
+        {% csrf_token %}
+        {% if messages %}
+          {% for message in messages %}
+            {% if 'success' in message.tags %}
+              {% with alert_class='alert alert-success' alert_role='status' %}
+                <div class="{{ alert_class }}" role="{{ alert_role }}">{{ message }}</div>
+              {% endwith %}
+            {% elif 'error' in message.tags or 'danger' in message.tags %}
+              {% with alert_class='alert alert-error' alert_role='alert' %}
+                <div class="{{ alert_class }}" role="{{ alert_role }}">{{ message }}</div>
+              {% endwith %}
+            {% elif 'warning' in message.tags %}
+              {% with alert_class='alert alert-warning' alert_role='alert' %}
+                <div class="{{ alert_class }}" role="{{ alert_role }}">{{ message }}</div>
+              {% endwith %}
+            {% else %}
+              {% with alert_class='alert alert-info' alert_role='status' %}
+                <div class="{{ alert_class }}" role="{{ alert_role }}">{{ message }}</div>
+              {% endwith %}
+            {% endif %}
+          {% endfor %}
+        {% endif %}
+        {% if form.non_field_errors %}
+          <div class="alert alert-error" role="alert">
+            {{ form.non_field_errors }}
+          </div>
+        {% endif %}
+        {% for field in form %}
+          {% include '_forms/field.html' with field=field %}
+        {% endfor %}
+        {% url 'accounts:perfil_sections_portfolio' as portfolio_url %}
+        <div class="flex justify-end gap-3 pt-4 border-t border-[var(--border)]">
+          {% include '_components/cancel_button.html' with href=portfolio_url fallback_href=portfolio_url classes='btn btn-secondary' %}
+          <button type="submit" class="btn btn-primary">{% trans "Salvar" %}</button>
+        </div>
+      </form>
+    </div>
+  </article>
 </section>

--- a/accounts/templates/perfil/partials/portfolio_list.html
+++ b/accounts/templates/perfil/partials/portfolio_list.html
@@ -1,70 +1,126 @@
 {% load i18n lucide_icons %}
-<div class="section-header mb-6">
-  <h2 class="text-xl font-semibold text-[var(--text-primary)]">{% trans "Portfólio" %}</h2>
-  <p class="text-sm text-[var(--text-primary)]">{% trans "Gerencie suas imagens, vídeos e documentos" %}</p>
-</div>
 
-{% if show_form %}
-  <form id="formPortfolio" class="space-y-6" method="post" action="{% url 'accounts:perfil_sections_portfolio' %}" enctype="multipart/form-data">
-    {% csrf_token %}
-    {% for field in form %}
-      {% include '_forms/field.html' with field=field %}
-    {% endfor %}
+<article class="card">
+  <div class="card-header">
     <div>
-      <button type="submit" class="btn btn-primary">
-        {% trans "Enviar" %}
-      </button>
+      <h2 class="text-xl font-semibold text-[var(--text-primary)]">{% trans "Portfólio" %}</h2>
+      <p class="text-sm text-[var(--text-secondary)]">{% trans "Gerencie suas imagens, vídeos e documentos" %}</p>
     </div>
-  </form>
-{% else %}
-  {% if is_owner %}
-    <a href="{% url 'accounts:perfil_sections_portfolio' %}?adicionar=1" class="btn btn-primary">
-      {% trans "Adicionar" %}
-    </a>
-  {% endif %}
-
-  <form method="get" class="mt-6">
-    <input type="text" name="q" value="{{ q }}" placeholder="{% trans 'Buscar por descrição ou tags...' %}"
-           class="form-input w-full rounded-lg px-4 py-2 text-sm" aria-label="{% trans 'Buscar' %}" aria-invalid="false">
-  </form>
-
-  <div class="card-grid sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-2">
-    {% for media in medias %}
-      <article class="card relative p-3">
-        {% if is_owner %}
-        <div class="absolute top-2 right-2 flex gap-2">
-          <a href="{% url 'accounts:perfil_sections_portfolio_edit' media.pk %}" class="btn-secondary btn-sm" aria-label="{% trans 'Editar' %}">
-            {% lucide 'pencil' class='w-4 h-4' aria_hidden='true' %}
-          </a>
-          <a href="{% url 'accounts:perfil_sections_portfolio_delete' media.pk %}" class="btn-danger btn-sm" aria-label="{% trans 'Excluir' %}">
-            {% lucide 'trash' class='w-4 h-4' aria_hidden='true' %}
-          </a>
-        </div>
-        {% endif %}
-        <a href="{% url 'accounts:perfil_sections_portfolio_detail' media.pk %}">
-          {% if media.media_type == 'image' %}
-            <img src="{{ media.file.url }}" alt="{{ media.descricao }}" class="w-full h-40 object-cover rounded" loading="lazy">
-          {% elif media.media_type == 'video' %}
-            <video src="{{ media.file.url }}" class="w-full h-40 object-cover rounded" controls></video>
-          {% elif media.media_type == 'pdf' %}
-            <object data="{{ media.file.url }}" type="application/pdf" class="w-full h-40 rounded"></object>
-          {% else %}
-            <span class="text-sm text-[var(--text-primary)]">{{ media.file.name }}</span>
-          {% endif %}
-        </a>
-        <div class="card-body mt-2">
-          <p class="text-sm font-medium text-[var(--text-primary)]">{{ media.descricao }}</p>
-          <p class="text-xs text-[var(--text-primary)]">{{ media.created_at|date:"SHORT_DATETIME_FORMAT" }}</p>
-          <div class="flex flex-wrap gap-1 mt-1">
-            {% for tag in media.tags.all %}
-              <span class="bg-[var(--bg-secondary)] text-[var(--text-primary)] text-xs px-2 py-0.5 rounded">{{ tag.nome }}</span>
-            {% endfor %}
-          </div>
-        </div>
-      </article>
-    {% empty %}
-      <p class="text-sm text-[var(--text-primary)]">{% trans "Nenhum arquivo enviado." %}</p>
-    {% endfor %}
   </div>
-{% endif %}
+  <div class="card-body space-y-6">
+    {% if show_form %}
+      <form
+        id="formPortfolio"
+        class="space-y-6"
+        method="post"
+        action="{% url 'accounts:perfil_sections_portfolio' %}"
+        enctype="multipart/form-data"
+      >
+        {% csrf_token %}
+        {% if messages %}
+          {% for message in messages %}
+            {% if 'success' in message.tags %}
+              {% with alert_class='alert alert-success' alert_role='status' %}
+                <div class="{{ alert_class }}" role="{{ alert_role }}">{{ message }}</div>
+              {% endwith %}
+            {% elif 'error' in message.tags or 'danger' in message.tags %}
+              {% with alert_class='alert alert-error' alert_role='alert' %}
+                <div class="{{ alert_class }}" role="{{ alert_role }}">{{ message }}</div>
+              {% endwith %}
+            {% elif 'warning' in message.tags %}
+              {% with alert_class='alert alert-warning' alert_role='alert' %}
+                <div class="{{ alert_class }}" role="{{ alert_role }}">{{ message }}</div>
+              {% endwith %}
+            {% else %}
+              {% with alert_class='alert alert-info' alert_role='status' %}
+                <div class="{{ alert_class }}" role="{{ alert_role }}">{{ message }}</div>
+              {% endwith %}
+            {% endif %}
+          {% endfor %}
+        {% endif %}
+        {% if form.non_field_errors %}
+          <div class="alert alert-error" role="alert">
+            {{ form.non_field_errors }}
+          </div>
+        {% endif %}
+        {% for field in form %}
+          {% include '_forms/field.html' with field=field %}
+        {% endfor %}
+        <div class="flex justify-end gap-3 pt-4 border-t border-[var(--border)]">
+          <button type="submit" class="btn btn-primary">
+            {% trans "Enviar" %}
+          </button>
+        </div>
+      </form>
+    {% else %}
+      {% if is_owner %}
+        <div class="flex justify-end gap-3">
+          <a href="{% url 'accounts:perfil_sections_portfolio' %}?adicionar=1" class="btn btn-primary">
+            {% trans "Adicionar" %}
+          </a>
+        </div>
+      {% endif %}
 
+      {% if filter_form %}
+        <form method="get" class="space-y-4">
+          {% include '_forms/field.html' with field=filter_form.q %}
+        </form>
+      {% endif %}
+
+      <div class="card-grid sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-2">
+        {% for media in medias %}
+          <article class="card">
+            <div class="card-body space-y-4 relative">
+              {% if is_owner %}
+                <div class="absolute right-0 top-0 flex gap-3">
+                  <a
+                    href="{% url 'accounts:perfil_sections_portfolio_edit' media.pk %}"
+                    class="btn btn-secondary btn-sm"
+                    aria-label="{% trans 'Editar' %}"
+                  >
+                    {% lucide 'pencil' class='w-4 h-4' aria_hidden='true' %}
+                  </a>
+                  <a
+                    href="{% url 'accounts:perfil_sections_portfolio_delete' media.pk %}"
+                    class="btn btn-danger btn-sm"
+                    aria-label="{% trans 'Excluir' %}"
+                  >
+                    {% lucide 'trash' class='w-4 h-4' aria_hidden='true' %}
+                  </a>
+                </div>
+              {% endif %}
+
+              <a href="{% url 'accounts:perfil_sections_portfolio_detail' media.pk %}" class="block">
+                <div class="aspect-video overflow-hidden rounded-lg bg-[var(--bg-tertiary)]">
+                  {% if media.media_type == 'image' %}
+                    <img src="{{ media.file.url }}" alt="{{ media.descricao }}" class="h-full w-full object-cover" loading="lazy">
+                  {% elif media.media_type == 'video' %}
+                    <video src="{{ media.file.url }}" class="h-full w-full object-cover" controls></video>
+                  {% elif media.media_type == 'pdf' %}
+                    <object data="{{ media.file.url }}" type="application/pdf" class="h-full w-full" aria-label="{{ media.descricao }}"></object>
+                  {% else %}
+                    <span class="flex h-full items-center justify-center text-sm text-[var(--text-primary)]">{{ media.file.name }}</span>
+                  {% endif %}
+                </div>
+              </a>
+
+              <div class="space-y-2">
+                <p class="text-sm font-medium text-[var(--text-primary)]">{{ media.descricao }}</p>
+                <p class="text-xs text-[var(--text-secondary)]">{{ media.created_at|date:"SHORT_DATETIME_FORMAT" }}</p>
+                {% if media.tags.all %}
+                  <div class="flex flex-wrap gap-2">
+                    {% for tag in media.tags.all %}
+                      <span class="rounded bg-[var(--bg-secondary)] px-2 py-0.5 text-xs text-[var(--text-secondary)]">{{ tag.nome }}</span>
+                    {% endfor %}
+                  </div>
+                {% endif %}
+              </div>
+            </div>
+          </article>
+        {% empty %}
+          <p class="text-sm text-[var(--text-secondary)]">{% trans "Nenhum arquivo enviado." %}</p>
+        {% endfor %}
+      </div>
+    {% endif %}
+  </div>
+</article>


### PR DESCRIPTION
## Summary
- adiciona PortfolioFilterForm para renderizar o campo de busca com o template compartilhado
- aplica o layout padronizado de cards nos parciais de portfólio, incluindo barras de ação unificadas e alertas de mensagens
- centraliza o detalhamento de mídias e ajusta as ações de edição/remoção para reutilizar os botões compartilhados

## Testing
- python -m compileall accounts

------
https://chatgpt.com/codex/tasks/task_e_68dfd6669fac83259b0e1c00ebba9103