### PR TITLE
Add HTMX account deletion modal

### DIFF
--- a/accounts/templates/accounts/delete_account_confirm.html
+++ b/accounts/templates/accounts/delete_account_confirm.html
@@ -2,43 +2,91 @@
 {% load i18n %}
 {% block title %}{% trans "Excluir Conta" %} - HubX{% endblock %}
 {% block content %}
-<section class="max-w-md mx-auto px-4 py-12 bg-[var(--bg-primary)]">
+<section class="max-w-xl mx-auto px-4 py-12 bg-[var(--bg-primary)]">
   <h1 class="text-2xl font-bold text-center mb-6 text-[var(--text-primary)]">{% trans "Excluir Conta" %}</h1>
-  <p class="text-[var(--error)] bg-[var(--error-light)] rounded-xl px-4 py-2 mb-4 text-sm">
-    {% trans "A exclusão da conta é permanente e você perderá acesso aos seus dados." %}
-  </p>
-  <form method="post" class="rounded-2xl card p-6 space-y-4 bg-[var(--bg-secondary)]">
-    {% csrf_token %}
+  <div class="rounded-2xl card p-6 space-y-5 bg-[var(--bg-secondary)]">
+    <p class="text-sm text-[var(--error)] bg-[var(--error-light)] rounded-xl px-4 py-3">
+      {% blocktrans %}
+        A exclusão da conta é permanente e removerá todos os dados associados. Esta ação não pode ser desfeita.
+      {% endblocktrans %}
+    </p>
     {% if not is_self %}
       <p class="text-sm text-[var(--text-secondary)]">
         {% blocktrans with nome=target_user.get_full_name %}
           Você está excluindo a conta de {{ nome }}.
         {% endblocktrans %}
       </p>
-      <input type="hidden" name="public_id" value="{{ target_user.public_id }}" />
-      <input type="hidden" name="username" value="{{ target_user.username }}" />
     {% endif %}
-    <div>
-      <label for="confirm" class="block text-sm font-medium text-[var(--text-secondary)]">{% trans "Digite EXCLUIR para confirmar" %}</label>
-      <input
-        type="text"
-        name="confirm"
-        id="confirm"
-        required
-        class="w-full rounded-md border px-3 py-2 bg-[var(--bg-secondary)] border-[var(--border)] text-[var(--text-primary)]"
-        placeholder="EXCLUIR"
-        aria-label="{% trans 'Confirmação' %}"
-        aria-invalid="false"
-      />
-    </div>
-    <div class="text-right">
-      <button
-        type="submit"
-        class="rounded-xl px-4 py-2 text-white bg-[var(--error)] hover:bg-[var(--color-error-700)]"
-      >
-        {% trans "Confirmar exclusão" %}
-      </button>
-    </div>
-  </form>
+    <form method="post" class="space-y-5">
+      {% csrf_token %}
+      {% if not is_self %}
+        <input type="hidden" name="public_id" value="{{ target_user.public_id }}" />
+        <input type="hidden" name="username" value="{{ target_user.username }}" />
+      {% endif %}
+      <div class="space-y-2">
+        <label for="confirm" class="block text-sm font-medium text-[var(--text-secondary)]">
+          {% trans "Digite EXCLUIR para confirmar" %}
+        </label>
+        <input
+          type="text"
+          name="confirm"
+          id="confirm"
+          required
+          inputmode="latin"
+          autocomplete="off"
+          autocapitalize="characters"
+          spellcheck="false"
+          placeholder="{{ confirmation_token }}"
+          class="w-full rounded-md border px-3 py-2 bg-[var(--bg-primary)] border-[var(--border)] text-[var(--text-primary)] focus:border-[var(--primary)] focus:ring-2 focus:ring-[var(--primary-light)]"
+          aria-describedby="delete-account-helper"
+          data-confirm-input
+          data-confirm-token="{{ confirmation_token }}"
+        />
+        <p id="delete-account-helper" class="text-xs text-[var(--text-tertiary)]">
+          {% blocktrans with token=confirmation_token %}
+            Digite {{ token }} exatamente como mostrado para habilitar a exclusão.
+          {% endblocktrans %}
+        </p>
+      </div>
+      <div class="flex justify-end">
+        <button
+          type="submit"
+          class="btn btn-danger"
+          data-confirm-submit
+          disabled
+          aria-disabled="true"
+        >
+          {% trans "Confirmar exclusão" %}
+        </button>
+      </div>
+    </form>
+  </div>
 </section>
+{% endblock %}
+
+{% block scripts %}
+  {{ block.super }}
+  <script>
+    (function () {
+      const input = document.querySelector('[data-confirm-input]');
+      const submit = document.querySelector('[data-confirm-submit]');
+      if (!input || !submit) {
+        return;
+      }
+      const expectedToken = (input.getAttribute('data-confirm-token') || '').trim().toUpperCase();
+      const updateState = () => {
+        const normalized = (input.value || '').trim().toUpperCase();
+        if (input.value !== normalized) {
+          input.value = normalized;
+        }
+        const isValid = normalized === expectedToken && expectedToken.length > 0;
+        submit.disabled = !isValid;
+        submit.setAttribute('aria-disabled', String(!isValid));
+      };
+      input.addEventListener('input', updateState);
+      input.addEventListener('blur', updateState);
+      updateState();
+      input.focus();
+    })();
+  </script>
 {% endblock %}

