### PR TITLE
Fix profile connections dashboard search form initialization

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -436,7 +436,16 @@ def perfil_section(request, section):
         if not is_owner:
             return HttpResponseForbidden(_("Esta seção está disponível apenas para o proprietário do perfil."))
 
-        q = request.GET.get("q", "").strip()
+        search_form = ConnectionsSearchForm(
+            request.GET or None,
+            placeholder=_("Buscar conexões..."),
+            label=_("Buscar conexões"),
+            aria_label=_("Buscar conexões"),
+        )
+        if search_form.is_valid():
+            q = search_form.cleaned_data.get("q", "") or ""
+        else:
+            q = ""
         connections = (
             profile.connections.select_related("organizacao", "nucleo")
             if hasattr(profile, "connections")
@@ -457,6 +466,7 @@ def perfil_section(request, section):
                 "connections": connections,
                 "connection_requests": connection_requests,
                 "q": q,
+                "form": search_form,
             }
         )
         template = "perfil/partials/conexoes_dashboard.html"


### PR DESCRIPTION
## Summary
- build the connections search form when rendering the profile connections section
- pass the search form to the dashboard context so the connections template loads correctly

## Testing
- pytest tests/accounts/test_views_perfil.py::test_perfil_connections_search_uses_search_partial -q *(fails: coverage fail-under 90% triggered in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dffdcae9a08325b7199289d8c1adb1