### PR TITLE
Link header notifications icon to history page

### DIFF
--- a/notificacoes/templates/notificacoes/historico_list.html
+++ b/notificacoes/templates/notificacoes/historico_list.html
@@ -3,7 +3,7 @@
 {% block title %}{% trans 'Histórico de Notificações' %} | HubX{% endblock %}
 
 {% block hero %}
-  {% include '_components/hero.html' with title=_('Histórico de Notificações') %}
+  {% include '_components/hero.html' with title=_('Histórico de Notificações') subtitle=_('Consulte notificações recorrentes enviadas para os núcleos.') %}
 {% endblock %}
 
 {% block content %}

--- a/templates/_partials/header.html
+++ b/templates/_partials/header.html
@@ -27,7 +27,7 @@
         <span class="sr-only">{% trans "Escuro" %}</span>
       </button>
     </div>
-    <a href="#" class="relative" aria-label="{% trans 'Notificações' %}">
+    <a href="{% url 'notificacoes:historico' %}" class="relative" aria-label="{% trans 'Notificações' %}">
       <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
         <path d="M10 21a1 1 0 0 0 2 0" />
         <path d="M18 8a6 6 0 1 0-12 0c0 7-3 9-3 9h18s-3-2-3-9" />


### PR DESCRIPTION
## Summary
- point the header notifications bell to the notifications history view
- add a subtitle to the notifications history hero to keep the page aligned with the system template pattern

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e571f1890483259d8e6f41edc24865