### PR TITLE
Adjust feed pages to a single-column layout

### DIFF
--- a/app/static/css/hubx.css
+++ b/app/static/css/hubx.css
@@ -629,6 +629,7 @@
 
   /* Grid/Card */
   .card-grid { @apply grid gap-6 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4; }
+  .card-grid-single { @apply grid-cols-1 sm:grid-cols-1 md:grid-cols-1 lg:grid-cols-1 xl:grid-cols-1 2xl:grid-cols-1; }
 
   .card        { @apply bg-[var(--bg-secondary)] text-[var(--text-primary)] rounded-xl shadow-card-md p-6 border border-[var(--border)]; }
   .card-header { @apply mb-3 font-semibold; }

--- a/feed/templates/feed/_grid.html
+++ b/feed/templates/feed/_grid.html
@@ -2,7 +2,7 @@
 {# Exceção HTMX: parcial renderizado isoladamente durante atualizações dinâmicas #}
 {% if request.user.user_type != 'root' %}
 
-<section id="feed-grid" class="card-grid auto-rows-[1fr] gap-6 sm:grid-cols-1 md:grid-cols-1 lg:grid-cols-1 xl:grid-cols-1 2xl:grid-cols-1">
+<section id="feed-grid" class="card-grid card-grid-single auto-rows-[1fr] gap-6">
   {% for post in posts %}
   <article class="card group relative flex h-full flex-col overflow-hidden border border-transparent bg-[var(--bg-secondary)] shadow-lg transition-all duration-300 hover:-translate-y-1 hover:border-[var(--accent)] hover:shadow-2xl">
     <span aria-hidden="true" class="pointer-events-none absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-[var(--primary)] via-[var(--accent-light)] to-[var(--accent)] opacity-80 transition-opacity duration-300 group-hover:opacity-100"></span>


### PR DESCRIPTION
## Summary
- add a reusable `card-grid-single` helper to keep specific grids in one column
- update the feed post grid partial to use the new helper so feed, mural, and bookmarks show a single column

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e02f02ca748325b347f398c0382681