--- a/accounts/templates/accounts/partials/account_delete_modal.html
+++ b/accounts/templates/accounts/partials/account_delete_modal.html
@@ -1,0 +1,180 @@
+{% load i18n %}
+{% with modal_title_id="modal-delete-account-title" modal_description_id="modal-delete-account-description" %}
+<div
+  class="modal !active"
+  role="dialog"
+  aria-modal="true"
+  aria-labelledby="{{ modal_title_id }}"
+  aria-describedby="{{ modal_description_id }}"
+  data-modal-root
+>
+  <div class="modal-content rounded-lg bg-[var(--bg-primary)] shadow-xl focus:outline-none">
+    <div class="flex items-start justify-between gap-4 border-b border-[var(--border)] px-6 py-4">
+      <h2 id="{{ modal_title_id }}" class="text-xl font-semibold text-[var(--text-primary)]">
+        {% trans "Excluir conta" %}
+      </h2>
+      <button
+        type="button"
+        class="btn btn-secondary"
+        aria-label="{% trans 'Fechar modal' %}"
+        data-modal-dismiss
+      >
+        <span aria-hidden="true">&times;</span>
+      </button>
+    </div>
+    <div class="px-6 py-5 space-y-5">
+      <p id="{{ modal_description_id }}" class="text-sm text-[var(--text-secondary)]">
+        {% blocktrans %}
+          A exclusão da conta é permanente e removerá todos os dados associados. Esta ação não pode ser desfeita.
+        {% endblocktrans %}
+      </p>
+      {% if not is_self %}
+        <p class="text-sm text-[var(--text-secondary)]">
+          {% blocktrans with nome=target_user.get_full_name %}
+            Você está prestes a excluir a conta de {{ nome }}.
+          {% endblocktrans %}
+        </p>
+      {% endif %}
+      {% if error_message %}
+        <div class="alert alert-error" role="alert">
+          <p class="text-sm">{{ error_message }}</p>
+        </div>
+      {% endif %}
+      <form
+        method="post"
+        action="{{ form_action|default:request.get_full_path }}"
+        class="space-y-4"
+        hx-post="{{ form_action|default:request.get_full_path }}"
+        hx-target="#modal"
+        hx-swap="innerHTML"
+      >
+        {% csrf_token %}
+        {% if not is_self %}
+          <input type="hidden" name="public_id" value="{{ target_user.public_id }}" />
+          <input type="hidden" name="username" value="{{ target_user.username }}" />
+        {% endif %}
+        <div class="space-y-2">
+          <label for="confirm" class="block text-sm font-medium text-[var(--text-secondary)]">
+            {% trans "Digite EXCLUIR para confirmar" %}
+          </label>
+          <input
+            type="text"
+            name="confirm"
+            id="confirm"
+            required
+            inputmode="latin"
+            autocomplete="off"
+            autocapitalize="characters"
+            spellcheck="false"
+            value="{{ confirm_value|default_if_none:'' }}"
+            placeholder="{{ confirmation_token }}"
+            class="w-full rounded-md border px-3 py-2 bg-[var(--bg-secondary)] border-[var(--border)] text-[var(--text-primary)] focus:border-[var(--primary)] focus:ring-2 focus:ring-[var(--primary-light)]"
+            aria-describedby="delete-confirm-helper"
+            data-confirm-input
+            data-confirm-token="{{ confirmation_token }}"
+          />
+          <p id="delete-confirm-helper" class="text-xs text-[var(--text-tertiary)]">
+            {% blocktrans with token=confirmation_token %}
+              Digite {{ token }} exatamente como mostrado para habilitar a exclusão.
+            {% endblocktrans %}
+          </p>
+        </div>
+        <div class="flex flex-col gap-3 sm:flex-row sm:justify-end sm:gap-4 border-t border-[var(--border)] pt-4">
+          <button
+            type="button"
+            class="btn btn-secondary"
+            data-modal-dismiss
+          >
+            {% trans "Cancelar" %}
+          </button>
+          <button
+            type="submit"
+            class="btn btn-danger"
+            data-confirm-submit
+            disabled
+            aria-disabled="true"
+          >
+            {% trans "Confirmar exclusão" %}
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+<script>
+  (function () {
+    const modalContainer = document.getElementById('modal');
+    if (!modalContainer) {
+      return;
+    }
+    const dialog = modalContainer.querySelector('[data-modal-root]');
+    if (!dialog) {
+      return;
+    }
+    const focusableSelectors = [
+      'a[href]',
+      'area[href]',
+      'input:not([disabled])',
+      'select:not([disabled])',
+      'textarea:not([disabled])',
+      'button:not([disabled])',
+      '[tabindex]:not([tabindex="-1"])'
+    ].join(',');
+    const focusableElements = Array.from(dialog.querySelectorAll(focusableSelectors)).filter((el) => !el.hasAttribute('hidden'));
+    const previouslyFocused = window.HubxModalTrigger instanceof HTMLElement ? window.HubxModalTrigger : document.activeElement;
+    function closeModal(event) {
+      if (event) {
+        event.preventDefault();
+      }
+      modalContainer.innerHTML = '';
+      if (previouslyFocused && typeof previouslyFocused.focus === 'function') {
+        previouslyFocused.focus();
+      }
+      if (window.HubxModalTrigger) {
+        window.HubxModalTrigger = null;
+      }
+    }
+    const cancelButtons = dialog.querySelectorAll('[data-modal-dismiss]');
+    cancelButtons.forEach((button) => {
+      button.addEventListener('click', closeModal);
+    });
+    modalContainer.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') {
+        closeModal(event);
+      }
+      if (event.key === 'Tab' && focusableElements.length) {
+        const first = focusableElements[0];
+        const last = focusableElements[focusableElements.length - 1];
+        if (event.shiftKey && document.activeElement === first) {
+          event.preventDefault();
+          last.focus();
+        } else if (!event.shiftKey && document.activeElement === last) {
+          event.preventDefault();
+          first.focus();
+        }
+      }
+    });
+
+    const confirmInput = dialog.querySelector('[data-confirm-input]');
+    const submitButton = dialog.querySelector('[data-confirm-submit]');
+    if (confirmInput && submitButton) {
+      const expectedToken = (confirmInput.getAttribute('data-confirm-token') || '').trim().toUpperCase();
+      const updateState = () => {
+        const normalized = (confirmInput.value || '').trim().toUpperCase();
+        if (confirmInput.value !== normalized) {
+          confirmInput.value = normalized;
+        }
+        const isValid = normalized === expectedToken && expectedToken.length > 0;
+        submitButton.disabled = !isValid;
+        submitButton.setAttribute('aria-disabled', String(!isValid));
+      };
+      confirmInput.addEventListener('input', updateState);
+      confirmInput.addEventListener('blur', updateState);
+      updateState();
+      confirmInput.focus();
+    } else if (focusableElements.length) {
+      focusableElements[0].focus();
+    }
+  })();
+</script>
+{% endwith %}

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -73,6 +73,7 @@ urlpatterns = [
     ),
 
     path("perfil/<str:username>/", views.perfil_publico, name="perfil_publico_username"),
