### PR TITLE
Move organização totals to hero component

### DIFF
--- a/organizacoes/templates/organizacoes/detail.html
+++ b/organizacoes/templates/organizacoes/detail.html
@@ -4,7 +4,16 @@
 {% block title %}{{ object.nome }} | Hubx{% endblock %}
 
 {% block hero %}
-  {% include '_components/hero.html' with title=object.nome subtitle=_('Acompanhe os detalhes da organização.') neural_background='home' %}
+  {% include '_components/hero_organizacao.html' with
+    organizacao=object
+    title=object.nome
+    subtitle=_('Acompanhe os detalhes da organização.')
+    neural_background='home'
+    show_stats=request.user.user_type == 'root'
+    usuarios_total=usuarios|length
+    nucleos_total=nucleos|length
+    eventos_total=eventos|length
+  %}
 {% endblock %}
 
 {% block content %}
@@ -102,29 +111,6 @@
         <a href="{% url 'organizacoes:list' %}" class="btn btn-secondary">{% trans 'Voltar' %}</a>
       </footer>
     </article>
-
-    {% if request.user.user_type == 'root' %}
-      <section class="card-grid" aria-label="{% trans 'Indicadores da organização' %}" id="org-stats">
-        <div class="card">
-          <div class="card-body text-center">
-            <p class="text-xs text-[var(--text-muted)]">{% trans 'Usuários' %}</p>
-            <p class="text-lg font-semibold text-[var(--text-primary)]">{{ usuarios|length }}</p>
-          </div>
-        </div>
-        <div class="card">
-          <div class="card-body text-center">
-            <p class="text-xs text-[var(--text-muted)]">{% trans 'Núcleos' %}</p>
-            <p class="text-lg font-semibold text-[var(--text-primary)]">{{ nucleos|length }}</p>
-          </div>
-        </div>
-        <div class="card">
-          <div class="card-body text-center">
-            <p class="text-xs text-[var(--text-muted)]">{% trans 'Eventos' %}</p>
-            <p class="text-lg font-semibold text-[var(--text-primary)]">{{ eventos|length }}</p>
-          </div>
-        </div>
-      </section>
-    {% endif %}
 
     {% if request.user.user_type != 'root' %}
       <section class="space-y-6" aria-label="{% trans 'Relacionamentos da organização' %}">

--- a/organizacoes/templates/organizacoes/organizacao_form.html
+++ b/organizacoes/templates/organizacoes/organizacao_form.html
@@ -11,9 +11,24 @@
 
 {% block hero %}
   {% if form.instance.pk %}
-    {% include '_components/hero.html' with title=_('Editar Organização') subtitle=_('Atualize as informações da organização.') neural_background='home' %}
+    {% include '_components/hero_organizacao.html' with
+      organizacao=form.instance
+      title=_('Editar Organização')
+      subtitle=_('Atualize as informações da organização.')
+      neural_background='home'
+      show_stats=request.user.user_type == 'root'
+      usuarios_total=organizacao_usuarios_total
+      nucleos_total=organizacao_nucleos_total
+      eventos_total=organizacao_eventos_total
+    %}
   {% else %}
-    {% include '_components/hero.html' with title=_('Nova Organização') subtitle=_('Cadastre uma nova organização no Hubx.') neural_background='home' %}
+    {% include '_components/hero_organizacao.html' with
+      organizacao=form.instance
+      title=_('Nova Organização')
+      subtitle=_('Cadastre uma nova organização no Hubx.')
+      neural_background='home'
+      show_stats=False
+    %}
   {% endif %}
 {% endblock %}
 

--- a/organizacoes/views.py
+++ b/organizacoes/views.py
@@ -167,6 +167,10 @@ class OrganizacaoUpdateView(SuperadminRequiredMixin, LoginRequiredMixin, UpdateV
             "fallback_href": fallback_url,
             "aria_label": _("Cancelar edição"),
         }
+        if self.object:
+            context["organizacao_usuarios_total"] = self.object.users.count()
+            context["organizacao_nucleos_total"] = self.object.nucleos.count()
+            context["organizacao_eventos_total"] = self.object.evento_set.count()
         return context
 
     def get_queryset(self):

