### PR TITLE
Refatore exclusão de templates de notificação para modal htmx

### DIFF
--- a/notificacoes/templates/notificacoes/partials/template_delete_modal.html
+++ b/notificacoes/templates/notificacoes/partials/template_delete_modal.html
@@ -1,0 +1,117 @@
+{% load i18n %}
+{% with identifier=modal_identifier|default:'template' %}
+{% with identifier=identifier|stringformat:"s" %}
+{% with modal_title_id="modal-delete-title-"|add:identifier modal_description_id="modal-delete-description-"|add:identifier %}
+<div
+  class="modal !active"
+  role="dialog"
+  aria-modal="true"
+  aria-labelledby="{{ modal_title_id }}"
+  aria-describedby="{{ modal_description_id }}"
+  data-modal-root
+>
+  <div class="modal-content rounded-lg bg-[var(--bg-primary)] shadow-xl focus:outline-none">
+    <div class="flex items-start justify-between gap-4 border-b border-[var(--border)] px-6 py-4">
+      <h2 id="{{ modal_title_id }}" class="text-xl font-semibold text-[var(--text-primary)]">{{ titulo }}</h2>
+      <button
+        type="button"
+        class="btn btn-secondary"
+        aria-label="{% trans 'Fechar modal' %}"
+        data-modal-dismiss
+      >
+        <span aria-hidden="true">&times;</span>
+      </button>
+    </div>
+    <div class="px-6 py-5 space-y-5">
+      <p id="{{ modal_description_id }}" class="text-sm text-[var(--text-secondary)] space-y-2">
+        <span>{{ mensagem }}</span>
+        {% if pergunta %}
+          <span class="block text-[var(--text-primary)]">{{ pergunta }}</span>
+        {% endif %}
+      </p>
+      <form
+        method="post"
+        action="{{ form_action }}"
+        class="flex flex-col gap-3"
+        hx-post="{{ form_action }}"
+        hx-target="#modal"
+        hx-swap="none"
+      >
+        {% csrf_token %}
+        <div class="flex flex-col gap-3 sm:flex-row sm:justify-end sm:gap-4 border-t border-[var(--border)] pt-4">
+          <button
+            type="button"
+            class="btn btn-secondary"
+            data-modal-dismiss
+          >
+            {% trans 'Cancelar' %}
+          </button>
+          <button type="submit" class="btn btn-danger">
+            {{ submit_label }}
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+<script>
+  (function () {
+    const modalContainer = document.getElementById('modal');
+    if (!modalContainer) {
+      return;
+    }
+    const dialog = modalContainer.querySelector('[data-modal-root]');
+    if (!dialog) {
+      return;
+    }
+    const focusableSelectors = [
+      'a[href]',
+      'area[href]',
+      'input:not([disabled])',
+      'select:not([disabled])',
+      'textarea:not([disabled])',
+      'button:not([disabled])',
+      '[tabindex]:not([tabindex="-1"])'
+    ].join(',');
+    const focusableElements = Array.from(dialog.querySelectorAll(focusableSelectors)).filter((el) => !el.hasAttribute('hidden'));
+    const previouslyFocused = window.HubxModalTrigger instanceof HTMLElement ? window.HubxModalTrigger : document.activeElement;
+    function closeModal(event) {
+      if (event) {
+        event.preventDefault();
+      }
+      modalContainer.innerHTML = '';
+      if (previouslyFocused && typeof previouslyFocused.focus === 'function') {
+        previouslyFocused.focus();
+      }
+      if (window.HubxModalTrigger) {
+        window.HubxModalTrigger = null;
+      }
+    }
+    const cancelButtons = dialog.querySelectorAll('[data-modal-dismiss]');
+    cancelButtons.forEach((button) => {
+      button.addEventListener('click', closeModal);
+    });
+    modalContainer.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') {
+        closeModal(event);
+      }
+      if (event.key === 'Tab' && focusableElements.length) {
+        const first = focusableElements[0];
+        const last = focusableElements[focusableElements.length - 1];
+        if (event.shiftKey && document.activeElement === first) {
+          event.preventDefault();
+          last.focus();
+        } else if (!event.shiftKey && document.activeElement === last) {
+          event.preventDefault();
+          first.focus();
+        }
+      }
+    });
+    if (focusableElements.length) {
+      focusableElements[0].focus();
+    }
+  })();
+</script>
+{% endwith %}
+{% endwith %}
+{% endwith %}

--- a/notificacoes/templates/notificacoes/templates_list.html
+++ b/notificacoes/templates/notificacoes/templates_list.html
@@ -47,10 +47,16 @@
                           <button type="submit" class="btn btn-secondary btn-sm">{% trans 'Ativar' %}</button>
                         {% endif %}
                       </form>
-                      <form method="post" action="{% url 'notificacoes:template_delete' tpl.codigo %}">
-                        {% csrf_token %}
-                        <button type="submit" class="btn btn-danger btn-sm">{% trans 'Excluir' %}</button>
-                      </form>
+                      <a
+                        href="{% url 'notificacoes:template_delete' tpl.codigo %}"
+                        hx-get="{% url 'notificacoes:template_delete' tpl.codigo %}"
+                        hx-target="#modal"
+                        hx-trigger="click"
+                        hx-swap="innerHTML"
+                        hx-on="htmx:beforeRequest: window.HubxModalTrigger = this;"
+                        class="btn btn-danger btn-sm"
+                        aria-haspopup="dialog"
+                      >{% trans 'Excluir' %}</a>
                     </div>
                   </td>
                 </tr>
@@ -69,4 +75,5 @@
       </div>
     </article>
   </div>
+  <div id="modal"></div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- adiciona parcial de modal para confirmar exclusão de templates via htmx
- ajusta view de exclusão para responder com o modal e redirecionar após POSTs htmx
- atualiza listagem de templates para acionar o modal mantendo fallback sem JavaScript

## Testing
- python -m compileall notificacoes

------
https://chatgpt.com/codex/tasks/task_e_68e5532490cc8325b8fa5c3fbd079b33