### PR TITLE
Refatora exclusão de núcleos para modal HTMX

### DIFF
--- a/nucleos/templates/nucleos/detail.html
+++ b/nucleos/templates/nucleos/detail.html
@@ -107,8 +107,12 @@
             {% if perms.nucleos.delete_nucleo or request.user.user_type == 'admin' or request.user.user_type == 'coordenador' %}
               <a
                 href="{% url 'nucleos:delete' object.pk %}"
+                hx-get="{% url 'nucleos:delete' object.pk %}"
+                hx-target="#modal"
+                hx-trigger="click"
+                hx-swap="innerHTML"
+                hx-on="htmx:beforeRequest: window.HubxModalTrigger = this;"
                 class="btn btn-danger"
-                hx-confirm="{% trans 'Deseja realmente excluir?' %}"
               >{% trans "Excluir" %}</a>
             {% endif %}
           </div>
@@ -144,7 +148,7 @@
         {% endif %}
       {% endwith %}
     </div>
-  
 
-  
+    <div id="modal" role="presentation" aria-live="polite"></div>
+
 {% endblock %}

--- a/nucleos/templates/nucleos/meus_list.html
+++ b/nucleos/templates/nucleos/meus_list.html
@@ -55,4 +55,6 @@
     </div>
   </div>
 
+  <div id="modal" role="presentation" aria-live="polite"></div>
+
 {% endblock %}

--- a/nucleos/templates/nucleos/nucleo_list.html
+++ b/nucleos/templates/nucleos/nucleo_list.html
@@ -35,4 +35,5 @@
       {% block list_footer %}{% endblock %}
     </div>
   </div>
+  <div id="modal" role="presentation" aria-live="polite"></div>
 {% endblock %}

--- a/nucleos/templates/nucleos/partials/membros_list.html
+++ b/nucleos/templates/nucleos/partials/membros_list.html
@@ -15,8 +15,12 @@
     {% if perms.nucleos.delete_nucleo or request.user.user_type == 'admin' or request.user.user_type == 'coordenador' %}
       <a
         href="{% url 'nucleos:delete' object.pk %}"
+        hx-get="{% url 'nucleos:delete' object.pk %}"
+        hx-target="#modal"
+        hx-trigger="click"
+        hx-swap="innerHTML"
+        hx-on="htmx:beforeRequest: window.HubxModalTrigger = this;"
         class="btn btn-danger"
-        hx-confirm="{% trans 'Deseja realmente excluir?' %}"
       >{% trans "Excluir" %}</a>
     {% endif %}
   </div>

--- a/nucleos/templates/nucleos/partials/nucleo_delete_modal.html
+++ b/nucleos/templates/nucleos/partials/nucleo_delete_modal.html
@@ -1,0 +1,105 @@
+{% load i18n %}
+{% with modal_title_id="modal-delete-title-"|add:objeto.pk|stringformat:"s" modal_description_id="modal-delete-description-"|add:objeto.pk|stringformat:"s" %}
+<div
+  class="modal !active"
+  role="dialog"
+  aria-modal="true"
+  aria-labelledby="{{ modal_title_id }}"
+  aria-describedby="{{ modal_description_id }}"
+  data-modal-root
+>
+  <div class="modal-content w-full max-w-lg rounded-lg bg-[var(--bg-primary)] shadow-xl focus:outline-none">
+    <div class="flex items-start justify-between gap-4 border-b border-[var(--border)] px-6 py-4">
+      <h2 id="{{ modal_title_id }}" class="text-xl font-semibold text-[var(--text-primary)]">{{ titulo }}</h2>
+      <button
+        type="button"
+        class="btn btn-secondary"
+        aria-label="{% trans 'Fechar modal' %}"
+        data-modal-dismiss
+      >
+        <span aria-hidden="true">&times;</span>
+      </button>
+    </div>
+    <div class="px-6 py-5 space-y-5">
+      <p id="{{ modal_description_id }}" class="text-sm text-[var(--text-secondary)]">
+        {{ mensagem }}
+      </p>
+      <form
+        method="post"
+        action="{{ form_action }}"
+        class="flex flex-col gap-3"
+        hx-post="{{ form_action }}"
+        hx-target="#modal"
+        hx-swap="none"
+      >
+        {% csrf_token %}
+        <div class="flex flex-col gap-3 sm:flex-row sm:justify-end sm:gap-4 border-t border-[var(--border)] pt-4">
+          <button
+            type="button"
+            class="btn btn-secondary"
+            data-modal-dismiss
+          >
+            {% trans 'Cancelar' %}
+          </button>
+          <button type="submit" class="btn btn-danger">
+            {{ submit_label }}
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+<script>
+  (function () {
+    const modalContainer = document.getElementById('modal');
+    if (!modalContainer) {
+      return;
+    }
+    const dialog = modalContainer.querySelector('[data-modal-root]');
+    if (!dialog) {
+      return;
+    }
+    const focusableSelectors = [
+      'a[href]','area[href]','input:not([disabled])','select:not([disabled])','textarea:not([disabled])',
+      'button:not([disabled])','[tabindex]:not([tabindex="-1"])'
+    ].join(',');
+    const focusableElements = Array.from(dialog.querySelectorAll(focusableSelectors)).filter((el) => !el.hasAttribute('hidden'));
+    const previouslyFocused = window.HubxModalTrigger instanceof HTMLElement ? window.HubxModalTrigger : document.activeElement;
+    function closeModal(event) {
+      if (event) {
+        event.preventDefault();
+      }
+      modalContainer.innerHTML = '';
+      if (previouslyFocused && typeof previouslyFocused.focus === 'function') {
+        previouslyFocused.focus();
+      }
+      if (window.HubxModalTrigger) {
+        window.HubxModalTrigger = null;
+      }
+    }
+    const cancelButtons = dialog.querySelectorAll('[data-modal-dismiss]');
+    cancelButtons.forEach((button) => {
+      button.addEventListener('click', closeModal);
+    });
+    modalContainer.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') {
+        closeModal(event);
+      }
+      if (event.key === 'Tab' && focusableElements.length) {
+        const first = focusableElements[0];
+        const last = focusableElements[focusableElements.length - 1];
+        if (event.shiftKey && document.activeElement === first) {
+          event.preventDefault();
+          last.focus();
+        } else if (!event.shiftKey && document.activeElement === last) {
+          event.preventDefault();
+          first.focus();
+        }
+      }
+    });
+    if (focusableElements.length) {
+      focusableElements[0].focus();
+    }
+  })();
+</script>
+{% endwith %}


### PR DESCRIPTION
## Summary
- add a reusable HTMX modal fragment for núcleo deletion with focus trapping, CSRF protection and translations
- adjust the delete view to serve the modal on HTMX requests and redirect after deletion via HX-Redirect
- update núcleo detail and list templates to load the modal container and trigger deletion via HTMX

## Testing
- python -m compileall nucleos/views.py

------
https://chatgpt.com/codex/tasks/task_e_68e5261cc41c83259dea54df94866411