### PR TITLE
Reorganiza ordem dos campos no formulário de eventos

### DIFF
--- a/eventos/templates/eventos/partials/eventos/_form_fields.html
+++ b/eventos/templates/eventos/partials/eventos/_form_fields.html
@@ -1,5 +1,30 @@
 {% load widget_tweaks %}
 <div class="space-y-6">
+  <div class="grid gap-6 md:grid-cols-3">
+    <div>
+      {% include '_forms/field.html' with field=form.status %}
+    </div>
+    <div{% if coordinator_in_status_group %} class="space-y-6"{% endif %}>
+      <div id="nucleo-field-container">
+        {% include '_forms/field.html' with field=form.nucleo %}
+      </div>
+      {% if coordinator_in_status_group %}
+        <div>
+          {% include '_forms/field.html' with field=form.coordenador %}
+        </div>
+      {% endif %}
+    </div>
+    <div>
+      {% include '_forms/field.html' with field=form.publico_alvo %}
+    </div>
+  </div>
+
+  {% if not coordinator_in_status_group %}
+    <div>
+      {% include '_forms/field.html' with field=form.coordenador %}
+    </div>
+  {% endif %}
+
   <div>
     {% include '_forms/field.html' with field=form.titulo %}
   </div>
@@ -12,10 +37,6 @@
     {% include '_forms/field.html' with field=form.cronograma %}
   </div>
 
-  <div>
-    {% include '_forms/field.html' with field=form.local %}
-  </div>
-
   <div class="grid gap-6 md:grid-cols-2">
     <div>
       {% include '_forms/field.html' with field=form.data_inicio %}
@@ -23,6 +44,10 @@
     <div>
       {% include '_forms/field.html' with field=form.data_fim %}
     </div>
+  </div>
+
+  <div>
+    {% include '_forms/field.html' with field=form.local %}
   </div>
 
   <div class="grid gap-6 md:grid-cols-3">
@@ -36,40 +61,6 @@
       {% include '_forms/field.html' with field=form.cep %}
     </div>
   </div>
-
-  {% if coordinator_in_status_group %}
-    <div class="grid gap-6 md:grid-cols-3">
-      <div>
-        {% include '_forms/field.html' with field=form.status %}
-      </div>
-      <div>
-        {% include '_forms/field.html' with field=form.publico_alvo %}
-      </div>
-      <div class="space-y-6">
-        <div>
-          {% include '_forms/field.html' with field=form.coordenador %}
-        </div>
-        <div id="nucleo-field-container">
-          {% include '_forms/field.html' with field=form.nucleo %}
-        </div>
-      </div>
-    </div>
-  {% else %}
-    <div class="grid gap-6 md:grid-cols-3">
-      <div>
-        {% include '_forms/field.html' with field=form.status %}
-      </div>
-      <div>
-        {% include '_forms/field.html' with field=form.publico_alvo %}
-      </div>
-      <div id="nucleo-field-container">
-        {% include '_forms/field.html' with field=form.nucleo %}
-      </div>
-    </div>
-    <div>
-      {% include '_forms/field.html' with field=form.coordenador %}
-    </div>
-  {% endif %}
 
   <div class="grid gap-6 md:grid-cols-3">
     <div>


### PR DESCRIPTION
## Summary
- posiciona os campos de status e núcleo antes do título no formulário de eventos
- mantém o campo de coordenador alinhado ao núcleo quando necessário
- apresenta as datas de início e fim antes do campo de local

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e50714fda48325a7eece8ce5825243