### PR TITLE
Atualiza hierarquia do menu de conexões

### DIFF
--- a/core/menu.py
+++ b/core/menu.py
@@ -301,13 +301,6 @@ def _get_menu_items() -> List[MenuItem]:
     conexoes_dashboard_url = reverse("conexoes:perfil_sections_conexoes")
     conexoes_children = [
         MenuItem(
-            id="conexoes_minhas",
-            path=conexoes_dashboard_url,
-            label="Minhas conexões",
-            icon=ICON_USERS,
-            permissions=["authenticated"],
-        ),
-        MenuItem(
             id="conexoes_solicitacoes",
             path=f"{conexoes_dashboard_url}?tab=solicitacoes",
             label="Solicitações",
@@ -317,7 +310,7 @@ def _get_menu_items() -> List[MenuItem]:
         MenuItem(
             id="conexoes_buscar",
             path=reverse("conexoes:perfil_conexoes_buscar"),
-            label="Buscar pessoas",
+            label="Adicionar conexão",
             icon=ICON_LINK,
             permissions=["authenticated"],
         ),


### PR DESCRIPTION
## Summary
- remove o item filho "Minhas conexões" para o menu raiz de Conexões apontar direto para a listagem padrão
- mantém o submenu de solicitações e renomeia o item de busca para "Adicionar conexão" para refletir o novo fluxo

## Testing
- pytest tests/core/test_menu.py *(falha: cobertura total abaixo do limiar exigido pela suíte)*

------
https://chatgpt.com/codex/tasks/task_e_68e04a88d860832587e52fd963f7d067