### PR TITLE
Add neural hero backgrounds to auth templates

### DIFF
--- a/accounts/templates/login/login.html
+++ b/accounts/templates/login/login.html
@@ -4,7 +4,10 @@
 {% block title %}{% trans "Entrar" %} - HubX{% endblock %}
 
 {% block hero %}
-  {% include '_components/hero.html' with title=_('Bem-vindo de volta') %}
+  {% include '_components/hero_auth.html' with
+    title=_('Bem-vindo de volta')
+    subtitle=_('Entre para acessar sua conta e conectar-se à sua rede.')
+  %}
 {% endblock %}
 
 {% block content %}
@@ -12,7 +15,7 @@
   <div class="card" role="dialog">
     <div class="card-body space-y-6">
       <p class="text-center text-sm text-[var(--text-secondary)]">
-        {% trans "Entre para acessar sua conta e conectar-se à sua rede" %}
+        {% trans "Informe seu e-mail e senha cadastrados para continuar." %}
       </p>
 
       {% if form.non_field_errors %}

--- a/accounts/templates/register/_hero.html
+++ b/accounts/templates/register/_hero.html
@@ -1,0 +1,6 @@
+{% load i18n %}
+{% include '_components/hero_auth.html' with
+    title=title|default:_('Crie sua conta no HubX')
+    subtitle=subtitle|default:_('Siga as etapas para configurar sua presença e conectar-se à comunidade.')
+    helper_text=helper_text
+%}

--- a/accounts/templates/register/cpf.html
+++ b/accounts/templates/register/cpf.html
@@ -4,7 +4,7 @@
 {% block title %}{% trans "Registro - CPF" %} | Hubx{% endblock %}
 
 {% block hero %}
-  {% include '_components/hero.html' %}
+  {% include 'register/_hero.html' %}
 {% endblock %}
 
 {% block content %}

--- a/accounts/templates/register/email.html
+++ b/accounts/templates/register/email.html
@@ -4,7 +4,7 @@
 {% block title %}{% trans "Registro - Email" %} | Hubx{% endblock %}
 
 {% block hero %}
-  {% include '_components/hero.html' %}
+  {% include 'register/_hero.html' %}
 {% endblock %}
 
 {% block content %}

--- a/accounts/templates/register/foto.html
+++ b/accounts/templates/register/foto.html
@@ -4,7 +4,7 @@
 {% block title %}{% trans "Registro - Foto" %} | Hubx{% endblock %}
 
 {% block hero %}
-  {% include '_components/hero.html' %}
+  {% include 'register/_hero.html' %}
 {% endblock %}
 
 {% block content %}

--- a/accounts/templates/register/nome.html
+++ b/accounts/templates/register/nome.html
@@ -4,7 +4,7 @@
 {% block title %}{% trans "Registro - Nome" %} | Hubx{% endblock %}
 
 {% block hero %}
-  {% include '_components/hero.html' %}
+  {% include 'register/_hero.html' %}
 {% endblock %}
 
 {% block content %}

--- a/accounts/templates/register/onboarding.html
+++ b/accounts/templates/register/onboarding.html
@@ -4,7 +4,10 @@
 {% block title %}{% trans "Cadastre-se" %} - HubX{% endblock %}
 
 {% block hero %}
-  {% include '_components/hero.html' %}
+  {% include 'register/_hero.html' with
+    title=_('Junte-se ao HubX')
+    subtitle=_('Conecte-se com comunidades e organizações em uma única plataforma.')
+  %}
 {% endblock %}
 
 {% block content %}
@@ -22,7 +25,7 @@
         </div>
         <div class="space-y-2">
           <h1 class="text-2xl font-bold text-[var(--text-primary)]">{% trans "Junte-se ao HubX" %}</h1>
-          <p class="text-[var(--text-secondary)]">{% trans "Conecte-se com comunidades e organizações em uma única plataforma" %}</p>
+          <p class="text-[var(--text-secondary)]">{% trans "Escolha a melhor forma de começar sua jornada no HubX." %}</p>
         </div>
       </div>
 

