### PR TITLE
Fix associado creation redirect and add regression tests

### DIFF
--- a/associados/templates/associados/usuario_form.html
+++ b/associados/templates/associados/usuario_form.html
@@ -16,6 +16,9 @@
   <div class="card-body space-y-6">
     <form method="post" class="space-y-6">
       {% csrf_token %}
+      {% if back_href %}
+        <input type="hidden" name="next" value="{{ back_href }}">
+      {% endif %}
       {% if form.non_field_errors %}
         <div class="alert alert-error" role="alert">
           <ul class="space-y-1">

--- a/tests/associados/test_user_create_view.py
+++ b/tests/associados/test_user_create_view.py
@@ -1,0 +1,68 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+from accounts.models import UserType
+from organizacoes.factories import OrganizacaoFactory
+
+
+class OrganizacaoUserCreateViewTests(TestCase):
+    def setUp(self):
+        self.organizacao = OrganizacaoFactory()
+        self.admin = get_user_model().objects.create_user(
+            email="admin@example.com",
+            username="admin",
+            password="Admin!123",
+            user_type=UserType.ADMIN,
+            organizacao=self.organizacao,
+        )
+        self.url = reverse("associados:associados_adicionar")
+
+    def test_form_contains_hidden_next_with_back_href(self):
+        self.client.force_login(self.admin)
+        referer = "/associados/"
+        response = self.client.get(self.url, HTTP_REFERER=referer)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["back_href"], referer)
+        self.assertContains(response, f'name="next" value="{referer}"')
+
+    def test_success_redirects_to_next_when_valid(self):
+        self.client.force_login(self.admin)
+        next_url = "/organizacoes/"
+        response = self.client.post(
+            self.url,
+            {
+                "username": "novo_associado",
+                "email": "novo@example.com",
+                "contato": "Novo Associado",
+                "user_type": UserType.ASSOCIADO.value,
+                "password1": "StrongPass!1",
+                "password2": "StrongPass!1",
+                "next": next_url,
+            },
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, next_url)
+        self.assertTrue(
+            get_user_model().objects.filter(email="novo@example.com").exists()
+        )
+
+    def test_invalid_next_falls_back_to_default_success(self):
+        self.client.force_login(self.admin)
+        response = self.client.post(
+            self.url,
+            {
+                "username": "outro_associado",
+                "email": "outro@example.com",
+                "contato": "Outro Associado",
+                "user_type": UserType.ASSOCIADO.value,
+                "password1": "Another1!",
+                "password2": "Another1!",
+                "next": "http://example.com/externo",
+            },
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, "/associados/")
+        self.assertTrue(
+            get_user_model().objects.filter(email="outro@example.com").exists()
+        )


### PR DESCRIPTION
## Summary
- allow the associado creation view to honor a safe `next` destination when submitting the form
- persist the calculated back link in the associado form so the redirect target is preserved after saving
- add regression tests covering the redirect logic for the associado creation flow

## Testing
- pytest --override-ini addopts="-ra" tests/associados/test_user_create_view.py

------
https://chatgpt.com/codex/tasks/task_e_68e416bf5f208325b9d64b93610339a8