### PR TITLE
Fix dark mode styling for feed type checkboxes

### DIFF
--- a/feed/templates/feed/post_form.html
+++ b/feed/templates/feed/post_form.html
@@ -78,7 +78,7 @@
                            id="tipo_feed_global"
                            name="tipo_feed"
                            value="global"
-                           class="form-checkbox"
+                           class="form-checkbox text-[var(--primary)] focus:ring-[var(--primary)]"
                            data-exclusive="tipo-feed"
                            {% if selected_tipo_feed|default:'global' == 'global' %}checked{% endif %}>
                     <span>{% trans "Feed Público" %}</span>
@@ -91,7 +91,7 @@
                            id="tipo_feed_usuario"
                            name="tipo_feed"
                            value="usuario"
-                           class="form-checkbox"
+                           class="form-checkbox text-[var(--primary)] focus:ring-[var(--primary)]"
                            data-exclusive="tipo-feed"
                            {% if selected_tipo_feed == 'usuario' %}checked{% endif %}>
                     <span>{% trans "Mural" %}</span>


### PR DESCRIPTION
## Summary
- ensure the feed type checkboxes in the new post template use the primary color so the checked state remains visible in dark mode

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e416f6a7dc832581c516fa12e66098