### PR TITLE
Ajusta rotas do menu de conexões

### DIFF
--- a/core/menu.py
+++ b/core/menu.py
@@ -298,24 +298,25 @@ def _get_menu_items() -> List[MenuItem]:
         ),
     ]
 
+    conexoes_dashboard_url = reverse("conexoes:perfil_sections_conexoes")
     conexoes_children = [
         MenuItem(
             id="conexoes_minhas",
-            path=f"{perfil_url}?section=conexoes",
+            path=conexoes_dashboard_url,
             label="Minhas conexões",
             icon=ICON_USERS,
             permissions=["authenticated"],
         ),
         MenuItem(
             id="conexoes_solicitacoes",
-            path=f"{perfil_url}?section=conexoes&tab=solicitacoes",
+            path=f"{conexoes_dashboard_url}?tab=solicitacoes",
             label="Solicitações",
             icon=ICON_PLUG,
             permissions=["authenticated"],
         ),
         MenuItem(
             id="conexoes_buscar",
-            path=f"{perfil_url}?section=conexoes&view=buscar",
+            path=reverse("conexoes:perfil_conexoes_buscar"),
             label="Buscar pessoas",
             icon=ICON_LINK,
             permissions=["authenticated"],
@@ -463,7 +464,7 @@ def _get_menu_items() -> List[MenuItem]:
         ),
         MenuItem(
             id="conexoes",
-            path=f"{perfil_url}?section=conexoes",
+            path=conexoes_dashboard_url,
             label="Conexões",
             icon=ICON_LINK,
             permissions=["authenticated"],


### PR DESCRIPTION
## Summary
- atualiza o item principal de Conexões para usar a view dedicada com layout completo
- ajusta os atalhos filhos (Minhas conexões, Solicitações e Buscar pessoas) para apontarem para as novas rotas diretas

## Testing
- python -m compileall core/menu.py

------
https://chatgpt.com/codex/tasks/task_e_68e03b105f00832587a56459ac8f7c3d