### PR TITLE
Ensure CDL Mulher script marks nucleated members as associates

### DIFF
--- a/scripts/setup_cdl_mulher.py
+++ b/scripts/setup_cdl_mulher.py
@@ -283,6 +283,13 @@ def upsert_participacao(user, nucleo):
     if created or updated:
         participacao.save()
 
+    # Pelo requisito de negócio, todo nucleado também precisa estar marcado
+    # como associado. Garantimos o flag mesmo que o usuário já exista e tenha
+    # sido importado anteriormente com outro estado.
+    if not getattr(user, "is_associado", False):
+        user.is_associado = True
+        user.save(update_fields=["is_associado"])
+
     return created, updated
 
 


### PR DESCRIPTION
## Summary
- ensure that CDL Mulher members imported via the setup script are also flagged as associates when their nucleus participation is created

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6741670a4832586c61a5e2984e012