### PR TITLE
Fix fallback URL for evento delete view

### DIFF
--- a/eventos/views.py
+++ b/eventos/views.py
@@ -406,7 +406,7 @@ class EventoDeleteView(LoginRequiredMixin, NoSuperadminMixin, AdminRequiredMixin
         context["evento"] = self.object
         context["title"] = _("Remover Evento")
         context["subtitle"] = getattr(self.object, "descricao", None)
-        fallback = reverse("eventos:detail", args=[self.object.pk])
+        fallback = reverse("eventos:evento_detalhe", args=[self.object.pk])
         context["back_href"] = resolve_back_href(self.request, fallback=fallback)
         return context
 


### PR DESCRIPTION
## Summary
- update the EventoDeleteView fallback link to use the correct `evento_detalhe` URL name

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e54080bad48325924d2a776aa0b5d9