### PR TITLE
Fix avatar overlap on event cards

### DIFF
--- a/templates/_partials/cards/base_card.html
+++ b/templates/_partials/cards/base_card.html
@@ -21,7 +21,7 @@
       {% else %}
         <div class="h-24 w-full bg-gradient-to-r from-[var(--hero-from)] to-[var(--hero-to)]"{% if style %} style="{{ style }}"{% endif %}></div>
       {% endif %}
-      <div class="absolute -bottom-8 left-4">
+      <div class="absolute -bottom-8 left-4 z-10">
         {% if avatar %}
           <img src="{{ avatar.url|default:avatar }}" alt="{{ title }}" class="h-16 w-16 rounded-full ring-4 ring-[var(--bg-primary)] object-cover" loading="lazy" />
         {% else %}


### PR DESCRIPTION
## Summary
- ensure the avatar container on card components renders above the card body to avoid clipping

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e053b77f1083259b028bd4a8330435