--- a/templates/_components/hero_organizacao.html
+++ b/templates/_components/hero_organizacao.html
@@ -1,0 +1,56 @@
+{% load i18n %}
+{% with hero_title=title|default:organizacao.nome hero_subtitle=subtitle|default:_('Acompanhe os detalhes da organização.') hero_neural_background=neural_background|default:'home' hero_alignment=alignment|default:'responsive-left' hero_section_classes=section_classes|default:'' hero_container_classes=container_classes|default:'max-w-7xl mx-auto w-full px-4 py-12 md:py-16 space-y-8' hero_content_classes=content_classes|default:'flex flex-col gap-6 md:flex-row md:items-center md:justify-between' hero_title_classes=title_classes|default:'text-4xl md:text-5xl font-bold text-white' hero_subtitle_classes=subtitle_classes|default:'text-lg text-white/90' hero_action_container_classes=action_container_classes|default:'flex justify-center md:justify-end md:self-start' hero_helper_text=helper_text hero_helper_classes=helper_classes|default:'text-base text-white/80' hero_action_template=action_template|default:'' hero_style_attr=style|default:'' %}
+<section class="hero-with-neural relative isolate overflow-hidden text-white{% if hero_section_classes %} {{ hero_section_classes }}{% endif %}"
+         style="--hero-from: var(--color-primary-500); --hero-to: var(--color-primary-700);{% if hero_style_attr %} {{ hero_style_attr }}{% endif %}">
+  {% if hero_neural_background %}
+    <div class="hero-neural-background" aria-hidden="true">
+      {% include 'backgrounds/neural_backgrounds.html' with bg_type=hero_neural_background only %}
+    </div>
+    <div class="hero-overlay" aria-hidden="true"></div>
+  {% endif %}
+  <div class="hero-content relative z-10 w-full">
+    <div class="{{ hero_container_classes }} {% if hero_alignment == 'center' %}text-center{% elif hero_alignment == 'left' %}text-left{% elif hero_alignment == 'right' %}text-right{% else %}text-center md:text-left{% endif %}">
+      <div class="{{ hero_content_classes }}">
+        <div class="space-y-3 md:max-w-3xl">
+          {% if hero_title %}
+            <h1 class="{{ hero_title_classes }}">{{ hero_title }}</h1>
+          {% endif %}
+          {% if hero_subtitle %}
+            <p class="{{ hero_subtitle_classes }}">{{ hero_subtitle }}</p>
+          {% endif %}
+        </div>
+        {% if hero_action_template %}
+          <div class="{{ hero_action_container_classes }}">{% include hero_action_template %}</div>
+        {% elif actions %}
+          <div class="{{ hero_action_container_classes }}">{% include actions %}</div>
+        {% endif %}
+      </div>
+      {% if hero_helper_text %}
+        <p class="{{ hero_helper_classes }}">{{ hero_helper_text }}</p>
+      {% endif %}
+      {% if show_stats and (usuarios_total is not None or nucleos_total is not None or eventos_total is not None or extra_stats) %}
+        {% with default_card_class='card-compact border border-white/30 bg-white/20 text-slate-900 shadow-lg shadow-black/20 backdrop-blur-md dark:border-white/15 dark:bg-slate-950/55 dark:text-white' default_body_class='card-body-compact' %}
+          <div class="mt-8 space-y-4 text-left">
+            <div class="card-grid">
+              {% if usuarios_total is not None %}
+                {% include '_partials/cards/total_card.html' with label=_('Usuários') valor=usuarios_total icon_name='users' card_class=default_card_class body_class=default_body_class %}
+              {% endif %}
+              {% if nucleos_total is not None %}
+                {% include '_partials/cards/total_card.html' with label=_('Núcleos') valor=nucleos_total icon_name='share-2' card_class=default_card_class body_class=default_body_class %}
+              {% endif %}
+              {% if eventos_total is not None %}
+                {% include '_partials/cards/total_card.html' with label=_('Eventos') valor=eventos_total icon_name='calendar' card_class=default_card_class body_class=default_body_class %}
+              {% endif %}
+              {% if extra_stats %}
+                {% for stat in extra_stats %}
+                  {% include '_partials/cards/total_card.html' with label=stat.label valor=stat.valor icon_name=stat.icon_name icon_svg=stat.icon_svg icon_class=stat.icon_class card_class=stat.card_class|default:default_card_class body_class=stat.body_class|default:default_body_class %}
+                {% endfor %}
+              {% endif %}
+            </div>
+          </div>
+        {% endwith %}
+      {% endif %}
+    </div>
+  </div>
+</section>
+{% endwith %}


### PR DESCRIPTION
## Summary
- add a reusable organization hero component that renders optional total cards
- adopt the new hero in the organization detail and form templates
- expose organization relationship counts to the update view for hero rendering

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5944fdd8c8325a10a869fb9037109