### PR TITLE
Improve feed type selection dark mode styling

### DIFF
--- a/feed/static/feed/js/feed.js
+++ b/feed/static/feed/js/feed.js
@@ -196,13 +196,24 @@ function bindFeedEvents(root = document) {
       return acc;
     }, {});
 
+    const syncExclusiveLabelState = (checkbox) => {
+      const label = checkbox.closest('[data-feed-type-option]');
+      if (!label) {
+        return;
+      }
+      label.dataset.checked = checkbox.checked ? 'true' : 'false';
+    };
+
     Object.values(groups).forEach((group) => {
       group.forEach((checkbox) => {
+        syncExclusiveLabelState(checkbox);
+
         checkbox.addEventListener('change', () => {
           if (checkbox.checked) {
             group.forEach((other) => {
-              if (other !== checkbox) {
+              if (other !== checkbox && other.checked) {
                 other.checked = false;
+                syncExclusiveLabelState(other);
               }
             });
           } else {
@@ -211,6 +222,8 @@ function bindFeedEvents(root = document) {
               checkbox.checked = true;
             }
           }
+
+          syncExclusiveLabelState(checkbox);
         });
       });
     });

--- a/feed/templates/feed/post_form.html
+++ b/feed/templates/feed/post_form.html
@@ -69,28 +69,34 @@
               <span class="block text-sm font-medium text-[var(--text-primary)]">
                 {% trans "Tipo de feed" %} *
               </span>
-              <div class="flex flex-col gap-2 sm:flex-row sm:items-center">
-                <label for="tipo_feed_global" class="flex items-center gap-2 rounded-xl border border-[var(--border-secondary)] bg-[var(--bg-secondary)] px-4 py-3 text-sm text-[var(--text-primary)]">
-                  <input type="checkbox"
-                         id="tipo_feed_global"
-                         name="tipo_feed"
-                         value="global"
-                         class="form-checkbox"
-                         data-exclusive="tipo-feed"
-                         {% if selected_tipo_feed|default:'global' == 'global' %}checked{% endif %}>
-                  <span>{% trans "Feed Público" %}</span>
-                </label>
-                <label for="tipo_feed_usuario" class="flex items-center gap-2 rounded-xl border border-[var(--border-secondary)] bg-[var(--bg-secondary)] px-4 py-3 text-sm text-[var(--text-primary)]">
-                  <input type="checkbox"
-                         id="tipo_feed_usuario"
-                         name="tipo_feed"
-                         value="usuario"
-                         class="form-checkbox"
-                         data-exclusive="tipo-feed"
-                         {% if selected_tipo_feed == 'usuario' %}checked{% endif %}>
-                  <span>{% trans "Mural" %}</span>
-                </label>
-              </div>
+                <div class="flex flex-col gap-2 sm:flex-row sm:items-center">
+                  <label for="tipo_feed_global"
+                         class="feed-type-option flex items-center gap-2 rounded-xl border border-[var(--border-secondary)] bg-[var(--bg-secondary)] px-4 py-3 text-sm text-[var(--text-primary)] transition cursor-pointer"
+                         data-feed-type-option
+                         data-checked="{% if selected_tipo_feed|default:'global' == 'global' %}true{% else %}false{% endif %}">
+                    <input type="checkbox"
+                           id="tipo_feed_global"
+                           name="tipo_feed"
+                           value="global"
+                           class="form-checkbox"
+                           data-exclusive="tipo-feed"
+                           {% if selected_tipo_feed|default:'global' == 'global' %}checked{% endif %}>
+                    <span>{% trans "Feed Público" %}</span>
+                  </label>
+                  <label for="tipo_feed_usuario"
+                         class="feed-type-option flex items-center gap-2 rounded-xl border border-[var(--border-secondary)] bg-[var(--bg-secondary)] px-4 py-3 text-sm text-[var(--text-primary)] transition cursor-pointer"
+                         data-feed-type-option
+                         data-checked="{% if selected_tipo_feed == 'usuario' %}true{% else %}false{% endif %}">
+                    <input type="checkbox"
+                           id="tipo_feed_usuario"
+                           name="tipo_feed"
+                           value="usuario"
+                           class="form-checkbox"
+                           data-exclusive="tipo-feed"
+                           {% if selected_tipo_feed == 'usuario' %}checked{% endif %}>
+                    <span>{% trans "Mural" %}</span>
+                  </label>
+                </div>
               {% if form.tipo_feed.errors %}
                 <ul class="errorlist">
                   {% for error in form.tipo_feed.errors %}

--- a/static/tailwind.css
+++ b/static/tailwind.css
@@ -1004,9 +1004,9 @@ a:focus {
   flex-shrink: 0;
   height: 1rem;
   width: 1rem;
-  color: #2563eb;
-  background-color: #fff;
-  border-color: #6b7280;
+  color: var(--primary);
+  background-color: var(--bg-primary);
+  border-color: var(--border);
   border-width: 1px;
   --tw-shadow: 0 0 #0000;
 }
@@ -1020,8 +1020,8 @@ a:focus {
   outline-offset: 2px;
   --tw-ring-inset: var(--tw-empty,/*!*/ /*!*/);
   --tw-ring-offset-width: 2px;
-  --tw-ring-offset-color: #fff;
-  --tw-ring-color: #2563eb;
+  --tw-ring-offset-color: var(--bg-primary);
+  --tw-ring-color: var(--primary);
   --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
   --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
   box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
@@ -1072,6 +1072,26 @@ a:focus {
 .form-checkbox:indeterminate:hover,.form-checkbox:indeterminate:focus {
   border-color: transparent;
   background-color: currentColor;
+}
+
+.feed-type-option {
+  position: relative;
+  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.feed-type-option:focus-within {
+  border-color: var(--primary);
+  box-shadow: 0 0 0 2px var(--bg-primary), 0 0 0 4px var(--primary-soft-border,rgba(59,130,246,0.35));
+}
+
+.feed-type-option[data-checked="true"] {
+  border-color: var(--primary);
+  background-color: var(--primary-soft,rgba(59,130,246,0.15));
+  color: var(--primary);
+}
+
+.feed-type-option input[type="checkbox"] {
+  accent-color: var(--primary);
 }
 
 .prose {


### PR DESCRIPTION
## Summary
- restyle the feed type selection labels so they behave as accessible toggle buttons in dark mode
- sync the label state from JavaScript so the visual state tracks the exclusive checkbox logic
- update form checkbox styling variables and add focused/selected styles for feed type options

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3fe9891f48325982fb7f1a0608cbc