### PR TITLE
Fix modal template variable resolution

### DIFF
--- a/feed/templates/feed/partials/post_delete_modal.html
+++ b/feed/templates/feed/partials/post_delete_modal.html
@@ -1,5 +1,6 @@
 {% load i18n %}
-{% with modal_suffix=post.pk|stringformat:"s" modal_title_id="modal-delete-title-"|add:modal_suffix modal_description_id="modal-delete-description-"|add:modal_suffix %}
+{% with modal_suffix=post.pk|stringformat:"s" %}
+{% with modal_title_id="modal-delete-title-"|add:modal_suffix modal_description_id="modal-delete-description-"|add:modal_suffix %}
 <div
   class="modal !active"
   role="dialog"
@@ -102,4 +103,5 @@
     }
   })();
 </script>
+{% endwith %}
 {% endwith %}


### PR DESCRIPTION
## Summary
- adjust the post deletion modal template to nest context assignments so computed IDs can reuse the generated suffix

## Testing
- `pytest feed/tests/test_views.py -k delete` *(fails: file or directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e54c20ec488325ac870b8b5e13b006