--- a/accounts/templates/register/registro_sucesso.html
+++ b/accounts/templates/register/registro_sucesso.html
@@ -4,7 +4,10 @@
 {% block title %}{% trans "Registro Concluído" %} | Hubx{% endblock %}
 
 {% block hero %}
-  {% include '_components/hero.html' %}
+  {% include 'register/_hero.html' with
+    title=_('Registro concluído')
+    subtitle=_('Verifique seu e-mail para ativar sua conta e começar a utilizar o HubX.')
+  %}
 {% endblock %}
 
 {% block content %}

--- a/accounts/templates/register/senha.html
+++ b/accounts/templates/register/senha.html
@@ -4,7 +4,7 @@
 {% block title %}{% trans "Registro - Senha" %} | Hubx{% endblock %}
 
 {% block hero %}
-  {% include '_components/hero.html' %}
+  {% include 'register/_hero.html' %}
 {% endblock %}
 
 {% block content %}

--- a/accounts/templates/register/termos.html
+++ b/accounts/templates/register/termos.html
@@ -4,7 +4,7 @@
 {% block title %}{% trans "Registro - Termos" %} | Hubx{% endblock %}
 
 {% block hero %}
-  {% include '_components/hero.html' %}
+  {% include 'register/_hero.html' %}
 {% endblock %}
 
 {% block content %}

--- a/accounts/templates/register/token.html
+++ b/accounts/templates/register/token.html
@@ -4,7 +4,7 @@
 {% block title %}{% trans "Token de Convite" %} - HubX{% endblock %}
 
 {% block hero %}
-  {% include '_components/hero.html' %}
+  {% include 'register/_hero.html' %}
 {% endblock %}
 
 {% block content %}

--- a/accounts/templates/register/usuario.html
+++ b/accounts/templates/register/usuario.html
@@ -4,7 +4,7 @@
 {% block title %}{% trans "Registro - Usuário" %} | Hubx{% endblock %}
 
 {% block hero %}
-  {% include '_components/hero.html' %}
+  {% include 'register/_hero.html' %}
 {% endblock %}
 
 {% block content %}

--- a/templates/_components/hero_auth.html
+++ b/templates/_components/hero_auth.html
@@ -1,0 +1,31 @@
+{% load i18n %}
+{% with
+  hero_title=title|default:_('Conecte-se ao HubX')
+  hero_subtitle=subtitle|default:_('Acesse ferramentas para fortalecer sua rede e comunidade.')
+  hero_helper_text=helper_text
+  hero_alignment=alignment|default:'center'
+  hero_container_classes=container_classes|default:'max-w-4xl mx-auto w-full px-4 py-12 md:py-16'
+  hero_content_classes=content_classes|default:'flex flex-col items-center gap-6'
+  hero_title_classes=title_classes|default:'text-4xl md:text-5xl font-bold text-white text-center'
+  hero_subtitle_classes=subtitle_classes|default:'text-lg text-white/90 max-w-2xl mx-auto text-center'
+  hero_helper_classes=helper_classes|default:'mt-6 text-base text-white/80 text-center'
+  hero_section_classes=section_classes|default:'bg-gradient-to-br from-[var(--hero-from)] to-[var(--hero-to)] text-white'
+  hero_action_template=action_template|default:''
+  hero_actions=actions|default:''
+%}
+  {% include '_components/hero.html' with
+      title=hero_title
+      subtitle=hero_subtitle
+      helper_text=hero_helper_text
+      neural_background='home'
+      alignment=hero_alignment
+      container_classes=hero_container_classes
+      content_classes=hero_content_classes
+      title_classes=hero_title_classes
+      subtitle_classes=hero_subtitle_classes
+      helper_classes=hero_helper_classes
+      section_classes=hero_section_classes
+      action_template=hero_action_template
+      actions=hero_actions
+  %}
+{% endwith %}


### PR DESCRIPTION
## Summary
- add a reusable authentication hero component with the home neural background
- update login and registration templates to adopt the new hero and refreshed copy

## Testing
- not run (templates only)

------
https://chatgpt.com/codex/tasks/task_e_68e55dfff67c83259dc63348d6170cd8