### PR TITLE
Refatora exclusão de organização para modal HTMX

### DIFF
--- a/organizacoes/templates/organizacoes/detail.html
+++ b/organizacoes/templates/organizacoes/detail.html
@@ -111,7 +111,16 @@
     {% endif %}
     {% if request.user.user_type == 'root' %}
       {% if perms.organizacoes.delete_organizacao %}
-        <a href="{% url 'organizacoes:delete' object.id %}" class="btn btn-danger">{% trans 'Excluir' %}</a>
+        <a
+          href="{% url 'organizacoes:delete' object.id %}"
+          hx-get="{% url 'organizacoes:delete' object.id %}"
+          hx-target="#modal"
+          hx-trigger="click"
+          hx-swap="innerHTML"
+          hx-on="htmx:beforeRequest: window.HubxModalTrigger = this;"
+          class="btn btn-danger"
+          aria-label="{% trans 'Excluir organização' %}"
+        >{% trans 'Excluir' %}</a>
       {% endif %}
       <form method="post" action="{% url 'organizacoes:toggle' object.id %}">
         {% csrf_token %}

--- a/organizacoes/templates/organizacoes/partials/organizacao_delete_modal.html
+++ b/organizacoes/templates/organizacoes/partials/organizacao_delete_modal.html
@@ -1,0 +1,105 @@
+{% load i18n %}
+{% with modal_title_id="modal-delete-organizacao-title-"|add:organizacao.pk|stringformat:"s" modal_description_id="modal-delete-organizacao-description-"|add:organizacao.pk|stringformat:"s" %}
+<div
+  class="modal !active"
+  role="dialog"
+  aria-modal="true"
+  aria-labelledby="{{ modal_title_id }}"
+  aria-describedby="{{ modal_description_id }}"
+  data-modal-root
+>
+  <div class="modal-content rounded-lg bg-[var(--bg-primary)] shadow-xl focus:outline-none">
+    <div class="flex items-start justify-between gap-4 border-b border-[var(--border)] px-6 py-4">
+      <h2 id="{{ modal_title_id }}" class="text-xl font-semibold text-[var(--text-primary)]">{{ titulo }}</h2>
+      <button
+        type="button"
+        class="btn btn-secondary"
+        aria-label="{% trans 'Fechar modal' %}"
+        data-modal-dismiss
+      >
+        <span aria-hidden="true">&times;</span>
+      </button>
+    </div>
+    <div class="px-6 py-5 space-y-5">
+      <p id="{{ modal_description_id }}" class="text-sm text-[var(--text-secondary)]">
+        {{ mensagem|safe }}
+      </p>
+      <form
+        method="post"
+        action="{{ form_action }}"
+        class="flex flex-col gap-3"
+        hx-post="{{ form_action }}"
+        hx-target="#modal"
+        hx-swap="none"
+      >
+        {% csrf_token %}
+        <div class="flex flex-col gap-3 sm:flex-row sm:justify-end sm:gap-4 border-t border-[var(--border)] pt-4">
+          <button
+            type="button"
+            class="btn btn-secondary"
+            data-modal-dismiss
+          >
+            {% trans 'Cancelar' %}
+          </button>
+          <button type="submit" class="btn btn-danger">
+            {{ submit_label }}
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+<script>
+  (function () {
+    const modalContainer = document.getElementById('modal');
+    if (!modalContainer) {
+      return;
+    }
+    const dialog = modalContainer.querySelector('[data-modal-root]');
+    if (!dialog) {
+      return;
+    }
+    const focusableSelectors = [
+      'a[href]','area[href]','input:not([disabled])','select:not([disabled])','textarea:not([disabled])',
+      'button:not([disabled])','[tabindex]:not([tabindex="-1"])'
+    ].join(',');
+    const focusableElements = Array.from(dialog.querySelectorAll(focusableSelectors)).filter((el) => !el.hasAttribute('hidden'));
+    const previouslyFocused = window.HubxModalTrigger instanceof HTMLElement ? window.HubxModalTrigger : document.activeElement;
+    function closeModal(event) {
+      if (event) {
+        event.preventDefault();
+      }
+      modalContainer.innerHTML = '';
+      if (previouslyFocused && typeof previouslyFocused.focus === 'function') {
+        previouslyFocused.focus();
+      }
+      if (window.HubxModalTrigger) {
+        window.HubxModalTrigger = null;
+      }
+    }
+    const cancelButtons = dialog.querySelectorAll('[data-modal-dismiss]');
+    cancelButtons.forEach((button) => {
+      button.addEventListener('click', closeModal);
+    });
+    modalContainer.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') {
+        closeModal(event);
+      }
+      if (event.key === 'Tab' && focusableElements.length) {
+        const first = focusableElements[0];
+        const last = focusableElements[focusableElements.length - 1];
+        if (event.shiftKey && document.activeElement === first) {
+          event.preventDefault();
+          last.focus();
+        } else if (!event.shiftKey && document.activeElement === last) {
+          event.preventDefault();
+          first.focus();
+        }
+      }
+    });
+    if (focusableElements.length) {
+      focusableElements[0].focus();
+    }
+  })();
+</script>
+{% endwith %}


### PR DESCRIPTION
## Summary
- implementa modal de confirmação carregado via HTMX para exclusão de organizações
- ajusta a view de remoção para responder com o modal e redirecionar após exclusão
- atualiza a ação de exclusão nos detalhes para acionar o modal com atributos de acessibilidade

## Testing
- pytest organizacoes/tests/test_list_cards.py -q *(interrompido manualmente após ~13s)*

------
https://chatgpt.com/codex/tasks/task_e_68e5506aa38c8325ae1343e42864e7f3