### PR TITLE
Fix hero component for event detail and edit templates

### DIFF
--- a/eventos/templates/eventos/detail.html
+++ b/eventos/templates/eventos/detail.html
@@ -3,7 +3,7 @@
 
 {% block title %}{{ title|default:object.titulo|default:_('Eventos') }}{% endblock %}
 
-{% block hero %}{% include '_components/hero_evento_detail.html' with evento=object %}{% endblock %}
+{% block hero %}{% include '_components/hero_evento_detail.html' with evento=evento %}{% endblock %}
 
 {% block content %}
   

--- a/eventos/templates/eventos/evento_form.html
+++ b/eventos/templates/eventos/evento_form.html
@@ -3,7 +3,13 @@
 
 {% block title %}{{ title|default:_('Evento') }}{% endblock %}
 
-{% block hero %}{% include "_components/hero_evento.html" with title=title|default:_("Eventos") subtitle=subtitle|default_if_none:"" neural_background="eventos" %}{% endblock %}
+{% block hero %}
+  {% if object and object.pk %}
+    {% include "_components/hero_evento_detail.html" with evento=object total_inscricoes=total_inscricoes total_inscricoes_confirmadas=total_inscricoes_confirmadas total_inscricoes_pendentes=total_inscricoes_pendentes total_inscricoes_canceladas=total_inscricoes_canceladas total_presentes=total_presentes vagas_disponiveis=vagas_disponiveis media_feedback=media_feedback total_feedbacks=total_feedbacks %}
+  {% else %}
+    {% include "_components/hero_evento.html" with title=title|default:_("Eventos") subtitle=subtitle|default_if_none:"" neural_background="eventos" %}
+  {% endif %}
+{% endblock %}
 
 {% block content %}
 


### PR DESCRIPTION
## Summary
- ensure the event detail template renders the hero_evento_detail component with the existing evento context
- update the shared event form to display hero_evento_detail when editing an existing event while keeping the original hero for new events

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e051a87ed88325843a1e7abd65bd8a