### PR TITLE
Refatora exibição da lista de conexões

### DIFF
--- a/conexoes/templates/conexoes/connections_list.html
+++ b/conexoes/templates/conexoes/connections_list.html
@@ -8,5 +8,23 @@
 {% endblock %}
 
 {% block content %}
-  {% include 'conexoes/partiais/dashboard.html' %}
+  <div class="space-y-6" id="connections-dashboard">
+    <article class="card" aria-labelledby="connections-list-heading">
+      <div class="card-header">
+        <h2 id="connections-list-heading" class="text-base font-semibold text-[var(--text-primary)]">{% trans "Minhas conexões" %}</h2>
+      </div>
+      <div class="card-body space-y-6">
+        {% include 'conexoes/partiais/connections_list.html' %}
+      </div>
+    </article>
+
+    <article class="card" aria-labelledby="connections-requests-heading">
+      <div class="card-header">
+        <h2 id="connections-requests-heading" class="text-base font-semibold text-[var(--text-primary)]">{% trans "Solicitações de conexão" %}</h2>
+      </div>
+      <div class="card-body space-y-6">
+        {% include 'conexoes/partiais/request_list.html' %}
+      </div>
+    </article>
+  </div>
 {% endblock %}

--- a/conexoes/templates/conexoes/partiais/connections_list_content.html
+++ b/conexoes/templates/conexoes/partiais/connections_list_content.html
@@ -5,7 +5,7 @@
       <h2 id="connections-list-heading" class="text-base font-semibold text-[var(--text-primary)]">{% trans "Minhas conexões" %}</h2>
     </div>
     <div class="card-body space-y-6">
-      {% include 'conexoes/partiais/connections_list.html' with search_form_action=search_form_action search_form_hx_get=search_form_hx_get search_form_hx_target=search_form_hx_target search_form_hx_push_url=search_form_hx_push_url search_page_url=search_page_url search_page_hx_get=search_page_hx_get search_page_hx_target=search_page_hx_target search_page_hx_push_url=search_page_hx_push_url %}
+      {% include 'conexoes/partiais/connections_list.html' %}
     </div>
   </article>
 

--- a/conexoes/views.py
+++ b/conexoes/views.py
@@ -45,25 +45,22 @@ def _connection_totals(user):
     return total_conexoes, total_solicitacoes, total_solicitacoes_enviadas
 
 
-def _build_dashboard_context(request, form, connections, connection_requests, query: str):
+def _build_connections_page_context(request, form, connections, connection_requests, query: str):
     total_conexoes, total_solicitacoes, total_solicitacoes_enviadas = _connection_totals(request.user)
     search_params = {"q": query} if query else {}
     search_page_url = reverse("conexoes:perfil_conexoes_buscar")
     if search_params:
         search_page_url = f"{search_page_url}?{urlencode(search_params)}"
-    solicitacoes_url = f"{reverse('conexoes:perfil_sections_conexoes')}?tab=solicitacoes"
 
     return {
         "connections": connections,
         "connection_requests": connection_requests,
         "form": form,
-        "q": query,
-        "search_page_url": search_page_url,
-        "solicitacoes_url": solicitacoes_url,
         "search_form_action": request.get_full_path(),
         "search_form_hx_get": None,
         "search_form_hx_target": None,
         "search_form_hx_push_url": None,
+        "search_page_url": search_page_url,
         "search_page_hx_get": None,
         "search_page_hx_target": None,
         "search_page_hx_push_url": None,
@@ -160,11 +157,11 @@ def perfil_conexoes(request):
         q = ""
 
     connections, connection_requests = _connection_lists_for_user(request.user, q)
-    context = _build_dashboard_context(request, search_form, connections, connection_requests, q)
+    context = _build_connections_page_context(request, search_form, connections, connection_requests, q)
 
     if is_htmx_or_ajax(request):
         context.update(_profile_dashboard_hx_context())
-        return render(request, "conexoes/partiais/dashboard.html", context)
+        return render(request, "conexoes/partiais/connections_list_content.html", context)
 
     return render(request, "conexoes/connections_list.html", context)
 
@@ -200,9 +197,9 @@ def perfil_conexoes_partial(request):
 
     connections, connection_requests = _connection_lists_for_user(request.user, q)
 
-    context = _build_dashboard_context(request, search_form, connections, connection_requests, q)
+    context = _build_connections_page_context(request, search_form, connections, connection_requests, q)
     context.update(_profile_dashboard_hx_context())
-    return render(request, "conexoes/partiais/dashboard.html", context)
+    return render(request, "conexoes/partiais/connections_list_content.html", context)
 
 
 @login_required


### PR DESCRIPTION
## Summary
- move o layout do dashboard de conexões diretamente para o template principal
- ajusta as respostas HTMX para reutilizar a nova estrutura
- simplifica o contexto montado para a página de conexões

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e045e6ac48832588f7ef6bd416010c