### PR TITLE
Padroniza templates de conexões

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -339,6 +339,29 @@ class InformacoesPessoaisForm(forms.ModelForm):
         return user
 
 
+class ConnectionsSearchForm(forms.Form):
+    q = forms.CharField(label=_("Buscar"), max_length=255, required=False)
+
+    def __init__(
+        self,
+        *args,
+        placeholder: str | None = None,
+        label: str | None = None,
+        aria_label: str | None = None,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+
+        field = self.fields["q"]
+        if label:
+            field.label = label
+        field.widget.attrs.setdefault("autocomplete", "off")
+        if placeholder:
+            field.widget.attrs["placeholder"] = placeholder
+        if aria_label:
+            field.widget.attrs["aria-label"] = aria_label
+
+
 class PortfolioFilterForm(forms.Form):
     q = forms.CharField(
         label=_("Buscar"),

--- a/accounts/templates/perfil/partials/conexoes_busca.html
+++ b/accounts/templates/perfil/partials/conexoes_busca.html
@@ -1,6 +1,6 @@
 {% load i18n lucide_icons %}
-<div class="space-y-6">
-  <div class="flex items-center justify-between">
+<article class="card">
+  <div class="card-header flex items-center justify-between gap-3">
     <h2 class="text-base font-semibold text-[var(--text-primary)]">{% trans "Buscar pessoas" %}</h2>
     {% url 'accounts:perfil_sections_conexoes' as conexoes_partial_url %}
     {% url 'accounts:perfil' as perfil_url %}
@@ -37,112 +37,109 @@
     {% endwith %}
   </div>
 
-  <form
-    method="get"
-    class="flex gap-2"
-    hx-get="{% url 'accounts:perfil_conexoes_buscar' %}"
-    hx-target="#perfil-content"
-    hx-push-url="?section=conexoes&view=buscar"
-  >
-    <input
-      type="text"
-      name="q"
-      value="{{ q }}"
-      placeholder="{% trans 'Buscar por nome, razão social ou CNPJ...' %}"
-      class="flex-grow border rounded-lg p-2 text-sm"
-      aria-label="{% trans 'Buscar por nome, razão social ou CNPJ' %}"
-    />
-    <button type="submit" class="btn btn-primary btn-sm" aria-label="{% trans 'Buscar' %}">
-      {% lucide 'search' class='w-4 h-4' aria_hidden='true' %}
-    </button>
-  </form>
+  <div class="card-body space-y-6">
+    <form
+      method="get"
+      class="space-y-4 sm:flex sm:items-end sm:gap-3"
+      hx-get="{% url 'accounts:perfil_conexoes_buscar' %}"
+      hx-target="#perfil-content"
+      hx-push-url="?section=conexoes&view=buscar"
+    >
+      <div class="sm:flex-1">
+        {% include '_forms/field.html' with field=form.q %}
+      </div>
+      <button type="submit" class="btn btn-primary btn-sm" aria-label="{% trans 'Buscar' %}">
+        {% lucide 'search' class='w-4 h-4' aria_hidden='true' %}
+      </button>
+    </form>
 
-  {% if tem_organizacao %}
-    {% if associados %}
-      <div role="list" class="space-y-3">
-        {% for associado in associados %}
-          <article
-            role="listitem"
-            id="connection-{{ associado.id }}"
-            data-connection-card
-            class="flex items-center justify-between gap-4 rounded-xl border border-[var(--border-primary)] bg-[var(--bg-primary)] p-4 shadow-sm"
-          >
-            <div class="flex items-center gap-3">
-              {% if associado.avatar %}
-                <img src="{{ associado.avatar.url }}" alt="{{ associado.display_name|default:associado.username }}" class="h-12 w-12 rounded-full object-cover" loading="lazy" />
-              {% else %}
-                <div class="h-12 w-12 rounded-full bg-[var(--bg-tertiary)] flex items-center justify-center text-sm font-semibold text-[var(--text-secondary)]" role="img" aria-label="{{ associado.display_name|default:associado.username }}">
-                  {{ associado.username|first|upper }}
+    {% if tem_organizacao %}
+      {% if associados %}
+        <div role="list" class="space-y-3">
+          {% for associado in associados %}
+            <article
+              role="listitem"
+              id="connection-{{ associado.id }}"
+              data-connection-card
+              class="card"
+            >
+              <div class="card-body space-y-4">
+                <div class="flex items-center gap-3">
+                  {% if associado.avatar %}
+                    <img src="{{ associado.avatar.url }}" alt="{{ associado.display_name|default:associado.username }}" class="h-12 w-12 rounded-full object-cover" loading="lazy" />
+                  {% else %}
+                    <div class="flex h-12 w-12 items-center justify-center rounded-full bg-[var(--bg-tertiary)] text-sm font-semibold text-[var(--text-secondary)]" role="img" aria-label="{{ associado.display_name|default:associado.username }}">
+                      {{ associado.username|first|upper }}
+                    </div>
+                  {% endif %}
+                  <div class="min-w-0 space-y-1">
+                    <p class="truncate font-semibold text-[var(--text-primary)]">{{ associado.display_name }}</p>
+                    <p class="text-sm text-[var(--text-secondary)]">@{{ associado.username }}</p>
+                    {% if associado.razao_social %}
+                      <p class="text-xs text-[var(--text-secondary)]">{{ associado.razao_social }}</p>
+                    {% endif %}
+                    {% if associado.cnpj %}
+                      <p class="text-xs text-[var(--text-tertiary)]">CNPJ: {{ associado.cnpj }}</p>
+                    {% endif %}
+                  </div>
                 </div>
-              {% endif %}
-              <div class="min-w-0">
-                <p class="truncate font-semibold text-[var(--text-primary)]">{{ associado.display_name }}</p>
-                <p class="text-sm text-[var(--text-secondary)]">@{{ associado.username }}</p>
-                {% if associado.razao_social %}
-                  <p class="text-xs text-[var(--text-secondary)]">{{ associado.razao_social }}</p>
-                {% endif %}
-                {% if associado.cnpj %}
-                  <p class="text-xs text-[var(--text-tertiary)]">CNPJ: {{ associado.cnpj }}</p>
-                {% endif %}
-              </div>
-            </div>
-            <div class="flex flex-col items-stretch gap-2 sm:flex-row sm:items-center">
-              <a
-                href="{% url 'accounts:perfil_publico_uuid' associado.public_id %}"
-                class="btn-secondary btn-sm"
-                data-connection-link="connection-{{ associado.id }}"
-              >
-                {% trans "Ver perfil" %}
-              </a>
+                <div class="flex flex-wrap justify-end gap-3 pt-4 border-t border-[var(--border)]">
+                  <a
+                    href="{% url 'accounts:perfil_publico_uuid' associado.public_id %}"
+                    class="btn btn-secondary btn-sm"
+                    data-connection-link="connection-{{ associado.id }}"
+                  >
+                    {% trans "Ver perfil" %}
+                  </a>
 
-              {% if associado.id in conexoes_ids %}
-                <form
-                  hx-post="{% url 'accounts:remover_conexao' associado.id %}"
-                  hx-target="#perfil-content"
-                  hx-swap="innerHTML"
-                >
-                  {% csrf_token %}
-                  <input type="hidden" name="q" value="{{ q }}" />
-                  <button type="submit" class="btn-danger btn-sm">
-                    {% trans "Desconectar" %}
-                  </button>
-                </form>
-              {% elif associado.id in solicitacoes_enviadas_ids %}
-                <button type="button" class="btn-secondary btn-sm cursor-default opacity-70" disabled>
-                  {% trans "Solicitação enviada" %}
-                </button>
-              {% elif associado.id in solicitacoes_recebidas_ids %}
-                <a
-                  href="{% url 'accounts:perfil_sections_conexoes' %}?tab=solicitacoes"
-                  class="btn-outline btn-sm text-center"
-                >
-                  {% trans "Responder solicitação" %}
-                </a>
-              {% else %}
-                <form
-                  hx-post="{% url 'accounts:solicitar_conexao' associado.id %}"
-                  hx-target="#perfil-content"
-                  hx-swap="innerHTML"
-                >
-                  {% csrf_token %}
-                  <input type="hidden" name="q" value="{{ q }}" />
-                  <button type="submit" class="btn btn-primary btn-sm">
-                    {% trans "Conectar" %}
-                  </button>
-                </form>
-              {% endif %}
-            </div>
-          </article>
-        {% endfor %}
-      </div>
+                  {% if associado.id in conexoes_ids %}
+                    <form
+                      hx-post="{% url 'accounts:remover_conexao' associado.id %}"
+                      hx-target="#perfil-content"
+                      hx-swap="innerHTML"
+                      class="space-y-4"
+                    >
+                      {% csrf_token %}
+                      <input type="hidden" name="q" value="{{ q }}" />
+                      <button type="submit" class="btn btn-danger btn-sm">
+                        {% trans "Desconectar" %}
+                      </button>
+                    </form>
+                  {% elif associado.id in solicitacoes_enviadas_ids %}
+                    <button type="button" class="btn btn-secondary btn-sm cursor-default opacity-70" disabled>
+                      {% trans "Solicitação enviada" %}
+                    </button>
+                  {% elif associado.id in solicitacoes_recebidas_ids %}
+                    <a
+                      href="{% url 'accounts:perfil_sections_conexoes' %}?tab=solicitacoes"
+                      class="btn btn-secondary btn-sm"
+                    >
+                      {% trans "Responder solicitação" %}
+                    </a>
+                  {% else %}
+                    <form
+                      hx-post="{% url 'accounts:solicitar_conexao' associado.id %}"
+                      hx-target="#perfil-content"
+                      hx-swap="innerHTML"
+                      class="space-y-4"
+                    >
+                      {% csrf_token %}
+                      <input type="hidden" name="q" value="{{ q }}" />
+                      <button type="submit" class="btn btn-primary btn-sm">
+                        {% trans "Conectar" %}
+                      </button>
+                    </form>
+                  {% endif %}
+                </div>
+              </div>
+            </article>
+          {% endfor %}
+        </div>
+      {% else %}
+        <p class="text-sm text-[var(--text-secondary)]">{% trans "Nenhum associado encontrado para os critérios informados." %}</p>
+      {% endif %}
     {% else %}
-      <div class="text-center text-sm text-[var(--text-secondary)]">
-        <p>{% trans "Nenhum associado encontrado para os critérios informados." %}</p>
-      </div>
+      <p class="text-sm text-[var(--text-secondary)]">{% trans "Você não está vinculado a uma organização no momento." %}</p>
     {% endif %}
-  {% else %}
-    <div class="text-center text-sm text-[var(--text-secondary)]">
-      <p>{% trans "Você não está vinculado a uma organização no momento." %}</p>
-    </div>
-  {% endif %}
-</div>
+  </div>
+</article>

--- a/accounts/templates/perfil/partials/conexoes_dashboard.html
+++ b/accounts/templates/perfil/partials/conexoes_dashboard.html
@@ -1,16 +1,21 @@
 {% load i18n %}
-<div class="space-y-10">
-  <section aria-labelledby="perfil-conexoes-list">
-    <div class="section-header mb-4 flex items-center justify-between">
+{# Este parcial é carregado dentro do card principal do perfil; cada seção usa cards próprios para manter o layout padronizado. #}
+<div class="space-y-6">
+  <article class="card" aria-labelledby="perfil-conexoes-list">
+    <div class="card-header">
       <h2 id="perfil-conexoes-list" class="text-base font-semibold text-[var(--text-primary)]">{% trans "Minhas conexões" %}</h2>
     </div>
-    {% include 'perfil/partials/conexoes_minhas.html' %}
-  </section>
+    <div class="card-body space-y-6">
+      {% include 'perfil/partials/conexoes_minhas.html' %}
+    </div>
+  </article>
 
-  <section aria-labelledby="perfil-conexoes-requests">
-    <div class="section-header mb-4 flex items-center justify-between">
+  <article class="card" aria-labelledby="perfil-conexoes-requests">
+    <div class="card-header">
       <h2 id="perfil-conexoes-requests" class="text-base font-semibold text-[var(--text-primary)]">{% trans "Solicitações de conexão" %}</h2>
     </div>
-    {% include 'perfil/partials/conexoes_solicitacoes.html' %}
-  </section>
+    <div class="card-body space-y-6">
+      {% include 'perfil/partials/conexoes_solicitacoes.html' %}
+    </div>
+  </article>
 </div>

--- a/accounts/templates/perfil/partials/conexoes_minhas.html
+++ b/accounts/templates/perfil/partials/conexoes_minhas.html
@@ -1,29 +1,33 @@
 {% load i18n lucide_icons %}
-<form method="get" class="flex gap-2 mb-4" hx-get="{% url 'accounts:perfil_conexoes_partial' %}" hx-target="#perfil-content" hx-push-url="?section=conexoes">
-  <input
-    type="text"
-    name="q"
-    value="{{ q }}"
-    placeholder="{% trans 'Buscar conexões...' %}"
-    class="flex-grow border rounded-lg p-2 text-sm"
-  />
-  <button type="submit" class="btn-secondary btn-sm" aria-label="{% trans 'Buscar' %}">
+{# Este parcial é renderizado dentro de cards pai via HTMX; mantemos a estrutura flat e o vocabulário padrão de espaçamentos. #}
+<form
+  method="get"
+  class="space-y-4 sm:flex sm:items-end sm:gap-3"
+  hx-get="{% url 'accounts:perfil_conexoes_partial' %}"
+  hx-target="#perfil-content"
+  hx-push-url="?section=conexoes"
+>
+  <div class="sm:flex-1">
+    {% include '_forms/field.html' with field=form.q %}
+  </div>
+  <button type="submit" class="btn btn-primary btn-sm" aria-label="{% trans 'Buscar' %}">
     {% lucide 'search' class='w-4 h-4' aria_hidden='true' %}
   </button>
 </form>
 
-  <div role="list" class="space-y-3">
-    {% for connection in connections %}
-      <article
-        role="listitem"
-        id="connection-{{ connection.id }}"
-        class="connection-card flex items-center justify-between gap-4 rounded-xl border border-[var(--border-primary)] bg-[var(--bg-primary)] p-4 shadow-sm"
-      >
+<div role="list" class="space-y-3">
+  {% for connection in connections %}
+    <article
+      role="listitem"
+      id="connection-{{ connection.id }}"
+      class="card connection-card"
+    >
+      <div class="card-body space-y-4">
         <div class="flex items-center gap-3">
           {% if connection.avatar %}
-            <img src="{{ connection.avatar.url }}" alt="{{ connection.display_name|default:connection.username }}" class="w-12 h-12 rounded-full object-cover" loading="lazy" />
+            <img src="{{ connection.avatar.url }}" alt="{{ connection.display_name|default:connection.username }}" class="h-12 w-12 rounded-full object-cover" loading="lazy" />
           {% else %}
-            <div class="w-12 h-12 rounded-full bg-[var(--bg-tertiary)] flex items-center justify-center text-sm font-semibold text-[var(--text-secondary)]" role="img" aria-label="{{ connection.display_name|default:connection.username }}">
+            <div class="flex h-12 w-12 items-center justify-center rounded-full bg-[var(--bg-tertiary)] text-sm font-semibold text-[var(--text-secondary)]" role="img" aria-label="{{ connection.display_name|default:connection.username }}">
               {{ connection.username|first|upper }}
             </div>
           {% endif %}
@@ -32,10 +36,10 @@
             <p class="text-sm text-[var(--text-secondary)]">@{{ connection.username }}</p>
           </div>
         </div>
-        <div class="flex flex-col items-stretch gap-2 sm:flex-row sm:items-center">
+        <div class="flex justify-end gap-3 pt-4 border-t border-[var(--border)]">
           <a
             href="{% url 'accounts:perfil_publico_uuid' connection.public_id %}"
-            class="btn-secondary btn-sm"
+            class="btn btn-secondary btn-sm"
             data-connection-link="connection-{{ connection.id }}"
           >
             {% trans "Ver perfil" %}
@@ -45,28 +49,32 @@
             hx-target="closest .connection-card"
             hx-swap="outerHTML"
             hx-confirm="{% trans 'Tem certeza que deseja remover esta conexão?' %}"
-            class="sm:w-auto"
+            class="space-y-4"
           >
             {% csrf_token %}
-            <button type="submit" class="btn-danger btn-sm">
+            <button type="submit" class="btn btn-danger btn-sm">
               {% trans "Desconectar" %}
             </button>
           </form>
         </div>
-      </article>
-    {% empty %}
-      <div class="text-center text-sm text-[var(--text-secondary)]">
-        <p>{% trans "Você ainda não tem conexões." %}</p>
-        <button
-          type="button"
-          class="mt-2 inline-flex items-center justify-center btn btn-primary btn-sm"
-          hx-get="{% url 'accounts:perfil_conexoes_buscar' %}"
-          hx-target="#perfil-content"
-          hx-push-url="?section=conexoes&view=buscar"
-        >
-          {% trans "Buscar Pessoas" %}
-        </button>
       </div>
-    {% endfor %}
-  </div>
-
+    </article>
+  {% empty %}
+    <article class="card">
+      <div class="card-body space-y-4 text-center text-sm text-[var(--text-secondary)]">
+        <p>{% trans "Você ainda não tem conexões." %}</p>
+        <div class="flex justify-center gap-3 pt-4 border-t border-[var(--border)]">
+          <button
+            type="button"
+            class="btn btn-primary btn-sm"
+            hx-get="{% url 'accounts:perfil_conexoes_buscar' %}"
+            hx-target="#perfil-content"
+            hx-push-url="?section=conexoes&view=buscar"
+          >
+            {% trans "Buscar Pessoas" %}
+          </button>
+        </div>
+      </div>
+    </article>
+  {% endfor %}
+</div>

--- a/accounts/templates/perfil/partials/conexoes_solicitacoes.html
+++ b/accounts/templates/perfil/partials/conexoes_solicitacoes.html
@@ -1,45 +1,50 @@
 {% load i18n %}
-<div class="space-y-4">
+{# Este parcial é incorporado em cards maiores; mantemos estrutura flat para funcionar via HTMX. #}
+<div class="space-y-3" role="list">
   {% for solicitante in connection_requests %}
-  <article class="card request-card">
-    <div class="card-body flex items-start justify-between">
-    <div class="flex items-center gap-3">
-      {% if solicitante.avatar %}
-        <img src="{{ solicitante.avatar.url }}" alt="{{ solicitante.display_name|default:solicitante.username }}" class="w-10 h-10 rounded-full object-cover" loading="lazy" />
-      {% else %}
-        <div class="w-10 h-10 rounded-full bg-[var(--bg-tertiary)] flex items-center justify-center text-sm font-semibold text-[var(--text-secondary)]" role="img" aria-label="{{ solicitante.display_name|default:solicitante.username }}">
-          {{ solicitante.username|first|upper }}
+    <article class="card request-card" role="listitem">
+      <div class="card-body space-y-4">
+        <div class="flex items-center gap-3">
+          {% if solicitante.avatar %}
+            <img src="{{ solicitante.avatar.url }}" alt="{{ solicitante.display_name|default:solicitante.username }}" class="h-10 w-10 rounded-full object-cover" loading="lazy" />
+          {% else %}
+            <div class="flex h-10 w-10 items-center justify-center rounded-full bg-[var(--bg-tertiary)] text-sm font-semibold text-[var(--text-secondary)]" role="img" aria-label="{{ solicitante.display_name|default:solicitante.username }}">
+              {{ solicitante.username|first|upper }}
+            </div>
+          {% endif %}
+          <div>
+            <p class="font-medium text-[var(--text-primary)]">{{ solicitante.display_name }}</p>
+            <p class="text-sm text-[var(--text-secondary)]">@{{ solicitante.username }}</p>
+          </div>
         </div>
-      {% endif %}
-      <div>
-        <p class="font-medium">{{ solicitante.display_name }}</p>
-        <p class="text-sm text-[var(--text-secondary)]">@{{ solicitante.username }}</p>
+        <div class="flex justify-end gap-3 pt-4 border-t border-[var(--border)]">
+          <form
+            hx-post="{% url 'accounts:aceitar_conexao' solicitante.id %}"
+            hx-target="closest .request-card"
+            hx-swap="outerHTML"
+            class="space-y-4"
+          >
+            {% csrf_token %}
+            <button class="btn btn-primary btn-sm">{% trans "Aceitar" %}</button>
+          </form>
+          <form
+            hx-post="{% url 'accounts:recusar_conexao' solicitante.id %}"
+            hx-target="closest .request-card"
+            hx-swap="outerHTML"
+            class="space-y-4"
+          >
+            {% csrf_token %}
+            <button class="btn btn-danger btn-sm">{% trans "Recusar" %}</button>
+          </form>
+        </div>
       </div>
-    </div>
-    <div class="flex flex-col gap-1">
-      <form
-        hx-post="{% url 'accounts:aceitar_conexao' solicitante.id %}"
-        hx-target="closest .request-card"
-        hx-swap="outerHTML"
-      >
-        {% csrf_token %}
-        <button class="btn btn-primary btn-sm">{% trans "Aceitar" %}</button>
-      </form>
-      <form
-        hx-post="{% url 'accounts:recusar_conexao' solicitante.id %}"
-        hx-target="closest .request-card"
-        hx-swap="outerHTML"
-      >
-        {% csrf_token %}
-        <button class="btn btn-danger btn-sm">{% trans "Recusar" %}</button>
-      </form>
-    </div>
-    </div>
-  </article>
+    </article>
   {% empty %}
-  <div class="text-center text-sm text-[var(--text-secondary)]">
-    <p>{% trans "Você não tem solicitações de conexão pendentes." %}</p>
-  </div>
+    <article class="card">
+      <div class="card-body space-y-4 text-sm text-[var(--text-secondary)]">
+        <p>{% trans "Você não tem solicitações de conexão pendentes." %}</p>
+      </div>
+    </article>
   {% endfor %}
 </div>
 


### PR DESCRIPTION
## Summary
- adiciona ConnectionsSearchForm para centralizar placeholders e atributos de busca nas telas de conexões
- atualiza os parciais de conexões para usar layout padronizado com cards, barras de ação e includes de campos

## Testing
- python -m compileall accounts

------
https://chatgpt.com/codex/tasks/task_e_68dfe3b9c59c83259ef84b293c254558