### PR TITLE
Add solicitacoes page for pending connection requests

### DIFF
--- a/conexoes/templates/conexoes/solicitacoes.html
+++ b/conexoes/templates/conexoes/solicitacoes.html
@@ -1,0 +1,21 @@
+{% extends 'base.html' %}
+{% load i18n %}
+
+{% block title %}{% trans "Solicitações de conexão" %}{% endblock %}
+
+{% block hero %}
+  {% include '_components/hero_conexoes.html' with title=_('Solicitações pendentes') subtitle=_('Gerencie as solicitações de conexão que aguardam sua resposta') action_url=search_page_url action_icon='user-round-plus' total_conexoes=total_conexoes total_solicitacoes=total_solicitacoes total_solicitacoes_enviadas=total_solicitacoes_enviadas %}
+{% endblock %}
+
+{% block content %}
+  <section class="space-y-6" aria-labelledby="connection-requests-heading">
+    <article class="card">
+      <div class="card-header">
+        <h2 id="connection-requests-heading" class="text-base font-semibold text-[var(--text-primary)]">{% trans "Solicitações de conexão" %}</h2>
+      </div>
+      <div class="card-body space-y-6">
+        {% include 'conexoes/partiais/request_list.html' %}
+      </div>
+    </article>
+  </section>
+{% endblock %}

--- a/tests/conexoes/test_connections.py
+++ b/tests/conexoes/test_connections.py
@@ -37,6 +37,36 @@ def test_recusar_conexao(client):
 
 
 @pytest.mark.django_db
+def test_perfil_conexoes_solicitacoes_page(client):
+    user = User.objects.create_user(email="a@example.com", username="a", password="x")
+    follower = User.objects.create_user(email="b@example.com", username="b", password="x")
+    user.followers.add(follower)
+
+    client.force_login(user)
+    url = reverse("conexoes:perfil_sections_conexoes")
+    response = client.get(url, {"tab": "solicitacoes"})
+
+    assert response.status_code == 200
+    assert any(template.name == "conexoes/solicitacoes.html" for template in response.templates)
+    assert list(response.context["connection_requests"]) == [follower]
+
+
+@pytest.mark.django_db
+def test_perfil_conexoes_solicitacoes_partial_htmx(client):
+    user = User.objects.create_user(email="a@example.com", username="a", password="x")
+    follower = User.objects.create_user(email="b@example.com", username="b", password="x")
+    user.followers.add(follower)
+
+    client.force_login(user)
+    url = reverse("conexoes:perfil_conexoes_partial")
+    response = client.get(url, {"tab": "solicitacoes"}, HTTP_HX_REQUEST="true")
+
+    assert response.status_code == 200
+    assert any(template.name == "conexoes/partiais/request_list.html" for template in response.templates)
+    assert list(response.context["connection_requests"]) == [follower]
+
+
+@pytest.mark.django_db
 def test_buscar_pessoas_lista_associados_da_organizacao(client):
     organizacao = OrganizacaoFactory()
     outra_org = OrganizacaoFactory()


### PR DESCRIPTION
## Summary
- add a dedicated `solicitacoes.html` template with hero messaging for pending connection requests
- refactor connections views to reuse a helper for request context and serve the solicitations tab and HTMX partials
- expand tests to cover the new solicitations page and HTMX response

## Testing
- pytest tests/conexoes/test_connections.py -k solicitacoes --no-cov

------
https://chatgpt.com/codex/tasks/task_e_68e04842733c832580b6e232a8b1148e