### PR TITLE
Fix feed edit back navigation fallback

### DIFF
--- a/core/context_processors.py
+++ b/core/context_processors.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 
-from core.utils import resolve_back_href
+from core.utils import get_back_navigation_fallback, resolve_back_href
 
 
 def htmx_version(request):
@@ -18,4 +18,12 @@ def menu_items(request):
 
 
 def back_navigation(request):
-    return {"back_href": resolve_back_href(request)}
+    fallback = get_back_navigation_fallback(request)
+    back_href = resolve_back_href(request, fallback=fallback)
+    context = {"back_href": back_href}
+    if fallback:
+        context["back_component_config"] = {
+            "href": back_href,
+            "fallback_href": fallback,
+        }
+    return context

--- a/core/utils/__init__.py
+++ b/core/utils/__init__.py
@@ -1,5 +1,5 @@
 """Utility helpers shared across Hubx apps."""
 
-from .navigation import resolve_back_href
+from .navigation import get_back_navigation_fallback, resolve_back_href
 
-__all__ = ["resolve_back_href"]
+__all__ = ["get_back_navigation_fallback", "resolve_back_href"]

--- a/feed/views.py
+++ b/feed/views.py
@@ -22,7 +22,7 @@ from accounts.models import User, UserType
 from eventos.models import Evento
 from core.cache import get_cache_version
 from core.permissions import NoSuperadminMixin, no_superadmin_required
-from core.utils import resolve_back_href
+from core.utils import get_back_navigation_fallback, resolve_back_href
 
 # Moderação desativada: não é necessário notificar moderação
 from nucleos.models import Nucleo
@@ -380,7 +380,7 @@ class NovaPostagemView(LoginRequiredMixin, NoSuperadminMixin, CreateView):
         context["selected_tipo_feed"] = selected_tipo
         context["selected_nucleo"] = (self.request.POST.get("nucleo") or self.request.GET.get("nucleo") or "").strip()
         context["tags_text_value"] = (self.request.POST.get("tags_text", "") or "").strip()
-        fallback_url = reverse("feed:listar")
+        fallback_url = get_back_navigation_fallback(self.request, fallback=reverse("feed:listar"))
         back_href = resolve_back_href(self.request, fallback=fallback_url)
         context["back_href"] = back_href
         context["back_component_config"] = {
@@ -566,7 +566,7 @@ def post_update(request, pk):
     else:
         form = PostForm(instance=post, user=request.user)
 
-    fallback_url = reverse("feed:post_detail", args=[post.pk])
+    fallback_url = get_back_navigation_fallback(request, fallback=reverse("feed:post_detail", args=[post.pk]))
     back_href = resolve_back_href(request, fallback=fallback_url)
     form_action = reverse("feed:post_update", args=[post.pk])
     context = {


### PR DESCRIPTION
## Summary
- add a back-navigation fallback map that routes the feed edit screen to the listing when history is unavailable
- expose the fallback helper through the context processor and feed views so the global back component always receives the mapped URL

## Testing
- `pytest feed/tests/test_views.py -k back` *(fails: file not found in repository)*
- `pytest feed/tests/test_post_form.py` *(fails: repository enforces 90% coverage for partial runs)*

------
https://chatgpt.com/codex/tasks/task_e_68e00d70c89c83258dd82d30a225e12a