### PR TITLE
Fix feed reactions and favorites UI feedback

### DIFF
--- a/feed/templates/feed/_like_button.html
+++ b/feed/templates/feed/_like_button.html
@@ -2,21 +2,19 @@
 {% if request.user.user_type != 'root' %}
 {% with liked=post.is_liked count=post.like_count %}
 <button
-  hx-post="/api/feed/posts/{{ post.id }}/reacoes/"
-  hx-ext="json-enc"
-  hx-vals='{"vote":"like"}'
-  hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
-  hx-swap="none"
-  hx-on="click: event.stopPropagation(); htmx:afterRequest: if(event.detail.xhr.status===201){const i=this.querySelector('svg');i.classList.add('text-emerald-600');const s=this.querySelector('span');s.textContent=parseInt(s.textContent)+1;}else if(event.detail.xhr.status===204){const i=this.querySelector('svg');i.classList.remove('text-emerald-600');const s=this.querySelector('span');s.textContent=parseInt(s.textContent)-1;}"
-  class="btn btn-secondary hover:text-emerald-600"
+  type="button"
+  class="reaction-btn btn btn-secondary hover:text-emerald-600"
+  data-post-id="{{ post.id }}"
+  data-reaction-type="like"
+  data-active-class="text-emerald-600"
+  aria-pressed="{% if liked %}true{% else %}false{% endif %}"
+  data-reaction-state="{% if liked %}active{% else %}inactive{% endif %}"
   aria-label="{% if liked %}{% translate 'Descurtir' %}{% else %}{% translate 'Curtir' %}{% endif %}"
 >
-  {% if liked %}
-    {% lucide 'heart' class='w-4 h-4 text-emerald-600' %}
-  {% else %}
+  <span data-reaction-icon class="reaction-icon {% if liked %}text-emerald-600{% endif %}">
     {% lucide 'heart' class='w-4 h-4' %}
-  {% endif %}
-  <span>{{ count }}</span>
+  </span>
+  <span data-reaction-count>{{ count }}</span>
 </button>
 {% endwith %}
 {% endif %}


### PR DESCRIPTION
## Summary
- replace the inline HTMX reaction handler with a dedicated JavaScript listener that updates counts and icon states for likes
- refactor the like button partial to expose data attributes so the active state and styling persist across feed, mural, and favorites views

## Testing
- pytest feed/tests/test_reactions.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e05c2e58fc8325bf4815bd33fb98ac