### PR TITLE
Ajusta ordenação de campos no formulário de eventos

### DIFF
--- a/eventos/templates/eventos/partials/eventos/_form_fields.html
+++ b/eventos/templates/eventos/partials/eventos/_form_fields.html
@@ -46,6 +46,18 @@
     </div>
   </div>
 
+  <div class="grid gap-6 md:grid-cols-3">
+    <div>
+      {% include '_forms/field.html' with field=form.numero_convidados %}
+    </div>
+    <div>
+      {% include '_forms/field.html' with field=form.participantes_maximo %}
+    </div>
+    <div>
+      {% include '_forms/field.html' with field=form.valor_ingresso %}
+    </div>
+  </div>
+
   <div>
     {% include '_forms/field.html' with field=form.local %}
   </div>
@@ -64,13 +76,13 @@
 
   <div class="grid gap-6 md:grid-cols-3">
     <div>
-      {% include '_forms/field.html' with field=form.numero_convidados %}
+      {% include '_forms/field.html' with field=form.contato_nome %}
     </div>
     <div>
-      {% include '_forms/field.html' with field=form.participantes_maximo %}
+      {% include '_forms/field.html' with field=form.contato_email %}
     </div>
     <div>
-      {% include '_forms/field.html' with field=form.valor_ingresso %}
+      {% include '_forms/field.html' with field=form.contato_whatsapp %}
     </div>
   </div>
 
@@ -80,18 +92,6 @@
     </div>
     <div>
       {% include '_forms/field.html' with field=form.parcerias %}
-    </div>
-  </div>
-
-  <div class="grid gap-6 md:grid-cols-3">
-    <div>
-      {% include '_forms/field.html' with field=form.contato_nome %}
-    </div>
-    <div>
-      {% include '_forms/field.html' with field=form.contato_email %}
-    </div>
-    <div>
-      {% include '_forms/field.html' with field=form.contato_whatsapp %}
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- posiciona os campos de participantes e valor logo após a seleção de datas
- move a seção de briefing e parcerias para antes das informações adicionais

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e50a0982f883259984492189571f8a