### PR TITLE
Adjust hero detail overlays transparency

### DIFF
--- a/templates/_components/hero_evento_detail.html
+++ b/templates/_components/hero_evento_detail.html
@@ -23,7 +23,7 @@
               </div>
             {% endif %}
           </div>
-          <div class="inline-flex min-w-0 max-w-full items-center rounded-xl border border-black/10 bg-white/80 px-4 py-2 text-[var(--text-primary)] shadow-lg shadow-black/10 backdrop-blur-md dark:border-white/15 dark:bg-slate-950/70 dark:text-white dark:shadow-black/40">
+          <div class="inline-flex min-w-0 max-w-full items-center rounded-xl border border-black/5 bg-white/60 px-4 py-2 text-[var(--text-primary)] shadow-lg shadow-black/10 backdrop-blur-md dark:border-white/10 dark:bg-slate-950/55 dark:text-white dark:shadow-black/40">
             <h1 class="text-3xl font-bold md:text-4xl">{{ evento.titulo }}</h1>
           </div>
         </div>
@@ -33,13 +33,13 @@
         <div class="mt-6 space-y-4 text-left">
           <div class="card-grid">
             {% if total_inscricoes is not None %}
-              {% include '_partials/cards/total_card.html' with label=_('Inscrições') valor=total_inscricoes icon_name='users' card_class='card-compact border border-white/40 bg-white/30 text-slate-900 shadow-lg shadow-black/20 backdrop-blur-md dark:border-white/25 dark:bg-slate-950/70 dark:text-white' body_class='card-body-compact' %}
+              {% include '_partials/cards/total_card.html' with label=_('Inscrições') valor=total_inscricoes icon_name='users' card_class='card-compact border border-white/30 bg-white/20 text-slate-900 shadow-lg shadow-black/20 backdrop-blur-md dark:border-white/15 dark:bg-slate-950/55 dark:text-white' body_class='card-body-compact' %}
             {% endif %}
             {% if vagas_disponiveis is not None %}
-              {% include '_partials/cards/total_card.html' with label=_('Vagas disponíveis') valor=vagas_disponiveis icon_name='ticket' card_class='card-compact border border-white/40 bg-white/30 text-slate-900 shadow-lg shadow-black/20 backdrop-blur-md dark:border-white/25 dark:bg-slate-950/70 dark:text-white' body_class='card-body-compact' %}
+              {% include '_partials/cards/total_card.html' with label=_('Vagas disponíveis') valor=vagas_disponiveis icon_name='ticket' card_class='card-compact border border-white/30 bg-white/20 text-slate-900 shadow-lg shadow-black/20 backdrop-blur-md dark:border-white/15 dark:bg-slate-950/55 dark:text-white' body_class='card-body-compact' %}
             {% endif %}
             {% if media_feedback is not None %}
-              {% include '_partials/cards/total_card.html' with label=_('Média de avaliação') valor=media_feedback|floatformat:1 icon_name='star' card_class='card-compact border border-white/40 bg-white/30 text-slate-900 shadow-lg shadow-black/20 backdrop-blur-md dark:border-white/25 dark:bg-slate-950/70 dark:text-white' body_class='card-body-compact' %}
+              {% include '_partials/cards/total_card.html' with label=_('Média de avaliação') valor=media_feedback|floatformat:1 icon_name='star' card_class='card-compact border border-white/30 bg-white/20 text-slate-900 shadow-lg shadow-black/20 backdrop-blur-md dark:border-white/15 dark:bg-slate-950/55 dark:text-white' body_class='card-body-compact' %}
             {% endif %}
           </div>
         </div>

--- a/templates/_components/hero_nucleo_detail.html
+++ b/templates/_components/hero_nucleo_detail.html
@@ -23,7 +23,7 @@
               </div>
             {% endif %}
           </div>
-          <div class="inline-flex min-w-0 max-w-full items-center rounded-xl border border-black/10 bg-white/80 px-4 py-2 text-[var(--text-primary)] shadow-lg shadow-black/10 backdrop-blur-md dark:border-white/15 dark:bg-slate-950/70 dark:text-white dark:shadow-black/40">
+          <div class="inline-flex min-w-0 max-w-full items-center rounded-xl border border-black/5 bg-white/60 px-4 py-2 text-[var(--text-primary)] shadow-lg shadow-black/10 backdrop-blur-md dark:border-white/10 dark:bg-slate-950/55 dark:text-white dark:shadow-black/40">
             <h1 class="text-3xl font-bold md:text-4xl">{{ nucleo.nome }}</h1>
           </div>
         </div>
@@ -34,7 +34,7 @@
         <div class="mt-6 space-y-4 text-left">
           <div class="card-grid">
             {% if total_membros is not None %}
-              {% include "_partials/cards/total_card.html" with label=_('Membros') valor=total_membros icon_name='users' card_class='card-compact border border-white/40 bg-white/30 text-slate-900 shadow-lg shadow-black/20 backdrop-blur-md dark:border-white/25 dark:bg-slate-950/70 dark:text-white' body_class='card-body-compact' %}
+              {% include "_partials/cards/total_card.html" with label=_('Membros') valor=total_membros icon_name='users' card_class='card-compact border border-white/30 bg-white/20 text-slate-900 shadow-lg shadow-black/20 backdrop-blur-md dark:border-white/15 dark:bg-slate-950/55 dark:text-white' body_class='card-body-compact' %}
             {% endif %}
            </div>
         </div>


### PR DESCRIPTION
## Summary
- soften the title banner background on hero detail templates for eventos and núcleos
- reduce opacity of total cards in hero sections for better translucency in light and dark themes

## Testing
- not run (HTML-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e05afa04e083259dc74100e0017d9a