### PR TITLE
Remove redundant back button on event detail

### DIFF
--- a/eventos/templates/eventos/detail.html
+++ b/eventos/templates/eventos/detail.html
@@ -92,8 +92,6 @@
             {% endif %}
           </dl>
           <div class="flex justify-end gap-3 pt-4 border-t border-[var(--border)]">
-            {% url 'eventos:calendario' as calendario_url %}
-            {% include '_components/back_button.html' with href=back_href fallback_href=calendario_url %}
             {% if perms.eventos.change_evento %}
               <a href="{% url 'eventos:evento_editar' object.pk %}"
                  class="btn btn-secondary"


### PR DESCRIPTION
## Summary
- remove the secondary back button from the event detail actions, keeping only the remaining page footer control

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e518da86e08325a59c1992a83fc20c