### PR TITLE
Add filter form to histórico de notificações view

### DIFF
--- a/notificacoes/forms.py
+++ b/notificacoes/forms.py
@@ -1,8 +1,9 @@
 from __future__ import annotations  # pragma: no cover
 
 from django import forms
+from django.utils.translation import gettext_lazy as _
 
-from .models import NotificationTemplate
+from .models import Canal, Frequencia, NotificationTemplate
 
 
 class NotificationTemplateForm(forms.ModelForm):
@@ -20,3 +21,47 @@ class NotificationTemplateForm(forms.ModelForm):
         if self.instance and self.instance.pk:
             return self.instance.codigo
         return self.cleaned_data["codigo"]
+
+
+class HistoricoNotificacaoFilterForm(forms.Form):
+    inicio = forms.DateField(
+        label=_("Data inicial"),
+        required=False,
+        widget=forms.DateInput(attrs={"type": "date"}),
+    )
+    fim = forms.DateField(
+        label=_("Data final"),
+        required=False,
+        widget=forms.DateInput(attrs={"type": "date"}),
+    )
+    canal = forms.ChoiceField(
+        label=_("Canal"),
+        required=False,
+        choices=[("", _("Todos os canais"))] + list(Canal.choices),
+    )
+    frequencia = forms.ChoiceField(
+        label=_("Frequência"),
+        required=False,
+        choices=[("", _("Todas as frequências"))] + list(Frequencia.choices),
+    )
+    ordenacao = forms.ChoiceField(
+        label=_("Ordenação"),
+        required=False,
+        choices=[
+            ("-enviado_em", _("Mais recentes primeiro")),
+            ("enviado_em", _("Mais antigas primeiro")),
+        ],
+        initial="-enviado_em",
+    )
+
+    def clean_canal(self) -> str:
+        canal = self.cleaned_data["canal"]
+        return canal or ""
+
+    def clean_frequencia(self) -> str:
+        frequencia = self.cleaned_data["frequencia"]
+        return frequencia or ""
+
+    def clean_ordenacao(self) -> str:
+        ordenacao = self.cleaned_data["ordenacao"]
+        return ordenacao or "-enviado_em"


### PR DESCRIPTION
## Summary
- add a dedicated form to capture histórico de notificações filter inputs
- bind and validate the filter form in the histórico view before applying queryset filters
- send the form to the template so the filter fields render alongside the table

## Testing
- pytest notificacoes -k historico -q *(fails: coverage threshold 90% not reached in existing suite)*

------
https://chatgpt.com/codex/tasks/task_e_68e57aefb4d883258a3ba086fa87d588