### PR TITLE
Ajusta contraste dos heros de evento e núcleo

### DIFF
--- a/templates/_components/hero_evento_detail.html
+++ b/templates/_components/hero_evento_detail.html
@@ -3,7 +3,7 @@
   {% if evento.cover %}
     <div class="absolute inset-0">
       <img src="{{ evento.cover.url }}" alt="" class="h-full w-full object-cover" loading="lazy">
-      <div class="absolute inset-0 bg-black/60"></div>
+      <div class="absolute inset-0 bg-black/45"></div>
     </div>
   {% else %}
     <div class="absolute inset-0 bg-gradient-to-r from-[var(--hero-from)] to-[var(--hero-to)]"
@@ -33,13 +33,13 @@
         <div class="mt-6 space-y-4 text-left">
           <div class="card-grid">
             {% if total_inscricoes is not None %}
-              {% include '_partials/cards/total_card.html' with label=_('Inscrições') valor=total_inscricoes icon_name='users' card_class='card-compact border border-white/30 bg-white/10 text-white/90 backdrop-blur-sm' body_class='card-body-compact' %}
+              {% include '_partials/cards/total_card.html' with label=_('Inscrições') valor=total_inscricoes icon_name='users' card_class='card-compact border border-white/40 bg-white/30 text-slate-900 shadow-lg shadow-black/20 backdrop-blur-md dark:border-white/25 dark:bg-slate-950/70 dark:text-white' body_class='card-body-compact' %}
             {% endif %}
             {% if vagas_disponiveis is not None %}
-              {% include '_partials/cards/total_card.html' with label=_('Vagas disponíveis') valor=vagas_disponiveis icon_name='ticket' card_class='card-compact border border-white/30 bg-white/10 text-white/90 backdrop-blur-sm' body_class='card-body-compact' %}
+              {% include '_partials/cards/total_card.html' with label=_('Vagas disponíveis') valor=vagas_disponiveis icon_name='ticket' card_class='card-compact border border-white/40 bg-white/30 text-slate-900 shadow-lg shadow-black/20 backdrop-blur-md dark:border-white/25 dark:bg-slate-950/70 dark:text-white' body_class='card-body-compact' %}
             {% endif %}
             {% if media_feedback is not None %}
-              {% include '_partials/cards/total_card.html' with label=_('Média de avaliação') valor=media_feedback|floatformat:1 icon_name='star' card_class='card-compact border border-white/30 bg-white/10 text-white/90 backdrop-blur-sm' body_class='card-body-compact' %}
+              {% include '_partials/cards/total_card.html' with label=_('Média de avaliação') valor=media_feedback|floatformat:1 icon_name='star' card_class='card-compact border border-white/40 bg-white/30 text-slate-900 shadow-lg shadow-black/20 backdrop-blur-md dark:border-white/25 dark:bg-slate-950/70 dark:text-white' body_class='card-body-compact' %}
             {% endif %}
           </div>
         </div>

--- a/templates/_components/hero_nucleo_detail.html
+++ b/templates/_components/hero_nucleo_detail.html
@@ -3,7 +3,7 @@
   {% if nucleo.cover %}
     <div class="absolute inset-0">
       <img src="{{ nucleo.cover.url }}" alt="" class="h-full w-full object-cover" loading="lazy">
-      <div class="absolute inset-0 bg-black/60"></div>
+      <div class="absolute inset-0 bg-black/45"></div>
     </div>
   {% else %}
     <div class="absolute inset-0 bg-gradient-to-r from-[var(--hero-from)] to-[var(--hero-to)]"
@@ -34,7 +34,7 @@
         <div class="mt-6 space-y-4 text-left">
           <div class="card-grid">
             {% if total_membros is not None %}
-              {% include "_partials/cards/total_card.html" with label=_('Membros') valor=total_membros icon_name='users' card_class='card-compact border border-white/30 bg-white/10 text-white/90 backdrop-blur-sm' body_class='card-body-compact' %}
+              {% include "_partials/cards/total_card.html" with label=_('Membros') valor=total_membros icon_name='users' card_class='card-compact border border-white/40 bg-white/30 text-slate-900 shadow-lg shadow-black/20 backdrop-blur-md dark:border-white/25 dark:bg-slate-950/70 dark:text-white' body_class='card-body-compact' %}
             {% endif %}
            </div>
         </div>


### PR DESCRIPTION
## Summary
- suaviza a película aplicada às capas dos heros de evento e núcleo para revelar melhor o conteúdo em modo claro
- atualiza os cartões de métricas com um vidro translúcido mais claro e tipografia adequada mantendo contraste também no modo escuro

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e058a1ac6883258c9bc57b5660e789