### PR TITLE
Fix setup script module path

### DIFF
--- a/scripts/setup_cdl_mulher.py
+++ b/scripts/setup_cdl_mulher.py
@@ -21,6 +21,7 @@ import argparse
 import json
 import os
 import re
+import sys
 from pathlib import Path
 from typing import Any, Optional, Tuple
 
@@ -41,6 +42,11 @@ def parse_args() -> argparse.Namespace:
         help="Senha padrão atribuída aos membros importados",
     )
     return parser.parse_args()
+
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+if str(BASE_DIR) not in sys.path:
+    sys.path.insert(0, str(BASE_DIR))
 
 
 def ensure_django() -> None:


### PR DESCRIPTION
## Summary
- ensure the CDL Mulher setup script adds the repository root to `sys.path` before configuring Django so the `Hubx` settings module can be imported reliably

## Testing
- python scripts/setup_cdl_mulher.py --engine sqlite

------
https://chatgpt.com/codex/tasks/task_e_68e66e9f689483259e49db8bb70289a8