### PR TITLE
Fix birth date display in profile form

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -43,7 +43,9 @@ class CustomUserCreationForm(UserCreationForm):
             "nucleo",
         )
         labels = {"contato": "Contato"}
-        widgets = {"birth_date": forms.DateInput(attrs={"type": "date"})}
+        widgets = {
+            "birth_date": forms.DateInput(format="%Y-%m-%d", attrs={"type": "date"})
+        }
 
     def clean_email(self):
         email = self.cleaned_data.get("email")
@@ -115,7 +117,9 @@ class CustomUserChangeForm(UserChangeForm):
             "nucleo",
         )
         labels = {"contato": "Contato"}
-        widgets = {"birth_date": forms.DateInput(attrs={"type": "date"})}
+        widgets = {
+            "birth_date": forms.DateInput(format="%Y-%m-%d", attrs={"type": "date"})
+        }
 
     def clean_cnpj(self):
         cnpj = self.cleaned_data.get("cnpj")
@@ -146,7 +150,8 @@ class InformacoesPessoaisForm(forms.ModelForm):
     birth_date = forms.DateField(
         required=False,
         label="Data de nascimento",
-        widget=forms.DateInput(attrs={"type": "date"}),
+        input_formats=["%Y-%m-%d"],
+        widget=forms.DateInput(format="%Y-%m-%d", attrs={"type": "date"}),
     )
 
     class Meta:

--- a/tests/accounts/test_birth_date_field_format.py
+++ b/tests/accounts/test_birth_date_field_format.py
@@ -1,0 +1,15 @@
+from datetime import date
+
+from accounts.forms import InformacoesPessoaisForm
+from accounts.models import User
+
+
+def test_birth_date_field_renders_iso_format():
+    user = User(email="user@example.com", username="user")
+    user.birth_date = date(1990, 1, 1)
+
+    form = InformacoesPessoaisForm(instance=user)
+
+    rendered = str(form["birth_date"])
+
+    assert "value=\"1990-01-01\"" in rendered


### PR DESCRIPTION
## Summary
- ensure all user birth date form widgets render ISO formatted values compatible with date inputs
- add a regression test guaranteeing the profile form outputs the correct value attribute

## Testing
- pytest --no-cov tests/accounts/test_birth_date_field_format.py

------
https://chatgpt.com/codex/tasks/task_e_68e4021ab8f883259c0da19a1435114e