+    path("excluir/modal/", views.excluir_conta, name="delete_account"),
     path("excluir/", views.excluir_conta, name="excluir_conta"),
     path(
         "confirmar-email/<str:token>/",

--- a/configuracoes/templates/configuracoes/_partials/seguranca.html
+++ b/configuracoes/templates/configuracoes/_partials/seguranca.html
@@ -57,3 +57,29 @@
     {% endif %}
   </div>
 </article>
+
+<article class="card" aria-labelledby="delete-account-heading">
+  <div class="card-body space-y-3">
+    <h2 id="delete-account-heading" class="text-lg font-semibold text-[var(--text-primary)]">
+      {% trans 'Excluir conta' %}
+    </h2>
+    <p class="text-sm text-[var(--text-secondary)]">
+      {% blocktrans %}
+        A exclusão é permanente e remove todo o histórico da sua conta. Digite "EXCLUIR" para confirmar quando o modal for aberto.
+      {% endblocktrans %}
+    </p>
+    <div>
+      <a
+        href="{% url 'accounts:excluir_conta' %}"
+        hx-get="{% url 'accounts:delete_account' %}"
+        hx-target="#modal"
+        hx-trigger="click"
+        hx-swap="innerHTML"
+        hx-on="htmx:beforeRequest: window.HubxModalTrigger = this;"
+        class="btn btn-danger"
+      >
+        {% trans 'Excluir conta' %}
+      </a>
+    </div>
+  </div>
+</article>

--- a/configuracoes/templates/configuracoes/configuracao_form.html
+++ b/configuracoes/templates/configuracoes/configuracao_form.html
@@ -36,6 +36,8 @@
     </div>
   </article>
 
+  <div id="modal" aria-live="polite"></div>
+
 {% endblock %}
 
 {% block scripts %}


### PR DESCRIPTION
## Summary
- add an HTMX-enabled account deletion modal with confirmation guard and focus management
- update the delete view to serve the modal for HTMX requests and send HX-Redirect responses
- expose the modal from the security settings page and keep the standalone confirmation view usable

## Testing
- pytest --no-cov tests/accounts/test_delete_account_view.py

------
https://chatgpt.com/codex/tasks/task_e_68e554e2c6c88325b75936f85ae597d5