### PR TITLE
Remover filtros da listagem de organizações

### DIFF
--- a/templates/_partials/organizacoes/list_section.html
+++ b/templates/_partials/organizacoes/list_section.html
@@ -1,83 +1,9 @@
 {% load i18n %}
-{% with select_classes="form-select w-full rounded-xl border border-[var(--border)] bg-[var(--bg-secondary)] px-3 py-2 text-[var(--text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--primary)] focus:border-[var(--primary)] transition" %}
 <article class="card">
   <div class="card-header">
-    <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-      <h2 class="text-xl font-semibold">{% trans 'Organizações' %}</h2>
-      {% if request.GET.urlencode %}
-        <a href="{{ request.path }}" class="text-sm font-medium text-[var(--text-secondary)] hover:text-[var(--text-primary)]">
-          {% trans 'Limpar filtros' %}
-        </a>
-      {% endif %}
-    </div>
+    <h2 class="text-xl font-semibold">{% trans 'Organizações' %}</h2>
   </div>
   <div class="card-body space-y-6">
-    <form method="get" class="grid gap-4 sm:grid-cols-2 xl:grid-cols-5" aria-label="{% trans 'Filtros de organizações' %}">
-      <div class="sm:col-span-2">
-        <label for="search" class="block text-sm font-medium text-[var(--text-secondary)]">{% trans 'Buscar' %}</label>
-        <input
-          type="search"
-          name="search"
-          id="search"
-          value="{{ request.GET.search|default_if_none:'' }}"
-          class="form-input w-full"
-          placeholder="{% trans 'Buscar por nome ou slug' %}"
-        />
-      </div>
-      <div>
-        <label for="tipo" class="block text-sm font-medium text-[var(--text-secondary)]">{% trans 'Tipo' %}</label>
-        <select name="tipo" id="tipo" class="{{ select_classes }}">
-          <option value="">{% trans 'Todos os tipos' %}</option>
-          {% for value, label in tipos %}
-            <option value="{{ value }}"{% if request.GET.tipo == value|stringformat:'s' %} selected{% endif %}>{{ label }}</option>
-          {% endfor %}
-        </select>
-      </div>
-      <div>
-        <label for="cidade" class="block text-sm font-medium text-[var(--text-secondary)]">{% trans 'Cidade' %}</label>
-        <select name="cidade" id="cidade" class="{{ select_classes }}">
-          <option value="">{% trans 'Todas as cidades' %}</option>
-          {% for cidade in cidades %}
-            <option value="{{ cidade }}"{% if request.GET.cidade == cidade %} selected{% endif %}>{{ cidade }}</option>
-          {% endfor %}
-        </select>
-      </div>
-      <div>
-        <label for="estado" class="block text-sm font-medium text-[var(--text-secondary)]">{% trans 'Estado' %}</label>
-        <select name="estado" id="estado" class="{{ select_classes }}">
-          <option value="">{% trans 'Todos os estados' %}</option>
-          {% for estado in estados %}
-            <option value="{{ estado }}"{% if request.GET.estado == estado %} selected{% endif %}>{{ estado }}</option>
-          {% endfor %}
-        </select>
-      </div>
-      <div>
-        <label for="ordering" class="block text-sm font-medium text-[var(--text-secondary)]">{% trans 'Ordenar por' %}</label>
-        {% with current_order=request.GET.ordering|default:'nome' %}
-          <select name="ordering" id="ordering" class="{{ select_classes }}">
-            <option value="nome"{% if current_order == 'nome' %} selected{% endif %}>{% trans 'Nome' %}</option>
-            <option value="tipo"{% if current_order == 'tipo' %} selected{% endif %}>{% trans 'Tipo' %}</option>
-            <option value="cidade"{% if current_order == 'cidade' %} selected{% endif %}>{% trans 'Cidade' %}</option>
-            <option value="estado"{% if current_order == 'estado' %} selected{% endif %}>{% trans 'Estado' %}</option>
-            <option value="created_at"{% if current_order == 'created_at' %} selected{% endif %}>{% trans 'Data de criação' %}</option>
-          </select>
-        {% endwith %}
-      </div>
-      <div>
-        <label for="inativa" class="block text-sm font-medium text-[var(--text-secondary)]">{% trans 'Status' %}</label>
-        {% with normalized=request.GET.inativa|default_if_none:''|lower %}
-          <select name="inativa" id="inativa" class="{{ select_classes }}">
-            <option value=""{% if normalized == '' or normalized == 'false' or normalized == '0' or normalized == 'no' %} selected{% endif %}>{% trans 'Somente ativas' %}</option>
-            <option value="true"{% if normalized == 'true' or normalized == 't' or normalized == '1' or normalized == 'yes' %} selected{% endif %}>{% trans 'Somente inativas' %}</option>
-          </select>
-        {% endwith %}
-      </div>
-      <div class="sm:col-span-2 xl:col-span-1 flex flex-col justify-end gap-3 sm:flex-row">
-        <button type="submit" class="btn btn-primary w-full sm:w-auto">{% trans 'Aplicar filtros' %}</button>
-        <a href="{{ request.path }}" class="btn btn-secondary w-full sm:w-auto">{% trans 'Limpar' %}</a>
-      </div>
-    </form>
-
     <div role="list" class="card-grid gap-6 sm:grid-cols-1 md:grid-cols-2 xl:grid-cols-2 items-stretch">
       {% for organizacao in object_list %}
         <article role="listitem" class="card flex flex-col">
@@ -142,4 +68,3 @@
     {% include '_partials/pagination.html' with page_obj=page_obj querystring=request.GET.urlencode hx_target='#org-list' hx_get=request.path hx_push_url='true' %}
   </div>
 </article>
-{% endwith %}


### PR DESCRIPTION
## Summary
- remove os campos de filtro da listagem de organizações
- simplifica a view para retornar apenas organizações ativas ordenadas por nome
- ajusta a chave de cache para refletir os novos parâmetros suportados

## Testing
- pytest tests/organizacoes -k list *(falha devido à configuração de cobertura mínima do projeto)*

------
https://chatgpt.com/codex/tasks/task_e_68e58dda1c88832597316406eb7ee97a